### PR TITLE
feat: mention-flag in unread suffix

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -21,7 +21,7 @@ import type {
 const CAP_CHATHISTORY = 'chathistory'
 
 const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-const mentionRegex = (nick: string) => new RegExp(`\\b${escapeRegex(nick)}\\b`, 'i')
+const buildMentionRegex = (nick: string) => new RegExp(`\\b${escapeRegex(nick)}\\b`, 'i')
 
 // ---- IRC event shapes ------------------------------------------------------
 
@@ -52,6 +52,7 @@ interface BatchEndEvent { id: string; params: string[]; commands: BatchCommand[]
 
 export class RoostIrcClientImpl implements RoostIrcClient {
   private readonly nick: string
+  private readonly nickMentionRegex: RegExp
   private readonly historySize: number
   private readonly joinHistoryLines: number
   private readonly joinHistoryMinutes: number
@@ -77,6 +78,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   constructor(config: ClientConfig) {
     this.nick = config.nick
+    this.nickMentionRegex = buildMentionRegex(config.nick)
     this.historySize = config.historySize
     this.joinHistoryLines = config.joinHistoryLines
     this.joinHistoryMinutes = config.joinHistoryMinutes
@@ -248,7 +250,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     this.addFingerprint(msg)
     if (!historical) {
       const prev = this.unread.get(msg.channel)
-      const isMention = mentionRegex(this.nick).test(msg.text)
+      const isMention = this.nickMentionRegex.test(msg.text)
       this.unread.set(msg.channel, {
         count: (prev?.count ?? 0) + 1,
         lastSender: msg.sender,

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -20,6 +20,9 @@ import type {
 
 const CAP_CHATHISTORY = 'chathistory'
 
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const mentionRegex = (nick: string) => new RegExp(`\\b${escapeRegex(nick)}\\b`, 'i')
+
 // ---- IRC event shapes ------------------------------------------------------
 
 interface JoinEvent { nick: string; channel: string }
@@ -245,7 +248,15 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     this.addFingerprint(msg)
     if (!historical) {
       const prev = this.unread.get(msg.channel)
-      this.unread.set(msg.channel, { count: (prev?.count ?? 0) + 1, lastSender: msg.sender, lastPreview: msg.text })
+      const isMention = mentionRegex(this.nick).test(msg.text)
+      this.unread.set(msg.channel, {
+        count: (prev?.count ?? 0) + 1,
+        lastSender: msg.sender,
+        lastPreview: msg.text,
+        mentionCount: (prev?.mentionCount ?? 0) + (isMention ? 1 : 0),
+        lastMentionSender: isMention ? msg.sender : (prev?.lastMentionSender ?? ''),
+        lastMentionPreview: isMention ? msg.text : (prev?.lastMentionPreview ?? ''),
+      })
     }
   }
 

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -7,6 +7,9 @@ export interface UnreadInfo {
   count: number
   lastSender: string
   lastPreview: string
+  mentionCount: number
+  lastMentionSender: string
+  lastMentionPreview: string
 }
 
 export interface ClientConfig {

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -173,13 +173,12 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
   }
 
   const formatUnreadLine = (ch: string, info: UnreadInfo, previewLength = 40): string => {
-    const [sender, preview] = info.mentionCount > 0
+    const hasMention = info.mentionCount > 0
+    const [sender, preview] = hasMention
       ? [info.lastMentionSender, info.lastMentionPreview]
       : [info.lastSender, info.lastPreview]
     const raw = preview.length > previewLength ? preview.slice(0, previewLength - 3) + '...' : preview
-    const count = info.mentionCount > 0
-      ? `${info.mentionCount} mention, ${info.count} total`
-      : String(info.count)
+    const count = hasMention ? `${info.mentionCount} mention, ${info.count} total` : String(info.count)
     return `${ch} (${count}) ${sender}: "${raw.replaceAll('"', "'")}"`
   }
 

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -173,10 +173,14 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
   }
 
   const formatUnreadLine = (ch: string, info: UnreadInfo, previewLength = 40): string => {
-    const raw = info.lastPreview.length > previewLength
-      ? info.lastPreview.slice(0, previewLength - 3) + '...'
-      : info.lastPreview
-    return `${ch} (${info.count}) ${info.lastSender}: "${raw.replaceAll('"', "'")}"`
+    const [sender, preview] = info.mentionCount > 0
+      ? [info.lastMentionSender, info.lastMentionPreview]
+      : [info.lastSender, info.lastPreview]
+    const raw = preview.length > previewLength ? preview.slice(0, previewLength - 3) + '...' : preview
+    const count = info.mentionCount > 0
+      ? `${info.mentionCount} mention, ${info.count} total`
+      : String(info.count)
+    return `${ch} (${count}) ${sender}: "${raw.replaceAll('"', "'")}"`
   }
 
   const unreadSuffix = (): string => {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -266,6 +266,86 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(reply2)).not.toContain('unread:')
   })
 
+  // ---- Mention tracking (issue #137) ------------------------------------
+
+  it('mention formats as "(N mention, M total)" with mention preview', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-ment1')
+    const peer = await connectPeer(ergo, 'ip-ment1-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-ment1' } })
+    await peer.joinChannel('#ip-ment1')
+
+    peer.say('#ip-ment1', 'ip-ment1: are you there?')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment1' && n.content === 'ip-ment1: are you there?')
+
+    const list = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list)).toContain('1 mention, 1 total')
+    expect(toolText(list)).toContain('ip-ment1: are you there?')
+  })
+
+  it('non-mention messages keep "(M)" format', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-ment2')
+    const peer = await connectPeer(ergo, 'ip-ment2-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-ment2' } })
+    await peer.joinChannel('#ip-ment2')
+
+    peer.say('#ip-ment2', 'just chatting')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment2' && n.content === 'just chatting')
+
+    const list = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list)).toContain('(1)')
+    expect(toolText(list)).not.toContain('mention')
+  })
+
+  it('mention preview persists when non-mention messages arrive after', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-ment3')
+    const peer = await connectPeer(ergo, 'ip-ment3-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-ment3' } })
+    await peer.joinChannel('#ip-ment3')
+
+    peer.say('#ip-ment3', '@ip-ment3 hey')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment3' && n.content === '@ip-ment3 hey')
+    peer.say('#ip-ment3', 'side comment')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment3' && n.content === 'side comment')
+
+    const list = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list)).toContain('1 mention, 2 total')
+    expect(toolText(list)).toContain('@ip-ment3 hey')
+  })
+
+  it('word-boundary match: nick embedded in longer word does not count as mention', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-ment4')
+    const peer = await connectPeer(ergo, 'ip-ment4-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-ment4' } })
+    await peer.joinChannel('#ip-ment4')
+
+    // "ip-ment4x" has "ip-ment4" as a prefix with an alphanumeric suffix — no word boundary after "4"
+    peer.say('#ip-ment4', 'ip-ment4x is not our nick')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment4' && n.content === 'ip-ment4x is not our nick')
+
+    const list = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list)).not.toContain('mention')
+  })
+
+  it('channel_ack clears mention count', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-ment5')
+    const peer = await connectPeer(ergo, 'ip-ment5-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-ment5' } })
+    await peer.joinChannel('#ip-ment5')
+
+    peer.say('#ip-ment5', 'ip-ment5: ping')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-ment5' && n.content === 'ip-ment5: ping')
+
+    // Verify mention is tracked
+    const list1 = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list1)).toContain('1 mention')
+
+    // Ack clears it — channel_list should no longer show any unread for this channel
+    await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-ment5' } })
+    const list2 = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    expect(toolText(list2)).not.toContain('mention')
+    expect(toolText(list2)).not.toContain('ip-ment5: ping')
+  })
+
   // ---- Reply reminder (issue #136) ---------------------------------------
 
   it('first inbound channel message triggers a reminder followup notification', async () => {


### PR DESCRIPTION
closes #137

when a channel has mentions, the unread suffix now shows `(N mention, M total)` with the last-mentioned message as preview. channels without mentions keep `(M)`.

mention detection: `\bnick\b` word-boundary regex (case-insensitive) — avoids false positives from substring nicks.

ack/post clearing works automatically since `ackUnread` deletes the whole `UnreadInfo` entry.

5 new tests covering: mention format, non-mention format, mention preview persistence after later non-mention messages, word-boundary non-match, and ack clears mention count.

[worker-137]