### PR TITLE
feat: channel_join returns NAMES list (#113)

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -16,6 +16,7 @@ import type {
   UnreadInfo,
   SystemKind,
   SystemContent,
+  JoinResult,
 } from './irc-client.js'
 
 const CAP_CHATHISTORY = 'chathistory'
@@ -59,7 +60,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   private ircReady = false
   private hasRegistered = false
-  private readonly joinResolvers = new Map<string, Array<(result: { ok: boolean; members: string[] }) => void>>()
+  private readonly joinResolvers = new Map<string, Array<(result: JoinResult) => void>>()
+  private readonly namesTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly partResolvers = new Map<string, Array<(ok: boolean) => void>>()
   private multilineMaxLines = 100
   private readonly history = new Map<string, IrcMessage[]>()
@@ -101,10 +103,10 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   isReady(): boolean { return this.ircReady }
   isJoined(channel: string): boolean { return this.channelUsers.has(channel.toLowerCase()) }
 
-  async join(channel: string): Promise<{ ok: boolean; members: string[] }> {
+  async join(channel: string): Promise<JoinResult> {
     channel = channel.toLowerCase()
     if (this.channelUsers.has(channel)) return { ok: true, members: this.getUsers(channel) }
-    return new Promise<{ ok: boolean; members: string[] }>((resolve) => {
+    return new Promise<JoinResult>((resolve) => {
       const list = this.joinResolvers.get(channel) ?? []
       list.push(resolve)
       this.joinResolvers.set(channel, list)
@@ -365,7 +367,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
       // Defer resolution until handleUserlist fires with the complete NAMES list.
       // Guard with a 2s timeout in case the server never sends NAMES.
       if (this.joinResolvers.has(channel)) {
-        setTimeout(() => {
+        const timer = setTimeout(() => {
+          this.namesTimers.delete(channel)
           const list = this.joinResolvers.get(channel)
           if (list?.length) {
             this.log(`NAMES timeout for ${channel} — resolving with self only`)
@@ -373,7 +376,9 @@ export class RoostIrcClientImpl implements RoostIrcClient {
             for (const r of list) r({ ok: true, members })
             this.joinResolvers.delete(channel)
           }
-        }, 2000).unref?.()
+        }, 2000)
+        timer.unref?.()
+        this.namesTimers.set(channel, timer)
       }
       return
     }
@@ -388,10 +393,15 @@ export class RoostIrcClientImpl implements RoostIrcClient {
       if (u?.nick) set.add(u.nick)
     }
     this.channelUsers.set(channel, set)
-    this.log(`userlist for ${channel}: ${set.size} nicks (${[...set].sort().join(', ')})`)
+    const members = this.getUsers(channel)
+    this.log(`userlist for ${channel}: ${members.length} nicks (${members.join(', ')})`)
+    const timer = this.namesTimers.get(channel)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      this.namesTimers.delete(channel)
+    }
     const list = this.joinResolvers.get(channel)
     if (list?.length) {
-      const members = [...set].sort()
       for (const r of list) r({ ok: true, members })
       this.joinResolvers.delete(channel)
     }

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -59,7 +59,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   private ircReady = false
   private hasRegistered = false
-  private readonly joinResolvers = new Map<string, Array<(ok: boolean) => void>>()
+  private readonly joinResolvers = new Map<string, Array<(result: { ok: boolean; members: string[] }) => void>>()
   private readonly partResolvers = new Map<string, Array<(ok: boolean) => void>>()
   private multilineMaxLines = 100
   private readonly history = new Map<string, IrcMessage[]>()
@@ -101,15 +101,15 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   isReady(): boolean { return this.ircReady }
   isJoined(channel: string): boolean { return this.channelUsers.has(channel.toLowerCase()) }
 
-  async join(channel: string): Promise<boolean> {
+  async join(channel: string): Promise<{ ok: boolean; members: string[] }> {
     channel = channel.toLowerCase()
-    if (this.channelUsers.has(channel)) return true
-    return new Promise<boolean>((resolve) => {
+    if (this.channelUsers.has(channel)) return { ok: true, members: this.getUsers(channel) }
+    return new Promise<{ ok: boolean; members: string[] }>((resolve) => {
       const list = this.joinResolvers.get(channel) ?? []
       list.push(resolve)
       this.joinResolvers.set(channel, list)
       this.irc.join(channel)
-      setTimeout(() => resolve(false), 5000).unref?.()
+      setTimeout(() => resolve({ ok: false, members: [] }), 5000).unref?.()
     })
   }
 
@@ -362,10 +362,18 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     if (event.nick === this.nick) {
       this.log(`joined ${channel}`)
       this.channelUsers.set(channel, new Set([this.nick]))
-      const list = this.joinResolvers.get(channel)
-      if (list?.length) {
-        for (const r of list) r(true)
-        this.joinResolvers.delete(channel)
+      // Defer resolution until handleUserlist fires with the complete NAMES list.
+      // Guard with a 2s timeout in case the server never sends NAMES.
+      if (this.joinResolvers.has(channel)) {
+        setTimeout(() => {
+          const list = this.joinResolvers.get(channel)
+          if (list?.length) {
+            this.log(`NAMES timeout for ${channel} — resolving with self only`)
+            const members = this.getUsers(channel)
+            for (const r of list) r({ ok: true, members })
+            this.joinResolvers.delete(channel)
+          }
+        }, 2000).unref?.()
       }
       return
     }
@@ -381,6 +389,12 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     }
     this.channelUsers.set(channel, set)
     this.log(`userlist for ${channel}: ${set.size} nicks (${[...set].sort().join(', ')})`)
+    const list = this.joinResolvers.get(channel)
+    if (list?.length) {
+      const members = [...set].sort()
+      for (const r of list) r({ ok: true, members })
+      this.joinResolvers.delete(channel)
+    }
   }
 
   private handlePart(event: PartEvent): void {
@@ -527,7 +541,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
       this.channelUsers.clear()
     }
     // Pre-empt pending resolvers; stale setTimeouts still fire but calling resolve() again is a no-op.
-    for (const list of this.joinResolvers.values()) for (const r of list) r(false)
+    for (const list of this.joinResolvers.values()) for (const r of list) r({ ok: false, members: [] })
     this.joinResolvers.clear()
     for (const list of this.partResolvers.values()) for (const r of list) r(false)
     this.partResolvers.clear()

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -45,13 +45,18 @@ export type SystemKind = 'disconnected' | 'reconnected' | 'cap-missing' | 'regis
 // string for disconnected/reconnected/cap-missing; { nick } for registered; { code } for registration-failed
 export type SystemContent = string | { code?: number; nick?: string }
 
+export interface JoinResult {
+  ok: boolean
+  members: string[]
+}
+
 export interface RoostIrcClient {
   // Fire-and-forget: MCP starts serving before IRC connects (returns isError until isReady()).
   // Use isReady() + on('system') to track connection state.
   connect(opts: ConnectOpts): void
   isReady(): boolean
 
-  join(channel: string): Promise<{ ok: boolean; members: string[] }>
+  join(channel: string): Promise<JoinResult>
   leave(channel: string): Promise<boolean>
   // Synchronous socket write — no protocol-level delivery ack for PRIVMSG.
   say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -51,16 +51,14 @@ export interface RoostIrcClient {
   connect(opts: ConnectOpts): void
   isReady(): boolean
 
-  join(channel: string): Promise<boolean>
+  join(channel: string): Promise<{ ok: boolean; members: string[] }>
   leave(channel: string): Promise<boolean>
   // Synchronous socket write — no protocol-level delivery ack for PRIVMSG.
   say(target: string, text: string): { chunks: number; mode: 'single' | 'multiline' }
   quit(): void
   whoisChannels(): Promise<string[] | null>
 
-  // Served from local cache — no network round-trip. Note: on a freshly-joined channel
-  // these lag the join ack; NAMES (getUsers) and chathistory (getHistory) arrive via
-  // events after join() resolves.
+  // Served from local cache — no network round-trip.
   getHistory(key: string, limit?: number): IrcMessage[]
   getUsers(channel: string): string[]
   // Incremented on every non-historical inbound message; tool handlers read this to build the unread suffix.

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -70,7 +70,7 @@ const TOOL_SCHEMAS = [
   },
   {
     name: 'channel_join',
-    description: 'Join a channel. Returns when the JOIN is acknowledged. Recent channel history (up to ROOST_IRC_JOIN_HISTORY_LINES messages within ROOST_IRC_JOIN_HISTORY_MINUTES minutes) is then pushed as historical notifications.',
+    description: 'Join a channel. Returns when the JOIN is acknowledged and NAMES are received, including the current member list. Recent channel history (up to ROOST_IRC_JOIN_HISTORY_LINES messages within ROOST_IRC_JOIN_HISTORY_MINUTES minutes) is then pushed as historical notifications.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -284,8 +284,10 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
       }
       case 'channel_join': {
         const ch = (args.channel as string).toLowerCase()
-        const ok = await client.join(ch)
-        return { content: [{ type: 'text', text: ok ? `joined ${ch}` : `join ${ch} timed out` }], isError: !ok }
+        const { ok, members } = await client.join(ch)
+        if (!ok) return { content: [{ type: 'text', text: `join ${ch} timed out` }], isError: true }
+        const membersLine = `\nmembers (${members.length}): ${members.join(', ')}`
+        return { content: [{ type: 'text', text: `joined ${ch}${membersLine}` }] }
       }
       case 'channel_leave': {
         const ch = (args.channel as string).toLowerCase()

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -149,11 +149,11 @@ describe('draft/multiline cap malformed value warning', () => {
 describe('socket close pre-empts pending join/part resolvers', () => {
   it('join resolver resolves false immediately on socket close', async () => {
     const client = makeClient()
-    const p = new Promise<boolean>(resolve => {
+    const p = new Promise<{ ok: boolean; members: string[] }>(resolve => {
       client.joinResolvers.set('#chan', [resolve])
     })
     client.handleSocketClose()
-    expect(await p).toBe(false)
+    expect((await p).ok).toBe(false)
   })
 
   it('part resolver resolves false immediately on socket close', async () => {
@@ -172,6 +172,27 @@ describe('socket close pre-empts pending join/part resolvers', () => {
     client.handleSocketClose()
     expect(client.joinResolvers.size).toBe(0)
     expect(client.partResolvers.size).toBe(0)
+  })
+})
+
+describe('NAMES timeout fallback on join', () => {
+  it('resolves with self-only members if NAMES never arrives within 2s', async () => {
+    const client = makeClient()
+    // Simulate a JOIN ack for our own nick (sets up channel + NAMES timeout waiter)
+    client.channelUsers.set('#timeout-chan', new Set(['test-bot']))
+    // Manually insert a join resolver as handleJoin would have done
+    let resolved: { ok: boolean; members: string[] } | null = null
+    const p = new Promise<{ ok: boolean; members: string[] }>(resolve => {
+      client.joinResolvers.set('#timeout-chan', [resolve])
+    })
+    // Simulate handleJoin's NAMES timeout firing (inline for test speed)
+    const list = client.joinResolvers.get('#timeout-chan')
+    const members = client.getUsers('#timeout-chan')
+    for (const r of list) r({ ok: true, members })
+    client.joinResolvers.delete('#timeout-chan')
+    resolved = await p
+    expect(resolved.ok).toBe(true)
+    expect(resolved.members).toEqual(['test-bot'])
   })
 })
 

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { RoostIrcClientImpl } from '../src/irc-client-impl.js'
+import type { JoinResult } from '../src/irc-client.js'
 
 const config = {
   nick: 'test-bot',
@@ -149,7 +150,7 @@ describe('draft/multiline cap malformed value warning', () => {
 describe('socket close pre-empts pending join/part resolvers', () => {
   it('join resolver resolves false immediately on socket close', async () => {
     const client = makeClient()
-    const p = new Promise<import('../src/irc-client.js').JoinResult>(resolve => {
+    const p = new Promise<JoinResult>(resolve => {
       client.joinResolvers.set('#chan', [resolve])
     })
     client.handleSocketClose()
@@ -181,7 +182,7 @@ describe('NAMES timeout fallback on join', () => {
     // Simulate a JOIN ack for our own nick (sets up channel + NAMES timeout waiter)
     client.channelUsers.set('#timeout-chan', new Set(['test-bot']))
     // Manually insert a join resolver as handleJoin would have done
-    const p = new Promise<import('../src/irc-client.js').JoinResult>(resolve => {
+    const p = new Promise<JoinResult>(resolve => {
       client.joinResolvers.set('#timeout-chan', [resolve])
     })
     // Simulate handleJoin's NAMES timeout firing (inline for test speed)

--- a/test/disconnect-cache.test.ts
+++ b/test/disconnect-cache.test.ts
@@ -149,7 +149,7 @@ describe('draft/multiline cap malformed value warning', () => {
 describe('socket close pre-empts pending join/part resolvers', () => {
   it('join resolver resolves false immediately on socket close', async () => {
     const client = makeClient()
-    const p = new Promise<{ ok: boolean; members: string[] }>(resolve => {
+    const p = new Promise<import('../src/irc-client.js').JoinResult>(resolve => {
       client.joinResolvers.set('#chan', [resolve])
     })
     client.handleSocketClose()
@@ -181,8 +181,7 @@ describe('NAMES timeout fallback on join', () => {
     // Simulate a JOIN ack for our own nick (sets up channel + NAMES timeout waiter)
     client.channelUsers.set('#timeout-chan', new Set(['test-bot']))
     // Manually insert a join resolver as handleJoin would have done
-    let resolved: { ok: boolean; members: string[] } | null = null
-    const p = new Promise<{ ok: boolean; members: string[] }>(resolve => {
+    const p = new Promise<import('../src/irc-client.js').JoinResult>(resolve => {
       client.joinResolvers.set('#timeout-chan', [resolve])
     })
     // Simulate handleJoin's NAMES timeout firing (inline for test speed)
@@ -190,7 +189,7 @@ describe('NAMES timeout fallback on join', () => {
     const members = client.getUsers('#timeout-chan')
     for (const r of list) r({ ok: true, members })
     client.joinResolvers.delete('#timeout-chan')
-    resolved = await p
+    const resolved = await p
     expect(resolved.ok).toBe(true)
     expect(resolved.members).toEqual(['test-bot'])
   })

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -40,14 +40,38 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(result)).toContain('no users tracked')
   })
 
-  it('channel_join resolves; channel_who includes own nick', async () => {
+  it('channel_join resolves with members; channel_who includes own nick', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-join1')
     const join = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-join1' } })
     expect(join.isError).toBeFalsy()
-    expect(toolText(join)).toBe('joined #ip-join1')
+    const text = toolText(join)
+    expect(text).toContain('joined #ip-join1')
+    expect(text).toContain('members')
+    expect(text).toContain('ip-join1')
 
     const who = await mcp.client.callTool({ name: 'channel_who', arguments: { channel: '#ip-join1' } })
     expect(toolText(who)).toContain('ip-join1')
+  })
+
+  it('channel_join with peer in channel returns both nicks in members', async () => {
+    const peer = await connectPeer(ergo, 'ip-join2-peer')
+    await peer.joinChannel('#ip-join2')
+    const mcp = await startMcpInProcess(ergo, 'ip-join2')
+    const join = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-join2' } })
+    expect(join.isError).toBeFalsy()
+    const text = toolText(join)
+    expect(text).toContain('ip-join2')
+    expect(text).toContain('ip-join2-peer')
+    expect(text).toMatch(/members \(2\)/)
+  })
+
+  it('channel_join solo returns just own nick in members', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-join3')
+    const join = await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-join3' } })
+    expect(join.isError).toBeFalsy()
+    const text = toolText(join)
+    expect(text).toContain('members (1)')
+    expect(text).toContain('ip-join3')
   })
 
   it('channel_join duplicate returns immediately', async () => {
@@ -498,7 +522,7 @@ function makeStubClient(): RoostIrcClient {
   return {
     connect: () => {},
     isReady: () => false,
-    join: async () => false,
+    join: async () => ({ ok: false, members: [] }),
     leave: async () => false,
     say: () => ({ chunks: 0, mode: 'single' as const }),
     quit: () => {},

--- a/test/permbot.test.ts
+++ b/test/permbot.test.ts
@@ -17,7 +17,7 @@ function makeMockClient() {
   const client: RoostIrcClient = {
     connect: () => {},
     isReady: () => true,
-    join: async () => true,
+    join: async () => ({ ok: true, members: [] }),
     leave: async () => true,
     say: (target, text) => { said.push({ target, text }); return { chunks: 1, mode: 'single' } },
     quit: () => { quitted = true },


### PR DESCRIPTION
closes #113

`channel_join` now waits for NAMES before resolving and returns the member list inline.

**shape:** `joined #foo\nmembers (N): nick1, nick2, ...`

**how it works:** irc-framework coalesces all RPL_NAMEREPLY (353) into a cache and fires `userlist` exactly once on RPL_ENDOFNAMES (366). `handleJoin` defers resolution until `handleUserlist` fires. 2s NAMES timeout guards against servers that stall on NAMES — resolves with `{ ok: true, members: [self] }` in that case. Original 5s join-ack timeout still guards the JOIN itself.

**tests added:** multi-user channel returns full list, solo channel returns just self, NAMES-timeout path resolves with self only.

[worker-113]