### PR TITLE
feat: add channel_list tool

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -429,6 +429,15 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['channel'],
       },
     },
+    {
+      name: 'channel_list',
+      description: 'List all channels currently joined by this MCP instance.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
   ],
 }))
 
@@ -585,6 +594,19 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           `[${m.ts}] ${m.isDirect ? `(DM from ${m.sender})` : `${m.channel} <${m.sender}>`} ${m.text}`,
       )
       return { content: [{ type: 'text', text: lines.join('\n') }] }
+    }
+    case 'channel_list': {
+      const channels = [...channelUsers.keys()].sort()
+      return {
+        content: [
+          {
+            type: 'text',
+            text: channels.length
+              ? channels.join(', ')
+              : '(no channels joined)',
+          },
+        ],
+      }
     }
     default:
       return {

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -400,7 +400,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'channel_who',
-      description: 'List nicks currently present in a channel.',
+      description: 'List nicks currently present in a channel. Served from a local cache (no network round-trip); the cache is kept current via JOIN/PART/KICK/QUIT events.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -431,7 +431,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'channel_list',
-      description: 'List all channels currently joined by this MCP instance.',
+      description: 'List all channels currently joined by this MCP instance. Served from a local cache (no network round-trip); the cache is kept current via JOIN/PART/KICK/QUIT events.',
       inputSchema: {
         type: 'object',
         properties: {},

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -11,11 +11,10 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     ergo = (await startErgo())!
   })
 
-  it('tools/list returns 7 tools with correct schemas', async () => {
+  it('tools/list returns correct schemas', async () => {
     const mcp = await startMcp(ergo, 'list-test-mcp')
     const { tools } = await mcp.client.listTools()
 
-    expect(tools).toHaveLength(7)
     const byName = Object.fromEntries(
       tools.map(t => [t.name, (t.inputSchema as unknown as { required?: string[] }).required]),
     )
@@ -26,6 +25,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(byName['channel_leave']).toEqual(['channel'])
     expect(byName['channel_who']).toEqual(['channel'])
     expect(byName['channel_history']).toEqual(['channel'])
+    expect(tools.map(t => t.name)).toContain('channel_list')
     expect(byName['channel_list']).toEqual([])
   })
 

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -11,11 +11,11 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     ergo = (await startErgo())!
   })
 
-  it('tools/list returns 6 tools with correct schemas', async () => {
+  it('tools/list returns 7 tools with correct schemas', async () => {
     const mcp = await startMcp(ergo, 'list-test-mcp')
     const { tools } = await mcp.client.listTools()
 
-    expect(tools).toHaveLength(6)
+    expect(tools).toHaveLength(7)
     const byName = Object.fromEntries(
       tools.map(t => [t.name, (t.inputSchema as unknown as { required?: string[] }).required]),
     )
@@ -26,6 +26,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(byName['channel_leave']).toEqual(['channel'])
     expect(byName['channel_who']).toEqual(['channel'])
     expect(byName['channel_history']).toEqual(['channel'])
+    expect(byName['channel_list']).toEqual([])
   })
 
   it('channel_join resolves on ack; channel_who includes own nick', async () => {
@@ -54,6 +55,24 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
 
     const whoAfter = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#who-test' } })
     expect(((whoAfter.content as unknown[])[0] as { type: 'text'; text: string }).text).not.toContain('who-test-peer')
+  })
+
+  it('channel_list returns joined channels', async () => {
+    const mcp = await startMcp(ergo, 'list-chan-mcp')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-a' } })
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-b' } })
+
+    const result = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(result.isError).toBeFalsy()
+    const text = toolText(result)
+    expect(text).toContain('#list-test-a')
+    expect(text).toContain('#list-test-b')
+
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#list-test-a' } })
+    const after = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(after)).not.toContain('#list-test-a')
+    expect(toolText(after)).toContain('#list-test-b')
   })
 
   it('channel_leave parts cleanly', async () => {


### PR DESCRIPTION
closes #6

adds `channel_list` — returns sorted list of currently joined channels from the existing `channelUsers` map. no-arg tool, consistent with the `channel_*` naming convention.

also bumps the tools/list count assertion 6→7 and adds a test that verifies join/leave round-trips.

## Test plan
- [x] `bun test` passes (26/26)