### PR TITLE
perf(tests): parallelize independent channel_join awaits

### DIFF
--- a/test/irc-server-inprocess.test.ts
+++ b/test/irc-server-inprocess.test.ts
@@ -57,8 +57,10 @@ describe.if(isErgoAvailable())('irc-server in-process (InMemoryTransport)', () =
 
   it('channel_list reflects joined channels', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-clist')
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-clist-a' } })
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-clist-b' } })
+    await Promise.all([
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-clist-a' } }),
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-clist-b' } }),
+    ])
     const result = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
     expect(toolText(result)).toContain('#ip-clist-a')
     expect(toolText(result)).toContain('#ip-clist-b')
@@ -217,8 +219,10 @@ describe.if(isErgoAvailable())('irc-server in-process (InMemoryTransport)', () =
   it('send reply includes unread nudge for other channels, omits if none', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-unread7')
     const peer = await connectPeer(ergo, 'ip-unread7-peer')
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread7-a' } })
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread7-b' } })
+    await Promise.all([
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread7-a' } }),
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread7-b' } }),
+    ])
     await peer.joinChannel('#ip-unread7-a')
     await peer.joinChannel('#ip-unread7-b')
 

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -61,8 +61,10 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
   it('channel_list returns joined channels', async () => {
     const mcp = await startMcp(ergo, 'list-chan-mcp')
 
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-a' } })
-    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-b' } })
+    await Promise.all([
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-a' } }),
+      mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#list-test-b' } }),
+    ])
 
     const result = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
     expect(result.isError).toBeFalsy()

--- a/test/multiline-edge-cases.test.ts
+++ b/test/multiline-edge-cases.test.ts
@@ -15,8 +15,10 @@ describe.if(isErgoAvailable())('multiline edge cases', () => {
   it('empty lines preserved (consecutive \\n round-trip)', async () => {
     const sender = await startMcp(ergo, 'ml-ec1-s')
     const receiver = await startMcp(ergo, 'ml-ec1-r')
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec1' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec1' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec1' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec1' } }),
+    ])
 
     const text = 'hello\n\nworld'
     await sender.client.callTool({ name: 'channel_message', arguments: { channel: '#ml-ec1', text } })
@@ -30,8 +32,10 @@ describe.if(isErgoAvailable())('multiline edge cases', () => {
   it('trailing newline preserved', async () => {
     const sender = await startMcp(ergo, 'ml-ec2-s')
     const receiver = await startMcp(ergo, 'ml-ec2-r')
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec2' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec2' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec2' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec2' } }),
+    ])
 
     const text = 'hello\nworld\n'
     await sender.client.callTool({ name: 'channel_message', arguments: { channel: '#ml-ec2', text } })
@@ -62,8 +66,10 @@ describe.if(isErgoAvailable())('multiline edge cases', () => {
   it('message one byte over boundary sends as draft/multiline batch', async () => {
     const sender = await startMcp(ergo, 'ml-ec4-s')
     const receiver = await startMcp(ergo, 'ml-ec4-r')
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec4' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec4' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec4' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec4' } }),
+    ])
 
     const text = 'x'.repeat(MULTILINE_LINE_BYTES + 1) // one byte over — must split with concat
     const result = await sender.client.callTool({
@@ -84,8 +90,10 @@ describe.if(isErgoAvailable())('multiline edge cases', () => {
     // known: legacy path drops newlines on delivery (client.say pre-splits on \n); see #58
     const sender = await startMcp(ergo, 'ml-ec5-s')
     const receiver = await startMcp(ergo, 'ml-ec5-r')
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec5' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec5' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec5' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec5' } }),
+    ])
 
     const text = Array.from({ length: 201 }, (_, i) => `line${i}`).join('\n')
     const result = await sender.client.callTool({
@@ -103,8 +111,10 @@ describe.if(isErgoAvailable())('multiline edge cases', () => {
   it('mix of long and short logical lines reassembles correctly', async () => {
     const sender = await startMcp(ergo, 'ml-ec6-s')
     const receiver = await startMcp(ergo, 'ml-ec6-r')
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec6' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec6' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec6' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ml-ec6' } }),
+    ])
 
     // Two long lines (each needs concat-split) bracketing a short line
     const longA = 'a'.repeat(MULTILINE_LINE_BYTES + 150)

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -63,8 +63,10 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     const sender = await startMcp(ergo, 'out-mcp4')
     const receiver = await startMcp(ergo, 'out-mcp5')
 
-    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } })
-    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } })
+    await Promise.all([
+      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } }),
+      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#out-ml' } }),
+    ])
 
     const longText = 'a'.repeat(150) + '\n' + 'b'.repeat(150) + '\n' + 'c'.repeat(50)
     // 352 bytes total, two embedded newlines — forces draft/multiline batch


### PR DESCRIPTION
closes #55

wraps 9 independent `channel_join` pairs in `Promise.all` across outbound, multiline-edge-cases, irc-server, and irc-server-inprocess test files. ~250ms savings per pair.

skipped: duplicate-join tests (irc-server.ts:82-83, irc-server-inprocess.ts:52-53) and all chathistory join/leave/rejoin flows — ordering is semantically required there.

[worker-55]