### PR TITLE
Add outbound message tests (closes #14)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "irc-framework": "^4.14.0",
+        "typescript": "^6.0.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.10",
@@ -254,6 +255,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/test/helpers/tool.ts
+++ b/test/helpers/tool.ts
@@ -1,0 +1,4 @@
+/** Extract the text content from a callTool result. */
+export function toolText(result: unknown): string {
+  return (((result as { content: unknown[] }).content)[0] as { text: string }).text
+}

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'bun:test'
 import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
+import { toolText } from './helpers/tool.js'
 
 describe.if(isErgoAvailable())('irc-server MCP tools', () => {
   let ergo: ErgoContext
@@ -34,7 +35,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(join.isError).toBeFalsy()
 
     const who = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#join-test' } })
-    expect(((who.content as unknown[])[0] as { type: 'text'; text: string }).text).toContain('join-test-mcp')
+    expect(toolText(who)).toContain('join-test-mcp')
   })
 
   it('channel_who reflects peer join and leave', async () => {
@@ -64,7 +65,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
 
     const result = await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#leave-test' } })
     expect(result.isError).toBeFalsy()
-    expect(((result.content as unknown[])[0] as { type: 'text'; text: string }).text).toBe('parted #leave-test')
+    expect(toolText(result)).toBe('parted #leave-test')
 
     await peer.waitForPart('#leave-test', 'leave-test-mcp')
   })

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { startMcp } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+
+describe.if(isErgoAvailable())('outbound message tools', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('channel_message: MCP send reaches peer', async () => {
+    const mcp = await startMcp(ergo, 'out-mcp1')
+    const peer = await connectPeer(ergo, 'out-peer1')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#out-msg' } })
+    await peer.joinChannel('#out-msg')
+
+    const result = await mcp.client.callTool({
+      name: 'channel_message',
+      arguments: { channel: '#out-msg', text: 'hello from mcp' },
+    })
+    expect(result.isError).toBeFalsy()
+    expect(((result.content as unknown[])[0] as { text: string }).text).toContain('sent to #out-msg')
+
+    const msg = await peer.waitForMessage('#out-msg', m => m.nick === 'out-mcp1' && m.text === 'hello from mcp')
+    expect(msg.text).toBe('hello from mcp')
+  })
+
+  it('direct_message: MCP→peer DM arrives', async () => {
+    const mcp = await startMcp(ergo, 'out-mcp2')
+    const peer = await connectPeer(ergo, 'out-peer2')
+
+    const result = await mcp.client.callTool({
+      name: 'direct_message',
+      arguments: { nick: 'out-peer2', text: 'dm from mcp' },
+    })
+    expect(result.isError).toBeFalsy()
+    expect(((result.content as unknown[])[0] as { text: string }).text).toContain('DM to out-peer2')
+
+    // For DMs in irc-framework, event.target === recipient nick, so waitForMessage on own nick.
+    const msg = await peer.waitForMessage('out-peer2', m => m.nick === 'out-mcp2' && m.text === 'dm from mcp')
+    expect(msg.text).toBe('dm from mcp')
+  })
+
+  it('direct_message: peer→MCP DM arrives as notification', async () => {
+    const mcp = await startMcp(ergo, 'out-mcp3')
+    const peer = await connectPeer(ergo, 'out-peer3')
+
+    peer.say('out-mcp3', 'dm from peer')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.isDirect === 'true' && n.meta.sender === 'out-peer3' && n.content === 'dm from peer',
+    )
+    expect(n.content).toBe('dm from peer')
+    expect(n.meta.isDirect).toBe('true')
+  })
+
+  it('channel_message: long multiline message reassembles to original text', async () => {
+    // Peer helper uses plain irc-framework without draft/multiline cap, so ergo degrades
+    // to individual PRIVMSGs for non-cap clients — peer cannot reassemble. Use two MCPs
+    // (both negotiate draft/multiline) to test the full send+reassembly round-trip.
+    const sender = await startMcp(ergo, 'out-mcp4')
+    const receiver = await startMcp(ergo, 'out-mcp5')
+
+    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } })
+    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } })
+
+    const longText = 'a'.repeat(150) + '\n' + 'b'.repeat(150) + '\n' + 'c'.repeat(50)
+    // 352 bytes total, two embedded newlines — forces draft/multiline batch
+
+    const result = await sender.client.callTool({
+      name: 'channel_message',
+      arguments: { channel: '#out-ml', text: longText },
+    })
+    expect(result.isError).toBeFalsy()
+    const resultText = ((result.content as unknown[])[0] as { text: string }).text
+    expect(resultText).toContain('draft/multiline batch')
+
+    const n = await receiver.waitForNotification(
+      n => n.meta.channel === '#out-ml' && n.meta.sender === 'out-mcp4',
+    )
+    expect(n.content).toBe(longText)
+  })
+
+  it('channel_history: returns recent messages in order', async () => {
+    const mcp = await startMcp(ergo, 'out-mcp6')
+    const peer = await connectPeer(ergo, 'out-peer6')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#out-hist' } })
+    await peer.joinChannel('#out-hist')
+
+    // Send one at a time, waiting for each notification so the receive buffer
+    // doesn't coalesce them into a single event.
+    peer.say('#out-hist', 'hist-msg-1')
+    await mcp.waitForNotification(n => n.meta.channel === '#out-hist' && n.content === 'hist-msg-1')
+
+    peer.say('#out-hist', 'hist-msg-2')
+    await mcp.waitForNotification(n => n.meta.channel === '#out-hist' && n.content === 'hist-msg-2')
+
+    peer.say('#out-hist', 'hist-msg-3')
+    await mcp.waitForNotification(n => n.meta.channel === '#out-hist' && n.content === 'hist-msg-3')
+
+    const hist = await mcp.client.callTool({
+      name: 'channel_history',
+      arguments: { channel: '#out-hist' },
+    })
+    expect(hist.isError).toBeFalsy()
+    const text = ((hist.content as unknown[])[0] as { text: string }).text
+    const idx1 = text.indexOf('hist-msg-1')
+    const idx2 = text.indexOf('hist-msg-2')
+    const idx3 = text.indexOf('hist-msg-3')
+    expect(idx1).toBeGreaterThanOrEqual(0)
+    expect(idx2).toBeGreaterThan(idx1)
+    expect(idx3).toBeGreaterThan(idx2)
+  })
+})

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'bun:test'
 import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
