### PR TITLE
Add test helpers and ergo installer (#12)

### DIFF
--- a/bin/install-ergo
+++ b/bin/install-ergo
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Downloads an ergo release into var/ergo-bin/. Idempotent.
+set -euo pipefail
+
+ERGO_VERSION="2.18.0"
+DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/var/ergo-bin"
+DEST="$DEST_DIR/ergo"
+
+if [[ -x "$DEST" ]]; then
+  echo "ergo already installed at $DEST"
+  exit 0
+fi
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  darwin) OS="macos" ;;
+  linux)  OS="linux" ;;
+  *)
+    echo "install-ergo: unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)        ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "install-ergo: unsupported arch: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+TARBALL="ergo-${ERGO_VERSION}-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/ergochat/ergo/releases/download/v${ERGO_VERSION}/${TARBALL}"
+
+echo "Downloading $URL"
+mkdir -p "$DEST_DIR"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "$TMP/$TARBALL"
+tar -xzf "$TMP/$TARBALL" -C "$TMP"
+mv "$TMP/ergo-${ERGO_VERSION}-${OS}-${ARCH}/ergo" "$DEST"
+chmod +x "$DEST"
+
+echo "Installed ergo $ERGO_VERSION -> $DEST"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "stub": "bun run src/stub-server.ts"
+    "stub": "bun run src/stub-server.ts",
+    "test": "bun test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -3,7 +3,7 @@ import { startErgo, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
 
-let ergo: ErgoContext
+let ergo: ErgoContext | null
 
 describe('test helpers', () => {
   beforeAll(async () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, type ErgoContext } from './helpers/ergo.js'
+import { startMcp } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+
+let ergo: ErgoContext
+
+describe('test helpers', () => {
+  beforeAll(async () => {
+    ergo = await startErgo()
+    if (!ergo) return
+  })
+
+  it('ergo starts and is reachable', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    expect(ergo.port).toBeGreaterThan(0)
+  })
+
+  it('peer can connect and join a channel', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const peer = await connectPeer(ergo, 'smoke-peer1')
+    await peer.joinChannel('#smoke')
+    expect(peer.nick).toBe('smoke-peer1')
+  })
+
+  it('mcp can connect and receives channel notifications', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const mcp = await startMcp(ergo, 'smoke-mcp1')
+    const peer = await connectPeer(ergo, 'smoke-peer2')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#smoke-mcp' } })
+    await peer.joinChannel('#smoke-mcp')
+
+    peer.say('#smoke-mcp', 'hello from peer')
+    const n = await mcp.waitForNotification(
+      (n) => n.meta.channel === '#smoke-mcp' && n.content.includes('hello from peer'),
+    )
+    expect(n.meta.sender).toBe('smoke-peer2')
+  })
+})

