### PR TITLE
fix(spawn): gate PermissionRequest hook on --perm-irc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ When a Claude Code session loads `roost-irc` as an MCP and connects:
 ```
 
 This puts `roost`, `roost-permbot`, and `irc-permission-prompt` on
-your PATH, auto-loads the `roost-irc` MCP for every session, and wires
-the `PreToolUse` hook for IRC permission oversight.
+your PATH and auto-loads the `roost-irc` MCP for every session.
 
 After installing, pull dependencies:
 
@@ -219,7 +218,7 @@ roost/
 │   └── plugin.json         Plugin manifest.
 ├── .mcp.json               MCP server config (auto-loaded by plugin).
 ├── hooks/
-│   └── hooks.json          PreToolUse hook for IRC permission oversight.
+│   └── hooks.json          Plugin hook config (PermissionRequest wired per-session via --perm-irc).
 ├── skills/roost/SKILL.md   Claude Code skill wrapping the roost command surface.
 ├── src/
 │   ├── irc-server.ts       The MCP server.
@@ -229,7 +228,7 @@ roost/
 │   ├── roost               Wrapper: spawn / shutdown / list / attach / tail / status / root.
 │   ├── roost-irc-server    PATH-resolvable launcher for the MCP server.
 │   ├── roost-permbot       IRC permission oversight daemon.
-│   └── irc-permission-prompt  PreToolUse hook (thin socket client).
+│   └── irc-permission-prompt  PermissionRequest hook (thin socket client, loaded per-session by --perm-irc).
 ├── etc/ergo.yaml           Sample ergo IRC server config.
 ├── extras/weechat/         Optional weechat notification script.
 ├── ARCHITECTURE.md         Channel topology, roles, routing, lifecycle.

--- a/bin/roost
+++ b/bin/roost
@@ -99,6 +99,7 @@ perm_paths() {
   PERM_SOCK="/tmp/roost-permbot-${nick}.sock"
   PERM_PID="/tmp/roost-permbot-${nick}.pid"
   PERM_LOG="/tmp/roost-permbot-${nick}.log"
+  PERM_SETTINGS="/tmp/roost-perm-settings-${nick}.json"
 }
 
 start_permbot() {
@@ -131,7 +132,10 @@ start_permbot() {
 stop_permbot() {
   local nick="$1"
   perm_paths "${nick}"
-  [ ! -f "${PERM_PID}" ] && return 0
+  if [ ! -f "${PERM_PID}" ]; then
+    rm -f "${PERM_SETTINGS}"
+    return 0
+  fi
   local pid
   pid="$(cat "${PERM_PID}" 2>/dev/null || true)"
   if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
@@ -146,7 +150,7 @@ stop_permbot() {
     kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null || true
     echo "  killed permbot (pid ${pid})"
   fi
-  rm -f "${PERM_PID}" "${PERM_SOCK}"
+  rm -f "${PERM_PID}" "${PERM_SOCK}" "${PERM_SETTINGS}"
 }
 
 cmd_spawn() {
@@ -230,13 +234,17 @@ cmd_spawn() {
 
   # Start the permbot side daemon if --perm-irc was passed. Done before
   # spawning the worker so the unix socket exists when the worker fires
-  # its first PreToolUse hook. The worker's settings.json must wire the
-  # hook to bin/irc-permission-prompt for this to do anything visible.
+  # its first PermissionRequest hook.
+  # Also writes a per-session settings file that wires the PermissionRequest
+  # hook only for this session; cleaned up by cmd_shutdown → stop_permbot.
   local perm_sock=""
+  local perm_settings_flag=""
   if [ "${perm_irc}" -eq 1 ]; then
     start_permbot "${nick}" "${perm_target}" || true
     perm_paths "${nick}"
     perm_sock="${PERM_SOCK}"
+    printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${PERM_SETTINGS}"
+    perm_settings_flag=" --settings ${PERM_SETTINGS}"
   fi
 
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode}, cwd: ${cwd})"
@@ -262,7 +270,7 @@ cmd_spawn() {
     mcp_flag=" --mcp-config ${mcp_config}"
     channel_server="server:roost-irc"
   fi
-  local inner_cmd="claude --model ${model} --permission-mode ${permission_mode}${mcp_flag} --dangerously-load-development-channels ${channel_server}${extra_str}"
+  local inner_cmd="claude --model ${model} --permission-mode ${permission_mode}${mcp_flag}${perm_settings_flag} --dangerously-load-development-channels ${channel_server}${extra_str}"
   if [ -n "${prompt_file}" ]; then
     inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"'
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")

--- a/bin/roost
+++ b/bin/roost
@@ -99,7 +99,9 @@ perm_paths() {
   PERM_SOCK="/tmp/roost-permbot-${nick}.sock"
   PERM_PID="/tmp/roost-permbot-${nick}.pid"
   PERM_LOG="/tmp/roost-permbot-${nick}.log"
-  PERM_SETTINGS="/tmp/roost-perm-settings-${nick}.json"
+  # Pointer to the actual (mktemp'd) settings file path; allows shutdown to
+  # find and clean up the file without knowing its random suffix.
+  PERM_SETTINGS_PTR="/tmp/roost-perm-settings-ptr-${nick}"
 }
 
 start_permbot() {
@@ -129,11 +131,17 @@ start_permbot() {
   return 1
 }
 
+_cleanup_perm_settings() {
+  local settings_file
+  settings_file="$(cat "${PERM_SETTINGS_PTR}" 2>/dev/null || true)"
+  rm -f "${settings_file}" "${PERM_SETTINGS_PTR}"
+}
+
 stop_permbot() {
   local nick="$1"
   perm_paths "${nick}"
   if [ ! -f "${PERM_PID}" ]; then
-    rm -f "${PERM_SETTINGS}"
+    _cleanup_perm_settings
     return 0
   fi
   local pid
@@ -150,7 +158,8 @@ stop_permbot() {
     kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null || true
     echo "  killed permbot (pid ${pid})"
   fi
-  rm -f "${PERM_PID}" "${PERM_SOCK}" "${PERM_SETTINGS}"
+  _cleanup_perm_settings
+  rm -f "${PERM_PID}" "${PERM_SOCK}"
 }
 
 cmd_spawn() {
@@ -241,12 +250,17 @@ cmd_spawn() {
   local perm_settings_flag=""
   if [ "${perm_irc}" -eq 1 ]; then
     start_permbot "${nick}" "${perm_target}" || true
-    # perm_paths already called inside start_permbot; PERM_SOCK/PERM_SETTINGS are set.
+    # perm_paths already called inside start_permbot; PERM_SOCK/PERM_SETTINGS_PTR are set.
     perm_sock="${PERM_SOCK}"
+    # mktemp keeps the settings file isolated even if two repos share the same nick.
+    # Write its path to PERM_SETTINGS_PTR so stop_permbot can find and clean it up.
     # ROOST_DIR is derived from the script's own path (cd … && pwd) so it won't
     # contain quotes or backslashes — the printf JSON embedding is safe.
-    printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${PERM_SETTINGS}"
-    perm_settings_flag=" --settings ${PERM_SETTINGS}"
+    local perm_settings_file
+    perm_settings_file="$(mktemp /tmp/roost-perm-settings-XXXXXX.json)"
+    printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${perm_settings_file}"
+    printf '%s\n' "${perm_settings_file}" > "${PERM_SETTINGS_PTR}"
+    perm_settings_flag=" --settings ${perm_settings_file}"
   fi
 
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode}, cwd: ${cwd})"

--- a/bin/roost
+++ b/bin/roost
@@ -241,8 +241,10 @@ cmd_spawn() {
   local perm_settings_flag=""
   if [ "${perm_irc}" -eq 1 ]; then
     start_permbot "${nick}" "${perm_target}" || true
-    perm_paths "${nick}"
+    # perm_paths already called inside start_permbot; PERM_SOCK/PERM_SETTINGS are set.
     perm_sock="${PERM_SOCK}"
+    # ROOST_DIR is derived from the script's own path (cd … && pwd) so it won't
+    # contain quotes or backslashes — the printf JSON embedding is safe.
     printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${PERM_SETTINGS}"
     perm_settings_flag=" --settings ${PERM_SETTINGS}"
   fi

--- a/bin/roost
+++ b/bin/roost
@@ -99,9 +99,7 @@ perm_paths() {
   PERM_SOCK="/tmp/roost-permbot-${nick}.sock"
   PERM_PID="/tmp/roost-permbot-${nick}.pid"
   PERM_LOG="/tmp/roost-permbot-${nick}.log"
-  # Pointer to the actual (mktemp'd) settings file path; allows shutdown to
-  # find and clean up the file without knowing its random suffix.
-  PERM_SETTINGS_PTR="/tmp/roost-perm-settings-ptr-${nick}"
+  PERM_SETTINGS="/tmp/roost-perm-settings-${nick}.json"
 }
 
 start_permbot() {
@@ -131,17 +129,11 @@ start_permbot() {
   return 1
 }
 
-_cleanup_perm_settings() {
-  local settings_file
-  settings_file="$(cat "${PERM_SETTINGS_PTR}" 2>/dev/null || true)"
-  rm -f "${settings_file}" "${PERM_SETTINGS_PTR}"
-}
-
 stop_permbot() {
   local nick="$1"
   perm_paths "${nick}"
   if [ ! -f "${PERM_PID}" ]; then
-    _cleanup_perm_settings
+    rm -f "${PERM_SETTINGS}"
     return 0
   fi
   local pid
@@ -158,8 +150,7 @@ stop_permbot() {
     kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null || true
     echo "  killed permbot (pid ${pid})"
   fi
-  _cleanup_perm_settings
-  rm -f "${PERM_PID}" "${PERM_SOCK}"
+  rm -f "${PERM_PID}" "${PERM_SOCK}" "${PERM_SETTINGS}"
 }
 
 cmd_spawn() {
@@ -250,17 +241,12 @@ cmd_spawn() {
   local perm_settings_flag=""
   if [ "${perm_irc}" -eq 1 ]; then
     start_permbot "${nick}" "${perm_target}" || true
-    # perm_paths already called inside start_permbot; PERM_SOCK/PERM_SETTINGS_PTR are set.
+    # perm_paths already called inside start_permbot; PERM_SOCK/PERM_SETTINGS are set.
     perm_sock="${PERM_SOCK}"
-    # mktemp keeps the settings file isolated even if two repos share the same nick.
-    # Write its path to PERM_SETTINGS_PTR so stop_permbot can find and clean it up.
     # ROOST_DIR is derived from the script's own path (cd … && pwd) so it won't
     # contain quotes or backslashes — the printf JSON embedding is safe.
-    local perm_settings_file
-    perm_settings_file="$(mktemp /tmp/roost-perm-settings-XXXXXX.json)"
-    printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${perm_settings_file}"
-    printf '%s\n' "${perm_settings_file}" > "${PERM_SETTINGS_PTR}"
-    perm_settings_flag=" --settings ${perm_settings_file}"
+    printf '%s\n' "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]}}" > "${PERM_SETTINGS}"
+    perm_settings_flag=" --settings ${PERM_SETTINGS}"
   fi
 
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode}, cwd: ${cwd})"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/irc-permission-prompt"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -86,10 +86,9 @@ roost spawn scratch-h -c '#sandbox' -m haiku \
 ```
 
 Worker prerequisite: the worker must have the roost plugin active.
-The plugin's `hooks/hooks.json` wires `PreToolUse` to
-`irc-permission-prompt` automatically. The hook degrades gracefully
-when no daemon is running (returns `ask`, terminal prompt fires as
-normal), so it's safe to have wired at all times.
+`roost spawn --perm-irc` injects the `PermissionRequest` hook into
+the spawned session via `--settings`; sessions without `--perm-irc`
+do not have the hook loaded.
 
 The hook auto-passes any `mcp__roost-irc__*` tool through without
 asking — otherwise the worker couldn't talk on IRC, including replying


### PR DESCRIPTION
`hooks/hooks.json` was registering the PermissionRequest hook for every session. Now it's only wired for sessions spawned with `--perm-irc`.

- `hooks/hooks.json`: empty `"hooks": {}`
- `bin/roost cmd_spawn`: when `--perm-irc`, writes `/tmp/roost-perm-settings-<nick>.json` with the hook config and passes `--settings <path>` to claude (`--settings` merges with existing settings layers, it doesn't replace)
- `bin/roost stop_permbot`: cleans up the settings file alongside the permbot pid/socket (mirrors existing leak-on-direct-kill behaviour)
- README + SKILL.md: drop "wires PreToolUse" / "safe to have wired at all times" language

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)