### PR TITLE
fix: prevent bun runner hang from abandoned helper rejections (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Requires ergo (IRCv3 server). Install with `bin/install-ergo` or set `ERGO_BIN` 
 
 **Never pipe `bun test` through `tail`, `head`, or `grep`.** The shell returns the *last* command's exit code, which is always 0 for those filters — so `bun test ... | tail -N` reports success even when bun failed. The pipe also buffers the entire run until exit, masking hangs. If you need to trim noisy output, write the full result to a file and read it: `bun test ... > /tmp/out 2>&1; echo "exit=$?"; tail -N /tmp/out`. The exit code is the only honest signal.
 
+**Bun-specific footgun (issue #170, upstream report TBD):** when an unhandled promise rejection arrives from a test the runner has already abandoned, bun 1.2.20 deadlocks the runner (no subsequent test runs, process never exits). Any test helper that resolves/rejects via a `setTimeout(reject, ...)` race against the user's `await` will hit this if the user's await is ever aborted (test timeout, prior failure, etc.). Wrap such promises with `suppressLateRejection` from `test/helpers/tool.ts`: it pre-attaches a no-op `.catch()` so an abandoned rejection is silently absorbed, while a still-active `await` still throws normally. The existing wait-style helpers in `test/helpers/mcp-core.ts` and `test/helpers/peer.ts` already use it.
+
 ## Worktrees
 
 Use `script/worktree <branch> [--from <base>] [path]` to bootstrap a new worktree — it creates the sibling worktree, runs `bun install`, and copies `.claude/settings.local.json` from the main worktree so spawned workers don't hit a permission-prompt flood.

--- a/test/abandoned-rejection.test.ts
+++ b/test/abandoned-rejection.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'bun:test'
+import { suppressLateRejection } from './helpers/tool.js'
+
+// Regression for issue #170. Bun 1.2.20 hangs the test runner indefinitely
+// when an unhandled promise rejection arrives from a test the runner has
+// already abandoned (e.g. after a test timeout). Our timeout-based test
+// helpers (waitForNotification, waitForMessage, waitForPart, joinChannel,
+// changeNick) wrap their internal Promise in `suppressLateRejection` so the
+// stale reject() never becomes unhandled. These tests pin that contract.
+//
+// If you remove the .catch() inside `suppressLateRejection`, the second test
+// here will not fail-and-hang; it will fail-and-hang the entire bun process.
+describe('suppressLateRejection — issue #170 regression', () => {
+  it('a still-pending await receives the rejection normally', async () => {
+    const p = suppressLateRejection(
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('expected reject')), 50)
+      }),
+    )
+
+    let caught: Error | null = null
+    try { await p } catch (e) { caught = e as Error }
+    expect(caught?.message).toBe('expected reject')
+  })
+
+  it('an abandoned helper rejection does not hang the runner', async () => {
+    // Simulate the scenario from #170: caller creates a helper-style promise
+    // with a 50ms reject timer, never awaits it, and the test continues.
+    // Without suppressLateRejection, this rejection becomes unhandled at 50ms
+    // and (combined with any further work) wedges the bun runner.
+    suppressLateRejection(
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('abandoned reject')), 50)
+      }),
+    )
+
+    // Yield long enough for the rejection timer to fire.
+    await new Promise(r => setTimeout(r, 100))
+
+    // If we reach this assertion, the runner did not hang.
+    expect(true).toBe(true)
+  })
+})

--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { sleep } from './tool.js'
+import { sleep, suppressLateRejection } from './tool.js'
 
 export interface ChannelNotification {
   content: string
@@ -63,7 +63,7 @@ export async function wireMcpClient(
     notifications,
     waiterCount: () => waiters.length,
     waitForNotification(pred, timeoutMs = 5000, fromCursor = 0) {
-      return new Promise((resolve, reject) => {
+      return suppressLateRejection(new Promise((resolve, reject) => {
         for (let i = fromCursor; i < notifications.length; i++) {
           if (pred(notifications[i])) { resolve(notifications[i]); return }
         }
@@ -74,7 +74,7 @@ export async function wireMcpClient(
           reject(new Error(`waitForNotification timed out after ${timeoutMs}ms`))
         }, timeoutMs)
         waiters.push({ pred, resolve: wrappedResolve })
-      })
+      }))
     },
   }
 }

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -43,7 +43,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
   const client = new IRC.Client()
 
-  await new Promise<void>((resolve, reject) => {
+  await suppressLateRejection(new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error(`peer ${peerNick} connect timed out`)), 5000)
     client.on('registered', () => { clearTimeout(timeout); resolve() })
     client.on('close', () => reject(new Error('peer connection closed during connect')))
@@ -54,7 +54,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
       auto_reconnect: false,
       enable_echomessage: true,
     })
-  })
+  }))
 
   const messageWaiters: Array<{
     channel: string

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -2,6 +2,7 @@
 import IRC from 'irc-framework'
 import { afterAll } from 'bun:test'
 import type { ErgoContext } from './ergo.js'
+import { suppressLateRejection } from './tool.js'
 
 let peerCounter = 0
 
@@ -78,7 +79,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
   })
 
   const waitForPart = (channel: string, nick: string, timeoutMs = 5000): Promise<void> =>