+import { toolText } from './helpers/tool.js'
 
 describe.if(isErgoAvailable())('outbound message tools', () => {
   let ergo: ErgoContext
@@ -22,10 +23,9 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
       arguments: { channel: '#out-msg', text: 'hello from mcp' },
     })
     expect(result.isError).toBeFalsy()
-    expect(((result.content as unknown[])[0] as { text: string }).text).toContain('sent to #out-msg')
+    expect(toolText(result)).toContain('sent to #out-msg')
 
-    const msg = await peer.waitForMessage('#out-msg', m => m.nick === 'out-mcp1' && m.text === 'hello from mcp')
-    expect(msg.text).toBe('hello from mcp')
+    await peer.waitForMessage('#out-msg', m => m.nick === 'out-mcp1' && m.text === 'hello from mcp')
   })
 
   it('direct_message: MCP→peer DM arrives', async () => {
@@ -37,11 +37,10 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
       arguments: { nick: 'out-peer2', text: 'dm from mcp' },
     })
     expect(result.isError).toBeFalsy()
-    expect(((result.content as unknown[])[0] as { text: string }).text).toContain('DM to out-peer2')
+    expect(toolText(result)).toContain('DM to out-peer2')
 
     // For DMs in irc-framework, event.target === recipient nick, so waitForMessage on own nick.
-    const msg = await peer.waitForMessage('out-peer2', m => m.nick === 'out-mcp2' && m.text === 'dm from mcp')
-    expect(msg.text).toBe('dm from mcp')
+    await peer.waitForMessage('out-peer2', m => m.nick === 'out-mcp2' && m.text === 'dm from mcp')
   })
 
   it('direct_message: peer→MCP DM arrives as notification', async () => {
@@ -75,8 +74,7 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
       arguments: { channel: '#out-ml', text: longText },
     })
     expect(result.isError).toBeFalsy()
-    const resultText = ((result.content as unknown[])[0] as { text: string }).text
-    expect(resultText).toContain('draft/multiline batch')
+    expect(toolText(result)).toContain('draft/multiline batch')
 
     const n = await receiver.waitForNotification(
       n => n.meta.channel === '#out-ml' && n.meta.sender === 'out-mcp4',
@@ -107,7 +105,7 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
       arguments: { channel: '#out-hist' },
     })
     expect(hist.isError).toBeFalsy()
-    const text = ((hist.content as unknown[])[0] as { text: string }).text
+    const text = toolText(hist)
     const idx1 = text.indexOf('hist-msg-1')
     const idx2 = text.indexOf('hist-msg-2')
     const idx3 = text.indexOf('hist-msg-3')


### PR DESCRIPTION
5 integration tests covering the 4 acceptance bullets from #14:

- `channel_message` round-trip to peer
- `direct_message` MCP→peer and peer→MCP (two tests)
- long multiline message (352 bytes, 2 embedded newlines) goes out as `draft/multiline` batch; second MCP reassembles to original text
- `channel_history` returns recent messages in order

Two MCPs used for the multiline test — the raw `irc-framework` peer doesn't negotiate `draft/multiline` cap, so ergo degrades to individual PRIVMSGs for it; only an MCP client can reassemble the batch.

All 12 tests (8 existing + 5 new) pass green.