### PR TITLE
feat: add --help / -h support to roost CLI

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -371,10 +371,11 @@ cmd_status() {
 
 if [ "$#" -eq 0 ]; then
   usage
-  exit 1
+  exit 0
 fi
 cmd="$1"
 shift
+case "$1" in -h|--help) usage; exit 0 ;; esac
 case "${cmd}" in
   spawn)    cmd_spawn "$@" ;;
   shutdown) cmd_shutdown "$@" ;;


### PR DESCRIPTION
## Summary
Implements support for `--help` and `-h` flags on roost subcommands, closes #23.

- `roost spawn --help` now prints help instead of attempting to spawn with nick="--help"
- `roost spawn -h` / `roost attach --help` / etc all work as expected
- `roost` with no args now exits 0 (was 1)
- Centralized check at dispatcher level before command dispatch

## Testing
- Manual testing of all help scenarios (roost, roost --help, roost spawn --help, etc)
- Verified exit codes are 0
- Verified normal operations still work (roost list, etc)
- Test suite passes (25 tests skipped - ergo not installed)