### PR TITLE
feat: channel_list authoritative via WHOIS

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -379,7 +379,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
       },
       {
         name: 'channel_list',
-        description: 'List all channels currently joined by this MCP instance. Served from a local cache (no network round-trip); the cache is kept current via JOIN/PART/KICK/QUIT events.',
+        description: 'List all channels currently joined by this MCP instance. Issues a live WHOIS query to the IRC server on every call for an authoritative result.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -497,7 +497,21 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
         return { content: [{ type: 'text', text: lines.join('\n') }] }
       }
       case 'channel_list': {
-        const channels = [...channelUsers.keys()].sort()
+        const channels = await new Promise<string[] | null>((resolve) => {
+          ircClient.whois(NICK, (event: { channels?: string }) => {
+            if (!event.channels) { resolve([]); return }
+            const list = event.channels
+              .split(' ')
+              .map((ch: string) => ch.replace(/^[@+%&~]+/, ''))
+              .filter(Boolean)
+              .sort()
+            resolve(list)
+          })
+          setTimeout(() => resolve(null), 5000).unref?.()
+        })
+        if (channels === null) {
+          return { content: [{ type: 'text', text: 'whois timed out' }], isError: true }
+        }
         if (channels.length === 0) {
           return { content: [{ type: 'text', text: '(no channels joined)' }] }
         }

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -497,7 +497,7 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
         return { content: [{ type: 'text', text: lines.join('\n') }] }
       }
       case 'channel_list': {
-        const channels = await new Promise<string[] | null>((resolve) => {
+        const channels = await new Promise<string[] | false>((resolve) => {
           ircClient.whois(NICK, (event: { channels?: string }) => {
             if (!event.channels) { resolve([]); return }
             const list = event.channels
@@ -507,9 +507,9 @@ export function createMcpServer(ircClient: any, config: McpServerConfig): { serv
               .sort()
             resolve(list)
           })
-          setTimeout(() => resolve(null), 5000).unref?.()
+          setTimeout(() => resolve(false), 5000).unref?.()
         })
-        if (channels === null) {
+        if (channels === false) {
           return { content: [{ type: 'text', text: 'whois timed out' }], isError: true }
         }
         if (channels.length === 0) {


### PR DESCRIPTION
closes #98

`channel_list` now calls `ircClient.whois(NICK)` and parses the 319 RPL_WHOISCHANNELS response instead of reading the local `channelUsers` cache. 5s timeout → `isError: true`, same pattern as `channel_join`. Unread overlay unchanged.