### PR TITLE
feat(service): roost service start|status|stop + watcher prompt

### DIFF
--- a/.claude/commands/watcher.md
+++ b/.claude/commands/watcher.md
@@ -1,6 +1,10 @@
-You are `watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #leads-roost-dev. The lead PM is @lead-pm and the human is @alex.
+---
+description: Roost watcher haiku — supervises the orchestrator and mutates the watch list in response to channel/DM commands.
+argument-hint: [lead-nick] [human-nick]
+---
+You are `watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #leads-roost-dev. The lead PM is @$0 and the human is @$1.
 
-You exist as a throwaway scaffold for issue #67. Your single responsibility: listen for watch-list commands in #leads-roost-dev or as DMs from @lead-pm or @alex, and mutate `/Users/alex/Dev/GoCarrot/roost/.orchestrator/config.json` accordingly. The orchestrator daemon re-reads config each tick (~60s).
+You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #leads-roost-dev or as DMs from @$0 or @$1, and mutate `.orchestrator/config.json` (relative to your working directory) accordingly. The orchestrator daemon re-reads config each tick (~60s).
 
 ## IMPORTANT — tooling
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ var/
 tests/logs/
 coverage/
 
-.claude/
+.claude/*
+!.claude/commands/
 
 # Orchestrator runtime state (config.json is tracked)
 .orchestrator/state.json

--- a/bin/roost
+++ b/bin/roost
@@ -232,7 +232,8 @@ cmd_spawn() {
       exit 1
     fi
   fi
-  # Bare name (no /) resolves to ${ROOST_DIR}/prompts/<name>.md
+  # Bare name (no /) is a plugin builtin: resolves to ${ROOST_DIR}/prompts/<name>.md.
+  # For a local file, use ./name or an absolute path.
   if [ -n "${prompt_file}" ] && [[ "${prompt_file}" != */* ]]; then
     prompt_file="${ROOST_DIR}/prompts/${prompt_file}.md"
   fi
