### PR TITLE
feat: replay channel history on join

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -18,7 +18,9 @@
  *   ROOST_IRC_NICK       Nick       (REQUIRED, no default)
  *   ROOST_IRC_REALNAME   Realname   (default: same as nick)
  *   ROOST_IRC_CHANNELS   Comma-separated auto-join list (default: none)
- *   ROOST_IRC_HISTORY    Per-channel history buffer size (default: 50)
+ *   ROOST_IRC_HISTORY              Per-channel history buffer size (default: 50)
+ *   ROOST_IRC_JOIN_HISTORY_LINES   Max historical messages emitted on join (default: 20)
+ *   ROOST_IRC_JOIN_HISTORY_MINUTES Time window for join history in minutes (default: 30)
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
@@ -51,6 +53,10 @@ const AUTO_JOIN = (env('ROOST_IRC_CHANNELS', '') || '')
   .map(s => s.trim())
   .filter(Boolean)
 const HISTORY_SIZE = Number(env('ROOST_IRC_HISTORY', '50'))
+// History replayed to the agent on channel join (via IRCv3 chathistory autoreplay).
+// If the server doesn't ack the chathistory cap, no batch is sent and these are unused.
+const JOIN_HISTORY_LINES = Number(env('ROOST_IRC_JOIN_HISTORY_LINES', '20'))
+const JOIN_HISTORY_MINUTES = Number(env('ROOST_IRC_JOIN_HISTORY_MINUTES', '30'))
 
 // ---- IRC client wiring -------------------------------------------------
 
@@ -378,7 +384,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'channel_join',
-      description: 'Join a channel. Returns when the JOIN is acknowledged.',
+      description: 'Join a channel. Returns when the JOIN is acknowledged. Recent channel history (up to ROOST_IRC_JOIN_HISTORY_LINES messages within ROOST_IRC_JOIN_HISTORY_MINUTES minutes) is then pushed as historical notifications.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -650,6 +656,11 @@ client.on('registered', () => {
       `roost-irc[${NICK}]: draft/multiline NOT enabled (server caps: ${enabled.join(',') || '(none)'}); falling back to legacy chunker\n`,
     )
   }
