### PR TITLE
test(mcp-core): regression tests for waitForNotification waiter cleanup

### DIFF
--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'bun:test'
 import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcp } from './helpers/mcp.js'
+import { startMcpInProcess } from './helpers/mcp-inprocess.js'
 import { connectPeer } from './helpers/peer.js'
 
 describe.if(isErgoAvailable())('test helpers', () => {
@@ -32,5 +33,26 @@ describe.if(isErgoAvailable())('test helpers', () => {
       (n) => n.meta.channel === '#smoke-mcp' && n.content.includes('hello from peer'),
     )
     expect(n.meta.sender).toBe('smoke-peer2')
+  })
+
+  it('waitForNotification removes waiter on timeout', async () => {
+    const mcp = await startMcpInProcess(ergo, 'waiter-timeout-mcp')
+    await expect(mcp.waitForNotification(() => false, 50)).rejects.toThrow('timed out')
+    expect(mcp.waiterCount()).toBe(0)
+  })
+
+  it('waitForNotification removes waiter on success', async () => {
+    const mcp = await startMcpInProcess(ergo, 'waiter-success-mcp')
+    const peer = await connectPeer(ergo, 'waiter-success-peer')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#waiter-cleanup' } })
+    await peer.joinChannel('#waiter-cleanup')
+
+    const notifP = mcp.waitForNotification(
+      n => n.meta.channel === '#waiter-cleanup' && n.content.includes('cleanup-probe'),
+    )
+    peer.say('#waiter-cleanup', 'cleanup-probe')
+    await notifP
+    expect(mcp.waiterCount()).toBe(0)
   })
 })

--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -13,7 +13,6 @@ export interface McpHandle {
   client: Client
   nick: string
   notifications: ChannelNotification[]
-  waiterCount: () => number
   waitForNotification(
     pred: (n: ChannelNotification) => boolean,
     timeoutMs?: number,
@@ -31,7 +30,7 @@ export async function wireMcpClient(
   transport: Transport,
   nick: string,
   clientName = 'roost-test',
-): Promise<McpHandle> {
+): Promise<McpHandle & { waiterCount: () => number }> {
   const notifications: ChannelNotification[] = []
   const waiters: Array<{
     pred: (n: ChannelNotification) => boolean

--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -13,6 +13,7 @@ export interface McpHandle {
   client: Client
   nick: string
   notifications: ChannelNotification[]
+  waiterCount: () => number
   waitForNotification(
     pred: (n: ChannelNotification) => boolean,
     timeoutMs?: number,
@@ -62,6 +63,7 @@ export async function wireMcpClient(
     client,
     nick,
     notifications,
+    waiterCount: () => waiters.length,
     waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
       return new Promise((resolve, reject) => {
         for (let i = fromCursor; i < notifications.length; i++) {

--- a/test/helpers/mcp-inprocess.ts
+++ b/test/helpers/mcp-inprocess.ts
@@ -9,6 +9,7 @@ import { wireMcpClient, pollUntilIrcReady, type McpHandle, type ChannelNotificat
 export type { ChannelNotification }
 
 export interface McpInProcessContext extends McpHandle {
+  waiterCount: () => number
   emitUnreadSummary: () => void
 }
 


### PR DESCRIPTION
closes #36

the bug (raw `resolve` in findIndex vs wrapper stored in waiters) was already fixed in 517a93e when mcp-core.ts was created. this adds the regression guard that was missing.

**changes:**
- `McpHandle` gets `waiterCount: () => number` (exposes internal waiter state for testing)
- two new tests in `helpers.test.ts`: timeout path and success path both assert `waiterCount() === 0` after cleanup

[worker-36]