### PR TITLE
Add irc-server tool tests (closes #13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Roost
+
+A Claude Code plugin to allow teams of agents (and humans!) to communicate over IRC.
+
+Delivers
+- A CLI for spawning new Claude code instances (see `bin/roost`)
+- An MCP server to let Claude work with IRC and receive IRC messages (see `src/irc-server.ts`)
+- A hook to proxy permissions requests over IRC (see `bin/irc-permission-prompt` and `bin/roost-permbot`)
+
+Intended to ride ergo for IRCv3 (multiline and chathistory) support.
+
+Uses Github issues and PRs for workflow and project management.
+
+## Running tests
+
+```
+bun test
+```
+
+Requires ergo (IRCv3 server). Install with `bin/install-ergo` or set `ERGO_BIN` to the binary path. Tests skip gracefully if ergo isn't found.
+
+## Committing
+
+When making a commit, ensure you include a human/claude interaction log. This is mandatory, and captures the human intent of actions you perform. Make the humans accountable.
+
+```
+## Human-Claude Interaction Log
+
+### Human prompts (VERBATIM - include typos, informal language, COMPLETE text):
+**Include EVERY prompt since last commit - even short ones, corrections, clarifications**
+1. "[Copy-paste ENTIRE first prompt since last commit]"
+   → Claude: [What Claude did in response]
+
+2. "[Copy-paste ENTIRE second prompt - including [Request interrupted] if present]"
+   → Claude: [How Claude adjusted]
+
+[Continue numbering ALL prompts - don't skip any or judge importance]
+```

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,30 +1,26 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
-import { startErgo, type ErgoContext } from './helpers/ergo.js'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
 
-let ergo: ErgoContext | null
+describe.if(isErgoAvailable())('test helpers', () => {
+  let ergo: ErgoContext
 
-describe('test helpers', () => {
   beforeAll(async () => {
-    ergo = await startErgo()
-    if (!ergo) return
+    ergo = (await startErgo())!
   })
 
   it('ergo starts and is reachable', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     expect(ergo.port).toBeGreaterThan(0)
   })
 
   it('peer can connect and join a channel', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const peer = await connectPeer(ergo, 'smoke-peer1')
     await peer.joinChannel('#smoke')
     expect(peer.nick).toBe('smoke-peer1')
   })
 
   it('mcp can connect and receives channel notifications', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const mcp = await startMcp(ergo, 'smoke-mcp1')
     const peer = await connectPeer(ergo, 'smoke-peer2')
 

--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -7,6 +7,10 @@ import { afterAll } from 'bun:test'
 
 const ROOST_ROOT = join(import.meta.dirname, '..', '..')
 
+export function isErgoAvailable(): boolean {
+  return findErgoBin() !== null
+}
+
 function findErgoBin(): string | null {
   const candidates: string[] = [
     ...(process.env.ERGO_BIN ? [resolve(process.env.ERGO_BIN)] : []),

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -62,6 +62,17 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
 
   await client.connect(transport)
 
+  // Poll until the IRC client has registered — tools return isError before that.
+  const deadline = Date.now() + 5000
+  while (true) {
+    const r = await client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+    if (!r.isError) break
+    const text = ((r.content[0] ?? {}) as { text?: string }).text ?? ''
+    if (!text.includes('not ready')) break // unexpected error — don't loop forever
+    if (Date.now() > deadline) throw new Error(`startMcp: IRC not ready within 5s (nick=${clientNick})`)
+    await new Promise<void>(res => setTimeout(res, 50))
+  }
+
   afterAll(async () => {
     await client.close()
   })

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -13,12 +13,14 @@ export interface PeerMessage {
 export interface PeerContext {
   nick: string
   joinChannel(channel: string): Promise<void>
+  leaveChannel(channel: string): Promise<void>
   say(channel: string, text: string): void
   waitForMessage(
     channel: string,
     pred: (msg: PeerMessage) => boolean,
     timeoutMs?: number,
   ): Promise<PeerMessage>
+  waitForPart(channel: string, nick: string, timeoutMs?: number): Promise<void>
 }
 
 export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext> {
@@ -60,6 +62,22 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
     client.quit()
   })
 
+  const waitForPart = (channel: string, nick: string, timeoutMs = 5000): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        client.removeListener('part', onPart)
+        reject(new Error(`waitForPart ${nick} in ${channel} timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+      const onPart = (event: { nick: string; channel: string }) => {
+        if (event.nick === nick && event.channel === channel) {
+          client.removeListener('part', onPart)
+          clearTimeout(timer)
+          resolve()
+        }
+      }
+      client.on('part', onPart)
+    })
+
   return {
     nick: peerNick,
 
@@ -81,9 +99,16 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
       })
     },
 
+    leaveChannel(channel) {
+      client.part(channel)
+      return waitForPart(channel, peerNick)
+    },
+
     say(channel, text) {
       client.say(channel, text)
     },
+
+    waitForPart,
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return new Promise((resolve, reject) => {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, type ErgoContext } from './helpers/ergo.js'
+import { startMcp } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+
+let ergo: ErgoContext | null
+
+describe('irc-server MCP tools', () => {
+  beforeAll(async () => {
+    ergo = await startErgo()
+  })
+
+  it('tools/list returns 6 tools with correct schemas', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const mcp = await startMcp(ergo, 'list-test-mcp')
+    const { tools } = await mcp.client.listTools()
+
+    expect(tools).toHaveLength(6)
+    const byName = Object.fromEntries(
+      tools.map(t => [t.name, (t.inputSchema as unknown as { required?: string[] }).required]),
+    )
+
+    expect(byName['channel_message']).toEqual(expect.arrayContaining(['channel', 'text']))
+    expect(byName['direct_message']).toEqual(expect.arrayContaining(['nick', 'text']))
+    expect(byName['channel_join']).toEqual(['channel'])
+    expect(byName['channel_leave']).toEqual(['channel'])
+    expect(byName['channel_who']).toEqual(['channel'])
+    expect(byName['channel_history']).toEqual(['channel'])
+  })
+
+  it('channel_join resolves on ack; channel_who includes own nick', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const mcp = await startMcp(ergo, 'join-test-mcp')
+
+    const join = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#join-test' } })
+    expect(join.isError).toBeFalsy()
+
+    const who = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#join-test' } })
+    expect((who.content[0] as { type: 'text'; text: string }).text).toContain('join-test-mcp')
+  })
+
+  it('channel_who reflects peer join and leave', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const mcp = await startMcp(ergo, 'who-test-mcp')
+    const peer = await connectPeer(ergo, 'who-test-peer')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#who-test' } })
+    await peer.joinChannel('#who-test')
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === 'who-test-peer')
+
+    const whoBefore = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#who-test' } })
+    expect((whoBefore.content[0] as { type: 'text'; text: string }).text).toContain('who-test-peer')
+
+    await peer.leaveChannel('#who-test')
+    await mcp.waitForNotification(n => n.meta.event === 'leave' && n.meta.sender === 'who-test-peer')
+
+    const whoAfter = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#who-test' } })
+    expect((whoAfter.content[0] as { type: 'text'; text: string }).text).not.toContain('who-test-peer')
+  })
+
+  it('channel_leave parts cleanly', async () => {
+    if (!ergo) { console.log('skipped — ergo not found'); return }
+    const mcp = await startMcp(ergo, 'leave-test-mcp')
+    const peer = await connectPeer(ergo, 'leave-test-peer')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#leave-test' } })
+    await peer.joinChannel('#leave-test')
+
+    const result = await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#leave-test' } })
+    expect(result.isError).toBeFalsy()
+    expect((result.content[0] as { type: 'text'; text: string }).text).toBe('parted #leave-test')
+
+    await peer.waitForPart('#leave-test', 'leave-test-mcp')
+  })
+})

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
-import { startErgo, type ErgoContext } from './helpers/ergo.js'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
 
-let ergo: ErgoContext | null
+describe.if(isErgoAvailable())('irc-server MCP tools', () => {
+  let ergo: ErgoContext
 
-describe('irc-server MCP tools', () => {
   beforeAll(async () => {
-    ergo = await startErgo()
+    ergo = (await startErgo())!
   })
 
   it('tools/list returns 6 tools with correct schemas', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const mcp = await startMcp(ergo, 'list-test-mcp')
     const { tools } = await mcp.client.listTools()
 
@@ -29,7 +28,6 @@ describe('irc-server MCP tools', () => {
   })
 
   it('channel_join resolves on ack; channel_who includes own nick', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const mcp = await startMcp(ergo, 'join-test-mcp')
 
     const join = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#join-test' } })
@@ -40,7 +38,6 @@ describe('irc-server MCP tools', () => {
   })
 
   it('channel_who reflects peer join and leave', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const mcp = await startMcp(ergo, 'who-test-mcp')
     const peer = await connectPeer(ergo, 'who-test-peer')
 
@@ -59,7 +56,6 @@ describe('irc-server MCP tools', () => {
   })
 
   it('channel_leave parts cleanly', async () => {
-    if (!ergo) { console.log('skipped — ergo not found'); return }
     const mcp = await startMcp(ergo, 'leave-test-mcp')
     const peer = await connectPeer(ergo, 'leave-test-peer')
 


### PR DESCRIPTION
4 integration tests covering the cases from #13:

- `tools/list` returns 6 tools with correct schemas
- `channel_join` resolves on ack; `channel_who` includes own nick
- peer join/leave reflected in `channel_who`
- `channel_leave` parts cleanly (confirmed via peer observing PART)

Also fixed a pre-existing race in `startMcp` — it was returning before the IRC client registered, causing tools to immediately return `isError: true`. Added a readiness poll so callers get a fully-connected context. This unblocked an intermittent failure in `helpers.test.ts` too.

`test/helpers/peer.ts` gets `leaveChannel` and `waitForPart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)