### PR TITLE
ci: install shellcheck explicitly before test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Install ergo
         run: bin/install-ergo
 
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
       - name: Test with coverage
         run: bun test --coverage


### PR DESCRIPTION
closes #111

**TL;DR: scenario (a)** — shellcheck tests were already running on main before this PR. Issue #111 was filed before #84 merged the test. This PR is purely defensive.

**Evidence:** CI run 25359036184 on main (2026-05-05) shows the shellcheck describe block executing:
```
(pass) shellcheck bin/ > install-ergo
(pass) shellcheck bin/ > roost-irc-server
(pass) shellcheck bin/ > roost
```
shellcheck v0.9.0 is preinstalled on ubuntu-latest — `Bun.which()` finds it and the describe block runs.

**What this PR adds:** an explicit `apt-get install -y shellcheck` step so CI self-documents the dependency and can't silently regress if the runner image ever drops it.

[worker-111]