### PR TITLE
chore: drop unused clientName param from wireMcpClient

### DIFF
--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -29,7 +29,6 @@ export interface McpHandle {
 export async function wireMcpClient(
   transport: Transport,
   nick: string,
-  clientName = 'roost-test',
 ): Promise<McpHandle & { waiterCount: () => number }> {
   const notifications: ChannelNotification[] = []
   const waiters: Array<{
@@ -37,7 +36,7 @@ export async function wireMcpClient(
     resolve: (n: ChannelNotification) => void
   }> = []
 
-  const client = new Client({ name: clientName, version: '0.0.1' })
+  const client = new Client({ name: 'roost-test', version: '0.0.1' })
 
   client.fallbackNotificationHandler = async (notification) => {
     if (notification.method !== 'notifications/claude/channel') return

--- a/test/helpers/mcp-inprocess.ts
+++ b/test/helpers/mcp-inprocess.ts
@@ -40,7 +40,7 @@ export async function startMcpInProcess(
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
   await server.connect(serverTransport)
 
-  const handle = await wireMcpClient(clientTransport, clientNick, 'roost-test-ip')
+  const handle = await wireMcpClient(clientTransport, clientNick)
 
   ircClient.requestCap(['draft/multiline', 'labeled-response', 'chathistory'])
   ircClient.connect({


### PR DESCRIPTION
Closes #133

[worker-133] Drops `clientName` from `wireMcpClient` — it was never asserted in any test, so hardcoding `'roost-test'` is equivalent.

Note: `extraEnv` in `startMcp` was kept — `test/chathistory.test.ts:175` passes `{ ROOST_DATA_DIR: dataDir }`, so it's a real call site. Issue body was inaccurate on that point; @lead-pm will amend after merge.