### PR TITLE
fix: clear channelUsers on disconnect (#151)

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -65,6 +65,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   private readonly unread = new Map<string, UnreadInfo>()
   private readonly seenFingerprints = new Map<string, Set<string>>()
   private readonly channelUsers = new Map<string, Set<string>>()
+  private pendingRejoinChannels: string[] = []
 
   private readonly messageHandlers: Array<(msg: IrcMessage, meta: MessageMeta) => void> = []
   private readonly membershipHandlers: Array<(kind: 'join' | 'leave' | 'nick', nick: string, channel: string, extras: MembershipExtras) => void> = []
@@ -331,8 +332,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   }
 
   private handleReconnect(): void {
-    const snapshot = [...this.channelUsers.keys()].sort()
-    this.channelUsers.clear()
+    const snapshot = this.pendingRejoinChannels
+    this.pendingRejoinChannels = []
     const content = snapshot.length > 0
       ? `[roost] reconnected to IRC — rejoining: ${snapshot.join(', ')}`
       : '[roost] reconnected to IRC'
@@ -490,8 +491,12 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   private handleSocketClose(): void {
     this.log('socket closed')
+    if (this.channelUsers.size > 0) {
+      this.pendingRejoinChannels = [...this.channelUsers.keys()].sort()
+      this.channelUsers.clear()
+    }
     this.ircReady = false
-    this.emitSystem('disconnected', '[roost] disconnected from IRC — channel state may be stale until reconnect')
+    this.emitSystem('disconnected', '[roost] disconnected from IRC')
   }
 
   private handleSocketError(err: Error): void {

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'bun:test'
+import { RoostIrcClientImpl } from '../src/irc-client-impl.js'
+
+const config = {
+  nick: 'test-bot',
+  autoJoin: [],
+  historySize: 50,
+  joinHistoryLines: 20,
+  joinHistoryMinutes: 5,
+}
+
+function makeClient() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new RoostIrcClientImpl(config) as any
+}
+
+describe('channelUsers cache cleared on disconnect', () => {
+  it('isJoined returns false immediately after socket close', () => {
+    const client = makeClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.channelUsers.set('#test', new Set(['test-bot', 'peer']))
+
+    expect(client.isJoined('#test')).toBe(true)
+
+    client.handleSocketClose()
+
+    expect(client.isJoined('#test')).toBe(false)
+  })
+
+  it('pendingRejoinChannels captures the channel set for rejoin', () => {
+    const client = makeClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.channelUsers.set('#alpha', new Set(['test-bot']))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.channelUsers.set('#beta', new Set(['test-bot']))
+
+    client.handleSocketClose()
+
+    expect(client.pendingRejoinChannels).toEqual(['#alpha', '#beta'])
+  })
+
+  it('second socket close (failed reconnect) does not wipe pending list', () => {
+    const client = makeClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.channelUsers.set('#keep', new Set(['test-bot']))
+
+    client.handleSocketClose()
+    expect(client.pendingRejoinChannels).toEqual(['#keep'])
+
+    // Second close — channelUsers is already empty; pending list must survive
+    client.handleSocketClose()
+    expect(client.pendingRejoinChannels).toEqual(['#keep'])
+  })
+
+  it('handleReconnect consumes pendingRejoinChannels and clears it', () => {
+    const client = makeClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.channelUsers.set('#ch', new Set(['test-bot']))
+    client.handleSocketClose()
+
+    // Simulate reconnect (normally called from handleRegistered on second connect)
+    // We need hasRegistered=true so handleRegistered routes to handleReconnect
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.hasRegistered = true
+    client.handleReconnect()
+
+    expect(client.pendingRejoinChannels).toEqual([])
+  })
+})

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -17,7 +17,6 @@ function makeClient() {
 describe('channelUsers cache cleared on disconnect', () => {
   it('isJoined returns false immediately after socket close', () => {
     const client = makeClient()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.channelUsers.set('#test', new Set(['test-bot', 'peer']))
 
     expect(client.isJoined('#test')).toBe(true)
@@ -29,9 +28,7 @@ describe('channelUsers cache cleared on disconnect', () => {
 
   it('pendingRejoinChannels captures the channel set for rejoin', () => {
     const client = makeClient()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.channelUsers.set('#alpha', new Set(['test-bot']))
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.channelUsers.set('#beta', new Set(['test-bot']))
 
     client.handleSocketClose()
@@ -41,7 +38,6 @@ describe('channelUsers cache cleared on disconnect', () => {
 
   it('second socket close (failed reconnect) does not wipe pending list', () => {
     const client = makeClient()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.channelUsers.set('#keep', new Set(['test-bot']))
 
     client.handleSocketClose()
@@ -54,13 +50,10 @@ describe('channelUsers cache cleared on disconnect', () => {
 
   it('handleReconnect consumes pendingRejoinChannels and clears it', () => {
     const client = makeClient()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.channelUsers.set('#ch', new Set(['test-bot']))
     client.handleSocketClose()
 
     // Simulate reconnect (normally called from handleRegistered on second connect)
-    // We need hasRegistered=true so handleRegistered routes to handleReconnect
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client.hasRegistered = true
     client.handleReconnect()
 


### PR DESCRIPTION
Clears `channelUsers` on socket close so `isJoined()` is honest between disconnect and reconnect. Channel list for rejoin moves to `pendingRejoinChannels`, consumed by `handleReconnect()`.

Double-disconnect safety: only overwrites `pendingRejoinChannels` when `channelUsers` is non-empty, so a failed auto_reconnect attempt doesn't wipe the list.

`history`, `unread`, `seenFingerprints` left alone — agent-facing state, not server-state. `seenFingerprints` in particular needed for chathistory dedup on rejoin.

Closes #151.

## Test plan
- [ ] `bun test` (33 pass, 0 fail)
- [ ] `test/disconnect-cache.test.ts` — 4 unit tests, no ergo needed: isJoined false after close, pending list captured, double-close safety, handleReconnect consumes list

🤖 Generated with [Claude Code](https://claude.com/claude-code)