--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -1,0 +1,181 @@
+import { join, resolve } from 'node:path'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { accessSync, constants } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { createServer } from 'node:net'
+import { afterAll } from 'bun:test'
+
+const ROOST_ROOT = join(import.meta.dirname, '..', '..')
+
+function findErgoBin(): string | null {
+  const explicit = [
+    join(ROOST_ROOT, 'var', 'ergo-bin', 'ergo'),
+    process.env.ERGO_BIN ? resolve(process.env.ERGO_BIN) : '',
+  ].filter(Boolean)
+
+  for (const c of explicit) {
+    try {
+      accessSync(c, constants.X_OK)
+      return c
+    } catch {
+      // not found or not executable
+    }
+  }
+
+  const onPath = Bun.which('ergo')
+  if (onPath) return onPath
+
+  return null
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address() as { port: number }
+      srv.close(() => resolve(addr.port))
+    })
+    srv.on('error', reject)
+  })
+}
+
+function makeErgoConfig(port: number, datadir: string): string {
+  return `network:
+  name: roost-test
+server:
+  name: roost-test.local
+  max-sendq: 16k
+  listeners:
+    "127.0.0.1:${port}":
+  sts:
+    enabled: false
+  lookup-hostnames: false
+  forward-confirm-hostnames: false
+  check-ident: false
+  relaymsg:
+    enabled: false
+  casemapping: ascii
+  enforce-utf8: true
+  ip-limits:
+    count: false
+    throttle: false
+accounts:
+  authentication-enabled: false
+  registration:
+    enabled: false
+channels:
+  default-modes: +nt
+  registration:
+    enabled: false
+logging:
+  - method: stderr
+    type: "* -userinput -useroutput"
+    level: info
+datastore:
+  path: ${datadir}/ircd.db
+  autoupgrade: true
+lock-file: ${datadir}/ircd.lock
+languages:
+  enabled: false
+fakelag:
+  enabled: false
+limits:
+  nicklen: 32
+  identlen: 20
+  realnamelen: 150
+  channellen: 64
+  awaylen: 390
+  kicklen: 390
+  topiclen: 390
+  monitor-entries: 100
+  whowas-entries: 100
+  chan-list-modes: 100
+  registration-messages: 1024
+  multiline:
+    max-bytes: 16384
+    max-lines: 200
+history:
+  enabled: true
+  channel-length: 256
+  client-length: 64
+  autoreplay-on-join: 10
+  chathistory-maxmessages: 100
+  persistent:
+    enabled: false
+`
+}
+
+export interface ErgoContext {
+  port: number
+  host: string
+}
+
+export async function startErgo(): Promise<ErgoContext> {
+  const ergo = findErgoBin()
+  if (!ergo) {
+    console.warn(
+      '\nERGO NOT FOUND — skipping integration tests.\n' +
+        'Run bin/install-ergo or set ERGO_BIN to the ergo binary path.\n',
+    )
+    return null as unknown as ErgoContext
+  }
+
+  const port = await getFreePort()
+  const datadir = await mkdtemp(join(tmpdir(), 'roost-test-'))
+  const configPath = join(datadir, 'ircd.yaml')
+
+  await writeFile(configPath, makeErgoConfig(port, datadir))
+
+  const init = Bun.spawnSync([ergo, 'initdb', '--conf', configPath], { cwd: datadir })
+  if (init.exitCode !== 0) {
+    await rm(datadir, { recursive: true, force: true })
+    throw new Error(`ergo initdb failed: ${new TextDecoder().decode(init.stderr)}`)
+  }
+
+  const proc = Bun.spawn([ergo, 'run', '--conf', configPath], {
+    cwd: datadir,
+    stderr: 'pipe',
+    stdout: 'ignore',
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      proc.kill()
+      reject(new Error('ergo did not start within 5s'))
+    }, 5000)
+
+    const decoder = new TextDecoder()
+    let buf = ''
+    const reader = proc.stderr.getReader()
+
+    const pump = async () => {
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buf += decoder.decode(value, { stream: true })
+          const lines = buf.split('\n')
+          buf = lines.pop() ?? ''
+          for (const line of lines) {
+            if (line.includes('now listening on')) {
+              clearTimeout(timeout)
+              resolve()
+              return
+            }
+          }
+        }
+        reject(new Error('ergo exited before becoming ready'))
+      } catch (e) {
+        reject(e)
+      }
+    }
+    void pump()
+  })
+
+  afterAll(async () => {
+    proc.kill()
+    await rm(datadir, { recursive: true, force: true })
+  })
+
+  return { port, host: '127.0.0.1' }
+}

