### PR TITLE
fix: dispatcher daemon dies on whoisChannels timeout (#166)

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -53,6 +53,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   private readonly joinHistoryLines: number
   private readonly joinHistoryMinutes: number
   private readonly autoJoin: string[]
+  private readonly whoisTimeoutMs: number
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- irc-framework ships no types; see #156
   private readonly irc: any
@@ -78,6 +79,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     this.joinHistoryLines = config.joinHistoryLines
     this.joinHistoryMinutes = config.joinHistoryMinutes
     this.autoJoin = config.autoJoin
+    this.whoisTimeoutMs = config.whoisTimeoutMs ?? 5000
     this.irc = new IRC.Client()
     this.registerHandlers()
   }
@@ -153,8 +155,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     return { chunks: wireLines.length, mode: 'multiline' }
   }
 
-  async whoisChannels(): Promise<string[] | false> {
-    return new Promise<string[] | false>((resolve) => {
+  async whoisChannels(): Promise<string[] | null> {
+    return new Promise<string[] | null>((resolve) => {
       this.irc.whois(this.nick, (event: { channels?: string }) => {
         if (!event.channels) { resolve([]); return }
         const list = event.channels
@@ -164,7 +166,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
           .sort()
         resolve(list)
       })
-      setTimeout(() => resolve(false), 5000).unref?.()
+      setTimeout(() => resolve(null), this.whoisTimeoutMs).unref?.()
     })
   }
 

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -15,6 +15,7 @@ export interface ClientConfig {
   historySize: number
   joinHistoryLines: number
   joinHistoryMinutes: number
+  whoisTimeoutMs?: number
 }
 
 // Extras attached to inbound message events (buffered = reassembled multiline batch).
@@ -55,7 +56,7 @@ export interface RoostIrcClient {
   // Synchronous socket write — no protocol-level delivery ack for PRIVMSG.
   say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }
   quit(): void
-  whoisChannels(): Promise<string[] | false>
+  whoisChannels(): Promise<string[] | null>
 
   // Served from local cache — no network round-trip. Note: on a freshly-joined channel
   // these lag the join ack; NAMES (getUsers) and chathistory (getHistory) arrive via

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -279,7 +279,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
       }
       case 'channel_list': {
         const channels = await client.whoisChannels()
-        if (channels === false) return { content: [{ type: 'text', text: 'whois timed out' }], isError: true }
+        if (channels === null) return { content: [{ type: 'text', text: 'whois timed out' }], isError: true }
         if (channels.length === 0) return { content: [{ type: 'text', text: '(no channels joined)' }] }
         const unread = client.getUnread()
         const lines = channels.map(ch => { const info = unread.get(ch); return info ? formatUnreadLine(ch, info, 80) : ch })

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -112,7 +112,7 @@ async function runDaemon(stateDir: string): Promise<void> {
     joinHistoryMinutes: 0,
   })
 
-  await connectAndWait(client, { host: server, port, nick, autoReconnect: true }, initialChannels)
+  await connectAndWait(client, { host: server, port, nick, autoReconnect: true, autoReconnectMaxRetries: 30 }, initialChannels)
   log('orchestrator[daemon]: connected\n')
 
   let stop = false
@@ -143,12 +143,16 @@ async function runDaemon(stateDir: string): Promise<void> {
     }
 
     const desired = new Set(initialIrcChannels(config, projectChannel, await loadState(stateDir)))
-    const currentlyJoined = (await client.whoisChannels()) ?? []
-    for (const ch of currentlyJoined) {
-      if (!desired.has(ch)) await client.leave(ch)
-    }
-    for (const ch of desired) {
-      if (!client.isJoined(ch)) await client.join(ch)
+    try {
+      const currentlyJoined = (await client.whoisChannels()) ?? []
+      for (const ch of currentlyJoined) {
+        if (!desired.has(ch)) await client.leave(ch)
+      }
+      for (const ch of desired) {
+        if (!client.isJoined(ch)) await client.join(ch)
+      }
+    } catch (e) {
+      log(`orchestrator[daemon]: channel sync failed: ${e}\n`)
     }
 
     let events: OrchestratorEvent[] = []

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -106,3 +106,30 @@ describe('socket close pre-empts pending join/part resolvers', () => {
     expect(client.partResolvers.size).toBe(0)
   })
 })
+
+describe('whoisChannels', () => {
+  it('returns null on timeout (whois callback never fires)', async () => {
+    const client = new RoostIrcClientImpl({ ...config, whoisTimeoutMs: 10 }) as any
+    client.irc.whois = () => {}
+    const result = await client.whoisChannels()
+    expect(result).toBeNull()
+  })
+
+  it('returns sorted channel list on success', async () => {
+    const client = new RoostIrcClientImpl(config) as any
+    client.irc.whois = (_nick: string, cb: (e: { channels?: string }) => void) => {
+      cb({ channels: '#zebra #alpha #mid' })
+    }
+    const result = await client.whoisChannels()
+    expect(result).toEqual(['#alpha', '#mid', '#zebra'])
+  })
+
+  it('returns [] when WHOIS has no channel field', async () => {
+    const client = new RoostIrcClientImpl(config) as any
+    client.irc.whois = (_nick: string, cb: (e: { channels?: string }) => void) => {
+      cb({})
+    }
+    const result = await client.whoisChannels()
+    expect(result).toEqual([])
+  })
+})

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -109,6 +109,7 @@ describe('socket close pre-empts pending join/part resolvers', () => {
 
 describe('whoisChannels', () => {
   it('returns null on timeout (whois callback never fires)', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const client = new RoostIrcClientImpl({ ...config, whoisTimeoutMs: 10 }) as any
     client.irc.whois = () => {}
     const result = await client.whoisChannels()
@@ -116,6 +117,7 @@ describe('whoisChannels', () => {
   })
 
   it('returns sorted channel list on success', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const client = new RoostIrcClientImpl(config) as any
     client.irc.whois = (_nick: string, cb: (e: { channels?: string }) => void) => {
       cb({ channels: '#zebra #alpha #mid' })
@@ -125,6 +127,7 @@ describe('whoisChannels', () => {
   })
 
   it('returns [] when WHOIS has no channel field', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const client = new RoostIrcClientImpl(config) as any
     client.irc.whois = (_nick: string, cb: (e: { channels?: string }) => void) => {
       cb({})


### PR DESCRIPTION
closes #166

## What

- `whoisChannels()` returns `string[] | null` (null = timeout) instead of `string[] | false`. `?? []` handles null correctly; it did not handle `false`.
- orchestrator whois/join block wrapped in try/catch — logs error, keeps daemon alive through transient IRC weirdness.
- `irc-server` `channel_list`: `=== null` preserves the existing "whois timed out" error surface.
- `autoReconnectMaxRetries` bumped 3 → 30 so localhost reconnects don't eat the budget.
- `whoisTimeoutMs` config field (default 5000) added to make the timeout path unit-testable.
- 3 new unit tests: timeout→null, success→sorted list, no-channels-in-whois→[].

🤖 Generated with [Claude Code](https://claude.com/claude-code)