### PR TITLE
fix: channel_leave waits for own PART ack

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -64,6 +64,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
   let irc_ready = false
   let hasRegistered = false
   const join_resolvers = new Map<string, Array<(ok: boolean) => void>>()
+  const part_resolvers = new Map<string, Array<(ok: boolean) => void>>()
 
   // Max lines per draft/multiline batch, from the cap value
   // (`draft/multiline=max-bytes=16384,max-lines=200`). Pre-negotiation
@@ -459,8 +460,19 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       }
       case 'channel_leave': {
         const channel = String(args.channel ?? '')
-        ircClient.part(channel)
-        return { content: [{ type: 'text', text: `parted ${channel}` }] }
+        const ok = await new Promise<boolean>((resolve) => {
+          const list = part_resolvers.get(channel) ?? []
+          list.push(resolve)
+          part_resolvers.set(channel, list)
+          ircClient.part(channel)
+          setTimeout(() => resolve(false), 5000).unref?.()
+        })
+        return {
+          content: [
+            { type: 'text', text: ok ? `parted ${channel}` : `part ${channel} timed out` },
+          ],
+          isError: !ok,
+        }
       }
       case 'channel_who': {
         const channel = String(args.channel ?? '')
@@ -614,6 +626,11 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
     'part',
     (event: { nick: string; channel: string; message?: string }) => {
       if (event.nick === NICK) {
+        const list = part_resolvers.get(event.channel)
+        if (list?.length) {
+          for (const r of list) r(true)
+          part_resolvers.delete(event.channel)
+        }
         channelUsers.delete(event.channel)
         return
       }

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -459,7 +459,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
         }
       }
       case 'channel_leave': {
-        const channel = String(args.channel ?? '')
+        const channel = String(args.channel ?? '').toLowerCase()
         const ok = await new Promise<boolean>((resolve) => {
           const list = part_resolvers.get(channel) ?? []
           list.push(resolve)


### PR DESCRIPTION
closes #100

Mirrors `channel_join`'s `join_resolvers` pattern — adds `part_resolvers`, awaits the `'part'` event for our own nick before returning (5 s timeout), resolves before `channelUsers.delete` to avoid re-join races.