### PR TITLE
fix: DM operator on terminal fallback in irc-permission-prompt

### DIFF
--- a/bin/irc-permission-prompt
+++ b/bin/irc-permission-prompt
@@ -29,6 +29,9 @@ import time
 
 WORKER = os.environ.get("ROOST_IRC_NICK", "unknown")
 SOCK_PATH = os.environ.get("ROOST_PERM_SOCK", "")
+PERM_TARGET = os.environ.get("ROOST_PERM_TARGET", "")
+PERM_HOST = os.environ.get("ROOST_PERM_HOST", "127.0.0.1")
+PERM_PORT = int(os.environ.get("ROOST_PERM_PORT", "6667"))
 SOCKET_SAFETY_TIMEOUT = 570  # just under Claude Code's 600s hook default
 
 PASSTHROUGH_PREFIXES = ("mcp__roost-irc__", "mcp__plugin_roost_roost-irc__")
@@ -176,6 +179,54 @@ def extract_intent(transcript_path: str) -> str:
     return fallback_thinking
 
 
+def send_fallback_dm(summary: str, reason: str) -> None:
+    """DM ROOST_PERM_TARGET so the operator knows the worker is blocked on a terminal prompt."""
+    if not PERM_TARGET:
+        return
+    nick = f"pnotify-{WORKER}"
+    s = None
+    try:
+        s = socket.create_connection((PERM_HOST, PERM_PORT), timeout=10)
+        s.settimeout(10)
+        s.sendall(f"NICK {nick}\r\nUSER {nick} 0 * :perm-notify\r\n".encode())
+        buf = b""
+        deadline = time.time() + 10
+        registered = False
+        while not registered and time.time() < deadline:
+            try:
+                chunk = s.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            while b"\r\n" in buf:
+                ln, buf = buf.split(b"\r\n", 1)
+                text = ln.decode("utf-8", errors="replace")
+                if text.startswith("PING "):
+                    s.sendall(("PONG " + text[5:] + "\r\n").encode())
+                parts = text.split(" ", 3)
+                if len(parts) >= 2 and parts[1] == "001":
+                    registered = True
+        if registered:
+            def dm(msg: str) -> None:
+                s.sendall(f"PRIVMSG {PERM_TARGET} :{msg}\r\n".encode())  # type: ignore[union-attr]
+            dm(f"[{WORKER}] terminal fallback: {reason}")
+            for ln in summary.split("\n"):
+                if ln.strip():
+                    dm(f"  {ln.rstrip()}")
+            dm("(worker blocked on terminal — no one watching)")
+        s.sendall(b"QUIT :done\r\n")
+    except OSError as e:
+        sys.stderr.write(f"perm-hook: fallback DM failed: {e}\n")
+    finally:
+        if s is not None:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
 def ask_daemon(summary: str):
     """Round-trip a request through the permbot socket. Return reply str or None."""
     if not SOCK_PATH or not os.path.exists(SOCK_PATH):
@@ -246,6 +297,7 @@ def main() -> None:
     summary = "\n".join(summary_lines)
     reply = ask_daemon(summary)
     if reply is None:
+        send_fallback_dm(summary, "permbot unavailable / timed out")
         emit("ask", "permbot unavailable / timed out; falling back to terminal")
 
     parts = reply.strip().split(maxsplit=1) if reply.strip() else []
@@ -255,6 +307,7 @@ def main() -> None:
         emit("allow", msg)
     if norm in ("n", "no", "deny", "block"):
         emit("deny", msg)
+    send_fallback_dm(summary, f"unrecognized reply {reply!r}")
     emit("ask", f"unrecognized reply {reply!r}; falling back to terminal")
 
 

--- a/bin/irc-permission-prompt
+++ b/bin/irc-permission-prompt
@@ -208,6 +208,8 @@ def send_fallback_dm(summary: str, reason: str) -> None:
                 parts = text.split(" ", 3)
                 if len(parts) >= 2 and parts[1] == "001":
                     registered = True
+                elif len(parts) >= 2 and parts[1] in ("432", "433", "436"):
+                    break  # nick collision/invalid — skip DM, don't spin to deadline
         if registered:
             def dm(msg: str) -> None:
                 s.sendall(f"PRIVMSG {PERM_TARGET} :{msg}\r\n".encode())  # type: ignore[union-attr]

--- a/bin/roost
+++ b/bin/roost
@@ -305,7 +305,7 @@ cmd_spawn() {
   # RVM / nvm / shell-rc-managed toolchains. Env vars go through tmux -e so
   # the inner command stays a clean single-quoted string.
   local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}")
