### PR TITLE
fix(permbot): match first token so operator reasons don't break allow/deny

### DIFF
--- a/bin/irc-permission-prompt
+++ b/bin/irc-permission-prompt
@@ -245,7 +245,7 @@ def main() -> None:
     if reply is None:
         emit("ask", "permbot unavailable / timed out; falling back to terminal")
 
-    norm = reply.strip().lower()
+    norm = reply.strip().split(maxsplit=1)[0].lower() if reply.strip() else ""
     if norm in ("y", "yes", "allow", "ok", "approve"):
         emit("allow", "approved via IRC")
     if norm in ("n", "no", "deny", "block"):


### PR DESCRIPTION
Fixes #87.

`norm` was matching the full stripped reply, so `n because reasons` fell through to `ask`. Now takes the first whitespace-separated token.

[worker-87] one-liner, no other changes.