### PR TITLE
simplify(mcp): drop dead refs + share core test helper

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -33,7 +33,6 @@ import {
 import IRC from 'irc-framework'
 import { MULTILINE_LINE_BYTES } from './constants.js'
 import {
-  MAX_CHUNK_BODY,
   IrcMessage,
   splitText,
   splitLineForMultiline,
@@ -73,10 +72,11 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   // When enabled, outbound long messages go out as a draft/multiline BATCH
   // (server reassembles cleanly, capable receivers get one message); when
   // disabled, we fall back to the heuristic chunk + receiver-buffer dance
-  // below. Limits come from the cap value (e.g.
-  // `draft/multiline=max-bytes=16384,max-lines=200`); we cache them here.
+  // below. The max-lines limit comes from the cap value (e.g.
+  // `draft/multiline=max-bytes=16384,max-lines=200`); we cache it here so
+  // sendMultiline can fall back to the legacy chunker if the source text
+  // would exceed the server's per-batch ceiling.
   let multilineEnabled = false
-  let multilineMaxBytes = 4096
   // Pre-negotiation placeholder; overwritten by cap value once multilineEnabled=true.
   let multilineMaxLines = 100
 
@@ -175,7 +175,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     channel: string
     sender: string
     isDirect: boolean
-    firstSeen: number
     firstTs: string
     flushTimer: ReturnType<typeof setTimeout>
   }
@@ -572,11 +571,10 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
         const [k, v] = kv.split('=')
         const n = Number(v)
         if (!Number.isFinite(n) || n <= 0) continue
-        if (k === 'max-bytes') multilineMaxBytes = n
         if (k === 'max-lines') multilineMaxLines = n
       }
       process.stderr.write(
-        `roost-irc[${NICK}]: draft/multiline enabled (max-bytes=${multilineMaxBytes}, max-lines=${multilineMaxLines})\n`,
+        `roost-irc[${NICK}]: draft/multiline enabled (max-lines=${multilineMaxLines})\n`,
       )
     } else {
       process.stderr.write(
@@ -741,7 +739,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       channel,
       sender: event.nick,
       isDirect,
-      firstSeen: Date.now(),
       firstTs: ts,
       flushTimer: t,
     })

