### PR TITLE
feat: tie permbot lifecycle to MCP child process (issue #148)

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -39,12 +39,12 @@ spawn options:
   -c, --channels CHANS       Comma-separated channels to auto-join.
                              Default: #roost
   -m, --model MODEL          Override --model. Default: opus.
-  --perm-irc                 Start a permbot side daemon (bin/roost-permbot)
-                             that surfaces this worker's tool-permission
-                             prompts as DMs to --perm-target. Useful for
-                             non-Opus models that can't use auto mode and
-                             would otherwise flood the terminal with
-                             prompts. Daemon is killed by 'roost shutdown'.
+  --perm-irc                 Start a permbot side daemon that surfaces this
+                             worker's tool-permission prompts as DMs to
+                             --perm-target. Useful for non-Opus models that
+                             can't use auto mode and would otherwise flood the
+                             terminal with prompts. The daemon is spawned as a
+                             child of the MCP server and dies with it.
   --perm-target NICK         Operator nick to DM for permission prompts.
                              Required when --perm-irc is set.
   --permission-mode MODE     Override --permission-mode passed to claude.
@@ -102,99 +102,12 @@ require_ircd() {
   fi
 }
 
-# Side-daemon (permbot) lifecycle. All per-session files live under a
-# mktemp-generated directory created at spawn time (ROOST_DATA_DIR).
-# The dir is stored in the tmux session env so shutdown can find it:
+# All per-session files live under a mktemp-generated directory created at
+# spawn time (ROOST_DATA_DIR). The dir is stored in the tmux session env so
+# shutdown can find it:
 #   tmux show-environment -t roost-<nick> ROOST_DATA_DIR
-# Future per-session files belong in that dir; no additional convention needed.
-perm_paths() {
-  local data_dir="$1"
-  PERM_SOCK="${data_dir}/permbot.sock"
-  PERM_PID="${data_dir}/permbot.pid"
-  PERM_LOG="${data_dir}/permbot.log"
-}
-
-start_permbot() {
-  local nick="$1"
-  local target="$2"
-  local data_dir="$3"
-  local parent_pid="${4:-}"
-  perm_paths "${data_dir}"
-
-  # Reap any stale permbot from a prior unclean exit before registering the same nick.
-  local well_known_pid="/tmp/roost-permbot-${nick}.pid"
-  if [ -f "${well_known_pid}" ]; then
-    local stale
-    stale="$(cat "${well_known_pid}" 2>/dev/null || true)"
-    if [ -n "${stale}" ] && kill -0 "${stale}" 2>/dev/null; then
-      if ps -o args= -p "${stale}" 2>/dev/null | grep -qE "(roost-permbot|src/permbot\.ts)"; then
-        kill "${stale}" 2>/dev/null || true
-        local _j
-        for _j in 1 2 3 4; do
-          kill -0 "${stale}" 2>/dev/null || break
-          sleep 0.25
-        done
-        if kill -0 "${stale}" 2>/dev/null; then kill -9 "${stale}" 2>/dev/null || true; fi
-        echo "  reaped stale permbot (pid ${stale})"
-      fi
-    fi
-    rm -f "${well_known_pid}"
-  fi
-
-  if [ -f "${PERM_PID}" ] && kill -0 "$(cat "${PERM_PID}" 2>/dev/null)" 2>/dev/null; then
-    echo "  permbot already running (pid $(cat "${PERM_PID}")) — reusing"
-    return 0
-  fi
-  # PERM_LOG appears in both env assignment and redirect; shellcheck thinks they're the same pipeline file, but they're not
-  # shellcheck disable=SC2094
-  ROOST_PERM_NICK="permbot-${nick}" \
-  ROOST_PERM_SOCK="${PERM_SOCK}" \
-  ROOST_PERM_TARGET="${target}" \
-  ROOST_PERM_WORKER="${nick}" \
-  ROOST_PERM_DEBUG_LOG="${PERM_LOG}" \
-  ROOST_PERM_PARENT_PID="${parent_pid}" \
-    nohup "${ROOST_DIR}/bin/roost-permbot" >>"${PERM_LOG}" 2>&1 </dev/null &
-  local new_pid=$!
-  echo "${new_pid}" > "${PERM_PID}"
-  echo "${new_pid}" > "${well_known_pid}"
-  disown 2>/dev/null || true
-  echo "  permbot started (nick=permbot-${nick}, target=${target}, sock=${PERM_SOCK}, pid=${new_pid})"
-  # Wait up to 5s for the socket to appear; that's our handshake.
-  local i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    [ -S "${PERM_SOCK}" ] && return 0
-    sleep 0.5
-  done
-  echo "  warning: permbot socket did not appear within 5s; check ${PERM_LOG}" >&2
-  return 1
-}
-
-stop_permbot() {
-  local data_dir="${1:-}"
-  local nick="${2:-}"
-  if [ -z "${data_dir}" ] || [ ! -d "${data_dir}" ]; then
-    return 0
-  fi
-  perm_paths "${data_dir}"
-  if [ -f "${PERM_PID}" ]; then
-    local pid
-    pid="$(cat "${PERM_PID}" 2>/dev/null || true)"
-    if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
-      kill "${pid}" 2>/dev/null || true
-      # Daemon should respond to SIGTERM and clean up the socket; give it
-      # a moment, then SIGKILL if still alive.
-      local i
-      for i in 1 2 3 4; do
-        kill -0 "${pid}" 2>/dev/null || break
-        sleep 0.25
-      done
-      if kill -0 "${pid}" 2>/dev/null; then kill -9 "${pid}" 2>/dev/null; fi
-      echo "  killed permbot (pid ${pid})"
-    fi
-  fi
-  [ -n "${nick}" ] && rm -f "/tmp/roost-permbot-${nick}.pid"
-  rm -rf "${data_dir}"
-}
+# Permbot (when --perm-irc is on) is spawned as a child of the MCP server in
+# src/irc-server.ts and dies with it — no lifecycle management here.
 
 cmd_spawn() {
   local nick=""
@@ -295,14 +208,12 @@ cmd_spawn() {
   local ROOST_DATA_DIR
   ROOST_DATA_DIR="$(mktemp -d "/tmp/roost-${nick}.XXXXXXXX")"
   chmod 700 "${ROOST_DATA_DIR}"
-  perm_paths "${ROOST_DATA_DIR}"
   if [ -n "${prompt_text}" ]; then
     prompt_file="${ROOST_DATA_DIR}/prompt.txt"
     printf '%s' "${prompt_text}" > "${prompt_file}"
   fi
-  # On any failure before the tmux session is created, clean up the data dir
-  # (and any permbot that was started) so we don't leak orphans.
-  trap 'stop_permbot "${ROOST_DATA_DIR}" "${nick}"' EXIT
+  # On any failure before the tmux session is created, clean up the data dir.
+  trap 'rm -rf "${ROOST_DATA_DIR}"' EXIT
 
   require_ircd
 
@@ -319,8 +230,7 @@ cmd_spawn() {
   local perm_sock=""
   local perm_hook_json=""
   if [ "${perm_irc}" -eq 1 ]; then
-    perm_paths "${ROOST_DATA_DIR}"
-    perm_sock="${PERM_SOCK}"
+    perm_sock="${ROOST_DATA_DIR}/permbot.sock"
     perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]"
   fi
   local ROOST_SETTINGS="${ROOST_DATA_DIR}/roost-settings.json"
@@ -362,14 +272,10 @@ cmd_spawn() {
 
   # Session created successfully; clear the failure-cleanup trap.
   # ROOST_DATA_DIR is already in the tmux session env via -e at new-session,
-  # discoverable via: tmux show-environment -t roost-<nick> ROOST_DATA_DIR
+  # discoverable via: tmux show-environment -t roost-<nick> ROOST_DATA_DIR.
+  # Permbot (when enabled) is spawned by the MCP server inside the tmux pane;
+  # we don't manage its lifecycle from here.
   trap - EXIT
-
-  if [ "${perm_irc}" -eq 1 ]; then
-    local pane_pid
-    pane_pid="$(tmux list-panes -t "${session_name}" -F '#{pane_pid}' 2>/dev/null | head -1)"
-    start_permbot "${nick}" "${perm_target}" "${ROOST_DATA_DIR}" "${pane_pid}" || true
-  fi
 
   # Dismiss the dev-channels confirmation prompt. Default is option 1
   # (accept), so a single Enter is enough.
@@ -409,7 +315,11 @@ cmd_shutdown() {
   data_dir="$(tmux show-environment -t "${session_name}" ROOST_DATA_DIR 2>/dev/null | sed 's/^ROOST_DATA_DIR=//')"
   tmux kill-session -t "${session_name}"
   echo "killed ${session_name}"
-  stop_permbot "${data_dir}" "${nick}"
+  # MCP exits with the tmux pane → permbot reparents → permbot exits via
+  # its own ppid watcher. We just clean up the per-session data dir.
+  if [ -n "${data_dir}" ] && [ -d "${data_dir}" ]; then
+    rm -rf "${data_dir}"
+  fi
 }
 
 cmd_list() {

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -350,6 +350,46 @@ if (import.meta.main) {
     }
   }
 
+  // Spawn permbot as our child when the side-daemon is requested. Permbot's
+  // lifecycle then rides this MCP's lifecycle: when claude exits, we exit
+  // (stdio EOF), permbot detects ppid change and exits. No external pidfiles,
+  // no stale-reap on next spawn.
+  const PERM_SOCK = process.env['ROOST_PERM_SOCK'] ?? ''
+  const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''
+  let permbotProc: import('bun').Subprocess | null = null
+  if (PERM_SOCK && PERM_TARGET) {
+    const permbotPath = new URL('./permbot.ts', import.meta.url).pathname
+    const permbotEnv: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ROOST_PERM_NICK: `permbot-${NICK}`,
+      ROOST_PERM_SOCK: PERM_SOCK,
+      ROOST_PERM_TARGET: PERM_TARGET,
+      ROOST_PERM_WORKER: NICK,
+    }
+    if (!permbotEnv['ROOST_PERM_DEBUG_LOG'] && DATA_DIR) {
+      permbotEnv['ROOST_PERM_DEBUG_LOG'] = `${DATA_DIR}/permbot.log`
+    }
+    // stdout=ignore: MCP owns parent stdout for JSON-RPC protocol; permbot
+    // writes there would corrupt it. stderr=inherit lets permbot logs surface
+    // alongside MCP logs in the tmux pane.
+    permbotProc = Bun.spawn([process.execPath, permbotPath], {
+      env: permbotEnv,
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'inherit',
+    })
+    process.stderr.write(`roost-irc[${NICK}]: spawned permbot child (pid ${permbotProc.pid})\n`)
+  }
+
+  const killPermbot = () => {
+    if (permbotProc && permbotProc.exitCode === null) {
+      try { permbotProc.kill('SIGTERM') } catch { /* ignore */ }
+    }
+  }
+  process.on('exit', killPermbot)
+  process.on('SIGINT', () => { killPermbot(); process.exit(130) })
+  process.on('SIGTERM', () => { killPermbot(); process.exit(143) })
+
   const clientConfig: ClientConfig = {
     nick: NICK,
     autoJoin: AUTO_JOIN,

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -359,21 +359,16 @@ if (import.meta.main) {
   let permbotProc: import('bun').Subprocess | null = null
   if (PERM_SOCK && PERM_TARGET) {
     const permbotPath = new URL('./permbot.ts', import.meta.url).pathname
-    const permbotEnv: Record<string, string> = {
-      ...(process.env as Record<string, string>),
-      ROOST_PERM_NICK: `permbot-${NICK}`,
-      ROOST_PERM_SOCK: PERM_SOCK,
-      ROOST_PERM_TARGET: PERM_TARGET,
-      ROOST_PERM_WORKER: NICK,
-    }
-    if (!permbotEnv['ROOST_PERM_DEBUG_LOG'] && DATA_DIR) {
-      permbotEnv['ROOST_PERM_DEBUG_LOG'] = `${DATA_DIR}/permbot.log`
-    }
+    // ROOST_PERM_SOCK / ROOST_PERM_TARGET are already in process.env (set by
+    // bin/roost via tmux -e). ROOST_PERM_WORKER and ROOST_PERM_DEBUG_LOG
+    // default sensibly inside permbot.ts (worker = nick minus 'permbot-',
+    // log = dirname(sock)/permbot.log). Only ROOST_PERM_NICK needs explicit
+    // setting — the prefix convention lives in one place: here.
     // stdout=ignore: MCP owns parent stdout for JSON-RPC protocol; permbot
     // writes there would corrupt it. stderr=inherit lets permbot logs surface
     // alongside MCP logs in the tmux pane.
     permbotProc = Bun.spawn([process.execPath, permbotPath], {
-      env: permbotEnv,
+      env: { ...process.env, ROOST_PERM_NICK: `permbot-${NICK}` } as Record<string, string>,
       stdin: 'ignore',
       stdout: 'ignore',
       stderr: 'inherit',

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -13,7 +13,6 @@ export interface PermbotConfig {
   target: string
   worker: string
   debugLog: string
-  parentPid: number | null
   nudgeAfterMs?: number  // default: 5 minutes; exposed for testing
 }
 
@@ -183,22 +182,19 @@ export function startPermbot(
     }
   })
 
-  // ---- Parent-PID polling --------------------------------------------------
+  // ---- Parent reparent watcher ---------------------------------------------
+  // Capture initial ppid (the spawning process — typically the MCP server).
+  // When it dies, kernel reparents us to init/launchd → ppid changes → exit.
+  // Bounds orphan window to one poll interval; no env-var config needed.
 
-  if (config.parentPid !== null) {
-    const ppid = config.parentPid
-    ppidTimer = setInterval(() => {
-      try {
-        process.kill(ppid, 0)
-      } catch (e: unknown) {
-        if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
-          log(`parent ${ppid} gone, shutting down`)
-          stop()
-        }
-      }
-    }, 1000)
-    ppidTimer.unref?.()
-  }
+  const initialPpid = process.ppid
+  ppidTimer = setInterval(() => {
+    if (process.ppid !== initialPpid) {
+      log(`parent reparented (${initialPpid} → ${process.ppid}), shutting down`)
+      stop()
+    }
+  }, 1000)
+  ppidTimer.unref?.()
 
   return { stop, ready }
 }
@@ -220,8 +216,6 @@ if (import.meta.main) {
   const PORT     = Number(env('ROOST_PERM_PORT', '6667'))
   const WORKER   = env('ROOST_PERM_WORKER') ?? NICK.replace(/^permbot-/, '')
   const LOG      = env('ROOST_PERM_DEBUG_LOG') ?? path.join(path.dirname(SOCK), 'permbot.log')
-  const _ppid    = env('ROOST_PERM_PARENT_PID', '')
-  const PPID     = _ppid && /^\d+$/.test(_ppid) ? Number(_ppid) : null
 
   const { RoostIrcClientImpl } = await import('./irc-client-impl.js')
   const client = new RoostIrcClientImpl({
@@ -234,7 +228,7 @@ if (import.meta.main) {
 
   const config: PermbotConfig = {
     nick: NICK, sockPath: SOCK, target: TARGET,
-    worker: WORKER, debugLog: LOG, parentPid: PPID,
+    worker: WORKER, debugLog: LOG,
   }
 
   const { stop } = startPermbot(config, client)

--- a/test/permbot.test.ts
+++ b/test/permbot.test.ts
@@ -103,7 +103,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client, said, replyDm } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null' },
       client,
     )
     stops.push(stop)
@@ -124,7 +124,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null' },
       client,
     )
     stops.push(stop)
@@ -138,7 +138,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client, said, replyDm } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null' },
       client,
     )
     stops.push(stop)
@@ -169,7 +169,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client, said } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null, nudgeAfterMs: 50 },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', nudgeAfterMs: 50 },
       client,
     )
     stops.push(stop)
