### PR TITLE
feat(dispatcher): relay full comment bodies via draft/multiline IRC

### DIFF
--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -47,6 +47,7 @@ import subprocess
 import sys
 import tempfile
 import random
+import re
 import time
 import traceback
 from datetime import datetime, timezone
@@ -686,6 +687,15 @@ def _multiline_split_line(line: str) -> list[str]:
     return _utf8_split(line, MULTILINE_LINE_BYTES, boundary=False)
 
 
+# Matches: `:server CAP <nick> <sub> [*] :<caps>`
+# group 1 = subcommand, group 2 = "*" (non-final LS) or None, group 3 = caps string
+_RE_CAP = re.compile(r'^:\S+ CAP \S+ (\w+)(?: (\*))?(?:\s+:?(.*))?')
+_RE_001 = re.compile(r'^:\S+ 001 ')
+# Matches the draft/multiline cap token; group 1 = "key=val,…" params or None
+_RE_MULTILINE_CAP = re.compile(r'(?:^|\s)draft/multiline(?:=(\S+))?(?:\s|$)')
+_RE_MULTILINE_PARAMS = re.compile(r'max-bytes=(\d+)|max-lines=(\d+)')
+
+
 class IrcClient:
     def __init__(self, server: str, port: int, nick: str, default_channels: Iterable[str] = ()):
         self.server = server
@@ -720,44 +730,27 @@ class IrcClient:
                 if line.startswith("PING "):
                     self._send_raw("PONG " + line[5:])
                     continue
-                parts = line.split(" ", 4)
-                if len(parts) >= 4 and parts[1] == "CAP":
-                    subcommand = parts[3]
-                    rest = parts[4] if len(parts) > 4 else ""
-                    if subcommand == "LS":
-                        if rest.startswith("* "):
-                            caps_str = rest[2:].lstrip(":")
-                            is_last = False
-                        else:
-                            caps_str = rest.lstrip(":")
-                            is_last = True
-                        for token in caps_str.split():
-                            if token.startswith(CAP_MULTILINE):
-                                cap_eq = token[len(CAP_MULTILINE):]
-                                if cap_eq.startswith("="):
-                                    for param in cap_eq[1:].split(","):
-                                        if param.startswith("max-bytes="):
-                                            try:
-                                                self._multiline_max_bytes = int(param[10:])
-                                            except ValueError:
-                                                pass
-                                        elif param.startswith("max-lines="):
-                                            try:
-                                                self._multiline_max_lines = int(param[10:])
-                                            except ValueError:
-                                                pass
-                                if not _cap_req_sent:
-                                    self._send_raw(f"CAP REQ :{CAP_MULTILINE}")
-                                    _cap_req_sent = True
-                                break
-                        if is_last and not _cap_req_sent:
+                cap = _RE_CAP.match(line)
+                if cap:
+                    sub, is_cont, caps = cap.group(1), cap.group(2), cap.group(3) or ""
+                    if sub == "LS":
+                        ml = _RE_MULTILINE_CAP.search(caps)
+                        if ml and not _cap_req_sent:
+                            for mp in _RE_MULTILINE_PARAMS.finditer(ml.group(1) or ""):
+                                if mp.group(1):
+                                    self._multiline_max_bytes = int(mp.group(1))
+                                if mp.group(2):
+                                    self._multiline_max_lines = int(mp.group(2))
+                            self._send_raw(f"CAP REQ :{CAP_MULTILINE}")
+                            _cap_req_sent = True
+                        if is_cont is None and not _cap_req_sent:
                             self._send_raw("CAP END")
-                    elif subcommand == "ACK":
+                    elif sub == "ACK":
                         self._multiline_enabled = True
                         self._send_raw("CAP END")
-                    elif subcommand == "NAK":
+                    elif sub == "NAK":
                         self._send_raw("CAP END")
-                elif len(parts) >= 2 and parts[0].startswith(":") and parts[1] == "001":
+                elif _RE_001.match(line):
                     registered = True
                     break
         if not registered:

--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -66,6 +66,8 @@ SCHEMA_VERSION = 1
 # 300 is conservative-safe without knowing the server's prefix length at runtime.
 MULTILINE_LINE_BYTES = 300
 
+CAP_MULTILINE = "draft/multiline"
+
 
 class GhError(RuntimeError):
     pass
