### PR TITLE
test: chathistory backfill (#16)

### DIFF
--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { startMcp } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+import { toolText } from './helpers/tool.js'
+
+describe.if(isErgoAvailable())('chathistory backfill', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('pre-join messages arrive as historical notifications in seq order', async () => {
+    const peer = await connectPeer(ergo, 'hist-peer1')
+    const mcp = await startMcp(ergo, 'hist-mcp1')
+
+    await peer.joinChannel('#hist-backfill1')
+    peer.say('#hist-backfill1', 'before-join-1')
+    peer.say('#hist-backfill1', 'before-join-2')
+    peer.say('#hist-backfill1', 'before-join-3')
+    // Give ergo time to store messages before MCP joins
+    await new Promise<void>(res => setTimeout(res, 200))
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-backfill1' } })
+
+    const n1 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-1')
+    const n2 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-2')
+    const n3 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-3')
+
+    expect(n1.meta.historical).toBe('true')
+    expect(n1.meta.channel).toBe('#hist-backfill1')
+    expect(Number(n2.meta.seq)).toBeGreaterThan(Number(n1.meta.seq))
+    expect(Number(n3.meta.seq)).toBeGreaterThan(Number(n2.meta.seq))
+  })
+
+  it('messages sent while parted arrive as historical on rejoin', async () => {
+    const peer = await connectPeer(ergo, 'hist-peer2')
+    const mcp = await startMcp(ergo, 'hist-mcp2')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-backfill2' } })
+    await peer.joinChannel('#hist-backfill2')
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#hist-backfill2' } })
+
+    peer.say('#hist-backfill2', 'while-parted-1')
+    peer.say('#hist-backfill2', 'while-parted-2')
+    await new Promise<void>(res => setTimeout(res, 200))
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-backfill2' } })
+
+    const n1 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-1')
+    const n2 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-2')
+
+    expect(n1.meta.historical).toBe('true')
+    expect(n2.meta.historical).toBe('true')
+    expect(Number(n2.meta.seq)).toBeGreaterThan(Number(n1.meta.seq))
+  })
+
+  it('channel_history includes backfilled messages in order', async () => {
+    const peer = await connectPeer(ergo, 'hist-peer3')
+    const mcp = await startMcp(ergo, 'hist-mcp3')
+
+    await peer.joinChannel('#hist-order3')
+    peer.say('#hist-order3', 'order-one')
+    peer.say('#hist-order3', 'order-two')
+    await new Promise<void>(res => setTimeout(res, 200))
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-order3' } })
+    // Wait for backfill to land before querying history
+    await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'order-two')
+
+    const hist = await mcp.client.callTool({
+      name: 'channel_history',
+      arguments: { channel: '#hist-order3' },
+    })
+    expect(hist.isError).toBeFalsy()
+    const text = toolText(hist)
+    const idx1 = text.indexOf('order-one')
+    const idx2 = text.indexOf('order-two')
+    expect(idx1).toBeGreaterThanOrEqual(0)
+    expect(idx2).toBeGreaterThan(idx1)
+  })
+})

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll } from 'bun:test'
 import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
-import { toolText } from './helpers/tool.js'
+import { toolText, sleep } from './helpers/tool.js'
 
 describe.if(isErgoAvailable())('chathistory backfill', () => {
   let ergo: ErgoContext
@@ -19,16 +19,16 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     peer.say('#hist-backfill1', 'before-join-1')
     peer.say('#hist-backfill1', 'before-join-2')
     peer.say('#hist-backfill1', 'before-join-3')
-    // Give ergo time to store messages before MCP joins
-    await new Promise<void>(res => setTimeout(res, 200))
+    await sleep(200)
 
     await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-backfill1' } })
 
-    const n1 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-1')
-    const n2 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-2')
-    const n3 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-3')
+    const [n1, n2, n3] = await Promise.all([
+      mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-1'),
+      mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-2'),
+      mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'before-join-3'),
+    ])
 
-    expect(n1.meta.historical).toBe('true')
     expect(n1.meta.channel).toBe('#hist-backfill1')
     expect(Number(n2.meta.seq)).toBeGreaterThan(Number(n1.meta.seq))
     expect(Number(n3.meta.seq)).toBeGreaterThan(Number(n2.meta.seq))
@@ -44,15 +44,15 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
 
     peer.say('#hist-backfill2', 'while-parted-1')
     peer.say('#hist-backfill2', 'while-parted-2')
-    await new Promise<void>(res => setTimeout(res, 200))
+    await sleep(200)
 
     await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-backfill2' } })
 
-    const n1 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-1')
-    const n2 = await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-2')
+    const [n1, n2] = await Promise.all([
+      mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-1'),
+      mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'while-parted-2'),
+    ])
 
-    expect(n1.meta.historical).toBe('true')
-    expect(n2.meta.historical).toBe('true')
     expect(Number(n2.meta.seq)).toBeGreaterThan(Number(n1.meta.seq))
   })
 
@@ -63,10 +63,9 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     await peer.joinChannel('#hist-order3')
     peer.say('#hist-order3', 'order-one')
     peer.say('#hist-order3', 'order-two')
-    await new Promise<void>(res => setTimeout(res, 200))
+    await sleep(200)
 
     await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-order3' } })
-    // Wait for backfill to land before querying history
     await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'order-two')
 
     const hist = await mcp.client.callTool({

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -3,6 +3,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { join } from 'node:path'
 import { afterAll } from 'bun:test'
 import type { ErgoContext } from './ergo.js'
+import { sleep } from './tool.js'
 
 const ROOST_ROOT = join(import.meta.dirname, '..', '..')
 
@@ -70,7 +71,7 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
     const text = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
     if (!text.includes('not ready')) break // unexpected error — don't loop forever
     if (Date.now() > deadline) throw new Error(`startMcp: IRC not ready within 5s (nick=${clientNick})`)
-    await new Promise<void>(res => setTimeout(res, 50))
+    await sleep(50)
   }
 
   afterAll(async () => {

--- a/test/helpers/tool.ts
+++ b/test/helpers/tool.ts
@@ -2,3 +2,5 @@
 export function toolText(result: unknown): string {
   return (((result as { content: unknown[] }).content)[0] as { text: string }).text
 }
+
+export const sleep = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))


### PR DESCRIPTION
closes #16

3 tests in `test/chathistory.test.ts`:
- pre-join backfill: peer sends 3 msgs before MCP joins → all arrive as `historical=true` notifications, `seq` strictly increasing
- parted+rejoin: MCP joins, leaves, peer sends msgs, MCP rejoins → same historical treatment
- `channel_history` reflects the backfilled messages in order

All 15 tests green. Uses same ergo/peer/mcp helper pattern as existing test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)