### PR TITLE
Tests: reconnect, seq ordering, nick collision (#17)

### DIFF
--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -142,45 +142,7 @@ export async function startErgo(): Promise<ErgoContext | null> {
     throw new Error(`ergo initdb failed: ${new TextDecoder().decode(init.stderr)}`)
   }
 
-  const proc = Bun.spawn([ergo, 'run', '--conf', configPath], {
-    cwd: datadir,
-    stderr: 'pipe',
-    stdout: 'ignore',
-  })
-
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      proc.kill()
-      reject(new Error('ergo did not start within 5s'))
-    }, 5000)
-
-    const decoder = new TextDecoder()
-    let buf = ''
-    const reader = proc.stderr.getReader()
-
-    const pump = async () => {
-      try {
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          buf += decoder.decode(value, { stream: true })
-          const lines = buf.split('\n')
-          buf = lines.pop() ?? ''
-          for (const line of lines) {
-            if (line.includes('now listening on')) {
-              clearTimeout(timeout)
-              resolve()
-              return
-            }
-          }
-        }
-        reject(new Error('ergo exited before becoming ready'))
-      } catch (e) {
-        reject(e)
-      }
-    }
-    void pump()
-  })
+  const proc = await spawnErgoProcess(ergo, configPath, datadir)
 
   afterAll(async () => {
     proc.kill()

--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path'
-import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { mkdtemp, writeFile, rm, unlink } from 'node:fs/promises'
 import { accessSync, constants } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { createServer } from 'node:net'
@@ -111,6 +111,15 @@ export interface ErgoContext {
   host: string
 }
 
+export interface ErgoLifecycle extends ErgoContext {
+  /** Graceful shutdown (SIGTERM). Waits for process exit. */
+  kill(): Promise<void>
+  /** Start a new ergo process on the same port/datadir. */
+  restart(): Promise<void>
+  /** Kill process (if alive) and delete the tmp datadir. */
+  cleanup(): Promise<void>
+}
+
 export async function startErgo(): Promise<ErgoContext | null> {
   const ergo = findErgoBin()
   if (!ergo) {
@@ -179,4 +188,104 @@ export async function startErgo(): Promise<ErgoContext | null> {
   })
 
   return { port, host: '127.0.0.1' }
+}
+
+async function spawnErgoProcess(
+  ergo: string,
+  configPath: string,
+  datadir: string,
+): Promise<ReturnType<typeof Bun.spawn>> {
+  const proc = Bun.spawn([ergo, 'run', '--conf', configPath], {
+    cwd: datadir,
+    stderr: 'pipe',
+    stdout: 'ignore',
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      proc.kill()
+      reject(new Error('ergo did not start within 5s'))
+    }, 5000)
+
+    const decoder = new TextDecoder()
+    let buf = ''
+    const reader = proc.stderr.getReader()
+
+    const pump = async () => {
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) {
+            reader.releaseLock()
+            reject(new Error('ergo exited before becoming ready'))
+            return
+          }
+          buf += decoder.decode(value, { stream: true })
+          const lines = buf.split('\n')
+          buf = lines.pop() ?? ''
+          for (const line of lines) {
+            if (line.includes('now listening on')) {
+              clearTimeout(timeout)
+              reader.releaseLock() // release so proc.exited resolves cleanly
+              resolve()
+              return
+            }
+          }
+        }
+      } catch (e) {
+        try { reader.releaseLock() } catch { /* already released */ }
+        reject(e)
+      }
+    }
+    void pump()
+  })
+
+  return proc
+}
+
+/**
+ * Start a private ergo instance with lifecycle control (kill/restart/cleanup).
+ * The caller owns cleanup — no afterAll is registered.
+ * Returns null if ergo binary is not available (test should skip).
+ */
+export async function startErgoDedicated(): Promise<ErgoLifecycle | null> {
+  const ergo = findErgoBin()
+  if (!ergo) return null
+
+  const port = await getFreePort()
+  const datadir = await mkdtemp(join(tmpdir(), 'roost-test-'))
+  const configPath = join(datadir, 'ircd.yaml')
+  const lockPath = join(datadir, 'ircd.lock')
+
+  await writeFile(configPath, makeErgoConfig(port, datadir))
+
+  const init = Bun.spawnSync([ergo, 'initdb', '--conf', configPath], { cwd: datadir })
+  if (init.exitCode !== 0) {
+    await rm(datadir, { recursive: true, force: true })
+    throw new Error(`ergo initdb failed: ${new TextDecoder().decode(init.stderr)}`)
+  }
+
+  let proc = await spawnErgoProcess(ergo, configPath, datadir)
+
+  return {
+    port,
+    host: '127.0.0.1',
+
+    async kill() {
+      proc.kill() // SIGTERM — ergo cleans up lock file on graceful exit
+      await proc.exited
+      await new Promise<void>(res => setTimeout(res, 100)) // let OS release the port
+    },
+
+    async restart() {
+      // Remove lock in case previous kill was unclean
+      await unlink(lockPath).catch(() => {})
+      proc = await spawnErgoProcess(ergo, configPath, datadir)
+    },
+
+    async cleanup() {
+      try { proc.kill() } catch { /* already dead */ }
+      await rm(datadir, { recursive: true, force: true })
+    },
+  }
 }

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -62,6 +62,10 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
 
   await client.connect(transport)
 
