### PR TITLE
feat: emit unread suffix from channel_ack; document suffix contract

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -46,7 +46,7 @@ export type { ClientConfig as McpServerConfig } from './irc-client.js'
 const TOOL_SCHEMAS = [
   {
     name: 'channel_message',
-    description: 'Post a message to a channel (e.g., "#roost"). The channel must already be joined.',
+    description: 'Post a message to a channel (e.g., "#roost"). The channel must already be joined. Response includes a trailing \'unread:\' summary listing other channels with pending messages.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -58,7 +58,7 @@ const TOOL_SCHEMAS = [
   },
   {
     name: 'direct_message',
-    description: 'Send a private message (DM) to another nick.',
+    description: "Send a private message (DM) to another nick. Response includes a trailing 'unread:' summary listing other channels with pending messages.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -115,12 +115,12 @@ const TOOL_SCHEMAS = [
   },
   {
     name: 'channel_list',
-    description: 'List all channels currently joined by this MCP instance. Issues a live WHOIS query to the IRC server on every call for an authoritative result.',
+    description: "List all channels currently joined by this MCP instance. Issues a live WHOIS query to the IRC server on every call for an authoritative result. Response includes a trailing 'unread:' summary listing other channels with pending messages.",
     inputSchema: { type: 'object', properties: {}, required: [] },
   },
   {
     name: 'channel_ack',
-    description: "Mark a channel (or DM peer nick) as read, clearing its unread count. Only needed when you read a channel's messages but have nothing to say in response. Posting any message to a channel (channel_message / direct_message) implicitly acks it.",
+    description: "Mark a channel (or DM peer nick) as read, clearing its unread count. Only needed when you read a channel's messages but have nothing to say in response. Posting any message to a channel (channel_message / direct_message) implicitly acks it. Response includes a trailing 'unread:' summary listing other channels with pending messages.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -156,7 +156,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. Inbound: IRC traffic arrives as <channel source="roost-irc"> events with sender, channel, and isDirect attributes. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. Inbound: IRC traffic arrives as <channel source="roost-irc"> events with sender, channel, and isDirect attributes. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -317,7 +317,8 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
       case 'channel_ack': {
         const ch = args.channel as string
         client.ackUnread(ch)
-        return { content: [{ type: 'text', text: `acked ${ch}` }] }
+        const suffix = unreadSuffix()
+        return { content: [{ type: 'text', text: `acked ${ch}${suffix}` }] }
       }
       default:
         return {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -195,6 +195,30 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(list)).not.toMatch(/\(\d+\)/)
   })
 
+  it('channel_ack response includes unread suffix for other channels, omits if none', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-unread8')
+    const peer = await connectPeer(ergo, 'ip-unread8-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread8-a' } })
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread8-b' } })
+    await peer.joinChannel('#ip-unread8-a')
+    await peer.joinChannel('#ip-unread8-b')
+
+    // Message arrives in B while agent reads A
+    peer.say('#ip-unread8-b', 'check this out')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-unread8-b' && n.content === 'check this out')
+
+    // Acking A should report B as unread
+    const ack = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread8-a' } })
+    expect(toolText(ack)).toContain('acked #ip-unread8-a')
+    expect(toolText(ack)).toContain('unread:')
+    expect(toolText(ack)).toContain('#ip-unread8-b')
+    expect(toolText(ack)).toContain('check this out')
+
+    // Acking B clears the last unread — no suffix
+    const ack2 = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread8-b' } })
+    expect(toolText(ack2)).not.toContain('unread:')
+  })
+
   it('emitUnreadSummary emits notification with channel+preview; all-caught-up when none', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-unread5')
     const peer = await connectPeer(ergo, 'ip-unread5-peer')


### PR DESCRIPTION
Fixes #135.

## What

- `channel_ack` now appends the `unread:` suffix (same shape as `channel_message`/`direct_message`/`channel_list`). Reuses `unreadSuffix()` called after `ackUnread()`, so the just-acked channel is naturally excluded.
- All 4 tool descriptions (`channel_message`, `direct_message`, `channel_list`, `channel_ack`) now document the trailing `'unread:'` summary.
- MCP `instructions` string gets one new sentence describing the suffix as a passive nudge.

## Test plan
- [ ] New test: `channel_ack response includes unread suffix for other channels, omits if none` (uses nick `ip-unread8` to avoid collision with existing `ip-unread6` test)
- [ ] `bun test test/irc-server.test.ts` → 31 pass, 0 fail
- [ ] Full `bun test` → only pre-existing `service.test.ts` tmux flake fails
- [ ] `bun run lint` clean
- [ ] `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)