@@ -190,7 +190,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client, said, replyDm } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null, nudgeAfterMs: 80 },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', nudgeAfterMs: 80 },
       client,
     )
     stops.push(stop)
@@ -210,7 +210,7 @@ describe('permbot queue dispatch', () => {
     const sockPath = tmpSock()
     const { client } = makeMockClient()
     const { stop, ready } = startPermbot(
-      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null', parentPid: null },
+      { nick: 'permbot-test', sockPath, target: 'operator', worker: 'test', debugLog: '/dev/null' },
       client,
     )
     stops.push(stop)


### PR DESCRIPTION
Closes #148. Supersedes #147 (perm_paths/kill-loop dedup is gone — feel free to close that as superseded once this lands).

## What changed

- `src/irc-server.ts`: when `ROOST_PERM_SOCK` + `ROOST_PERM_TARGET` are set in env, the MCP entrypoint spawns `src/permbot.ts` as a child via `Bun.spawn` (stdin=ignore, stdout=ignore — MCP owns stdout for JSON-RPC — stderr=inherit). Derives `ROOST_PERM_NICK=permbot-${NICK}`, `ROOST_PERM_WORKER=${NICK}`, `ROOST_PERM_DEBUG_LOG=${DATA_DIR}/permbot.log`. SIGTERMs the child on `process.on('exit')`, SIGINT, and SIGTERM.
- `src/permbot.ts`: drops `parentPid` config field and `ROOST_PERM_PARENT_PID` env var. Captures `process.ppid` at startup and polls for change (1s); when MCP exits → kernel reparents → ppid changes → permbot exits. Bounded orphan window of one poll interval. Standalone-launched permbots get the same lifecycle automatically.
- `bin/roost`: deletes `start_permbot`, `stop_permbot`, `perm_paths`, the `/tmp/roost-permbot-${nick}.pid` stale-reaper, and the per-session `permbot.pid` file. Keeps env passing via `tmux -e` so MCP picks up the perm vars at startup. `cmd_shutdown` just `rm -rf`s the data dir; permbot exits on its own when its parent (the MCP, riding the tmux pane) dies.
- `test/permbot.test.ts`: drops the now-vestigial `parentPid: null` from each `startPermbot` call. Existing queue/dispatch/timeout/nudge/shutdown-drain tests remain valid because the `startPermbot` interface is unchanged.

## Lifecycle

```
zsh -l (tmux pane)
  └─ claude
      └─ bun src/irc-server.ts (MCP, nick: ${WORKER})
          └─ bun src/permbot.ts (permbot-${WORKER})
```

When claude exits (cleanly or via SIGKILL), MCP gets stdio EOF and exits. Permbot reparents to launchd/init, the ppid watcher fires within ~1s, and permbot exits. No stale daemon, no nick collision on next spawn.

## Test plan

- [x] `bun test` — 116 pass / 0 fail, no regressions in queue/dispatch/timeout/nudge/shutdown.
- [ ] Manual: `roost spawn --perm-irc` end-to-end; verify permbot is a child of bun-MCP via `pstree`.
- [ ] Manual: kill the parent claude with SIGKILL; verify permbot exits within ~1s without leaving a `/tmp/roost-permbot-*.pid` file.
- [ ] Manual: re-spawn the same nick; no 433 nick-in-use.

## Notes

- Lifecycle is now an integration concern, not unit-tested. The `startPermbot` interface is stable so existing unit tests still cover the daemon logic; the MCP-spawn + ppid-reparent path is exercised by manual roost spawn/kill testing.
- `disconnected → fatal` (the transient-ergo-restart issue PR #160 flagged) is out of scope — separate concern.

[worker-148]

🤖 Generated with [Claude Code](https://claude.com/claude-code)