--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -1,0 +1,99 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { sleep } from './tool.js'
+
+export interface ChannelNotification {
+  content: string
+  meta: Record<string, string>
+  /** Pass as `fromCursor` on the next call to skip past this notification. */
+  cursor: number
+}
+
+export interface McpHandle {
+  client: Client
+  nick: string
+  notifications: ChannelNotification[]
+  waitForNotification(
+    pred: (n: ChannelNotification) => boolean,
+    timeoutMs?: number,
+    fromCursor?: number,
+  ): Promise<ChannelNotification>
+}
+
+/**
+ * Connect an MCP client to `transport`, install a notifications/claude/channel
+ * handler that records into `notifications` and wakes any matching waiters,
+ * and return a handle. Caller is responsible for teardown (afterAll, etc.) and
+ * for any IRC-side connection bring-up.
+ */
+export async function wireMcpClient(
+  transport: Transport,
+  nick: string,
+  clientName = 'roost-test',
+): Promise<McpHandle> {
+  const notifications: ChannelNotification[] = []
+  const waiters: Array<{
+    pred: (n: ChannelNotification) => boolean
+    resolve: (n: ChannelNotification) => void
+  }> = []
+
+  const client = new Client({ name: clientName, version: '0.0.1' })
+
+  client.fallbackNotificationHandler = async (notification) => {
+    if (notification.method !== 'notifications/claude/channel') return
+    const params = notification.params as { content: string; meta: Record<string, string> }
+    const n: ChannelNotification = {
+      content: params.content,
+      meta: params.meta,
+      cursor: notifications.length + 1,
+    }
+    notifications.push(n)
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (waiters[i].pred(n)) {
+        const w = waiters.splice(i, 1)[0]
+        w.resolve(n)
+      }
+    }
+  }
+
+  await client.connect(transport)
+
+  return {
+    client,
+    nick,
+    notifications,
+    waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
+      return new Promise((resolve, reject) => {
+        for (let i = fromCursor; i < notifications.length; i++) {
+          if (pred(notifications[i])) { resolve(notifications[i]); return }
+        }
+        const wrappedResolve = (n: ChannelNotification) => { clearTimeout(timer); resolve(n) }
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex(w => w.resolve === wrappedResolve)
+          if (idx !== -1) waiters.splice(idx, 1)
+          reject(new Error(`waitForNotification timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+        waiters.push({ pred, resolve: wrappedResolve })
+      })
+    },
+  }
+}
+
+/**
+ * Poll `channel_who` until the MCP's IRC client has registered. Throws if not
+ * ready within `deadlineMs`. Returns immediately on the first non-error tool
+ * call (or on a non-`not ready` error, which is treated as "ready enough" —
+ * caller's tool call surfaced something we don't recognize as the not-ready
+ * sentinel and shouldn't loop forever).
+ */
+export async function pollUntilIrcReady(handle: McpHandle, deadlineMs = 5000): Promise<void> {
+  const deadline = Date.now() + deadlineMs
+  while (true) {
+    const r = await handle.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
+    if (!r.isError) return
+    const text = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
+    if (!text.includes('not ready')) return
+    if (Date.now() > deadline) throw new Error(`IRC not ready within ${deadlineMs / 1000}s (nick=${handle.nick})`)
+    await sleep(50)
+  }
+}

--- a/test/helpers/mcp-inprocess.ts
+++ b/test/helpers/mcp-inprocess.ts
@@ -1,35 +1,19 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { afterAll } from 'bun:test'
 // @ts-expect-error — irc-framework lacks first-class type defs
 import IRC from 'irc-framework'
 import { createMcpServer } from '../../src/irc-server.js'
 import type { ErgoContext } from './ergo.js'
-import { sleep } from './tool.js'
+import { wireMcpClient, pollUntilIrcReady, type McpHandle } from './mcp-core.js'
 
-export interface ChannelNotification {
-  content: string
-  meta: Record<string, string>
-  cursor: number
-}
-
-export interface McpInProcessContext {
-  client: Client
-  nick: string
-  notifications: ChannelNotification[]
-  waitForNotification(
-    pred: (n: ChannelNotification) => boolean,
-    timeoutMs?: number,
-    fromCursor?: number,
-  ): Promise<ChannelNotification>
-}
+export type { ChannelNotification, McpHandle as McpInProcessContext } from './mcp-core.js'
 
 let instanceCounter = 0
 
 export async function startMcpInProcess(
   ergo: ErgoContext,
   nick?: string,
-): Promise<McpInProcessContext> {
+): Promise<McpHandle> {
   const clientNick = nick ?? `ip-mcp${++instanceCounter}`
 
   const ircClient = new IRC.Client()
@@ -44,34 +28,8 @@ export async function startMcpInProcess(
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
   await server.connect(serverTransport)
 
-  const notifications: ChannelNotification[] = []
-  const waiters: Array<{
-    pred: (n: ChannelNotification) => boolean
-    resolve: (n: ChannelNotification) => void
-    reject: (e: Error) => void
-  }> = []
+  const handle = await wireMcpClient(clientTransport, clientNick, 'roost-test-ip')
 
-  const client = new Client({ name: 'roost-test-ip', version: '0.0.1' })
-  client.fallbackNotificationHandler = async (notification) => {
-    if (notification.method !== 'notifications/claude/channel') return
-    const params = notification.params as { content: string; meta: Record<string, string> }
-    const n: ChannelNotification = {
-      content: params.content,
-      meta: params.meta,
-      cursor: notifications.length + 1,
-    }
-    notifications.push(n)
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].pred(n)) {
-        const w = waiters.splice(i, 1)[0]
-        w.resolve(n)
-      }
-    }
-  }
-
-  await client.connect(clientTransport)
-
-  // Connect IRC client to ergo.
   ircClient.requestCap(['draft/multiline', 'labeled-response', 'chathistory'])
   ircClient.connect({
     host: ergo.host,
@@ -82,40 +40,12 @@ export async function startMcpInProcess(
     auto_reconnect: false,
   })
 
-  // Poll until IRC has registered (channel_who returns non-error).
-  const deadline = Date.now() + 5000
-  while (true) {
-    const r = await client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
-    if (!r.isError) break
-    const text = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
-    if (!text.includes('not ready')) break
-    if (Date.now() > deadline) throw new Error(`startMcpInProcess: IRC not ready within 5s (nick=${clientNick})`)
-    await sleep(50)
-  }
+  await pollUntilIrcReady(handle)
 
   afterAll(async () => {
     ircClient.quit()
-    await client.close()
+    await handle.client.close()
   })
 
-  return {
-    client,
-    nick: clientNick,
-    notifications,
-    waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
-      return new Promise((resolve, reject) => {
-        for (let i = fromCursor; i < notifications.length; i++) {
-          if (pred(notifications[i])) { resolve(notifications[i]); return }
-        }
-        let timer: ReturnType<typeof setTimeout>
-        const wrappedResolve = (n: ChannelNotification) => { clearTimeout(timer); resolve(n) }
-        timer = setTimeout(() => {
-          const idx = waiters.findIndex(w => w.resolve === wrappedResolve)
-          if (idx !== -1) waiters.splice(idx, 1)
-          reject(new Error(`waitForNotification timed out after ${timeoutMs}ms`))
-        }, timeoutMs)
-        waiters.push({ pred, resolve: wrappedResolve, reject })
-      })
-    },
-  }
+  return handle
 }

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -1,33 +1,16 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { join } from 'node:path'
 import { afterAll } from 'bun:test'
 import type { ErgoContext } from './ergo.js'
-import { sleep } from './tool.js'
+import { wireMcpClient, pollUntilIrcReady, type McpHandle } from './mcp-core.js'
+
+export type { ChannelNotification, McpHandle as McpContext } from './mcp-core.js'
 
 const ROOST_ROOT = join(import.meta.dirname, '..', '..')
 
-export interface ChannelNotification {
-  content: string
-  meta: Record<string, string>
-  /** Pass as `fromCursor` on the next call to skip past this notification. */
-  cursor: number
-}
-
-export interface McpContext {
-  client: Client
-  nick: string
-  notifications: ChannelNotification[]
-  waitForNotification(
-    pred: (n: ChannelNotification) => boolean,
-    timeoutMs?: number,
-    fromCursor?: number,
-  ): Promise<ChannelNotification>
-}
-
 let instanceCounter = 0
 
-export async function startMcp(ergo: ErgoContext, nick?: string, extraEnv?: Record<string, string>): Promise<McpContext> {
+export async function startMcp(ergo: ErgoContext, nick?: string, extraEnv?: Record<string, string>): Promise<McpHandle> {
   const clientNick = nick ?? `mcp${++instanceCounter}`
 
   const transport = new StdioClientTransport({
@@ -43,68 +26,13 @@ export async function startMcp(ergo: ErgoContext, nick?: string, extraEnv?: Reco
     stderr: 'inherit',
   })
 
-  const notifications: ChannelNotification[] = []
-  const waiters: Array<{
-    pred: (n: ChannelNotification) => boolean
-    resolve: (n: ChannelNotification) => void
-    reject: (e: Error) => void
-  }> = []
-
-  const client = new Client({ name: 'roost-test', version: '0.0.1' })
-
-  client.fallbackNotificationHandler = async (notification) => {
-    if (notification.method !== 'notifications/claude/channel') return
-    const params = notification.params as { content: string; meta: Record<string, string> }
-    const n: ChannelNotification = { content: params.content, meta: params.meta, cursor: notifications.length + 1 }
-    notifications.push(n)
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].pred(n)) {
-        const w = waiters.splice(i, 1)[0]
-        w.resolve(n)
-      }
-    }
-  }
-
-  await client.connect(transport)
+  const handle = await wireMcpClient(transport, clientNick)
 
   afterAll(async () => {
     // close() sends stdin EOF then SIGTERM (2s grace each) — terminates subprocess even if IRC reconnect timers are live
-    await client.close()
+    await handle.client.close()
   })
 
-  // Poll until the IRC client has registered — tools return isError before that.
-  const deadline = Date.now() + 5000
-  while (true) {
-    const r = await client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
-    if (!r.isError) break
-    const text = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
-    if (!text.includes('not ready')) break // unexpected error — don't loop forever
-    if (Date.now() > deadline) throw new Error(`startMcp: IRC not ready within 5s (nick=${clientNick})`)
-    await sleep(50)
-  }
-
-  return {
-    client,
-    nick: clientNick,
-    notifications,
-    waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
-      return new Promise((resolve, reject) => {
-        for (let i = fromCursor; i < notifications.length; i++) {
-          if (pred(notifications[i])) { resolve(notifications[i]); return }
-        }
-
-        const timer = setTimeout(() => {
-          const idx = waiters.findIndex(w => w.resolve === resolve)
-          if (idx !== -1) waiters.splice(idx, 1)
-          reject(new Error(`waitForNotification timed out after ${timeoutMs}ms`))
-        }, timeoutMs)
-
-        waiters.push({
-          pred,
-          resolve: (n) => { clearTimeout(timer); resolve(n) },
-          reject,
-        })
-      })
-    },
-  }
+  await pollUntilIrcReady(handle)
+  return handle
 }


### PR DESCRIPTION
[reviewer-63] cleanup PR from the #63 holistic /simplify pass. Approved scope from @lead-pm.

## Summary

- `src/irc-server.ts`: drop `MAX_CHUNK_BODY` import (unused), `RecvBuf.firstSeen` (set never read), `multilineMaxBytes` (parsed/logged, never gates anything).
- `test/helpers/mcp-core.ts` (new): shared `ChannelNotification` + `wireMcpClient` + `pollUntilIrcReady`. `test/helpers/mcp.ts` and `test/helpers/mcp-inprocess.ts` now contain only transport bring-up and teardown.

163 deleted / 119 added; net −44 LOC.

## Notes for triage

- **Coverage path preserved.** `bun test --coverage` still reports `src/irc-server.ts` at 63.18% lines via the in-process path (lead-pm's stated constraint for #65 prep).
- **Considered, not done:** inlining `src/constants.ts` into `irc-lib.ts`. One constant (`MULTILINE_LINE_BYTES`) shared between irc-lib + irc-server + two test files; the indirection earns its keep at four call sites.
- **Out of scope here:** legacy ngircd chunker drop is on #59; stub-server retention is on #68.

## Test plan

- [x] `bun test` — 72 pass / 0 fail
- [x] `bun test --coverage` — global thresholds met (line 92.65%, branch >=75%); `src/irc-server.ts` still instrumented
- [x] `bunx tsc --noEmit` — clean

Closes #63 (assuming #59 and #68 are tracked separately, as approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)