### PR TITLE
tests: inbound notifications + membership events

### DIFF
--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -16,7 +16,7 @@ export interface PeerContext {
   leaveChannel(channel: string): Promise<void>
   say(channel: string, text: string): void
   kick(channel: string, nick: string, reason?: string): void
-  changeNick(newNick: string): Promise<void>
+  changeNick(newNick: string, timeoutMs?: number): Promise<void>
   waitForMessage(
     channel: string,
     pred: (msg: PeerMessage) => boolean,
@@ -111,19 +111,15 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
     },
 
     kick(channel, nick, reason) {
-      if (reason) {
-        client.raw('KICK', channel, nick, reason)
-      } else {
-        client.raw('KICK', channel, nick)
-      }
+      client.raw('KICK', channel, nick, ...(reason ? [reason] : []))
     },
 
-    changeNick(newNick) {
+    changeNick(newNick, timeoutMs = 5000) {
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
           client.removeListener('nick', onNick)
           reject(new Error(`changeNick to ${newNick} timed out`))
-        }, 5000)
+        }, timeoutMs)
         const onNick = (event: { nick: string; new_nick: string }) => {
           if (event.new_nick === newNick) {
             client.removeListener('nick', onNick)

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -15,6 +15,8 @@ export interface PeerContext {
   joinChannel(channel: string): Promise<void>
   leaveChannel(channel: string): Promise<void>
   say(channel: string, text: string): void
+  kick(channel: string, nick: string, reason?: string): void
+  changeNick(newNick: string): Promise<void>
   waitForMessage(
     channel: string,
     pred: (msg: PeerMessage) => boolean,
@@ -106,6 +108,32 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
     say(channel, text) {
       client.say(channel, text)
+    },
+
+    kick(channel, nick, reason) {
+      if (reason) {
+        client.raw('KICK', channel, nick, reason)
+      } else {
+        client.raw('KICK', channel, nick)
+      }
+    },
+
+    changeNick(newNick) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          client.removeListener('nick', onNick)
+          reject(new Error(`changeNick to ${newNick} timed out`))
+        }, 5000)
+        const onNick = (event: { nick: string; new_nick: string }) => {
+          if (event.new_nick === newNick) {
+            client.removeListener('nick', onNick)
+            clearTimeout(timer)
+            resolve()
+          }
+        }
+        client.on('nick', onNick)
+        client.changeNick(newNick)
+      })
     },
 
     waitForPart,

