### PR TITLE
fix(roost): fix roost list $1 unbound; add shellcheck

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -123,6 +123,8 @@ start_permbot() {
     echo "  permbot already running (pid $(cat "${PERM_PID}")) — reusing"
     return 0
   fi
+  # PERM_LOG appears in both env assignment and redirect; shellcheck thinks they're the same pipeline file, but they're not
+  # shellcheck disable=SC2094
   ROOST_PERM_NICK="permbot-${nick}" \
   ROOST_PERM_SOCK="${PERM_SOCK}" \
   ROOST_PERM_TARGET="${target}" \
@@ -160,7 +162,7 @@ stop_permbot() {
         kill -0 "${pid}" 2>/dev/null || break
         sleep 0.25
       done
-      kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null || true
+      if kill -0 "${pid}" 2>/dev/null; then kill -9 "${pid}" 2>/dev/null; fi
       echo "  killed permbot (pid ${pid})"
     fi
   fi
@@ -322,6 +324,8 @@ cmd_spawn() {
   fi
   local inner_cmd="claude --model ${model} --permission-mode ${permission_mode}${mcp_flag} --settings ${ROOST_SETTINGS} --dangerously-load-development-channels ${channel_server}${extra_str}"
   if [ -n "${prompt_file}" ]; then
+    # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
+    # shellcheck disable=SC2016
     inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"'
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")
   fi
@@ -383,7 +387,7 @@ cmd_list() {
     return 0
   fi
   echo "${sessions}" | while IFS= read -r s; do
-    local nick="${s#${SESSION_PREFIX}}"
+    local nick="${s#"${SESSION_PREFIX}"}"
     local created_unix created
     created_unix="$(tmux display -t "${s}" -p '#{session_created}' 2>/dev/null)"
     if [ -n "${created_unix}" ]; then
@@ -553,7 +557,7 @@ if [ "$#" -eq 0 ]; then
 fi
 cmd="$1"
 shift
-case "$1" in -h|--help) usage; exit 0 ;; esac
+case "${1:-}" in -h|--help) usage; exit 0 ;; esac
 case "${cmd}" in
   spawn)    cmd_spawn "$@" ;;
   shutdown) cmd_shutdown "$@" ;;

--- a/test/shellcheck.test.ts
+++ b/test/shellcheck.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test'
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+
+const BIN_DIR = join(import.meta.dir, '../bin')
+
+function isShellScript(file: string): boolean {
+  try {
+    const first = readFileSync(join(BIN_DIR, file), { encoding: 'utf8' }).split('\n')[0]
+    return /^#!\s*(\/usr\/bin\/env\s+)?(ba)?sh\b/.test(first)
+  } catch {
+    return false
+  }
+}
+
+function shellcheckAvailable(): boolean {
+  return spawnSync('shellcheck', ['--version']).status === 0
+}
+
+const shellScripts = readdirSync(BIN_DIR).filter(isShellScript)
+
+describe.if(shellcheckAvailable())('shellcheck bin/', () => {
+  for (const script of shellScripts) {
+    it(script, () => {
+      const result = spawnSync('shellcheck', [join(BIN_DIR, script)], { encoding: 'utf8' })
+      expect(result.stdout + result.stderr).toBe('')
+      expect(result.status).toBe(0)
+    })
+  }
+})

--- a/test/shellcheck.test.ts
+++ b/test/shellcheck.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'bun:test'
-import { readdirSync, readFileSync } from 'fs'
-import { join } from 'path'
-import { spawnSync } from 'child_process'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-const BIN_DIR = join(import.meta.dir, '../bin')
+const BIN_DIR = join(import.meta.dirname, '../bin')
 
 function isShellScript(file: string): boolean {
   try {
@@ -14,18 +13,19 @@ function isShellScript(file: string): boolean {
   }
 }
 
-function shellcheckAvailable(): boolean {
-  return spawnSync('shellcheck', ['--version']).status === 0
-}
-
 const shellScripts = readdirSync(BIN_DIR).filter(isShellScript)
 
-describe.if(shellcheckAvailable())('shellcheck bin/', () => {
+describe.if(Bun.which('shellcheck') !== null)('shellcheck bin/', () => {
   for (const script of shellScripts) {
-    it(script, () => {
-      const result = spawnSync('shellcheck', [join(BIN_DIR, script)], { encoding: 'utf8' })
-      expect(result.stdout + result.stderr).toBe('')
-      expect(result.status).toBe(0)
+    it(script, async () => {
+      const proc = Bun.spawn(['shellcheck', join(BIN_DIR, script)], { stdout: 'pipe', stderr: 'pipe' })
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      expect(stdout + stderr).toBe('')
+      expect(exitCode).toBe(0)
     })
   }
 })


### PR DESCRIPTION
fixes #84

## What

- `roost list` (and any no-arg subcommand) errored with `$1: unbound variable` — line 556 checks `$1` after `shift` with `set -u` active. Fix: `${1:-}`.
- Cleaned up 4 shellcheck warnings in `bin/roost` (SC2094, SC2015, SC2016, SC2295) with explanatory comments where suppressed.
- Added `test/shellcheck.test.ts` — auto-discovers bash scripts in `bin/` by shebang, runs shellcheck on each. Skips if shellcheck not installed (CI wiring tracked in #80).

## Test plan
- [ ] `bun test test/shellcheck.test.ts` — 3 pass
- [ ] `shellcheck bin/roost bin/install-ergo bin/roost-irc-server` — clean
- [ ] `bash -n bin/roost` — syntax ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)