### PR TITLE
feat(dispatcher): append comment permalink to relay

### DIFF
--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -572,14 +572,20 @@ def format_event(event: dict) -> str:
         path = event.get("path")
         line = event.get("line")
         where = f" at {path}:{line}" if path else ""
-        snippet = (event.get("body_preview") or "").strip().splitlines()[:1]
-        snippet = snippet[0][:160] if snippet else ""
-        return f"PR {tag} comment by {author}{where}: {snippet}"
+        body_preview = (event.get("body_preview") or "").strip()
+        snippet_lines = body_preview.splitlines()[:1]
+        snippet = snippet_lines[0][:160] if snippet_lines else ""
+        ellipsis = "…" if body_preview != snippet else ""
+        url = event.get("comment_url") or event.get("url", "")
+        return f"PR {tag} comment by {author}{where}: {snippet}{ellipsis} — {url}"
     if kind == "issue_comment":
         author = event.get("author") or "?"
-        snippet = (event.get("body_preview") or "").strip().splitlines()[:1]
-        snippet = snippet[0][:160] if snippet else ""
-        return f"Issue {tag} comment by {author}: {snippet}"
+        body_preview = (event.get("body_preview") or "").strip()
+        snippet_lines = body_preview.splitlines()[:1]
+        snippet = snippet_lines[0][:160] if snippet_lines else ""
+        ellipsis = "…" if body_preview != snippet else ""
+        url = event.get("comment_url") or event.get("url", "")
+        return f"Issue {tag} comment by {author}: {snippet}{ellipsis} — {url}"
     if kind == "pr_review_submitted":
         author = event.get("author") or "?"
         state = event.get("state") or "?"
@@ -1128,6 +1134,74 @@ def _run_self_test() -> int:
     check("initial_channels_no_state",
           chans2,
           sorted({"#proj", "#issue-25", "#issue-14"}))
+
+    # format_event: pr_review_comment short body → no ellipsis, permalink appended
+    check("review_comment_short",
+          format_event({
+              "kind": "pr_review_comment",
+              "repo": "org/repo", "pr": 46, "url": "https://github.com/org/repo/pull/46",
+              "author": "alice",
+              "body_preview": "Looks good",
+              "comment_url": "https://github.com/org/repo/pull/46#issuecomment-111",
+          }),
+          "PR org/repo#46 comment by alice: Looks good — https://github.com/org/repo/pull/46#issuecomment-111")
+
+    # format_event: pr_review_comment 161-char body → ellipsis + permalink
+    long_body = "A" * 161
+    check("review_comment_truncated",
+          format_event({
+              "kind": "pr_review_comment",
+              "repo": "org/repo", "pr": 46, "url": "https://github.com/org/repo/pull/46",
+              "author": "alice",
+              "body_preview": long_body,
+              "comment_url": "https://github.com/org/repo/pull/46#issuecomment-222",
+          }),
+          f"PR org/repo#46 comment by alice: {'A' * 160}… — https://github.com/org/repo/pull/46#issuecomment-222")
+
+    # format_event: pr_review_comment multiline → ellipsis + permalink
+    check("review_comment_multiline",
+          format_event({
+              "kind": "pr_review_comment",
+              "repo": "org/repo", "pr": 46, "url": "https://github.com/org/repo/pull/46",
+              "author": "alice",
+              "path": "src/foo.ts", "line": 10,
+              "body_preview": "Line one\nLine two",
+              "comment_url": "https://github.com/org/repo/pull/46#pullrequestreview-333",
+          }),
+          "PR org/repo#46 comment by alice at src/foo.ts:10: Line one… — https://github.com/org/repo/pull/46#pullrequestreview-333")
+
+    # format_event: pr_conversation_comment short → no ellipsis, permalink appended
+    check("conv_comment_short",
+          format_event({
+              "kind": "pr_conversation_comment",
+              "repo": "org/repo", "pr": 46, "url": "https://github.com/org/repo/pull/46",
+              "author": "bob",
+              "body_preview": "Short comment",
+              "comment_url": "https://github.com/org/repo/pull/46#issuecomment-444",
+          }),
+          "PR org/repo#46 comment by bob: Short comment — https://github.com/org/repo/pull/46#issuecomment-444")
+
+    # format_event: issue_comment short → no ellipsis, permalink appended
+    check("issue_comment_short",
+          format_event({
+              "kind": "issue_comment",
+              "repo": "org/repo", "issue": 47, "url": "https://github.com/org/repo/issues/47",
+              "author": "carol",
+              "body_preview": "Hi there",
+              "comment_url": "https://github.com/org/repo/issues/47#issuecomment-555",
+          }),
+          "Issue org/repo#47 comment by carol: Hi there — https://github.com/org/repo/issues/47#issuecomment-555")
+
+    # format_event: issue_comment multiline → ellipsis + permalink
+    check("issue_comment_multiline",
+          format_event({
+              "kind": "issue_comment",
+              "repo": "org/repo", "issue": 47, "url": "https://github.com/org/repo/issues/47",
+              "author": "carol",
+              "body_preview": "First line\nSecond line",
+              "comment_url": "https://github.com/org/repo/issues/47#issuecomment-666",
+          }),
+          "Issue org/repo#47 comment by carol: First line… — https://github.com/org/repo/issues/47#issuecomment-666")
 
     if failures:
         for f in failures:

--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -555,9 +555,9 @@ def should_push(event: dict) -> bool:
 
 def _comment_snippet(event: dict) -> tuple[str, str, str]:
     body_preview = (event.get("body_preview") or "").strip()
