### PR TITLE
fix: server-time cap validated on registration (#126)

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -290,6 +290,12 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   private handleRegistered(): void {
     this.log('registered with the IRC server')
     if (!this.parseMultilineCap()) return
+    const enabled: string[] = this.irc.network?.cap?.enabled ?? []
+    if (!enabled.includes('server-time')) {
+      this.log(`server-time NOT enabled (server caps: ${enabled.join(',') || '(none)'})`)
+      this.emitSystem('cap-missing', 'server-time cap not enabled by server')
+      return
+    }
     this.ircReady = true
     this.logChathistoryCap()
     if (this.hasRegistered) {

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -61,6 +61,23 @@ describe('channelUsers cache cleared on disconnect', () => {
   })
 })
 
+describe('cap-missing system event on registration', () => {
+  it('emits cap-missing when server-time is absent', () => {
+    const client = makeClient()
+    client.irc.network = { cap: { enabled: ['draft/multiline'], available: new Map() } }
+
+    const events: Array<{ kind: string; content: unknown }> = []
+    client.on('system', (kind: string, content: unknown) => events.push({ kind, content }))
+
+    client.handleRegistered()
+
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('cap-missing')
+    expect(events[0].content).toContain('server-time')
+    expect(client.ircReady).toBe(false)
+  })
+})
+
 describe('socket close pre-empts pending join/part resolvers', () => {
   it('join resolver resolves false immediately on socket close', async () => {
     const client = makeClient()


### PR DESCRIPTION
closes #126

## what

after registration, check `enabled.includes('server-time')`. if absent, emit `system 'cap-missing'` with content `'server-time cap not enabled by server'` and bail — ircReady stays false. consumer decides what to do.

mirrors the existing draft/multiline gate exactly. no process.exit.

## test

unit test in disconnect-cache.test.ts (no ergo needed): inject caps without server-time, call handleRegistered directly, assert cap-missing fires and ircReady stays false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)