### PR TITLE
fix: pass all args through roost service start to tmux

### DIFF
--- a/.claude/commands/watcher.md
+++ b/.claude/commands/watcher.md
@@ -29,7 +29,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `roost service start bin/orchestrator_poll` to ensure the dispatcher daemon is up.
+- **On boot, first action:** run `roost service start bin/orchestrator_poll --daemon` to ensure the dispatcher daemon is up.
 - Read the config file before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.

--- a/bin/roost
+++ b/bin/roost
@@ -489,9 +489,8 @@ cmd_service() {
         echo "error: service start requires a command" >&2
         exit 1
       fi
-      local cmd="$1"
       local name
-      name="$(basename "${cmd}")"
+      name="$(basename "$1")"
       # Idempotency: window exists and process is alive → no-op
       if tmux list-windows -t "${SERVICE_SESSION}" -F '#{window_name}' 2>/dev/null \
            | grep -qx "${name}" && _service_is_alive "${name}"; then
@@ -508,9 +507,9 @@ cmd_service() {
       fi
       # Create session or window depending on what survived the kill above.
       if ! tmux has-session -t "${SERVICE_SESSION}" 2>/dev/null; then
-        tmux new-session -d -s "${SERVICE_SESSION}" -n "${name}" "${cmd}"
+        tmux new-session -d -s "${SERVICE_SESSION}" -n "${name}" "$@"
       else
-        tmux new-window -t "${SERVICE_SESSION}" -n "${name}" "${cmd}"
+        tmux new-window -t "${SERVICE_SESSION}" -n "${name}" "$@"
       fi
       echo "service ${name}: started"
       ;;


### PR DESCRIPTION
Fixes #106.

`cmd_service start` captured only `$1` and passed a single-word string to tmux, silently dropping any trailing flags. Changed to use `$@` so `roost service start bin/orchestrator_poll --daemon` works as expected. Also updated the watcher skill's boot instruction to include `--daemon`.

Smoke-tested: `roost service start /bin/sleep 600` → `ps` confirmed `sleep 600` in the tmux pane → status showed `up` → stopped clean.