### PR TITLE
fix: pre-empt join/part resolvers on socket close

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -495,6 +495,11 @@ export class RoostIrcClientImpl implements RoostIrcClient {
       this.pendingRejoinChannels = [...this.channelUsers.keys()].sort()
       this.channelUsers.clear()
     }
+    // Pre-empt pending resolvers; stale setTimeouts still fire but calling resolve() again is a no-op.
+    for (const list of this.joinResolvers.values()) for (const r of list) r(false)
+    this.joinResolvers.clear()
+    for (const list of this.partResolvers.values()) for (const r of list) r(false)
+    this.partResolvers.clear()
     this.ircReady = false
     this.emitSystem('disconnected', '[roost] disconnected from IRC')
   }

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -60,3 +60,32 @@ describe('channelUsers cache cleared on disconnect', () => {
     expect(client.pendingRejoinChannels).toEqual([])
   })
 })
+
+describe('socket close pre-empts pending join/part resolvers', () => {
+  it('join resolver resolves false immediately on socket close', async () => {
+    const client = makeClient()
+    const p = new Promise<boolean>(resolve => {
+      client.joinResolvers.set('#chan', [resolve])
+    })
+    client.handleSocketClose()
+    expect(await p).toBe(false)
+  })
+
+  it('part resolver resolves false immediately on socket close', async () => {
+    const client = makeClient()
+    const p = new Promise<boolean>(resolve => {
+      client.partResolvers.set('#chan', [resolve])
+    })
+    client.handleSocketClose()
+    expect(await p).toBe(false)
+  })
+
+  it('resolver maps are empty after socket close', () => {
+    const client = makeClient()
+    client.joinResolvers.set('#a', [() => {}])
+    client.partResolvers.set('#b', [() => {}])
+    client.handleSocketClose()
+    expect(client.joinResolvers.size).toBe(0)
+    expect(client.partResolvers.size).toBe(0)
+  })
+})


### PR DESCRIPTION
closes #125

in `handleSocketClose()`, walk both resolver maps, resolve each with `false`, then clear. callers already handle `false`. stale `setTimeout`s still fire but calling `resolve()` on a settled promise is a no-op per spec (noted in comment).

3 new tests in `disconnect-cache.test.ts` covering join/part resolver pre-emption and map clearing.