+  afterAll(async () => {
+    await client.close()
+  })
+
   // Poll until the IRC client has registered — tools return isError before that.
   const deadline = Date.now() + 5000
   while (true) {
@@ -72,10 +76,6 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
     if (Date.now() > deadline) throw new Error(`startMcp: IRC not ready within 5s (nick=${clientNick})`)
     await new Promise<void>(res => setTimeout(res, 50))
   }
-
-  afterAll(async () => {
-    await client.close()
-  })
 
   return {
     client,

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -63,6 +63,7 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
   await client.connect(transport)
 
   afterAll(async () => {
+    // close() sends stdin EOF then SIGTERM (2s grace each) — terminates subprocess even if IRC reconnect timers are live
     await client.close()
   })
 

--- a/test/reconnect.test.ts
+++ b/test/reconnect.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { startErgo, startErgoDedicated, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { startMcp, type ChannelNotification } from './helpers/mcp.js'
+import { connectPeer } from './helpers/peer.js'
+
+describe.if(isErgoAvailable())('reconnect, ordering, and nick collision', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('kill + restart ergo → MCP auto-reconnects; irc_ready flips false then true', async () => {
+    const dedicated = await startErgoDedicated()
+    if (!dedicated) return
+
+    try {
+      const mcp = await startMcp(dedicated, 'reconnect-mcp')
+
+      // Confirm ready
+      let r = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+      expect(r.isError).toBeFalsy()
+
+      // irc-framework only schedules auto_reconnect if registered_ms_ago > 5000.
+      // Wait 6s so the connection is "safely registered" before we kill it.
+      await new Promise<void>(res => setTimeout(res, 6000))
+
+      // Kill ergo — socket close fires, irc_ready goes false
+      await dedicated.kill()
+
+      const notReadyDeadline = Date.now() + 5000
+      while (true) {
+        r = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+        if (r.isError) break
+        if (Date.now() > notReadyDeadline) throw new Error('MCP did not go not-ready after ergo kill')
+        await new Promise<void>(res => setTimeout(res, 100))
+      }
+      const notReadyText = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
+      expect(notReadyText).toContain('not ready')
+
+      // Restart ergo on the same port — MCP auto_reconnect kicks in
+      await dedicated.restart()
+
+      const readyDeadline = Date.now() + 15000
+      while (true) {
+        r = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+        if (!r.isError) break
+        if (Date.now() > readyDeadline) throw new Error('MCP did not reconnect within 15s')
+        await new Promise<void>(res => setTimeout(res, 200))
+      }
+      expect(r.isError).toBeFalsy()
+    } finally {
+      await dedicated.cleanup()
+    }
+  }, 30_000)
+
+  it('burst of N messages from different peers → seq strictly monotonic', async () => {
+    const N = 5
+    const mcp = await startMcp(ergo, 'seq-mcp')
+    const peers = await Promise.all(
+      Array.from({ length: N }, (_, i) => connectPeer(ergo, `seq-peer-${i}`)),
+    )
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#seq-test' } })
+    await Promise.all(peers.map(p => p.joinChannel('#seq-test')))
+
+    // Drain join notifications so they don't interfere with message collection
+    await Promise.all(
+      peers.map(p => mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.sender === p.nick)),
+    )
+
+    // Send all messages simultaneously — each peer→channel pair gets its own
+    // recv buffer, so N messages → N separate flush timers → N notifications
+    peers.forEach((p, i) => p.say('#seq-test', `seq-msg-${i}`))
+
+    const seen = new Set<ChannelNotification>()
+    const notifs: ChannelNotification[] = []
+    for (let i = 0; i < N; i++) {
+      const n = await mcp.waitForNotification(
+        n => n.meta.channel === '#seq-test' && n.content.startsWith('seq-msg-') && !seen.has(n),
+      )
+      seen.add(n)
+      notifs.push(n)
+    }
+
+    const seqs = notifs.map(n => Number(n.meta.seq))
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1])
+    }
+  }, 15_000)
+
+  it('two MCPs with same nick → second fails cleanly; first unaffected', async () => {
+    // Observed: ergo refuses nick collision with 433 ERR_NICKNAMEINUSE.
+    // irc-framework auto_reconnects but always gets 433. startMcp's 5s
+    // readiness poll expires and throws.
+    const mcp1 = await startMcp(ergo, 'collision-mcp')
+
+    await expect(startMcp(ergo, 'collision-mcp')).rejects.toThrow('IRC not ready within 5s')
+
+    // First MCP is unaffected by the collision attempt
+    const r = await mcp1.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+    expect(r.isError).toBeFalsy()
+  }, 15_000)
+})


### PR DESCRIPTION
Closes #17.

Three integration tests in `test/reconnect.test.ts`:

**kill+restart**: dedicated ergo killed mid-test, MCP auto-reconnects. Verified via `channel_who` returning "not ready" after kill, then succeeding after restart. Had to wait 6s before kill — irc-framework won't schedule auto_reconnect unless `registered_ms_ago > 5000` (akill safety guard in connection.js).

**burst ordering**: 5 peers each send one message simultaneously. Each peer→channel has its own recv buffer, so N messages → N separate notifications. Verified `meta.seq` strictly monotonic.

**nick collision**: second `startMcp` with same nick — ergo sends 433, irc-framework retries, 5s readiness poll expires and throws. First MCP stays functional.

Helper changes:
- `ergo.ts`: `startErgoDedicated()` with `kill/restart/cleanup`. Also releases stderr reader lock before resolving so `proc.exited` resolves promptly (held lock caused a multi-second hang).
- `mcp.ts`: move `afterAll` before the readiness poll so subprocess is cleaned up even when `startMcp` throws.