@@ -570,11 +572,15 @@ def _comment_snippet(event: dict) -> tuple[str, str, str]:
     return snippet, ellipsis, url
 
 
-def format_event(event: dict) -> str:
-    kind = event.get("kind") or "unknown"
+def _event_tag(event: dict) -> str:
     n = event.get("pr") or event.get("issue")
     repo = event.get("repo")
-    tag = f"{repo}#{n}" if (n is not None and repo) else (f"#{n}" if n is not None else "")
+    return f"{repo}#{n}" if (n is not None and repo) else (f"#{n}" if n is not None else "")
+
+
+def format_event(event: dict) -> str:
+    kind = event.get("kind") or "unknown"
+    tag = _event_tag(event)
 
     if kind == "pr_ready_for_review":
         return f"PR {tag} ready for review: {event.get('title', '')} — {event.get('url', '')}"
@@ -640,50 +646,44 @@ def format_event(event: dict) -> str:
 IRC_MAX_CHUNK_BODY = 300
 
 
-def _irc_split_text(text: str) -> list[str]:
-    if len(text.encode("utf-8")) <= IRC_MAX_CHUNK_BODY:
+def _utf8_split(text: str, limit: int, *, boundary: bool) -> list[str]:
+    """Split text into ≤limit-byte chunks. boundary=True seeks sentence/word breaks."""
+    if len(text.encode("utf-8")) <= limit:
         return [text]
     out: list[str] = []
     s = text
     while s:
-        if len(s.encode("utf-8")) <= IRC_MAX_CHUNK_BODY:
+        if len(s.encode("utf-8")) <= limit:
             out.append(s)
             break
-        end = min(len(s), IRC_MAX_CHUNK_BODY)
-        while end > 0 and len(s[:end].encode("utf-8")) > IRC_MAX_CHUNK_BODY:
+        end = min(len(s), limit)
+        while end > 0 and len(s[:end].encode("utf-8")) > limit:
             end -= 1
