### PR TITLE
fix: warn on malformed draft/multiline cap values (#127)

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -318,9 +318,13 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     if (enabled.includes('draft/multiline')) {
       const val = available.get('draft/multiline') || ''
       for (const kv of val.split(',')) {
+        if (!kv) continue
         const [k, v] = kv.split('=')
         const n = Number(v)
-        if (!Number.isFinite(n) || n <= 0) continue
+        if (!Number.isFinite(n) || n <= 0) {
+          process.stderr.write(`[roost] draft/multiline cap: ignoring malformed value ${k}=${v}\n`)
+          continue
+        }
         if (k === 'max-lines') this.multilineMaxLines = n
       }
       this.log(`draft/multiline enabled (max-lines=${this.multilineMaxLines})`)

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -78,6 +78,74 @@ describe('cap-missing system event on registration', () => {
   })
 })
 
+describe('draft/multiline cap malformed value warning', () => {
+  it('writes a stderr warning for non-numeric max-lines', () => {
+    const client = makeClient()
+    client.irc.network = {
+      cap: {
+        enabled: ['draft/multiline', 'server-time'],
+        available: new Map([['draft/multiline', 'max-lines=abc']]),
+      },
+    }
+
+    const stderrLines: string[] = []
+    const orig = process.stderr.write.bind(process.stderr)
+    process.stderr.write = (s: string) => { stderrLines.push(s); return true }
+    try {
+      client.handleRegistered()
+    } finally {
+      process.stderr.write = orig
+    }
+
+    expect(stderrLines.some(l => l.includes('max-lines') && l.includes('abc'))).toBe(true)
+    expect(client.multilineMaxLines).toBe(100) // placeholder unchanged
+  })
+
+  it('writes a stderr warning for non-positive max-lines', () => {
+    const client = makeClient()
+    client.irc.network = {
+      cap: {
+        enabled: ['draft/multiline', 'server-time'],
+        available: new Map([['draft/multiline', 'max-lines=-5']]),
+      },
+    }
+
+    const stderrLines: string[] = []
+    const orig = process.stderr.write.bind(process.stderr)
+    process.stderr.write = (s: string) => { stderrLines.push(s); return true }
+    try {
+      client.handleRegistered()
+    } finally {
+      process.stderr.write = orig
+    }
+
+    expect(stderrLines.some(l => l.includes('max-lines') && l.includes('-5'))).toBe(true)
+    expect(client.multilineMaxLines).toBe(100)
+  })
+
+  it('does not warn for a well-formed max-lines value', () => {
+    const client = makeClient()
+    client.irc.network = {
+      cap: {
+        enabled: ['draft/multiline', 'server-time'],
+        available: new Map([['draft/multiline', 'max-lines=200']]),
+      },
+    }
+
+    const stderrLines: string[] = []
+    const orig = process.stderr.write.bind(process.stderr)
+    process.stderr.write = (s: string) => { stderrLines.push(s); return true }
+    try {
+      client.handleRegistered()
+    } finally {
+      process.stderr.write = orig
+    }
+
+    expect(stderrLines.some(l => l.includes('malformed'))).toBe(false)
+    expect(client.multilineMaxLines).toBe(200)
+  })
+})
+
 describe('socket close pre-empts pending join/part resolvers', () => {
   it('join resolver resolves false immediately on socket close', async () => {
     const client = makeClient()


### PR DESCRIPTION
## Summary

- `parseMultilineCap` silently `continue`d on non-finite/non-positive cap values, leaving `multilineMaxLines` at the 100-line placeholder with no operator-visible signal
- Now emits a `process.stderr.write` warning naming the bad key/value
- Also skips empty `kv` tokens (split artifact when cap has no params) to prevent a spurious `=undefined` warning

## Test plan

- [ ] `bun test test/disconnect-cache.test.ts` — 3 new unit tests: non-numeric, non-positive, well-formed (no false alarm)
- [ ] `bun test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)