### PR TITLE
feat: RoostIrcClient interface (R1)

### DIFF
--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -23,14 +23,15 @@ export interface MembershipExtras {
   newNick?: string
 }
 
+// camelCase — R2 translates to irc-framework's snake_case fields internally.
 export interface ConnectOpts {
   host: string
   port: number
   nick: string
   username?: string
   gecos?: string
-  auto_reconnect?: boolean
-  auto_reconnect_max_retries?: number
+  autoReconnect?: boolean
+  autoReconnectMaxRetries?: number
 }
 
 export interface RoostIrcClient {
@@ -40,11 +41,11 @@ export interface RoostIrcClient {
   join(channel: string, force?: boolean): Promise<boolean>
   leave(channel: string): Promise<boolean>
   say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }
-  whoisChannels(nick?: string): Promise<string[] | false>
+  whoisChannels(): Promise<string[] | false>
 
   getHistory(key: string, limit?: number): IrcMessage[]
   getUsers(channel: string): string[]
-  getUnread(): Map<string, UnreadInfo>
+  getUnread(): ReadonlyMap<string, UnreadInfo>
   ackUnread(key: string): void
 
   clearDedupeCache(): void

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -23,7 +23,6 @@ export interface MembershipExtras {
   newNick?: string
 }
 
-// camelCase — R2 translates to irc-framework's snake_case fields internally.
 export interface ConnectOpts {
   host: string
   port: number

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -34,16 +34,25 @@ export interface ConnectOpts {
 }
 
 export interface RoostIrcClient {
+  // Fire-and-forget: MCP starts serving before IRC connects (returns isError until isReady()).
+  // Use isReady() + on('system') to track connection state.
   connect(opts: ConnectOpts): void
   isReady(): boolean
 
+  // force bypasses the already-joined cache; use to recover wedged state without restarting.
   join(channel: string, force?: boolean): Promise<boolean>
   leave(channel: string): Promise<boolean>
+  // Synchronous socket write — no protocol-level delivery ack for PRIVMSG.
   say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }
   whoisChannels(): Promise<string[] | false>
 
+  // Served from local cache — no network round-trip. Note: on a freshly-joined channel
+  // these lag the join ack; NAMES (getUsers) and chathistory (getHistory) arrive via
+  // events after join() resolves.
   getHistory(key: string, limit?: number): IrcMessage[]
   getUsers(channel: string): string[]
+  // R2 increments on every non-historical inbound message; MCP reads this to build
+  // the unread suffix on tool responses.
   getUnread(): ReadonlyMap<string, UnreadInfo>
   ackUnread(key: string): void
 

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -1,5 +1,4 @@
-// Types-only seam between the IRC client layer and the MCP layer (R1).
-// No runtime code — implementation lives in R2.
+// Pure types — typed seam between the IRC client layer and the MCP layer.
 
 import type { IrcMessage } from './irc-lib.js'
 export type { IrcMessage }
@@ -51,7 +50,7 @@ export interface RoostIrcClient {
   // events after join() resolves.
   getHistory(key: string, limit?: number): IrcMessage[]
   getUsers(channel: string): string[]
-  // incremented on each inbound non-historical message; reset by ackUnread.
+  // Incremented on every non-historical inbound message; tool handlers read this to build the unread suffix.
   getUnread(): ReadonlyMap<string, UnreadInfo>
   ackUnread(key: string): void
 

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -51,8 +51,7 @@ export interface RoostIrcClient {
   // events after join() resolves.
   getHistory(key: string, limit?: number): IrcMessage[]
   getUsers(channel: string): string[]
-  // R2 increments on every non-historical inbound message; MCP reads this to build
-  // the unread suffix on tool responses.
+  // incremented on each inbound non-historical message; reset by ackUnread.
   getUnread(): ReadonlyMap<string, UnreadInfo>
   ackUnread(key: string): void
 

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -1,0 +1,55 @@
+// Types-only seam between the IRC client layer and the MCP layer (R1).
+// No runtime code — implementation lives in R2.
+
+import type { IrcMessage } from './irc-lib.js'
+export type { IrcMessage }
+
+export interface UnreadInfo {
+  count: number
+  lastSender: string
+  lastPreview: string
+}
+
+// Extras attached to inbound message events (buffered = reassembled multiline batch).
+export interface MessageMeta {
+  buffered?: boolean
+  chunkCount?: number
+  historical?: boolean
+}
+
+// Extras on membership events from join/part/kick/quit/nick.
+export interface MembershipExtras {
+  reason?: string
+  newNick?: string
+}
+
+export interface ConnectOpts {
+  host: string
+  port: number
+  nick: string
+  username?: string
+  gecos?: string
+  auto_reconnect?: boolean
+  auto_reconnect_max_retries?: number
+}
+
+export interface RoostIrcClient {
+  connect(opts: ConnectOpts): void
+  isReady(): boolean
+
+  join(channel: string, force?: boolean): Promise<boolean>
+  leave(channel: string): Promise<boolean>
+  say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }
+  whoisChannels(nick?: string): Promise<string[] | false>
+
+  getHistory(key: string, limit?: number): IrcMessage[]
+  getUsers(channel: string): string[]
+  getUnread(): Map<string, UnreadInfo>
+  ackUnread(key: string): void
+
+  clearDedupeCache(): void
+
+  on(event: 'message',    handler: (msg: IrcMessage, meta: MessageMeta) => void): void
+  on(event: 'membership', handler: (kind: 'join' | 'leave' | 'nick', nick: string, channel: string, extras: MembershipExtras) => void): void
+  on(event: 'system',     handler: (kind: 'disconnected' | 'reconnected', content: string) => void): void
+}


### PR DESCRIPTION
Closes #118

Types-only seam between the IRC client layer and the MCP layer. No runtime change.

- `RoostIrcClient` interface with `connect`, `isReady`, `join`, `leave`, `say`, `whoisChannels`, `getHistory`, `getUsers`, `getUnread`, `ackUnread`, `clearDedupeCache`, and three `on()` overloads for `message` / `membership` / `system` events
- Supporting types: `UnreadInfo` (promoted from local in createMcpServer), `MessageMeta`, `MembershipExtras`, `ConnectOpts`
- `IrcMessage` re-exported from irc-lib.ts

**Deviates from spec on `whoisChannels`:** issue #118 had `whoisChannels(nick?: string)` but reviewer-142 (TeakBuilds, issue author) flagged the optional param as dead surface area — nothing ever whois's a nick other than self. Dropped to `whoisChannels(): Promise<string[] | false>` per their review feedback.

**`ConnectOpts` is camelCase** (`autoReconnect`/`autoReconnectMaxRetries`); R2 translates to irc-framework's snake_case internally.

**`getUnread()` returns `ReadonlyMap`** to prevent callers from corrupting client state.

R2/R3 will implement this interface wrapping irc-framework. R4+ consume it. R2 absorbs `unread` + `seenFingerprints` state (currently in `createMcpServer`) including the `if (!historical)` unread guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)