--- a/test/inbound.test.ts
+++ b/test/inbound.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { startMcp } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+
+describe.if(isErgoAvailable())('inbound notifications', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('peer→channel: notification has correct meta', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp1')
+    const peer = await connectPeer(ergo, 'in-peer1')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-chan' } })
+    await peer.joinChannel('#in-chan')
+
+    peer.say('#in-chan', 'hello channel')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.channel === '#in-chan' && n.content === 'hello channel',
+    )
+
+    expect(n.content).toBe('hello channel')
+    expect(n.meta.sender).toBe('in-peer1')
+    expect(n.meta.channel).toBe('#in-chan')
+    expect(n.meta.isDirect).toBe('false')
+    expect(n.meta.source).toBe('roost-irc')
+    expect(n.meta.ts).toBeTruthy()
+    expect(Number(n.meta.seq)).toBeGreaterThan(0)
+  })
+
+  it('peer→DM: isDirect=true, channel=peer nick', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp2')
+    const peer = await connectPeer(ergo, 'in-peer2')
+
+    peer.say('in-mcp2', 'hello dm')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.isDirect === 'true' && n.content === 'hello dm',
+    )
+
+    expect(n.meta.sender).toBe('in-peer2')
+    expect(n.meta.channel).toBe('in-peer2')
+    expect(n.meta.isDirect).toBe('true')
+    expect(n.meta.source).toBe('roost-irc')
+    expect(n.meta.ts).toBeTruthy()
+    expect(Number(n.meta.seq)).toBeGreaterThan(0)
+  })
+
+  it('peer JOIN: notification with event=join', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp3')
+    const peer = await connectPeer(ergo, 'in-peer3')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-join' } })
+    await peer.joinChannel('#in-join')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.event === 'join' && n.meta.sender === 'in-peer3',
+    )
+
+    expect(n.meta.event).toBe('join')
+    expect(n.meta.sender).toBe('in-peer3')
+    expect(n.meta.channel).toBe('#in-join')
+    expect(n.meta.isDirect).toBe('false')
+    expect(n.meta.source).toBe('roost-irc')
+    expect(n.meta.ts).toBeTruthy()
+    expect(Number(n.meta.seq)).toBeGreaterThan(0)
+  })
+
+  it('peer PART: notification with event=leave', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp4')
+    const peer = await connectPeer(ergo, 'in-peer4')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-part' } })
+    await peer.joinChannel('#in-part')
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === 'in-peer4')
+
+    await peer.leaveChannel('#in-part')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.event === 'leave' && n.meta.sender === 'in-peer4',
+    )
+
+    expect(n.meta.event).toBe('leave')
+    expect(n.meta.sender).toBe('in-peer4')
+    expect(n.meta.channel).toBe('#in-part')
+    expect(n.meta.isDirect).toBe('false')
+    expect(n.meta.source).toBe('roost-irc')
+  })
+
+  it('peer KICK: notification with event=leave, reason contains "kicked"', async () => {
+    // kicker joins first to get channel op (+o as channel founder)
+    const kicker = await connectPeer(ergo, 'in-kicker')
+    await kicker.joinChannel('#in-kick')
+
+    const mcp = await startMcp(ergo, 'in-mcp5')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-kick' } })
+
+    const kicked = await connectPeer(ergo, 'in-kicked')
+    await kicked.joinChannel('#in-kick')
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === 'in-kicked')
+
+    kicker.kick('#in-kick', 'in-kicked', 'bye')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.event === 'leave' && n.meta.sender === 'in-kicked',
+    )
+
+    expect(n.meta.event).toBe('leave')
+    expect(n.meta.sender).toBe('in-kicked')
+    expect(n.meta.channel).toBe('#in-kick')
+    expect(n.meta.reason).toContain('kicked')
+  })
+
+  it('peer NICK: notification with event=nick and newNick', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp6')
+    const peer = await connectPeer(ergo, 'in-peer6')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-nick' } })
+    await peer.joinChannel('#in-nick')
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === 'in-peer6')
+
+    await peer.changeNick('in-peer6b')
+
+    const n = await mcp.waitForNotification(
+      n => n.meta.event === 'nick' && n.meta.sender === 'in-peer6',
+    )
+
+    expect(n.meta.event).toBe('nick')
+    expect(n.meta.sender).toBe('in-peer6')
+    expect(n.meta.newNick).toBe('in-peer6b')
+    expect(n.meta.isDirect).toBe('false')
+    expect(n.meta.source).toBe('roost-irc')
+  })
+
+  it('self JOIN/LEAVE suppressed: own events not emitted', async () => {
+    const mcp = await startMcp(ergo, 'in-mcp7')
+    const peer = await connectPeer(ergo, 'in-peer7')
+
+    // MCP joins — own join must not emit a notification
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#in-self' } })
+    // Peer join is our sync fence: any self-join notification would precede this
+    await peer.joinChannel('#in-self')
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === 'in-peer7')
+
+    expect(mcp.notifications.find(n => n.meta.sender === 'in-mcp7')).toBeUndefined()
+
+    // MCP leaves — own leave must not emit a notification
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#in-self' } })
+    // Use a peer DM as flush fence: any self-leave notification would precede this
+    peer.say('in-mcp7', 'ping')
+    await mcp.waitForNotification(n => n.meta.isDirect === 'true' && n.content === 'ping')
+
+    expect(mcp.notifications.find(n => n.meta.sender === 'in-mcp7')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
closes #15

peer→channel and peer→DM notifications with full meta verification (sender, channel, isDirect, ts, seq, source). JOIN/PART/KICK/NICK membership events. Self-event suppression with flush fences.

adds `kick` and `changeNick` to the peer test helper.