### PR TITLE
fix: narrow pushNotification catch — only suppress transport-closed errors

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -163,7 +163,11 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
     mcp.notification({
       method: 'notifications/claude/channel',
       params: { content, meta: { ...meta, source: SOURCE_NAME, seq: String(seq) } },
-    }).catch(() => { /* transport closed during teardown */ })
+    }).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (/not connected/i.test(msg)) return
+      process.stderr.write(`roost-irc[${NICK}]: pushNotification error: ${msg}\n`)
+    })
   }
 
   const formatUnreadLine = (ch: string, info: UnreadInfo, previewLength = 40): string => {

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -133,7 +133,7 @@ const TOOL_SCHEMAS = [
 // any transport or start the IRC connection — the caller does both after
 // createMcpServer returns. Call order: createMcpServer → server.connect(transport)
 // → ircClient.connect.
-export function createMcpServer(client: RoostIrcClient, config: ClientConfig): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => void } {
+export function createMcpServer(client: RoostIrcClient, config: ClientConfig): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
   const { nick: NICK, autoJoin: AUTO_JOIN } = config
 
   // Per-MCP monotonic receive counter — gives downstream consumers a
@@ -158,9 +158,9 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
     },
   )
 
-  const pushNotification = (content: string, meta: Record<string, string>) => {
+  const pushNotification = (content: string, meta: Record<string, string>): Promise<void> => {
     const seq = ++receiveSeq
-    mcp.notification({
+    return mcp.notification({
       method: 'notifications/claude/channel',
       params: { content, meta: { ...meta, source: SOURCE_NAME, seq: String(seq) } },
     }).catch((err: unknown) => {
@@ -325,7 +325,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
     }
   })
 
-  const emitUnreadSummary = () => {
+  const emitUnreadSummary = (): Promise<void> => {
     const entries = [...client.getUnread().entries()]
     let text: string
     if (entries.length === 0) {
@@ -334,8 +334,8 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
       const lines = entries.map(([ch, info]) => `  ${formatUnreadLine(ch, info)}`)
       text = `[roost] unread activity:\n${lines.join('\n')}`
     }
-    pushNotification(text, { event: 'unread-summary', channel: '', sender: '', isDirect: 'false', ts: new Date().toISOString() })
     process.stderr.write(`roost-irc[${NICK}]: unread summary emitted (${entries.length} channels with unread)\n`)
+    return pushNotification(text, { event: 'unread-summary', channel: '', sender: '', isDirect: 'false', ts: new Date().toISOString() })
   }
 
   return { server: mcp, clearDedupeCache: () => client.clearDedupeCache(), emitUnreadSummary }

--- a/test/helpers/mcp-inprocess.ts
+++ b/test/helpers/mcp-inprocess.ts
@@ -9,7 +9,7 @@ export type { ChannelNotification }
 
 export interface McpInProcessContext extends McpHandle {
   waiterCount: () => number
-  emitUnreadSummary: () => void
+  emitUnreadSummary: () => Promise<void>
 }
 
 export interface StartMcpInProcessOptions {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -8,7 +8,7 @@ import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcpInProcess } from './helpers/mcp-inprocess.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
-import { toolText, sleep } from './helpers/tool.js'
+import { toolText } from './helpers/tool.js'
 import { createMcpServer } from '../src/irc-server.js'
 import type { RoostIrcClient, ClientConfig } from '../src/irc-client.js'
 
@@ -504,8 +504,7 @@ describe('pushNotification error handling', () => {
 
     const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((() => true) as typeof process.stderr.write)
     try {
-      emitUnreadSummary()
-      await sleep(50)
+      await emitUnreadSummary()
       const errorCalls = stderrSpy.mock.calls.filter(([s]) => typeof s === 'string' && s.includes('pushNotification error'))
       expect(errorCalls).toHaveLength(0)
     } finally {
@@ -521,8 +520,7 @@ describe('pushNotification error handling', () => {
     const notifSpy = spyOn(server, 'notification').mockRejectedValue(new Error('kaboom unexpected'))
     const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((() => true) as typeof process.stderr.write)
     try {
-      emitUnreadSummary()
-      await sleep(50)
+      await emitUnreadSummary()
       const errorCalls = stderrSpy.mock.calls.filter(([s]) => typeof s === 'string' && s.includes('kaboom unexpected'))
       expect(errorCalls).toHaveLength(1)
     } finally {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -3,11 +3,14 @@
  * so the server runs in the test process and appears in the coverage report.
  */
 import { describe, it, expect, beforeAll, spyOn } from 'bun:test'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
 import { startMcpInProcess } from './helpers/mcp-inprocess.js'
 import { startMcp } from './helpers/mcp.js'
 import { connectPeer } from './helpers/peer.js'
-import { toolText } from './helpers/tool.js'
+import { toolText, sleep } from './helpers/tool.js'
+import { createMcpServer } from '../src/irc-server.js'
+import type { RoostIrcClient, ClientConfig } from '../src/irc-client.js'
 
 describe.if(isErgoAvailable())('irc-server MCP tools', () => {
   let ergo: ErgoContext
@@ -463,5 +466,69 @@ describe.if(isErgoAvailable())('irc-server MCP tools (subprocess)', () => {
     expect(toolText(result)).toBe('parted #leave-test')
 
     await partSeen
+  })
+})
+
+// Minimal stub — createMcpServer only needs on() at setup and getUnread() for emitUnreadSummary.
+function makeStubClient(): RoostIrcClient {
+  return {
+    connect: () => {},
+    isReady: () => false,
+    join: async () => false,
+    leave: async () => false,
+    say: () => ({ chunks: 0, mode: 'single' as const }),
+    quit: () => {},
+    whoisChannels: async () => null,
+    getHistory: () => [],
+    getUsers: () => [],
+    getUnread: () => new Map(),
+    ackUnread: () => {},
+    clearDedupeCache: () => {},
+    isJoined: () => false,
+    // Cast required: overloaded on() signature doesn't unify with a single no-op arrow.
+    on: (() => {}) as unknown as RoostIrcClient['on'],
+  }
+}
+
+const stubConfig: ClientConfig = {
+  nick: 'test-nick',
+  autoJoin: [],
+  historySize: 10,
+  joinHistoryLines: 5,
+  joinHistoryMinutes: 5,
+}
+
+describe('pushNotification error handling', () => {
+  it('silently suppresses Not connected (transport teardown)', async () => {
+    const { emitUnreadSummary } = createMcpServer(makeStubClient(), stubConfig)
+
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((() => true) as typeof process.stderr.write)
+    try {
+      emitUnreadSummary()
+      await sleep(50)
+      const errorCalls = stderrSpy.mock.calls.filter(([s]) => typeof s === 'string' && s.includes('pushNotification error'))
+      expect(errorCalls).toHaveLength(0)
+    } finally {
+      stderrSpy.mockRestore()
+    }
+  })
+
+  it('logs unexpected errors to stderr', async () => {
+    const { server, emitUnreadSummary } = createMcpServer(makeStubClient(), stubConfig)
+    const [, serverTransport] = InMemoryTransport.createLinkedPair()
+    await server.connect(serverTransport)
+
+    const notifSpy = spyOn(server, 'notification').mockRejectedValue(new Error('kaboom unexpected'))
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((() => true) as typeof process.stderr.write)
+    try {
+      emitUnreadSummary()
+      await sleep(50)
+      const errorCalls = stderrSpy.mock.calls.filter(([s]) => typeof s === 'string' && s.includes('kaboom unexpected'))
+      expect(errorCalls).toHaveLength(1)
+    } finally {
+      notifSpy.mockRestore()
+      stderrSpy.mockRestore()
+      await server.close()
+    }
   })
 })


### PR DESCRIPTION
Fixes #129.

`pushNotification` now only swallows rejections whose message matches `/not connected/i` (the MCP SDK's transport-teardown shape). Anything else gets a `process.stderr.write`.

Two unit tests added (no ergo required): one for the silent-suppress path, one for the stderr-log path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)