-    new Promise((resolve, reject) => {
+    suppressLateRejection(new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         client.removeListener('part', onPart)
         reject(new Error(`waitForPart ${nick} in ${channel} timed out after ${timeoutMs}ms`))
@@ -91,13 +92,13 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
         }
       }
       client.on('part', onPart)
-    })
+    }))
 
   return {
     nick: peerNick,
 
     joinChannel(channel) {
-      return new Promise((resolve, reject) => {
+      return suppressLateRejection(new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(
           () => reject(new Error(`joinChannel ${channel} timed out`)),
           5000,
@@ -111,7 +112,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
         }
         client.on('join', onJoin)
         client.join(channel)
-      })
+      }))
     },
 
     leaveChannel(channel) {
@@ -128,7 +129,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
     },
 
     changeNick(newNick, timeoutMs = 5000) {
-      return new Promise((resolve, reject) => {
+      return suppressLateRejection(new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
           client.removeListener('nick', onNick)
           reject(new Error(`changeNick to ${newNick} timed out`))
@@ -142,13 +143,13 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
         }
         client.on('nick', onNick)
         client.changeNick(newNick)
-      })
+      }))
     },
 
     waitForPart,
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
-      return new Promise((resolve, reject) => {
+      return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {
         const timer = setTimeout(() => {
           const idx = messageWaiters.findIndex(w => w.resolve === resolve)
           if (idx !== -1) messageWaiters.splice(idx, 1)
@@ -161,7 +162,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
           resolve: (msg) => { clearTimeout(timer); resolve(msg) },
           reject,
         })
-      })
+      }))
     },
   }
 }

--- a/test/helpers/tool.ts
+++ b/test/helpers/tool.ts
@@ -4,3 +4,15 @@ export function toolText(result: unknown): string {
 }
 
 export const sleep = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
+
+// Bun 1.2.20 deadlocks the runner when an unhandled promise rejection arrives
+// from a test the runner has already abandoned (see issue #170 / upstream
+// report TBD). Our timeout-based test helpers race the user's `await` against
+// bun's test timeout; if bun aborts first, the helper's setTimeout still fires
+// and the reject() becomes unhandled. Pre-attaching a no-op .catch keeps the
+// rejection "handled" without affecting an active `await` — that consumer
+// still receives the error.
+export function suppressLateRejection<T>(p: Promise<T>): Promise<T> {
+  p.catch(() => { /* swallow only if no awaiter is left */ })
+  return p
+}

--- a/test/helpers/tool.ts
+++ b/test/helpers/tool.ts
@@ -13,6 +13,9 @@ export const sleep = (ms: number): Promise<void> => new Promise(res => setTimeou
 // rejection "handled" without affecting an active `await` — that consumer
 // still receives the error.
 export function suppressLateRejection<T>(p: Promise<T>): Promise<T> {
-  p.catch(() => { /* swallow only if no awaiter is left */ })
+  // Attach a no-op handler so the rejection is never reported as unhandled.
+  // This handler always fires on rejection — it's a no-op when an awaiter
+  // already propagated the error, and the safety net when none exists.
+  p.catch(() => {})
   return p
 }


### PR DESCRIPTION
## Summary
- Bun 1.2.20 deadlocks the test runner when an unhandled promise rejection arrives from a test the runner has already abandoned (timeout, prior failure).
- Our wait-style helpers (`waitForNotification`, `waitForMessage`, `waitForPart`, `joinChannel`, `changeNick`) race the user's `await` against bun's test timeout via `setTimeout(reject, ...)` — when bun aborts first, the helper's `reject()` fires later on a Promise nobody is awaiting, becomes unhandled, and wedges the runner. That's the 58-minute CI burn from PR #169.
- Fix: pre-attach a no-op `.catch()` (`suppressLateRejection`) to each helper's inner Promise. A still-active `await` keeps throwing normally; an abandoned rejection is silently absorbed.
- Adds a regression test that exercises the abandoned-rejection path and a CLAUDE.md note documenting the footgun.

Closes #170.

## Followups (lead-pm to triage)
- File upstream bun bug. Minimal repro from the diagnosis (no roost code at all):
  ```ts
  import { describe, it } from 'bun:test'
  describe('repro', () => {
    it('test 1', async () => {
      new Promise((_, reject) => { setTimeout(() => reject(new Error('boom')), 200) })
      await new Promise(() => {})
    })
    it('test 2', async () => { await new Promise(r => setTimeout(r, 100)) })
  })
  ```
  Bun 1.2.20 hangs indefinitely on this — test 1 fails at 200ms via the unhandled rejection, then bun never proceeds to test 2 and never exits.

## Test plan
- [x] `bun test test/abandoned-rejection.test.ts` — passes (regression test)
- [x] `bun test` full suite — 184 pass, 0 fail, ~65s
- [x] Hang verification: induced a deliberate `waitForNotification` predicate-never-matches failure in `chathistory.test.ts` subprocess test; without the fix it hangs indefinitely, with the fix it exits cleanly in ~8s with exit code 1.
- [ ] CI runs full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)