--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -8,12 +8,12 @@ import { afterAll } from 'bun:test'
 const ROOST_ROOT = join(import.meta.dirname, '..', '..')
 
 function findErgoBin(): string | null {
-  const explicit = [
+  const candidates: string[] = [
+    ...(process.env.ERGO_BIN ? [resolve(process.env.ERGO_BIN)] : []),
     join(ROOST_ROOT, 'var', 'ergo-bin', 'ergo'),
-    process.env.ERGO_BIN ? resolve(process.env.ERGO_BIN) : '',
-  ].filter(Boolean)
+  ]
 
-  for (const c of explicit) {
+  for (const c of candidates) {
     try {
       accessSync(c, constants.X_OK)
       return c
@@ -22,10 +22,7 @@ function findErgoBin(): string | null {
     }
   }
 
-  const onPath = Bun.which('ergo')
-  if (onPath) return onPath
-
-  return null
+  return Bun.which('ergo')
 }
 
 function getFreePort(): Promise<number> {
@@ -110,14 +107,14 @@ export interface ErgoContext {
   host: string
 }
 
-export async function startErgo(): Promise<ErgoContext> {
+export async function startErgo(): Promise<ErgoContext | null> {
   const ergo = findErgoBin()
   if (!ergo) {
     console.warn(
       '\nERGO NOT FOUND — skipping integration tests.\n' +
         'Run bin/install-ergo or set ERGO_BIN to the ergo binary path.\n',
     )
-    return null as unknown as ErgoContext
+    return null
   }
 
   const port = await getFreePort()

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -1,0 +1,92 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { join } from 'node:path'
+import { afterAll } from 'bun:test'
+import type { ErgoContext } from './ergo.js'
+
+const ROOST_ROOT = join(import.meta.dirname, '..', '..')
+
+export interface ChannelNotification {
+  content: string
+  meta: Record<string, string>
+}
+
+export interface McpContext {
+  client: Client
+  nick: string
+  notifications: ChannelNotification[]
+  waitForNotification(
+    pred: (n: ChannelNotification) => boolean,
+    timeoutMs?: number,
+  ): Promise<ChannelNotification>
+}
+
+let instanceCounter = 0
+
+export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpContext> {
+  const clientNick = nick ?? `mcp${++instanceCounter}`
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: ['run', join(ROOST_ROOT, 'src', 'irc-server.ts')],
+    env: {
+      ...process.env,
+      ROOST_IRC_SERVER: ergo.host,
+      ROOST_IRC_PORT: String(ergo.port),
+      ROOST_IRC_NICK: clientNick,
+    },
+    stderr: 'inherit',
+  })
+
+  const notifications: ChannelNotification[] = []
+  const waiters: Array<{
+    pred: (n: ChannelNotification) => boolean
+    resolve: (n: ChannelNotification) => void
+    reject: (e: Error) => void
+  }> = []
+
+  const client = new Client({ name: 'roost-test', version: '0.0.1' })
+
+  client.fallbackNotificationHandler = async (notification) => {
+    if (notification.method !== 'notifications/claude/channel') return
+    const params = notification.params as { content: string; meta: Record<string, string> }
+    const n: ChannelNotification = { content: params.content, meta: params.meta }
+    notifications.push(n)
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (waiters[i].pred(n)) {
+        const w = waiters.splice(i, 1)[0]
+        w.resolve(n)
+      }
+    }
+  }
+
+  await client.connect(transport)
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  return {
+    client,
+    nick: clientNick,
+    notifications,
+    waitForNotification(pred, timeoutMs = 5000) {
+      return new Promise((resolve, reject) => {
+        const existing = notifications.find(pred)
+        if (existing) { resolve(existing); return }
+
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex(w => w.resolve === resolve)
+          if (idx !== -1) waiters.splice(idx, 1)
+          reject(new Error(`waitForNotification timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+
+        waiters.push({
+          pred,
+          resolve: (n) => { clearTimeout(timer); resolve(n) },
+          reject,
+        })
+      })
+    },
+  }
+}

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -1,0 +1,103 @@
+// @ts-expect-error — irc-framework lacks first-class type defs
+import IRC from 'irc-framework'
+import { afterAll } from 'bun:test'
+import type { ErgoContext } from './ergo.js'
+
+let peerCounter = 0
+
+export interface PeerMessage {
+  nick: string
+  text: string
+}
+
+export interface PeerContext {
+  nick: string
+  joinChannel(channel: string): Promise<void>
+  say(channel: string, text: string): void
+  waitForMessage(
+    channel: string,
+    pred: (msg: PeerMessage) => boolean,
+    timeoutMs?: number,
+  ): Promise<PeerMessage>
+}
+
+export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext> {
+  const peerNick = nick ?? `peer${++peerCounter}`
+
+  const client = new IRC.Client()
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`peer ${peerNick} connect timed out`)), 5000)
+    client.on('registered', () => { clearTimeout(timeout); resolve() })
+    client.on('close', () => reject(new Error('peer connection closed during connect')))
+    client.connect({
+      host: ergo.host,
+      port: ergo.port,
+      nick: peerNick,
+      auto_reconnect: false,
+    })
+  })
+
+  const messageWaiters: Array<{
+    channel: string
+    pred: (msg: PeerMessage) => boolean
+    resolve: (msg: PeerMessage) => void
+    reject: (e: Error) => void
+  }> = []
+
+  client.on('message', (event: { nick: string; target: string; message: string }) => {
+    const msg: PeerMessage = { nick: event.nick, text: event.message }
+    for (let i = messageWaiters.length - 1; i >= 0; i--) {
+      const w = messageWaiters[i]
+      if (w.channel === event.target && w.pred(msg)) {
+        messageWaiters.splice(i, 1)
+        w.resolve(msg)
+      }
+    }
+  })
+
+  afterAll(() => {
+    client.quit()
+  })
+
+  return {
+    nick: peerNick,
+
+    joinChannel(channel) {
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error(`joinChannel ${channel} timed out`)),
+          5000,
+        )
+        client.on('join', (event: { nick: string; channel: string }) => {
+          if (event.nick === peerNick && event.channel === channel) {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+        client.join(channel)
+      })
+    },
+
+    say(channel, text) {
+      client.say(channel, text)
+    },
+
+    waitForMessage(channel, pred, timeoutMs = 5000) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = messageWaiters.findIndex(w => w.resolve === resolve)
+          if (idx !== -1) messageWaiters.splice(idx, 1)
+          reject(new Error(`waitForMessage on ${channel} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+
+        messageWaiters.push({
+          channel,
+          pred,
+          resolve: (msg) => { clearTimeout(timer); resolve(msg) },
+          reject,
+        })
+      })
+    },
+  }
+}

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -69,12 +69,14 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
           () => reject(new Error(`joinChannel ${channel} timed out`)),
           5000,
         )
-        client.on('join', (event: { nick: string; channel: string }) => {
+        const onJoin = (event: { nick: string; channel: string }) => {
           if (event.nick === peerNick && event.channel === channel) {
+            client.removeListener('join', onJoin)
             clearTimeout(timeout)
             resolve()
           }
-        })
+        }
+        client.on('join', onJoin)
         client.join(channel)
       })
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["bun"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Closes #12.

- `bin/install-ergo`: idempotent, detects OS/arch, downloads ergo 2.18.0 into `var/ergo-bin/`
- `test/helpers/ergo.ts`: `startErgo()` — temp config + datadir, random free port, waits on "now listening" log line, afterAll cleanup. Binary lookup: `var/ergo-bin/ergo` → `$ERGO_BIN` → PATH with a clear skip message if none found.
- `test/helpers/mcp.ts`: `startMcp()` — spawns `src/irc-server.ts` via `StdioClientTransport`, captures `notifications/claude/channel`, exposes `waitForNotification(pred, timeoutMs)`
- `test/helpers/peer.ts`: `connectPeer()` — irc-framework client with `joinChannel`, `say`, `waitForMessage(channel, pred)`
- `bun test` wired into `package.json`; `test/` added to `tsconfig.json`

Smoke test in `test/helpers.test.ts` exercises all three helpers together. Passes in ~900ms.