-    snippet_lines = body_preview.splitlines()[:1]
+    snippet_lines = body_preview.splitlines()
     snippet = snippet_lines[0][:160] if snippet_lines else ""
-    ellipsis = "…" if len(body_preview) > len(snippet) or "\n" in body_preview else ""
+    ellipsis = "…" if len(body_preview) > len(snippet) or len(snippet_lines) > 1 else ""
     url = event.get("comment_url") or event.get("url", "")
     return snippet, ellipsis, url
 

--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -553,6 +553,15 @@ def should_push(event: dict) -> bool:
 # Channel formatting
 # ---------------------------------------------------------------------------
 
+def _comment_snippet(event: dict) -> tuple[str, str, str]:
+    body_preview = (event.get("body_preview") or "").strip()
+    snippet_lines = body_preview.splitlines()[:1]
+    snippet = snippet_lines[0][:160] if snippet_lines else ""
+    ellipsis = "…" if len(body_preview) > len(snippet) or "\n" in body_preview else ""
+    url = event.get("comment_url") or event.get("url", "")
+    return snippet, ellipsis, url
+
+
 def format_event(event: dict) -> str:
     kind = event.get("kind") or "unknown"
     n = event.get("pr") or event.get("issue")
@@ -572,19 +581,11 @@ def format_event(event: dict) -> str:
         path = event.get("path")
         line = event.get("line")
         where = f" at {path}:{line}" if path else ""
-        body_preview = (event.get("body_preview") or "").strip()
-        snippet_lines = body_preview.splitlines()[:1]
-        snippet = snippet_lines[0][:160] if snippet_lines else ""
-        ellipsis = "…" if body_preview != snippet else ""
-        url = event.get("comment_url") or event.get("url", "")
+        snippet, ellipsis, url = _comment_snippet(event)
         return f"PR {tag} comment by {author}{where}: {snippet}{ellipsis} — {url}"
     if kind == "issue_comment":
         author = event.get("author") or "?"
-        body_preview = (event.get("body_preview") or "").strip()
-        snippet_lines = body_preview.splitlines()[:1]
-        snippet = snippet_lines[0][:160] if snippet_lines else ""
-        ellipsis = "…" if body_preview != snippet else ""
-        url = event.get("comment_url") or event.get("url", "")
+        snippet, ellipsis, url = _comment_snippet(event)
         return f"Issue {tag} comment by {author}: {snippet}{ellipsis} — {url}"
     if kind == "pr_review_submitted":
         author = event.get("author") or "?"
@@ -1135,7 +1136,6 @@ def _run_self_test() -> int:
           chans2,
           sorted({"#proj", "#issue-25", "#issue-14"}))
 
-    # format_event: pr_review_comment short body → no ellipsis, permalink appended
     check("review_comment_short",
           format_event({
               "kind": "pr_review_comment",
@@ -1146,7 +1146,6 @@ def _run_self_test() -> int:
           }),
           "PR org/repo#46 comment by alice: Looks good — https://github.com/org/repo/pull/46#issuecomment-111")
 
-    # format_event: pr_review_comment 161-char body → ellipsis + permalink
     long_body = "A" * 161
     check("review_comment_truncated",
           format_event({
@@ -1158,7 +1157,6 @@ def _run_self_test() -> int:
           }),
           f"PR org/repo#46 comment by alice: {'A' * 160}… — https://github.com/org/repo/pull/46#issuecomment-222")
 
-    # format_event: pr_review_comment multiline → ellipsis + permalink
     check("review_comment_multiline",
           format_event({
               "kind": "pr_review_comment",
@@ -1170,7 +1168,6 @@ def _run_self_test() -> int:
           }),
           "PR org/repo#46 comment by alice at src/foo.ts:10: Line one… — https://github.com/org/repo/pull/46#pullrequestreview-333")
 
-    # format_event: pr_conversation_comment short → no ellipsis, permalink appended
     check("conv_comment_short",
           format_event({
               "kind": "pr_conversation_comment",
@@ -1181,7 +1178,6 @@ def _run_self_test() -> int:
           }),
           "PR org/repo#46 comment by bob: Short comment — https://github.com/org/repo/pull/46#issuecomment-444")
 
-    # format_event: issue_comment short → no ellipsis, permalink appended
     check("issue_comment_short",
           format_event({
               "kind": "issue_comment",
@@ -1192,7 +1188,6 @@ def _run_self_test() -> int:
           }),
           "Issue org/repo#47 comment by carol: Hi there — https://github.com/org/repo/issues/47#issuecomment-555")
 
-    # format_event: issue_comment multiline → ellipsis + permalink
     check("issue_comment_multiline",
           format_event({
               "kind": "issue_comment",

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'bun:test'
+
+const DISPATCHER = `${import.meta.dir}/../bin/orchestrator_poll`
+
+describe('orchestrator_poll --self-test', () => {
+  it('passes all self-tests', async () => {
+    const proc = Bun.spawn(['python3', DISPATCHER, '--self-test'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    if (exitCode !== 0) {
+      throw new Error(`self-test failed:\n${stderr}`)
+    }
+    expect(stdout).toContain('passed')
+  })
+})


### PR DESCRIPTION
Agents were missing truncated PR/issue comment bodies — the relay showed only the first line with no way to retrieve the rest.

Appends `comment_url` (already carried in the event) after the snippet, plus `…` when the body is longer than what's shown. Mirrors the existing review-state pattern.

Covers `pr_review_comment`, `pr_conversation_comment`, and `issue_comment`. `pr_review_submitted` already had this pattern and is left alone.

6 new cases in `_run_self_test`; wired into `bun test` via `test/dispatcher.test.ts`.

closes #47