### PR TITLE
maint: add cursor to waitForNotification to avoid re-matching

### DIFF
--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -88,8 +88,9 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
     notifications,
     waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
       return new Promise((resolve, reject) => {
-        const existing = notifications.slice(fromCursor).find(pred)
-        if (existing) { resolve(existing); return }
+        for (let i = fromCursor; i < notifications.length; i++) {
+          if (pred(notifications[i])) { resolve(notifications[i]); return }
+        }
 
         const timer = setTimeout(() => {
           const idx = waiters.findIndex(w => w.resolve === resolve)

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -10,6 +10,8 @@ const ROOST_ROOT = join(import.meta.dirname, '..', '..')
 export interface ChannelNotification {
   content: string
   meta: Record<string, string>
+  /** Pass as `fromCursor` on the next call to skip past this notification. */
+  cursor: number
 }
 
 export interface McpContext {
@@ -19,6 +21,7 @@ export interface McpContext {
   waitForNotification(
     pred: (n: ChannelNotification) => boolean,
     timeoutMs?: number,
+    fromCursor?: number,
   ): Promise<ChannelNotification>
 }
 
@@ -51,7 +54,7 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
   client.fallbackNotificationHandler = async (notification) => {
     if (notification.method !== 'notifications/claude/channel') return
     const params = notification.params as { content: string; meta: Record<string, string> }
-    const n: ChannelNotification = { content: params.content, meta: params.meta }
+    const n: ChannelNotification = { content: params.content, meta: params.meta, cursor: notifications.length + 1 }
     notifications.push(n)
     for (let i = waiters.length - 1; i >= 0; i--) {
       if (waiters[i].pred(n)) {
@@ -83,9 +86,9 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
     client,
     nick: clientNick,
     notifications,
-    waitForNotification(pred, timeoutMs = 5000) {
+    waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
       return new Promise((resolve, reject) => {
-        const existing = notifications.find(pred)
+        const existing = notifications.slice(fromCursor).find(pred)
         if (existing) { resolve(existing); return }
 
         const timer = setTimeout(() => {

--- a/test/reconnect.test.ts
+++ b/test/reconnect.test.ts
@@ -73,13 +73,15 @@ describe.if(isErgoAvailable())('reconnect, ordering, and nick collision', () => 
     // recv buffer, so N messages → N separate flush timers → N notifications
     peers.forEach((p, i) => p.say('#seq-test', `seq-msg-${i}`))
 
-    const seen = new Set<ChannelNotification>()
+    let cursor = 0
     const notifs: ChannelNotification[] = []
     for (let i = 0; i < N; i++) {
       const n = await mcp.waitForNotification(
-        n => n.meta.channel === '#seq-test' && n.content.startsWith('seq-msg-') && !seen.has(n),
+        n => n.meta.channel === '#seq-test' && n.content.startsWith('seq-msg-'),
+        5000,
+        cursor,
       )
-      seen.add(n)
+      cursor = n.cursor
       notifs.push(n)
     }
 


### PR DESCRIPTION
closes #32

`ChannelNotification` now has a `cursor: number` field (= index+1 in the notifications array). Pass it as the new optional `fromCursor` arg on `waitForNotification` to skip past already-seen notifications.

Removes the `seen` Set workaround in `reconnect.test.ts`; all other call sites unchanged (backward compat).

25/25 tests pass.

[worker-32]