-  [ -n "${perm_sock}" ] && tmux_env+=(-e "ROOST_PERM_SOCK=${perm_sock}")
+  [ -n "${perm_sock}" ] && tmux_env+=(-e "ROOST_PERM_SOCK=${perm_sock}" -e "ROOST_PERM_TARGET=${perm_target}" -e "ROOST_PERM_HOST=127.0.0.1" -e "ROOST_PERM_PORT=${IRC_PORT}")
 
   # Build the inner zsh command. Bash expands its own ${vars} here, then
   # we append the prompt placeholder as a single-quoted literal so $(...)

--- a/test/irc-permission-prompt.test.ts
+++ b/test/irc-permission-prompt.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'bun:test'
+import * as net from 'node:net'
+import { join } from 'node:path'
+
+const HOOK = join(import.meta.dirname, '../bin/irc-permission-prompt')
+const PAYLOAD = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm /tmp/x', description: 'test' }, transcript_path: '' })
+
+/** Spin up a minimal IRC stub that sends 001 on NICK and collects lines until connection closes. */
+function captureIRC(): Promise<{ port: number; lines: () => Promise<string[]> }> {
+  return new Promise((resolve) => {
+    const collected: string[] = []
+    let closed: () => void
+    const done = new Promise<string[]>((res) => { closed = () => res(collected) })
+
+    const server = net.createServer((sock) => {
+      let buf = ''
+      sock.on('data', (d) => {
+        buf += d.toString()
+        for (const line of buf.split('\r\n').slice(0, -1)) {
+          if (line.startsWith('NICK ')) {
+            const nick = line.slice(5).trim()
+            sock.write(`:s 001 ${nick} :Welcome\r\n`)
+          }
+          collected.push(line)
+        }
+        buf = buf.slice(buf.lastIndexOf('\r\n') + 2)
+      })
+      sock.on('close', () => { server.close(); closed() })
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as net.AddressInfo).port
+      resolve({ port, lines: () => done })
+    })
+  })
+}
+
+async function runHook(env: Record<string, string>): Promise<void> {
+  const proc = Bun.spawn(['python3', HOOK], {
+    env: { PATH: process.env.PATH ?? '/usr/bin:/bin', ...env },
+    stdin: new TextEncoder().encode(PAYLOAD),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  await proc.exited
+}
+
+describe('irc-permission-prompt fallback DM', () => {
+  it('sends PRIVMSG to target when daemon unreachable', async () => {
+    const { port, lines } = await captureIRC()
+    await runHook({
+      ROOST_IRC_NICK: 'worker-test',
+      ROOST_PERM_TARGET: 'operator',
+      ROOST_PERM_HOST: '127.0.0.1',
+      ROOST_PERM_PORT: String(port),
+      // no ROOST_PERM_SOCK → daemon unreachable path
+    })
+    const received = await lines()
+    const privmsgs = received.filter(l => l.startsWith('PRIVMSG operator :'))
+    expect(privmsgs.length).toBeGreaterThan(0)
+    expect(privmsgs.some(m => m.includes('fallback'))).toBe(true)
+    expect(privmsgs.some(m => m.includes('Bash'))).toBe(true)
+  })
+
+  it('skips DM when ROOST_PERM_TARGET not set', async () => {
+    let connected = false
+    const server = net.createServer(() => { connected = true })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const port = (server.address() as net.AddressInfo).port
+
+    await runHook({
+      ROOST_IRC_NICK: 'worker-test',
+      ROOST_PERM_HOST: '127.0.0.1',
+      ROOST_PERM_PORT: String(port),
+      // no ROOST_PERM_TARGET
+    })
+    await Bun.sleep(100)
+    server.close()
+    expect(connected).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #132

When the permbot socket is unreachable (or returns an unrecognized reply), the hook deferred to Claude Code's terminal prompt silently — invisible to an unattended worker's operator. Now fires a DM to `ROOST_PERM_TARGET` (if set) with the tool summary and reason before deferring.

**Changes:**
- `bin/irc-permission-prompt`: `send_fallback_dm()` — opens a short-lived IRC connection, registers as `pnotify-{WORKER}`, PRIVMSGs the summary+reason to `ROOST_PERM_TARGET`, QUITs. 10s timeout. Called before both fallback `emit("ask", ...)` sites.
- `bin/roost`: passes `ROOST_PERM_TARGET`, `ROOST_PERM_HOST`, `ROOST_PERM_PORT` into the worker tmux env alongside `ROOST_PERM_SOCK`.
- `test/irc-permission-prompt.test.ts`: Bun TCP stub verifies DM fires with the right content; second test verifies no connection when `ROOST_PERM_TARGET` is unset.

[worker-132]