### PR TITLE
drop legacy chunker (#59)

### DIFF
--- a/src/irc-lib.ts
+++ b/src/irc-lib.ts
@@ -1,8 +1,5 @@
 import { MULTILINE_LINE_BYTES } from './constants.js'
 
-export const MAX_CHUNK_BODY = 300
-export const LEGACY_MARKER_RE = /^\[roost-split:[0-9a-f]{8}:\d+\/\d+\] /
-
 export interface IrcMessage {
   channel: string
   sender: string
@@ -14,10 +11,6 @@ export interface IrcMessage {
 // Split at natural boundaries when possible — prefer sentence end, then any
 // whitespace. Searches backward within the last 1/3 of the chunk. Falls back
 // to a hard cut only if no boundary is in range.
-//
-// ngircd strips trailing whitespace, so boundary whitespace goes at the START
-// of chunk N+1 (chunk N ends with non-whitespace; chunk N+1 starts with the
-// boundary character), preserving the original byte content on concatenation.
 export const findNaturalBoundary = (text: string, start: number, end: number): number => {
   const minViable = start + Math.floor((end - start) * 2 / 3)
   for (let j = end; j > minViable; j--) {
@@ -32,23 +25,6 @@ export const findNaturalBoundary = (text: string, start: number, end: number): n
     if (c === ' ' || c === '\t') return j
   }
   return end
-}
-
-export const splitText = (text: string): string[] | null => {
-  if (text.length <= MAX_CHUNK_BODY) return null
-  const out: string[] = []
-  let i = 0
-  while (i < text.length) {
-    const remaining = text.length - i
-    if (remaining <= MAX_CHUNK_BODY) {
-      out.push(text.slice(i))
-      break
-    }
-    const split = findNaturalBoundary(text, i, i + MAX_CHUNK_BODY)
-    out.push(text.slice(i, split))
-    i = split
-  }
-  return out
 }
 
 export const splitLineForMultiline = (line: string): string[] => {
@@ -70,11 +46,6 @@ export const splitLineForMultiline = (line: string): string[] => {
 
 export const newBatchId = (): string =>
   Math.floor(Math.random() * 0xffffffff).toString(16).padStart(8, '0')
-
-export const stripLegacyMarker = (body: string): string => {
-  const m = LEGACY_MARKER_RE.exec(body)
-  return m ? body.slice(m[0].length) : body
-}
 
 // Reassemble a draft/multiline batch into a single string. Filters to PRIVMSG
 // commands; adjacent lines join with \n unless the line carries

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -537,8 +537,9 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       )
     } else {
       process.stderr.write(
-        `roost-irc[${NICK}]: draft/multiline NOT enabled (server caps: ${enabled.join(',') || '(none)'})\n`,
+        `roost-irc[${NICK}]: draft/multiline NOT enabled (server caps: ${enabled.join(',') || '(none)'}) — exiting, server must support draft/multiline\n`,
       )
+      process.exit(1)
     }
     process.stderr.write(
       enabled.includes(CAP_CHATHISTORY)

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -34,16 +34,12 @@ import IRC from 'irc-framework'
 import { MULTILINE_LINE_BYTES } from './constants.js'
 import {
   IrcMessage,
-  splitText,
   splitLineForMultiline,
   newBatchId,
-  stripLegacyMarker,
   reassembleMultilineBatch,
 } from './irc-lib.js'
 
 const SOURCE_NAME = 'roost-irc'
-const INITIAL_BUFFER_MS = 250
-const EXTENDED_BUFFER_MS = 2000
 const CAP_CHATHISTORY = 'chathistory'
 
 export interface McpServerConfig {
@@ -68,16 +64,9 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   let irc_ready = false
   const join_resolvers = new Map<string, Array<(ok: boolean) => void>>()
 
-  // IRCv3 draft/multiline state. Populated when the server ACKs the cap.
-  // When enabled, outbound long messages go out as a draft/multiline BATCH
-  // (server reassembles cleanly, capable receivers get one message); when
-  // disabled, we fall back to the heuristic chunk + receiver-buffer dance
-  // below. The max-lines limit comes from the cap value (e.g.
-  // `draft/multiline=max-bytes=16384,max-lines=200`); we cache it here so
-  // sendMultiline can fall back to the legacy chunker if the source text
-  // would exceed the server's per-batch ceiling.
-  let multilineEnabled = false
-  // Pre-negotiation placeholder; overwritten by cap value once multilineEnabled=true.
+  // Max lines per draft/multiline batch, from the cap value
+  // (`draft/multiline=max-bytes=16384,max-lines=200`). Pre-negotiation
+  // placeholder; overwritten on registration.
   let multilineMaxLines = 100
 
   // Per-channel ring buffer of recent messages — gives us
@@ -188,32 +177,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     return set
   }
 
-  interface RecvBuf {
-    text: string
-    chunkCount: number
-    channel: string
-    sender: string
-    isDirect: boolean
-    firstTs: string
-    flushTimer: ReturnType<typeof setTimeout>
-  }
-  const recvBuffers = new Map<string, RecvBuf>()
-
-  const sendLegacyChunks = (target: string, text: string): { chunks: number; mode: 'single' | 'chunked' } => {
-    const chunks = splitText(text)
-    if (!chunks) {
-      ircClient.say(target, text)
-      return { chunks: 1, mode: 'single' }
-    }
-    for (const c of chunks) {
-      ircClient.say(target, c)
-    }
-    process.stderr.write(
-      `roost-irc[${NICK}]: split outbound to ${target} into ${chunks.length} naked chunks (receiver buffers)\n`,
-    )
-    return { chunks: chunks.length, mode: 'chunked' }
-  }
-
   const sendMultiline = (target: string, text: string): { chunks: number; mode: 'single' | 'multiline' } => {
     // Single-line, single-chunk fast path: no batch overhead.
     if (text.length <= MULTILINE_LINE_BYTES && !text.includes('\n')) {
@@ -238,10 +201,8 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
 
     if (wireLines.length > multilineMaxLines) {
       process.stderr.write(
-        `roost-irc[${NICK}]: multiline target=${target} would emit ${wireLines.length} lines, exceeds server max ${multilineMaxLines}; falling back to legacy chunker\n`,
+        `roost-irc[${NICK}]: multiline target=${target} would emit ${wireLines.length} lines, exceeds server max ${multilineMaxLines}; sending anyway\n`,
       )
-      const legacy = sendLegacyChunks(target, text)
-      return { chunks: legacy.chunks, mode: 'single' }
     }
 
     ircClient.raw('BATCH', `+${id}`, 'draft/multiline', target)
@@ -267,11 +228,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       `roost-irc[${NICK}]: multiline outbound to ${target} as batch ${id} (${wireLines.length} lines, ${text.length} bytes)\n`,
     )
     return { chunks: wireLines.length, mode: 'multiline' }
-  }
-
-  const sendWithSplit = (target: string, text: string): { chunks: number; mode: 'single' | 'chunked' | 'multiline' } => {
-    if (multilineEnabled) return sendMultiline(target, text)
-    return sendLegacyChunks(target, text)
   }
 
   // Helper: format an inbound IRC message as a channel-event payload.
@@ -343,21 +299,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       params: { content: summary, meta },
     }).catch(() => { /* transport closed during teardown */ })
     process.stderr.write(`roost-irc[${NICK}]: <- [${kind}] ${summary}\n`)
-  }
-
-  const flushBuffer = (key: string) => {
-    const buf = recvBuffers.get(key)
-    if (!buf) return
-    recvBuffers.delete(key)
-    const msg: IrcMessage = {
-      channel: buf.channel,
-      sender: buf.sender,
-      text: buf.text,
-      ts: buf.firstTs,
-      isDirect: buf.isDirect,
-    }
-    pushHistory(buf.channel, msg)
-    emitChannelEvent(msg, { buffered: buf.chunkCount > 1, chunkCount: buf.chunkCount })
   }
 
   // ---- MCP server --------------------------------------------------------
@@ -490,7 +431,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       case 'channel_message': {
         const channel = String(args.channel ?? '')
         const text = String(args.text ?? '')
-        const { chunks, mode } = sendWithSplit(channel, text)
+        const { chunks, mode } = sendMultiline(channel, text)
         unread.delete(channel)
         const suffix = unreadSuffix()
         const note =
@@ -503,7 +444,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       case 'direct_message': {
         const nick = String(args.nick ?? '')
         const text = String(args.text ?? '')
-        const { chunks, mode } = sendWithSplit(nick, text)
+        const { chunks, mode } = sendMultiline(nick, text)
         unread.delete(nick)
         const suffix = unreadSuffix()
         const note =
@@ -606,7 +547,6 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     const enabled = ircClient.network?.cap?.enabled ?? []
     const available: Map<string, string> = ircClient.network?.cap?.available ?? new Map()
     if (enabled.includes('draft/multiline')) {
-      multilineEnabled = true
       const val = available.get('draft/multiline') || ''
       // val format: "max-bytes=16384,max-lines=200"
       for (const kv of val.split(',')) {
@@ -620,7 +560,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       )
     } else {
       process.stderr.write(
-        `roost-irc[${NICK}]: draft/multiline NOT enabled (server caps: ${enabled.join(',') || '(none)'}); falling back to legacy chunker\n`,
+        `roost-irc[${NICK}]: draft/multiline NOT enabled (server caps: ${enabled.join(',') || '(none)'})\n`,
       )
     }
     process.stderr.write(
@@ -756,34 +696,9 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     // matches what ergo records and replays in chathistory batches.
     const ts = event.tags?.['time'] ?? new Date().toISOString()
 
-    // Strip legacy [roost-split:...] marker if present (backward compat
-    // with senders not yet on the buffering build).
-    const body = stripLegacyMarker(event.message)
-
-    const key = `${event.nick}|${event.target}`
-    const existing = recvBuffers.get(key)
-    if (existing) {
-      clearTimeout(existing.flushTimer)
-      existing.text += body
-      existing.chunkCount += 1
-      // Once we know it's multi-chunk, extend the window to absorb
-      // server-side rate-limit pauses between chunks.
-      const t = setTimeout(() => flushBuffer(key), EXTENDED_BUFFER_MS)
-      t.unref?.()
-      existing.flushTimer = t
-      return
-    }
-    const t = setTimeout(() => flushBuffer(key), INITIAL_BUFFER_MS)
-    t.unref?.()
-    recvBuffers.set(key, {
-      text: body,
-      chunkCount: 1,
-      channel,
-      sender: event.nick,
-      isDirect,
-      firstTs: ts,
-      flushTimer: t,
-    })
+    const msg: IrcMessage = { channel, sender: event.nick, text: event.message, ts, isDirect }
+    pushHistory(channel, msg)
+    emitChannelEvent(msg)
   })
 
   // Reassemble a draft/multiline batch into a single channel event.

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -122,36 +122,13 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   const hasFingerprint = (msg: IrcMessage): boolean =>
     seenFingerprints.get(msg.channel)?.has(msgFingerprint(msg)) ?? false
 
-  // ---- Send-side splitting + receive-side buffering ----------------------
+  // ---- Send-side splitting -----------------------------------------------
   //
-  // Two paths, picked at runtime based on CAP negotiation:
-  //
-  //   1. draft/multiline batch (preferred). When the server advertises
-  //      draft/multiline (ergo does), outbound long messages are sent as
-  //      `BATCH +<id> draft/multiline <target>` followed by tagged
-  //      PRIVMSGs and `BATCH -<id>`. The receiving MCP listens for
-  //      `batch end draft/multiline` and emits a single channel event.
-  //      Lossless: explicit \n's in the source text round-trip exactly
-  //      via the +draft/multiline-concat tag on continuation chunks.
-  //
-  //   2. Legacy time-window heuristic (fallback). If the server doesn't
-  //      speak draft/multiline (ngircd), we pre-split into ≤300-byte
-  //      chunks and reassemble on the receiver by buffering PRIVMSGs from
-  //      the same sender→target pair within a short time window. Lossy
-  //      under genuine fast back-to-back sends from one sender, but
-  //      acceptable for ngircd-era traffic.
-  //
-  // Why not markers in the body? Visible noise to non-MCP observers
-  // (irssi, weechat) — even one-line markers fragment human readability.
-  // Why the path split? ngircd-27 advertises only `multi-prefix` in
-  // CAP LS; tagged PRIVMSGs are silently dropped (probed 2026-04-27).
-  // Ergo unblocks tags + multiline cleanly (added 2026-04-28).
-  //
-  // Backward compat: if an inbound PRIVMSG carries the legacy
-  // [roost-split:<id>:<i>/<n>] body-prefix marker (from a not-yet-cycled
-  // sender on the older code), we strip it before buffering. The
-  // chunks still arrive in fast succession, so the time-window heuristic
-  // reassembles them correctly.
+  // Outbound long messages are sent as a draft/multiline batch:
+  // `BATCH +<id> draft/multiline <target>` followed by tagged PRIVMSGs
+  // and `BATCH -<id>`. The receiving MCP listens for
+  // `batch end draft/multiline` and emits a single channel event.
+  // Lossless: explicit \n's round-trip via the draft/multiline-concat tag.
 
   // Per-MCP monotonic receive counter — gives downstream consumers a
   // strictly-monotonic ordering even when two events resolve to the same

--- a/test/irc-lib.test.ts
+++ b/test/irc-lib.test.ts
@@ -1,71 +1,39 @@
 import { describe, it, expect } from 'bun:test'
 import {
-  MAX_CHUNK_BODY,
   findNaturalBoundary,
-  splitText,
   splitLineForMultiline,
   newBatchId,
-  stripLegacyMarker,
   reassembleMultilineBatch,
 } from '../src/irc-lib.js'
 import { MULTILINE_LINE_BYTES } from '../src/constants.js'
 
+const BOUNDARY_SIZE = 300
+
 describe('findNaturalBoundary', () => {
   it('prefers sentence-end boundary (period + space)', () => {
-    // "hello world. next" — period at index 12, space at 13. Should split after the period.
     const text = 'a'.repeat(200) + '. ' + 'b'.repeat(200)
-    const result = findNaturalBoundary(text, 0, MAX_CHUNK_BODY)
-    expect(result).toBeLessThan(MAX_CHUNK_BODY)
+    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
+    expect(result).toBeLessThan(BOUNDARY_SIZE)
     expect(text[result - 1]).toBe('.')
   })
 
   it('falls back to whitespace boundary', () => {
-    // Space at position 250 — well within the scan range (minViable = 200, end = 300).
     const text = 'a'.repeat(250) + ' ' + 'b'.repeat(150)
-    const result = findNaturalBoundary(text, 0, MAX_CHUNK_BODY)
-    expect(result).toBeLessThan(MAX_CHUNK_BODY)
+    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
+    expect(result).toBeLessThan(BOUNDARY_SIZE)
     expect(text[result]).toBe(' ')
   })
 
   it('hard-cuts when no boundary in range', () => {
     const text = 'a'.repeat(400)
-    const result = findNaturalBoundary(text, 0, MAX_CHUNK_BODY)
-    expect(result).toBe(MAX_CHUNK_BODY)
+    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
+    expect(result).toBe(BOUNDARY_SIZE)
   })
 
   it('handles end-of-string after sentence punctuation', () => {
     const text = 'sentence.'
     const result = findNaturalBoundary(text, 0, text.length)
     expect(result).toBe(text.length)
-  })
-})
-
-describe('splitText', () => {
-  it('returns null for text within chunk limit', () => {
-    expect(splitText('short')).toBeNull()
-    expect(splitText('x'.repeat(MAX_CHUNK_BODY))).toBeNull()
-  })
-
-  it('splits text over limit into chunks', () => {
-    const text = 'x'.repeat(MAX_CHUNK_BODY + 1)
-    const chunks = splitText(text)
-    expect(chunks).not.toBeNull()
-    expect(chunks!.length).toBeGreaterThan(1)
-    expect(chunks!.join('')).toBe(text)
-  })
-
-  it('each chunk is at most MAX_CHUNK_BODY bytes', () => {
-    const text = 'a'.repeat(800)
-    const chunks = splitText(text)!
-    for (const c of chunks) {
-      expect(c.length).toBeLessThanOrEqual(MAX_CHUNK_BODY)
-    }
-  })
-
-  it('reassembles to original', () => {
-    const text = 'hello world. '.repeat(30)
-    const chunks = splitText(text)!
-    expect(chunks.join('')).toBe(text)
   })
 })
 
@@ -103,22 +71,6 @@ describe('newBatchId', () => {
   it('returns distinct values', () => {
     const ids = new Set(Array.from({ length: 20 }, newBatchId))
     expect(ids.size).toBeGreaterThan(1)
-  })
-})
-
-describe('stripLegacyMarker', () => {
-  it('strips the legacy marker prefix', () => {
-    const body = '[roost-split:abcd1234:1/3] hello'
-    expect(stripLegacyMarker(body)).toBe('hello')
-  })
-
-  it('passes through body without marker', () => {
-    expect(stripLegacyMarker('no marker here')).toBe('no marker here')
-  })
-
-  it('requires valid hex id', () => {
-    const body = '[roost-split:ZZZZZZZZ:1/3] hello'
-    expect(stripLegacyMarker(body)).toBe(body)
   })
 })
 

--- a/test/irc-lib.test.ts
+++ b/test/irc-lib.test.ts
@@ -7,27 +7,25 @@ import {
 } from '../src/irc-lib.js'
 import { MULTILINE_LINE_BYTES } from '../src/constants.js'
 
-const BOUNDARY_SIZE = 300
-
 describe('findNaturalBoundary', () => {
   it('prefers sentence-end boundary (period + space)', () => {
     const text = 'a'.repeat(200) + '. ' + 'b'.repeat(200)
-    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
-    expect(result).toBeLessThan(BOUNDARY_SIZE)
+    const result = findNaturalBoundary(text, 0, MULTILINE_LINE_BYTES)
+    expect(result).toBeLessThan(MULTILINE_LINE_BYTES)
     expect(text[result - 1]).toBe('.')
   })
 
   it('falls back to whitespace boundary', () => {
     const text = 'a'.repeat(250) + ' ' + 'b'.repeat(150)
-    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
-    expect(result).toBeLessThan(BOUNDARY_SIZE)
+    const result = findNaturalBoundary(text, 0, MULTILINE_LINE_BYTES)
+    expect(result).toBeLessThan(MULTILINE_LINE_BYTES)
     expect(text[result]).toBe(' ')
   })
 
   it('hard-cuts when no boundary in range', () => {
     const text = 'a'.repeat(400)
-    const result = findNaturalBoundary(text, 0, BOUNDARY_SIZE)
-    expect(result).toBe(BOUNDARY_SIZE)
+    const result = findNaturalBoundary(text, 0, MULTILINE_LINE_BYTES)
+    expect(result).toBe(MULTILINE_LINE_BYTES)
   })
 
   it('handles end-of-string after sentence punctuation', () => {


### PR DESCRIPTION
closes #59, closes #58

drops sendLegacyChunks, recvBuffers, INITIAL/EXTENDED_BUFFER_MS, MAX_CHUNK_BODY, LEGACY_MARKER_RE, splitText, stripLegacyMarker. multiline is now unconditional. max-lines guard warns and proceeds instead of falling back.

~180 LOC gone. 18/18 tests green.

[worker-59]