+  process.stderr.write(
+    enabled.includes('chathistory')
+      ? `roost-irc[${NICK}]: chathistory cap active — will replay up to ${JOIN_HISTORY_LINES} msgs / ${JOIN_HISTORY_MINUTES}min on join\n`
+      : `roost-irc[${NICK}]: chathistory cap NOT active — no history replay on join\n`,
+  )
   for (const ch of AUTO_JOIN) {
     client.join(ch)
     process.stderr.write(`roost-irc[${NICK}]: auto-joining ${ch}\n`)
@@ -883,6 +894,8 @@ client.on(
   }) => {
     const target = event.params[0]
     if (!target) return
+    const cutoffMs = JOIN_HISTORY_MINUTES > 0 ? Date.now() - JOIN_HISTORY_MINUTES * 60_000 : 0
+    const batch: IrcMessage[] = []
     for (const c of event.commands) {
       if (c.command !== 'PRIVMSG') continue
       const sender = c.nick
@@ -891,9 +904,15 @@ client.on(
       const isDirect = target === NICK
       const channel = isDirect ? sender : target
       const serverTimeMs = c.getServerTime?.()
+      // Drop messages outside the time window (skip filter if no server-time tag).
+      if (cutoffMs > 0 && serverTimeMs !== undefined && serverTimeMs < cutoffMs) continue
       const ts = (serverTimeMs ? new Date(serverTimeMs) : new Date()).toISOString()
-      const msg: IrcMessage = { channel, sender, text, ts, isDirect }
-      pushHistory(channel, msg)
+      batch.push({ channel, sender, text, ts, isDirect })
+    }
+    // Take the most-recent N (ergo sends oldest-first).
+    const limited = JOIN_HISTORY_LINES > 0 ? batch.slice(-JOIN_HISTORY_LINES) : batch
+    for (const msg of limited) {
+      pushHistory(msg.channel, msg)
       emitChannelEvent(msg, { historical: true })
     }
   },
@@ -911,7 +930,7 @@ client.on('socket error', (err: Error) => {
 // Ask the server for the IRCv3 caps we need beyond irc-framework's
 // defaults. labeled-response isn't strictly required for multiline, but
 // it pairs well with future features (await-able send confirmations).
-client.requestCap(['draft/multiline', 'labeled-response'])
+client.requestCap(['draft/multiline', 'labeled-response', 'chathistory'])
 
 client.connect({
   host: SERVER,

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -35,6 +35,7 @@ import IRC from 'irc-framework'
 const SOURCE_NAME = 'roost-irc'
 
 const env = (k: string, def?: string) => process.env[k] ?? def
+const numericEnv = (k: string, def: number) => Number(env(k, String(def)))
 const required = (k: string): string => {
   const v = process.env[k]
   if (!v) {
@@ -45,18 +46,18 @@ const required = (k: string): string => {
 }
 
 const SERVER = env('ROOST_IRC_SERVER', '127.0.0.1')!
-const PORT = Number(env('ROOST_IRC_PORT', '6667'))
+const PORT = numericEnv('ROOST_IRC_PORT', 6667)
 const NICK = required('ROOST_IRC_NICK')
 const REALNAME = env('ROOST_IRC_REALNAME', NICK)!
 const AUTO_JOIN = (env('ROOST_IRC_CHANNELS', '') || '')
   .split(',')
   .map(s => s.trim())
   .filter(Boolean)
-const HISTORY_SIZE = Number(env('ROOST_IRC_HISTORY', '50'))
-// History replayed to the agent on channel join (via IRCv3 chathistory autoreplay).
-// If the server doesn't ack the chathistory cap, no batch is sent and these are unused.
-const JOIN_HISTORY_LINES = Number(env('ROOST_IRC_JOIN_HISTORY_LINES', '20'))
-const JOIN_HISTORY_MINUTES = Number(env('ROOST_IRC_JOIN_HISTORY_MINUTES', '30'))
+const HISTORY_SIZE = numericEnv('ROOST_IRC_HISTORY', 50)
+// No-op if the server doesn't ack the chathistory cap — the batch end handler simply never fires.
+const JOIN_HISTORY_LINES = numericEnv('ROOST_IRC_JOIN_HISTORY_LINES', 20)
+const JOIN_HISTORY_MINUTES = numericEnv('ROOST_IRC_JOIN_HISTORY_MINUTES', 30)
+const CAP_CHATHISTORY = 'chathistory'
 
 // ---- IRC client wiring -------------------------------------------------
 
@@ -657,7 +658,7 @@ client.on('registered', () => {
     )
   }
   process.stderr.write(
-    enabled.includes('chathistory')
+    enabled.includes(CAP_CHATHISTORY)
       ? `roost-irc[${NICK}]: chathistory cap active — will replay up to ${JOIN_HISTORY_LINES} msgs / ${JOIN_HISTORY_MINUTES}min on join\n`
       : `roost-irc[${NICK}]: chathistory cap NOT active — no history replay on join\n`,
   )
@@ -781,7 +782,7 @@ client.on('message', (event: {
   // draft/multiline and chathistory batch members are handled in their
   // respective batch-end handlers below — skip here to avoid double-emit.
   if (event.batch?.type === 'draft/multiline') return
-  if (event.batch?.type === 'chathistory') return
+  if (event.batch?.type === CAP_CHATHISTORY) return
   const isDirect = event.target === NICK
   const channel = isDirect ? event.nick : event.target
   const ts = new Date().toISOString()
@@ -904,7 +905,7 @@ client.on(
       const isDirect = target === NICK
       const channel = isDirect ? sender : target
       const serverTimeMs = c.getServerTime?.()
-      // Drop messages outside the time window (skip filter if no server-time tag).
+      // Skip filter if no server-time tag.
       if (cutoffMs > 0 && serverTimeMs !== undefined && serverTimeMs < cutoffMs) continue
       const ts = (serverTimeMs ? new Date(serverTimeMs) : new Date()).toISOString()
       batch.push({ channel, sender, text, ts, isDirect })
@@ -930,7 +931,7 @@ client.on('socket error', (err: Error) => {
 // Ask the server for the IRCv3 caps we need beyond irc-framework's
 // defaults. labeled-response isn't strictly required for multiline, but
 // it pairs well with future features (await-able send confirmations).
-client.requestCap(['draft/multiline', 'labeled-response', 'chathistory'])
+client.requestCap(['draft/multiline', 'labeled-response', CAP_CHATHISTORY])
 
 client.connect({
   host: SERVER,

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -56,6 +56,29 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     expect(Number(n2.meta.seq)).toBeGreaterThan(Number(n1.meta.seq))
   })
 
+  it('ROOST_IRC_JOIN_HISTORY_LINES caps how many historical messages are emitted', async () => {
+    const peer = await connectPeer(ergo, 'hist-peer-limit')
+    // Only replay last 2 messages, even though 4 exist.
+    const mcp = await startMcp(ergo, 'hist-mcp-limit', { ROOST_IRC_JOIN_HISTORY_LINES: '2' })
+
+    await peer.joinChannel('#hist-limit')
+    peer.say('#hist-limit', 'limit-one')
+    peer.say('#hist-limit', 'limit-two')
+    peer.say('#hist-limit', 'limit-three')
+    peer.say('#hist-limit', 'limit-four')
+    await sleep(200)
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#hist-limit' } })
+
+    await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'limit-three')
+    await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'limit-four')
+
+    // Earlier messages are outside the limit and must not appear.
+    const all = mcp.notifications.filter(n => n.meta.historical === 'true' && n.meta.channel === '#hist-limit')
+    expect(all.some(n => n.content === 'limit-one')).toBe(false)
+    expect(all.some(n => n.content === 'limit-two')).toBe(false)
+  })
+
   it('channel_history includes backfilled messages in order', async () => {
     const peer = await connectPeer(ergo, 'hist-peer3')
     const mcp = await startMcp(ergo, 'hist-mcp3')

--- a/test/helpers/ergo.ts
+++ b/test/helpers/ergo.ts
@@ -99,7 +99,7 @@ history:
   enabled: true
   channel-length: 256
   client-length: 64
-  autoreplay-on-join: 10
+  autoreplay-on-join: 100
   chathistory-maxmessages: 100
   persistent:
     enabled: false

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -27,7 +27,7 @@ export interface McpContext {
 
 let instanceCounter = 0
 
-export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpContext> {
+export async function startMcp(ergo: ErgoContext, nick?: string, extraEnv?: Record<string, string>): Promise<McpContext> {
   const clientNick = nick ?? `mcp${++instanceCounter}`
 
   const transport = new StdioClientTransport({
@@ -38,6 +38,7 @@ export async function startMcp(ergo: ErgoContext, nick?: string): Promise<McpCon
       ROOST_IRC_SERVER: ergo.host,
       ROOST_IRC_PORT: String(ergo.port),
       ROOST_IRC_NICK: clientNick,
+      ...extraEnv,
     },
     stderr: 'inherit',
   })


### PR DESCRIPTION
closes #40

Wire the `chathistory` cap so ergo sends autoreplay batches when the MCP joins a channel. The existing `batch end chathistory` handler already emits historical notifications — it was just never getting called because we never negotiated the cap.

**Delivery**: synthetic notifications (`historical=true` in meta), same shape as live messages. Join response stays fast; history arrives async right after.

**Config knobs** (env vars):
- `ROOST_IRC_JOIN_HISTORY_LINES` — max messages to emit on join (default: 20)
- `ROOST_IRC_JOIN_HISTORY_MINUTES` — ignore messages older than N minutes (default: 30)

Client-side filter applied in the batch handler: drop msgs outside the time window, take the most-recent N of what remains. Ergo's `autoreplay-on-join` acts as server ceiling (test config bumped to 100 so client knob is binding).

**Graceful fallback**: if `chathistory` cap isn't acked (older server, restricted config), the batch never fires and join continues as before — no error path needed.

**#44 handoff**: dedupe on reconnect can track last-seen timestamp and skip already-emitted msgs in the handler. Nothing here forecloses that.