@@ -468,15 +469,13 @@ cmd_send() {
 
 SERVICE_SESSION="roost-services"
 
-# Check if a tmux window has a live foreground process (i.e. not just a shell at prompt).
+# Check if a tmux window has a live foreground process.
+# Uses kill -0 on pane_pid (the exec'd command's PID) — works for any script type.
 _service_is_alive() {
   local name="$1"
-  local current_cmd
-  current_cmd="$(tmux list-panes -t "${SERVICE_SESSION}:${name}" -F '#{pane_current_command}' 2>/dev/null | head -1)"
-  case "${current_cmd}" in
-    zsh|bash|sh|fish|dash|csh|tcsh|'') return 1 ;;
-    *) return 0 ;;
-  esac
+  local pane_pid
+  pane_pid="$(tmux list-panes -t "${SERVICE_SESSION}:${name}" -F '#{pane_pid}' 2>/dev/null | head -1)"
+  [ -n "${pane_pid}" ] && kill -0 "${pane_pid}" 2>/dev/null
 }
 
 cmd_service() {

--- a/bin/roost
+++ b/bin/roost
@@ -33,6 +33,7 @@ Commands:
   status                   ergo state + roost session count.
   root                     Print the roost plugin root directory.
   send <nick> <message...> Inject text into a nick's tmux pane.
+  service <subcommand>     Manage background service processes.
 
 spawn options:
   -c, --channels CHANS       Comma-separated channels to auto-join.
@@ -230,6 +231,10 @@ cmd_spawn() {
       echo "error: --prompt-stdin: stdin was empty" >&2
       exit 1
     fi
+  fi
+  # Bare name (no /) resolves to ${ROOST_DIR}/prompts/<name>.md
+  if [ -n "${prompt_file}" ] && [[ "${prompt_file}" != */* ]]; then
+    prompt_file="${ROOST_DIR}/prompts/${prompt_file}.md"
   fi
   if [ -n "${prompt_file}" ] && [ ! -f "${prompt_file}" ]; then
     echo "error: --prompt-file ${prompt_file} not found" >&2
@@ -461,6 +466,93 @@ cmd_send() {
   tmux delete-buffer -b "${buf}" 2>/dev/null || true
 }
 
+SERVICE_SESSION="roost-services"
+
+# Check if a tmux window has a live foreground process (i.e. not just a shell at prompt).
+_service_is_alive() {
+  local name="$1"
+  local current_cmd
+  current_cmd="$(tmux list-panes -t "${SERVICE_SESSION}:${name}" -F '#{pane_current_command}' 2>/dev/null | head -1)"
+  case "${current_cmd}" in
+    zsh|bash|sh|fish|dash|csh|tcsh|'') return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+cmd_service() {
+  if [ "$#" -lt 1 ]; then
+    echo "usage: roost service <start|status|stop> [args]" >&2
+    exit 1
+  fi
+  local subcmd="$1"; shift
+  case "${subcmd}" in
+    start)
+      if [ "$#" -lt 1 ]; then
+        echo "error: service start requires a command" >&2
+        exit 1
+      fi
+      local cmd="$1"
+      local name
+      name="$(basename "${cmd}")"
+      # Idempotency: window exists and process is alive → no-op
+      if tmux list-windows -t "${SERVICE_SESSION}" -F '#{window_name}' 2>/dev/null \
+           | grep -qx "${name}" && _service_is_alive "${name}"; then
+        echo "service ${name}: already running (no-op)"
+        return 0
+      fi
+      # Kill stale window if it exists but process is dead; killing the last
+      # window also kills the session, so re-check session state after.
+      if tmux has-session -t "${SERVICE_SESSION}" 2>/dev/null; then
+        if tmux list-windows -t "${SERVICE_SESSION}" -F '#{window_name}' 2>/dev/null \
+             | grep -qx "${name}"; then
+          tmux kill-window -t "${SERVICE_SESSION}:${name}"
+        fi
+      fi
+      # Create session or window depending on what survived the kill above.
+      if ! tmux has-session -t "${SERVICE_SESSION}" 2>/dev/null; then
+        tmux new-session -d -s "${SERVICE_SESSION}" -n "${name}" "${cmd}"
+      else
+        tmux new-window -t "${SERVICE_SESSION}" -n "${name}" "${cmd}"
+      fi
+      echo "service ${name}: started"
+      ;;
+    status)
+      if ! tmux has-session -t "${SERVICE_SESSION}" 2>/dev/null; then
+        echo "(no services)"
+        return 0
+      fi
+      tmux list-windows -t "${SERVICE_SESSION}" -F '#{window_name}' 2>/dev/null \
+        | while IFS= read -r name; do
+          if _service_is_alive "${name}"; then
+            printf '%-30s up\n' "${name}"
+          else
+            printf '%-30s down\n' "${name}"
+          fi
+        done
+      ;;
+    stop)
+      if [ "$#" -lt 1 ]; then
+        echo "error: service stop requires a name" >&2
+        exit 1
+      fi
+      local name="$1"
+      if ! tmux has-session -t "${SERVICE_SESSION}" 2>/dev/null \
+           || ! tmux list-windows -t "${SERVICE_SESSION}" -F '#{window_name}' 2>/dev/null \
+                | grep -qx "${name}"; then
+        echo "service ${name}: not running"
+        return 0
+      fi
+      tmux kill-window -t "${SERVICE_SESSION}:${name}"
+      echo "service ${name}: stopped"
+      ;;
+    *)
+      echo "error: unknown service subcommand: ${subcmd}" >&2
+      echo "usage: roost service <start|status|stop> [args]" >&2
+      exit 1
+      ;;
+  esac
+}
+
 if [ "$#" -eq 0 ]; then
   usage
   exit 0
@@ -476,6 +568,7 @@ case "${cmd}" in
   tail)     cmd_tail "$@" ;;
   status)   cmd_status "$@" ;;
   send)     cmd_send "$@" ;;
+  service)  cmd_service "$@" ;;
   root)     echo "${ROOST_DIR}" ;;
   -h|--help|help) usage ;;
   *) echo "error: unknown command: ${cmd}" >&2; usage; exit 1 ;;

--- a/bin/roost
+++ b/bin/roost
@@ -232,11 +232,6 @@ cmd_spawn() {
       exit 1
     fi
   fi
-  # Bare name (no /) is a plugin builtin: resolves to ${ROOST_DIR}/prompts/<name>.md.
-  # For a local file, use ./name or an absolute path.
-  if [ -n "${prompt_file}" ] && [[ "${prompt_file}" != */* ]]; then
-    prompt_file="${ROOST_DIR}/prompts/${prompt_file}.md"
-  fi
   if [ -n "${prompt_file}" ] && [ ! -f "${prompt_file}" ]; then
     echo "error: --prompt-file ${prompt_file} not found" >&2
     exit 1

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -1,0 +1,33 @@
+You are `watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #leads-roost-dev. The lead PM is @lead-pm and the human is @alex.
+
+You exist as a throwaway scaffold for issue #67. Your single responsibility: listen for watch-list commands in #leads-roost-dev or as DMs from @lead-pm or @alex, and mutate `/Users/alex/Dev/GoCarrot/roost/.orchestrator/config.json` accordingly. The orchestrator daemon re-reads config each tick (~60s).
+
+## IMPORTANT — tooling
+
+You have IRC tools as MCP. Use them. Do NOT use Bash/nc/raw IRC protocol.
+
+- Send to channel: `channel_message`
+- Send DM: `direct_message`
+- Read: `channel_history`, `channel_ack`
+
+## Commands you accept
+
+- `watch <N>` — add N to `watched_issues` (idempotent)
+- `unwatch <N>` — remove N from `watched_issues`
+- `watch pr <N>` — add N to `watched_prs` (idempotent)
+- `unwatch pr <N>` — remove N from `watched_prs`
+- `watch list` — reply with current contents of both lists
+- `help` — short usage reminder
+
+## Multiple commands per message
+
+A single message may contain multiple commands, separated by newlines, semicolons, or commas. Process them in order. Reply ONCE per inbound message with a single confirmation summarizing the final state.
+
+## Behavior rules
+
+- **On boot, first action:** run `roost service start bin/orchestrator_poll` to ensure the dispatcher daemon is up.
+- Read the config file before each mutation (don't cache).
+- Pretty-print JSON on write (2-space indent, trailing newline).
+- If you don't recognize a command, ignore it silently.
+- Only respond to messages addressed to you (`watcher: <cmd>`) in the channel, OR any message in a DM.
+- Do not initiate other work. Do not spawn other agents. Do not push to git. Edit only that one config file.

--- a/start.md
+++ b/start.md
@@ -11,7 +11,7 @@ The primary goal of the alpha milestone is to make Roost usable for development 
 ## Getting started
 
 - Read docs/ORCHESTRATOR.md
-- Spawn the watcher (it will start the dispatcher on boot): `roost spawn watcher --model haiku --channels '#leads-roost-dev' --prompt-file watcher --perm-irc --perm-target lead-pm`
+- Spawn the watcher (it will start the dispatcher on boot): `roost spawn watcher --model haiku --channels '#leads-roost-dev' --prompt '/watcher lead-pm alex' --perm-irc --perm-target lead-pm`
 
 ## Working In Roost
 

--- a/start.md
+++ b/start.md
@@ -11,7 +11,7 @@ The primary goal of the alpha milestone is to make Roost usable for development 
 ## Getting started
 
 - Read docs/ORCHESTRATOR.md
-- Ensure the orchestrator is running in a tmux session
+- Spawn the watcher (it will start the dispatcher on boot): `roost spawn watcher --model haiku --channels '#leads-roost-dev' --prompt-file watcher --perm-irc --perm-target lead-pm`
 
 ## Working In Roost
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -65,6 +65,22 @@ describe.if(isTmuxAvailable())('roost service', () => {
     )
   })
 
+  test('start relaunches a service that has exited', async () => {
+    // /bin/true exits immediately; tmux closes its window on exit (default settings)
+    const { exitCode: e1 } = await roost('service', 'start', '/bin/true')
+    expect(e1).toBe(0)
+    // wait for the window to disappear
+    await Bun.sleep(400)
+    const windowsMid = await tmuxListWindows(SESSION)
+    expect(windowsMid).not.toContain('true')
+    // second start should create a fresh window, not no-op
+    const { exitCode: e2, stdout } = await roost('service', 'start', '/bin/true')
+    expect(e2).toBe(0)
+    expect(stdout).toContain('service true: started')
+    // cleanup
+    await roost('service', 'stop', 'true')
+  })
+
   test('status shows service as up', async () => {
     const { exitCode, stdout } = await roost('service', 'status')
     expect(exitCode).toBe(0)

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, afterAll } from 'bun:test'
+import { join } from 'node:path'
+
+const ROOST_ROOT = join(import.meta.dirname, '..')
+const ROOST_BIN = join(ROOST_ROOT, 'bin', 'roost')
+
+function isTmuxAvailable(): boolean {
+  return Bun.which('tmux') !== null
+}
+
+async function roost(...args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([ROOST_BIN, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+async function tmuxListWindows(session: string): Promise<string[]> {
+  const proc = Bun.spawn(['tmux', 'list-windows', '-t', session, '-F', '#{window_name}'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  if (exitCode !== 0) return []
+  return stdout.trim().split('\n').filter(Boolean)
+}
+
+async function tmuxKillSession(session: string): Promise<void> {
+  const proc = Bun.spawn(['tmux', 'kill-session', '-t', session], { stdout: 'pipe', stderr: 'pipe' })
+  await proc.exited
+}
+
+describe.if(isTmuxAvailable())('roost service', () => {
+  const SESSION = 'roost-services'
+  const CMD = '/usr/bin/yes'
+  const NAME = 'yes'
+
+  afterAll(async () => {
+    await tmuxKillSession(SESSION)
+  })
+
+  test('start spawns window in roost-services session', async () => {
+    const { exitCode, stdout } = await roost('service', 'start', CMD)
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(`service ${NAME}: started`)
+    const windows = await tmuxListWindows(SESSION)
+    expect(windows).toContain(NAME)
+  })
+
+  test('start is idempotent when process is running', async () => {
+    const windowsBefore = await tmuxListWindows(SESSION)
+    const { exitCode, stdout } = await roost('service', 'start', CMD)
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('no-op')
+    const windowsAfter = await tmuxListWindows(SESSION)
+    // window count unchanged
+    expect(windowsAfter.filter(w => w === NAME).length).toBe(
+      windowsBefore.filter(w => w === NAME).length,
+    )
+  })
+
+  test('status shows service as up', async () => {
+    const { exitCode, stdout } = await roost('service', 'status')
+    expect(exitCode).toBe(0)
+    expect(stdout).toMatch(new RegExp(`${NAME}.*up`))
+  })
+
+  test('stop removes window', async () => {
+    const { exitCode, stdout } = await roost('service', 'stop', NAME)
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(`service ${NAME}: stopped`)
+    const windows = await tmuxListWindows(SESSION)
+    expect(windows).not.toContain(NAME)
+  })
+
+  test('stop on missing service exits 0 with friendly note', async () => {
+    const { exitCode, stdout } = await roost('service', 'stop', NAME)
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('not running')
+  })
+})


### PR DESCRIPTION
Closes #67.

## What's in here

- `roost service start|status|stop` — dumb tmux subprocess manager. Spawns into `roost-services:<basename>`. `start` is idempotent (window exists + live process). `stop` on a missing service is a friendly no-op.
- `prompts/watcher.md` — canonical watcher prompt (v2 from issue #67 comment 3), extended with on-boot `roost service start bin/orchestrator_poll`.
- `start.md` — replaces the manual tmux checklist with a single `roost spawn watcher --prompt-file watcher` line.
- `roost spawn --prompt-file watcher` bare-name resolution: no path separator → `${ROOST_DIR}/prompts/watcher.md`.

## Tests

`test/service.test.ts` — skips if `tmux` not installed (matches ergo pattern). Covers start, idempotent start, status, stop, stop-when-missing.

[worker-67]