### PR TITLE
fix(irc-server): reconnect cache invalidation, auto-rejoin, disconnect/reconnect events

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -62,6 +62,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   // ---- IRC client wiring -------------------------------------------------
 
   let irc_ready = false
+  let hasRegistered = false
   const join_resolvers = new Map<string, Array<(ok: boolean) => void>>()
 
   // Max lines per draft/multiline batch, from the cap value
@@ -278,6 +279,21 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     process.stderr.write(`roost-irc[${NICK}]: <- [${kind}] ${summary}\n`)
   }
 
+  // Emit a synthetic system event (e.g. disconnected, reconnected) as a
+  // channel notification. Not scoped to a channel — channel/sender are empty.
+  const emitSystemEvent = (event: 'disconnected' | 'reconnected', content: string) => {
+    const ts = new Date().toISOString()
+    const seq = ++receiveSeq
+    mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content,
+        meta: { source: SOURCE_NAME, event, channel: '', sender: '', isDirect: 'false', ts, seq: String(seq) },
+      },
+    }).catch(() => { /* transport closed during teardown */ })
+    process.stderr.write(`roost-irc[${NICK}]: [${event}] ${content}\n`)
+  }
+
   // ---- MCP server --------------------------------------------------------
 
   const mcp = new Server(
@@ -325,6 +341,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
           type: 'object',
           properties: {
             channel: { type: 'string', description: 'Channel name including "#".' },
+            force: { type: 'boolean', description: 'Force JOIN even if cache says already joined. Use to recover a wedged cache without restarting the MCP.' },
           },
           required: ['channel'],
         },
@@ -433,7 +450,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       }
       case 'channel_join': {
         const channel = String(args.channel ?? '').toLowerCase()
-        if (channelUsers.has(channel)) {
+        if (!args.force && channelUsers.has(channel)) {
           return { content: [{ type: 'text', text: `already in ${channel}` }] }
         }
         const ok = await new Promise<boolean>((resolve) => {
@@ -546,6 +563,25 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
         ? `roost-irc[${NICK}]: chathistory cap active — will replay up to ${JOIN_HISTORY_LINES} msgs / ${JOIN_HISTORY_MINUTES}min on join\n`
         : `roost-irc[${NICK}]: chathistory cap NOT active — no history replay on join\n`,
     )
+
+    if (hasRegistered) {
+      // Reconnect: snapshot channels we were in, clear stale cache, rejoin all.
+      // Two JOINs for the same channel (e.g. a concurrent channel_join call) are
+      // idempotent on ergo — benign if it races.
+      const snapshot = [...channelUsers.keys()].sort()
+      channelUsers.clear()
+      const content = snapshot.length > 0
+        ? `[roost] reconnected to IRC — rejoining: ${snapshot.join(', ')}`
+        : '[roost] reconnected to IRC'
+      emitSystemEvent('reconnected', content)
+      for (const ch of snapshot) {
+        ircClient.join(ch)
+        process.stderr.write(`roost-irc[${NICK}]: reconnect-rejoining ${ch}\n`)
+      }
+      return
+    }
+
+    hasRegistered = true
     for (const ch of AUTO_JOIN) {
       ircClient.join(ch)
       process.stderr.write(`roost-irc[${NICK}]: auto-joining ${ch}\n`)
@@ -757,6 +793,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   ircClient.on('socket close', () => {
     process.stderr.write(`roost-irc[${NICK}]: socket closed\n`)
     irc_ready = false
+    emitSystemEvent('disconnected', '[roost] disconnected from IRC — channel state may be stale until reconnect')
   })
 
   ircClient.on('socket error', (err: Error) => {

--- a/test/reconnect.test.ts
+++ b/test/reconnect.test.ts
@@ -61,6 +61,24 @@ describe.if(isErgoAvailable())('reconnect, ordering, and nick collision', () => 
     const r = await mcp1.client.callTool({ name: 'channel_who', arguments: { channel: '#_ready' } })
     expect(r.isError).toBeFalsy()
   }, 15_000)
+
+  it('channel_join force=true bypasses already-in cache', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-force-mcp')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-force-test' } })
+
+    // Normal re-join short-circuits with "already in" — no network call made
+    let r = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-force-test' } })
+    const cached = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
+    expect(cached).toContain('already in')
+
+    // force=true bypasses the cache and actually issues JOIN. When the server still
+    // has us (primary use case is stale cache / post-kick), ergo returns 443 and the
+    // join resolver times out — that's fine; the point is we didn't short-circuit.
+    r = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-force-test', force: true } })
+    const forced = (((r.content as unknown[])[0] ?? {}) as { text?: string }).text ?? ''
+    expect(forced).not.toContain('already in')
+  }, 10_000)
 })
 
 // Subprocess-only: tests binary reconnect behavior after ergo process death.
@@ -108,4 +126,43 @@ describe.if(isErgoAvailable())('reconnect (subprocess)', () => {
       await dedicated.cleanup()
     }
   }, 30_000)
+
+  it('kill + restart → disconnected then reconnected notification; channels auto-rejoined', async () => {
+    const dedicated = await startErgoDedicated()
+    if (!dedicated) return
+
+    try {
+      const mcp = await startMcp(dedicated, 'rc-notif-mcp')
+
+      // Join a channel before the disruption
+      await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#rc-notif-ch' } })
+
+      // Wait 6s so irc-framework will schedule auto_reconnect after the kill
+      await new Promise<void>(res => setTimeout(res, 6000))
+
+      // Kill ergo — expect a disconnected notification
+      const disconnPromise = mcp.waitForNotification(n => n.meta.event === 'disconnected', 8000)
+      await dedicated.kill()
+      const disconnNotif = await disconnPromise
+      expect(disconnNotif.content).toContain('disconnected from IRC')
+
+      // Restart ergo — expect a reconnected notification listing the channel
+      await dedicated.restart()
+      const reconnNotif = await mcp.waitForNotification(n => n.meta.event === 'reconnected', 15000)
+      expect(reconnNotif.content).toContain('reconnected to IRC')
+      expect(reconnNotif.content).toContain('#rc-notif-ch')
+
+      // Verify the channel is actually re-joined: a new peer can message it and MCP receives it
+      const peer = await connectPeer(dedicated, 'rc-notif-peer')
+      await peer.joinChannel('#rc-notif-ch')
+      peer.say('#rc-notif-ch', 'post-reconnect-hello')
+      const msgNotif = await mcp.waitForNotification(
+        n => n.meta.channel === '#rc-notif-ch' && n.content === 'post-reconnect-hello',
+        10000,
+      )
+      expect(msgNotif.content).toBe('post-reconnect-hello')
+    } finally {
+      await dedicated.cleanup()
+    }
+  }, 50_000)
 })


### PR DESCRIPTION
Fixes #92.

Three parts:
- **cache invalidation**: on reconnect (`registered` re-fires), snapshot `channelUsers`, clear it, re-join all channels from the snapshot
- **disconnect/reconnect events**: synthetic notifications on `socket close` (`event: disconnected`) and on reconnect (`event: reconnected`) so agents see the gap
- **`channel_join force=true`**: bypasses the already-in cache check for manual recovery of a wedged cache

`force=true` comment in the test documents the 443 edge case (server returns "already on channel" when genuinely still joined — the intended use is stale cache, not duplicate join).

[worker-92]