-        min_viable = max(1, end * 2 // 3)
-        split_at = end
-        for j in range(end, min_viable, -1):
-            if j < len(s) and s[j - 1] in ".!?" and (j == len(s) or s[j] in " \t\n"):
-                split_at = j
-                break
-        else:
+        if boundary:
+            min_viable = max(1, end * 2 // 3)
+            split_at = end
             for j in range(end, min_viable, -1):
-                if j < len(s) and s[j] in " \t":
+                if j < len(s) and s[j - 1] in ".!?" and (j == len(s) or s[j] in " \t\n"):
                     split_at = j
                     break
+            else:
+                for j in range(end, min_viable, -1):
+                    if j < len(s) and s[j] in " \t":
+                        split_at = j
+                        break
+        else:
+            split_at = end
         out.append(s[:split_at])
         s = s[split_at:]
     return out
 
 
+def _irc_split_text(text: str) -> list[str]:
+    return _utf8_split(text, IRC_MAX_CHUNK_BODY, boundary=True)
+
+
 def _multiline_split_line(line: str) -> list[str]:
-    """Split one logical line into ≤MULTILINE_LINE_BYTES-byte wire chunks."""
-    if len(line.encode("utf-8")) <= MULTILINE_LINE_BYTES:
-        return [line]
-    chunks: list[str] = []
-    remaining = line
-    while remaining:
-        if len(remaining.encode("utf-8")) <= MULTILINE_LINE_BYTES:
-            chunks.append(remaining)
-            break
-        end = MULTILINE_LINE_BYTES
-        while end > 0 and len(remaining[:end].encode("utf-8")) > MULTILINE_LINE_BYTES:
-            end -= 1
-        chunks.append(remaining[:end])
-        remaining = remaining[end:]
-    return chunks
+    return _utf8_split(line, MULTILINE_LINE_BYTES, boundary=False)
 
 
 class IrcClient:
@@ -695,6 +695,9 @@ class IrcClient:
         self.sock: socket.socket | None = None
         self._buffer = ""
         self._joined: set[str] = set()
+        self._reset_multiline_state()
+
+    def _reset_multiline_state(self) -> None:
         self._multiline_enabled = False
         self._multiline_max_bytes = 16384
         self._multiline_max_lines = 200
@@ -705,16 +708,13 @@ class IrcClient:
         self.sock = s
         self._buffer = ""
         self._joined = set()
-        self._multiline_enabled = False
-        self._multiline_max_bytes = 16384
-        self._multiline_max_lines = 200
+        self._reset_multiline_state()
         self._send_raw("CAP LS 302")
         self._send_raw(f"NICK {self.nick}")
         self._send_raw(f"USER {self.nick} 0 * :{self.nick}")
         deadline = time.time() + 10
         registered = False
         _cap_req_sent = False
-        _cap_end_sent = False
         while time.time() < deadline and not registered:
             for line in self._read_lines(timeout=1.0):
                 if line.startswith("PING "):
@@ -732,8 +732,8 @@ class IrcClient:
                             caps_str = rest.lstrip(":")
                             is_last = True
                         for token in caps_str.split():
-                            if token.startswith("draft/multiline"):
-                                cap_eq = token[len("draft/multiline"):]
+                            if token.startswith(CAP_MULTILINE):
+                                cap_eq = token[len(CAP_MULTILINE):]
                                 if cap_eq.startswith("="):
                                     for param in cap_eq[1:].split(","):
                                         if param.startswith("max-bytes="):
@@ -747,21 +747,16 @@ class IrcClient:
                                             except ValueError:
                                                 pass
                                 if not _cap_req_sent:
-                                    self._send_raw("CAP REQ :draft/multiline")
+                                    self._send_raw(f"CAP REQ :{CAP_MULTILINE}")
                                     _cap_req_sent = True
                                 break
-                        if is_last and not _cap_req_sent and not _cap_end_sent:
+                        if is_last and not _cap_req_sent:
                             self._send_raw("CAP END")
-                            _cap_end_sent = True
                     elif subcommand == "ACK":
                         self._multiline_enabled = True
-                        if not _cap_end_sent:
-                            self._send_raw("CAP END")
-                            _cap_end_sent = True
+                        self._send_raw("CAP END")
                     elif subcommand == "NAK":
-                        if not _cap_end_sent:
-                            self._send_raw("CAP END")
-                            _cap_end_sent = True
+                        self._send_raw("CAP END")
                 elif len(parts) >= 2 and parts[0].startswith(":") and parts[1] == "001":
                     registered = True
                     break
@@ -848,25 +843,19 @@ class IrcClient:
             self.pump(timeout=0.0)
 
     def comment_privmsg(self, channel: str, header: str, body: str, url: str, fallback: str) -> None:
-        """Send a comment as a draft/multiline batch when negotiated and within limits.
-
-        The batch contains: header line, body lines, permalink URL (last).
-        Non-multiline clients still see the URL as a regular PRIVMSG in the flood.
-        Falls back to privmsg(fallback) when multiline is not negotiated or the
-        body exceeds the server-advertised max-bytes / max-lines.
-        """
+        """Non-multiline clients still see the URL as a regular PRIVMSG in the flood."""
         if self._multiline_enabled:
-            logical_lines = [header] + (body.splitlines() if body else []) + [url]
+            logical_lines = [header] + body.splitlines() + [url]
             wire_lines: list[tuple[str, bool]] = []
             for logical in logical_lines:
                 chunks = _multiline_split_line(logical)
                 for i, chunk in enumerate(chunks):
                     wire_lines.append((chunk, i > 0))
-            total_bytes = sum(len(t.encode("utf-8")) for t, _ in wire_lines)
-            if len(wire_lines) <= self._multiline_max_lines and total_bytes <= self._multiline_max_bytes:
+            if (len(wire_lines) <= self._multiline_max_lines
+                    and len(wire_lines) * MULTILINE_LINE_BYTES <= self._multiline_max_bytes):
                 self.join(channel)
                 batch_id = f"{random.randint(0, 0xffffffff):08x}"
-                self._send_raw(f"BATCH +{batch_id} draft/multiline {channel}")
+                self._send_raw(f"BATCH +{batch_id} {CAP_MULTILINE} {channel}")
                 for text, is_concat in wire_lines:
                     tag = (f"batch={batch_id};draft/multiline-concat" if is_concat
                            else f"batch={batch_id}")
@@ -892,9 +881,7 @@ MULTILINE_COMMENT_KINDS = {
 def _format_comment_header(event: dict) -> str:
     """Header line for a comment event — same as format_event minus snippet and URL."""
     kind = event.get("kind") or ""
-    n = event.get("pr") or event.get("issue")
-    repo = event.get("repo")
-    tag = f"{repo}#{n}" if (n is not None and repo) else (f"#{n}" if n is not None else "")
+    tag = _event_tag(event)
     if kind in ("pr_review_comment", "pr_conversation_comment"):
         author = event.get("author") or "?"
         path = event.get("path")
@@ -946,15 +933,19 @@ def dispatch_events_irc(events: list[dict], irc: IrcClient, default_channel: str
             continue
         targets = _event_channels(ev, default_channel)
         kind = ev.get("kind", "")
+        if kind in MULTILINE_COMMENT_KINDS:
+            header = _format_comment_header(ev)
+            body = ev.get("body") or ""
+            url = ev.get("comment_url") or ev.get("review_url") or ev.get("url", "")
+            fallback = format_event(ev)
+        else:
+            text = format_event(ev)
         for target in dict.fromkeys(targets):  # de-dup, preserve order
             try:
                 if kind in MULTILINE_COMMENT_KINDS:
-                    header = _format_comment_header(ev)
-                    body = ev.get("body") or ""
-                    url = ev.get("comment_url") or ev.get("review_url") or ev.get("url", "")
-                    irc.comment_privmsg(target, header, body, url, format_event(ev))
+                    irc.comment_privmsg(target, header, body, url, fallback)
                 else:
-                    irc.privmsg(target, format_event(ev))
+                    irc.privmsg(target, text)
             except ConnectionError:
                 raise
             except Exception as e:

--- a/bin/orchestrator_poll
+++ b/bin/orchestrator_poll
@@ -46,6 +46,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import random
 import time
 import traceback
 from datetime import datetime, timezone
@@ -59,6 +60,11 @@ HEARTBEAT_PATH = STATE_DIR / "last-tick.txt"
 LAST_ERROR_PATH = STATE_DIR / "last-error.txt"
 
 SCHEMA_VERSION = 1
+
+# Per-line PRIVMSG body cap inside a draft/multiline batch. Matches
+# MULTILINE_LINE_BYTES in irc-lib.ts. IRC wire limit is 512 bytes total;
+# 300 is conservative-safe without knowing the server's prefix length at runtime.
+MULTILINE_LINE_BYTES = 300
 
 
 class GhError(RuntimeError):
@@ -359,6 +365,7 @@ def format_comment_event(c: dict, *, kind: str, repo: str | None, pr: int | None
         "comment_url": c.get("html_url"),
         "author": author,
         "is_worker_reply": is_worker,
+        "body": body,
         "body_preview": body[:280],
     }
     if repo:
@@ -462,6 +469,7 @@ def diff_pr(prev: dict, cur: dict, agent_logins: set[str] | None = None) -> list
             "review_url": review.get("html_url"),
             "author": author,
             "state": (review.get("state") or "").upper(),
+            "body": (review.get("body") or ""),
             "body_preview": (review.get("body") or "")[:280],
             "is_worker_reply": is_agent_author,
         }
@@ -660,6 +668,24 @@ def _irc_split_text(text: str) -> list[str]:
     return out
 
 
+def _multiline_split_line(line: str) -> list[str]:
+    """Split one logical line into ≤MULTILINE_LINE_BYTES-byte wire chunks."""
+    if len(line.encode("utf-8")) <= MULTILINE_LINE_BYTES:
+        return [line]
+    chunks: list[str] = []
+    remaining = line
+    while remaining:
+        if len(remaining.encode("utf-8")) <= MULTILINE_LINE_BYTES:
+            chunks.append(remaining)
+            break
+        end = MULTILINE_LINE_BYTES
+        while end > 0 and len(remaining[:end].encode("utf-8")) > MULTILINE_LINE_BYTES:
+            end -= 1
+        chunks.append(remaining[:end])
+        remaining = remaining[end:]
+    return chunks
+
+
 class IrcClient:
     def __init__(self, server: str, port: int, nick: str, default_channels: Iterable[str] = ()):
         self.server = server
@@ -669,6 +695,9 @@ class IrcClient:
         self.sock: socket.socket | None = None
         self._buffer = ""
         self._joined: set[str] = set()
+        self._multiline_enabled = False
+        self._multiline_max_bytes = 16384
+        self._multiline_max_lines = 200
 
     def connect(self) -> None:
         s = socket.create_connection((self.server, self.port), timeout=10)
@@ -676,18 +705,66 @@ class IrcClient:
         self.sock = s
         self._buffer = ""
         self._joined = set()
+        self._multiline_enabled = False
+        self._multiline_max_bytes = 16384
+        self._multiline_max_lines = 200
+        self._send_raw("CAP LS 302")
         self._send_raw(f"NICK {self.nick}")
         self._send_raw(f"USER {self.nick} 0 * :{self.nick}")
         deadline = time.time() + 10
         registered = False
+        _cap_req_sent = False
+        _cap_end_sent = False
         while time.time() < deadline and not registered:
             for line in self._read_lines(timeout=1.0):
-                parts = line.split(" ", 3)
-                if len(parts) >= 2 and parts[0].startswith(":") and parts[1] == "001":
-                    registered = True
-                    break
                 if line.startswith("PING "):
                     self._send_raw("PONG " + line[5:])
+                    continue
+                parts = line.split(" ", 4)
+                if len(parts) >= 4 and parts[1] == "CAP":
+                    subcommand = parts[3]
+                    rest = parts[4] if len(parts) > 4 else ""
+                    if subcommand == "LS":
+                        if rest.startswith("* "):
+                            caps_str = rest[2:].lstrip(":")
+                            is_last = False
+                        else:
+                            caps_str = rest.lstrip(":")
+                            is_last = True
+                        for token in caps_str.split():
+                            if token.startswith("draft/multiline"):
+                                cap_eq = token[len("draft/multiline"):]
+                                if cap_eq.startswith("="):
+                                    for param in cap_eq[1:].split(","):
+                                        if param.startswith("max-bytes="):
+                                            try:
+                                                self._multiline_max_bytes = int(param[10:])
+                                            except ValueError:
+                                                pass
+                                        elif param.startswith("max-lines="):
+                                            try:
+                                                self._multiline_max_lines = int(param[10:])
+                                            except ValueError:
+                                                pass
+                                if not _cap_req_sent:
+                                    self._send_raw("CAP REQ :draft/multiline")
+                                    _cap_req_sent = True
+                                break
+                        if is_last and not _cap_req_sent and not _cap_end_sent:
+                            self._send_raw("CAP END")
+                            _cap_end_sent = True
+                    elif subcommand == "ACK":
+                        self._multiline_enabled = True
+                        if not _cap_end_sent:
+                            self._send_raw("CAP END")
+                            _cap_end_sent = True
+                    elif subcommand == "NAK":
+                        if not _cap_end_sent:
+                            self._send_raw("CAP END")
+                            _cap_end_sent = True
+                elif len(parts) >= 2 and parts[0].startswith(":") and parts[1] == "001":
+                    registered = True
+                    break
         if not registered:
             raise RuntimeError(f"IRC registration to {self.server}:{self.port} timed out")
         for ch in self.default_channels:
@@ -770,10 +847,69 @@ class IrcClient:
             self._send_raw(f"PRIVMSG {channel} :{safe}")
             self.pump(timeout=0.0)
 
+    def comment_privmsg(self, channel: str, header: str, body: str, url: str, fallback: str) -> None:
+        """Send a comment as a draft/multiline batch when negotiated and within limits.
+
+        The batch contains: header line, body lines, permalink URL (last).
+        Non-multiline clients still see the URL as a regular PRIVMSG in the flood.
+        Falls back to privmsg(fallback) when multiline is not negotiated or the
+        body exceeds the server-advertised max-bytes / max-lines.
+        """
+        if self._multiline_enabled:
+            logical_lines = [header] + (body.splitlines() if body else []) + [url]
+            wire_lines: list[tuple[str, bool]] = []
+            for logical in logical_lines:
+                chunks = _multiline_split_line(logical)
+                for i, chunk in enumerate(chunks):
+                    wire_lines.append((chunk, i > 0))
+            total_bytes = sum(len(t.encode("utf-8")) for t, _ in wire_lines)
+            if len(wire_lines) <= self._multiline_max_lines and total_bytes <= self._multiline_max_bytes:
+                self.join(channel)
+                batch_id = f"{random.randint(0, 0xffffffff):08x}"
+                self._send_raw(f"BATCH +{batch_id} draft/multiline {channel}")
+                for text, is_concat in wire_lines:
+                    tag = (f"batch={batch_id};draft/multiline-concat" if is_concat
+                           else f"batch={batch_id}")
+                    self._send_raw(f"@{tag} PRIVMSG {channel} :{text}")
+                    self.pump(timeout=0.0)
+                self._send_raw(f"BATCH -{batch_id}")
+                return
+        self.privmsg(channel, fallback)
+
 
 # ---------------------------------------------------------------------------
 # IRC dispatch
 # ---------------------------------------------------------------------------
+
+MULTILINE_COMMENT_KINDS = {
+    "pr_review_comment",
+    "pr_conversation_comment",
+    "issue_comment",
+    "pr_review_submitted",
+}
+
+
+def _format_comment_header(event: dict) -> str:
+    """Header line for a comment event — same as format_event minus snippet and URL."""
+    kind = event.get("kind") or ""
+    n = event.get("pr") or event.get("issue")
+    repo = event.get("repo")
+    tag = f"{repo}#{n}" if (n is not None and repo) else (f"#{n}" if n is not None else "")
+    if kind in ("pr_review_comment", "pr_conversation_comment"):
+        author = event.get("author") or "?"
+        path = event.get("path")
+        line = event.get("line")
+        where = f" at {path}:{line}" if path else ""
+        return f"PR {tag} comment by {author}{where}:"
+    if kind == "issue_comment":
+        author = event.get("author") or "?"
+        return f"Issue {tag} comment by {author}:"
+    if kind == "pr_review_submitted":
+        author = event.get("author") or "?"
+        state = event.get("state") or "?"
+        return f"PR {tag} review by {author} ({state}):"
+    return ""
+
 
 def _event_channels(event: dict, default_channel: str) -> list[str]:
     if event.get("pr") is not None:
@@ -809,10 +945,16 @@ def dispatch_events_irc(events: list[dict], irc: IrcClient, default_channel: str
         if not should_push(ev):
             continue
         targets = _event_channels(ev, default_channel)
-        text = format_event(ev)
+        kind = ev.get("kind", "")
         for target in dict.fromkeys(targets):  # de-dup, preserve order
             try:
-                irc.privmsg(target, text)
+                if kind in MULTILINE_COMMENT_KINDS:
+                    header = _format_comment_header(ev)
+                    body = ev.get("body") or ""
+                    url = ev.get("comment_url") or ev.get("review_url") or ev.get("url", "")
+                    irc.comment_privmsg(target, header, body, url, format_event(ev))
+                else:
+                    irc.privmsg(target, format_event(ev))
             except ConnectionError:
                 raise
             except Exception as e:
@@ -1197,6 +1339,91 @@ def _run_self_test() -> int:
               "comment_url": "https://github.com/org/repo/issues/47#issuecomment-666",
           }),
           "Issue org/repo#47 comment by carol: First line… — https://github.com/org/repo/issues/47#issuecomment-666")
+
+    # _format_comment_header
+    check("header_pr_review_comment",
+          _format_comment_header({
+              "kind": "pr_review_comment", "repo": "org/repo", "pr": 46, "author": "alice",
+          }),
+          "PR org/repo#46 comment by alice:")
+
+    check("header_pr_review_comment_path",
+          _format_comment_header({
+              "kind": "pr_review_comment", "repo": "org/repo", "pr": 46,
+              "author": "alice", "path": "src/foo.ts", "line": 10,
+          }),
+          "PR org/repo#46 comment by alice at src/foo.ts:10:")
+
+    check("header_issue_comment",
+          _format_comment_header({
+              "kind": "issue_comment", "repo": "org/repo", "issue": 47, "author": "carol",
+          }),
+          "Issue org/repo#47 comment by carol:")
+
+    check("header_pr_review_submitted",
+          _format_comment_header({
+              "kind": "pr_review_submitted", "repo": "org/repo", "pr": 46,
+              "author": "dave", "state": "APPROVED",
+          }),
+          "PR org/repo#46 review by dave (APPROVED):")
+
+    # _multiline_split_line
+    check("split_short", _multiline_split_line("hello"), ["hello"])
+
+    long_line = "A" * (MULTILINE_LINE_BYTES + 10)
+    split_result = _multiline_split_line(long_line)
+    check("split_long_count", len(split_result) > 1, True)
+    check("split_long_reassemble", "".join(split_result), long_line)
+
+    # format_comment_event includes full body field
+    test_c = {"id": 1, "html_url": "https://example.com/c/1",
+              "user": {"login": "alice"}, "body": "Line one\nLine two"}
+    ev_body = format_comment_event(test_c, kind="issue_comment", repo="org/repo",
+                                   pr=None, issue=47, url="https://example.com/i/47")
+    check("event_full_body", ev_body.get("body"), "Line one\nLine two")
+    check("event_body_preview", ev_body.get("body_preview"), "Line one\nLine two")
+
+    # comment_privmsg: multiline path
+    _cl = IrcClient("127.0.0.1", 6667, "test-nick")
+    _cl._multiline_enabled = True
+    _cl._multiline_max_bytes = 16384
+    _cl._multiline_max_lines = 200
+    _cl._joined = {"#test"}
+    _sent_ml: list[str] = []
+    _cl._send_raw = _sent_ml.append  # type: ignore[method-assign]
+    _cl.pump = lambda timeout=0.0: None  # type: ignore[method-assign]
+    _cl.comment_privmsg("#test", "Header:", "Body line 1\n\nBody line 3",
+                        "https://example.com", "fallback")
+    check("ml_batch_start", any("BATCH +" in l and "draft/multiline" in l for l in _sent_ml), True)
+    check("ml_batch_end", any("BATCH -" in l for l in _sent_ml), True)
+    check("ml_has_header", any(":Header:" in l for l in _sent_ml), True)
+    check("ml_has_url", any("https://example.com" in l for l in _sent_ml), True)
+    check("ml_no_fallback", not any("fallback" in l for l in _sent_ml), True)
+
+    # comment_privmsg: fallback when not enabled
+    _cl2 = IrcClient("127.0.0.1", 6667, "test-nick2")
+    _cl2._multiline_enabled = False
+    _cl2._joined = {"#test"}
+    _sent_fb: list[str] = []
+    _cl2._send_raw = _sent_fb.append  # type: ignore[method-assign]
+    _cl2.pump = lambda timeout=0.0: None  # type: ignore[method-assign]
+    _cl2.comment_privmsg("#test", "Header:", "Body", "https://example.com", "fallback text")
+    check("fb_has_fallback", any("fallback text" in l for l in _sent_fb), True)
+    check("fb_no_batch", not any("BATCH" in l for l in _sent_fb), True)
+
+    # comment_privmsg: fallback when body exceeds server limits
+    _cl3 = IrcClient("127.0.0.1", 6667, "test-nick3")
+    _cl3._multiline_enabled = True
+    _cl3._multiline_max_bytes = 10
+    _cl3._multiline_max_lines = 200
+    _cl3._joined = {"#test"}
+    _sent_ov: list[str] = []
+    _cl3._send_raw = _sent_ov.append  # type: ignore[method-assign]
+    _cl3.pump = lambda timeout=0.0: None  # type: ignore[method-assign]
+    _cl3.comment_privmsg("#test", "Header:", "Body exceeds tiny byte limit",
+                         "https://example.com", "fallback oversized")
+    check("ov_has_fallback", any("fallback oversized" in l for l in _sent_ov), True)
+    check("ov_no_batch", not any("BATCH" in l for l in _sent_ov), True)
 
     if failures:
         for f in failures:


### PR DESCRIPTION
Fixes #66. See also #72 for full IRC library migration followup.

## What

Comments and reviews were truncated to a snippet + permalink on a single IRC line. Agents (and humans) read the snippet as self-contained and miss later sentences.

Now the dispatcher negotiates `draft/multiline` and relays the full body as a BATCH, with the permalink as the last batch member so non-multiline clients still see the canonical link.

## How

- `IrcClient.connect()`: `CAP LS 302 / REQ / ACK / END` handshake via regex parser; resets per-connection so `reconnect()` re-negotiates
- `IrcClient.comment_privmsg()`: sends `BATCH` if enabled + fits server limits, else falls back to `privmsg(fallback)` with existing truncated-snippet text
- `_utf8_split(text, limit, *, boundary)`: shared core for `_irc_split_text` and `_multiline_split_line`
- `_event_tag(event)`: extracted one-liner used by `format_event` and `_format_comment_header`
- `CAP_MULTILINE = "draft/multiline"` constant; 4 module-level regexes for CAP parsing
- `dispatch_events_irc()`: comment event kinds route to `comment_privmsg()`; non-comment events unchanged
- 16 new self-test checks

All existing tests still pass (`bun test`: 25 pass, 47 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)