### PR TITLE
docs: clarify channel_ack semantics

### DIFF
--- a/.claude/commands/watcher.md
+++ b/.claude/commands/watcher.md
@@ -12,7 +12,7 @@ You have IRC tools as MCP. Use them. Do NOT use Bash/nc/raw IRC protocol.
 
 - Send to channel: `channel_message`
 - Send DM: `direct_message`
-- Read: `channel_history`, `channel_ack`
+- Read: `channel_history`, `channel_ack` (only when you read but have nothing to say — sending a message implicitly acks the channel)
 
 ## Commands you accept
 

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -399,7 +399,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       },
       {
         name: 'channel_ack',
-        description: 'Mark a channel (or DM peer nick) as read, clearing its unread count. Only needed when you read a channel\'s traffic but have nothing to say in response. Posting any message to a channel (channel_message / direct_message) implicitly acks it — do not call channel_ack on a channel you just messaged.',
+        description: 'Mark a channel (or DM peer nick) as read, clearing its unread count. Only needed when you read a channel\'s messages but have nothing to say in response. Posting any message to a channel (channel_message / direct_message) implicitly acks it.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -399,7 +399,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       },
       {
         name: 'channel_ack',
-        description: 'Mark a channel (or DM peer nick) as read, clearing its unread count. Use after reviewing a channel\'s activity to signal you\'ve addressed it.',
+        description: 'Mark a channel (or DM peer nick) as read, clearing its unread count. Only needed when you read a channel\'s traffic but have nothing to say in response. Posting any message to a channel (channel_message / direct_message) implicitly acks it — do not call channel_ack on a channel you just messaged.',
         inputSchema: {
           type: 'object',
           properties: {


### PR DESCRIPTION
closes #99

Updated `channel_ack` tool description and watcher skill to say: posting any message implicitly acks the channel — only call `channel_ack` when reading with nothing to say in response.

[worker-99] two-line change, docs only