### PR TITLE
fix: single source of truth for IRC loopback host

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -16,6 +16,7 @@
 set -uo pipefail
 
 ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+IRC_HOST="${ROOST_IRC_SERVER:-127.0.0.1}"
 IRC_PORT=6667
 SESSION_PREFIX="roost-"
 
@@ -94,7 +95,7 @@ EOF
 
 require_ircd() {
   if ! lsof -nP -iTCP:${IRC_PORT} -sTCP:LISTEN >/dev/null 2>&1; then
-    echo "error: no IRC daemon listening on 127.0.0.1:${IRC_PORT}" >&2
+    echo "error: no IRC daemon listening on ${IRC_HOST}:${IRC_PORT}" >&2
     echo "  start ergo with:" >&2
     echo "    cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml" >&2
     exit 2
@@ -241,7 +242,8 @@ cmd_spawn() {
   # RVM / nvm / shell-rc-managed toolchains. Env vars go through tmux -e so
   # the inner command stays a clean single-quoted string.
   local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}")
-  [ -n "${perm_sock}" ] && tmux_env+=(-e "ROOST_PERM_SOCK=${perm_sock}" -e "ROOST_PERM_TARGET=${perm_target}" -e "ROOST_PERM_HOST=127.0.0.1" -e "ROOST_PERM_PORT=${IRC_PORT}")
+  tmux_env+=(-e "ROOST_IRC_SERVER=${IRC_HOST}")
+  [ -n "${perm_sock}" ] && tmux_env+=(-e "ROOST_PERM_SOCK=${perm_sock}" -e "ROOST_PERM_TARGET=${perm_target}" -e "ROOST_PERM_HOST=${IRC_HOST}" -e "ROOST_PERM_PORT=${IRC_PORT}")
 
   # Build the inner zsh command. Bash expands its own ${vars} here, then
   # we append the prompt placeholder as a single-quoted literal so $(...)
@@ -375,7 +377,7 @@ cmd_tail() {
 
 cmd_status() {
   if lsof -nP -iTCP:${IRC_PORT} -sTCP:LISTEN >/dev/null 2>&1; then
-    echo "ircd: up on 127.0.0.1:${IRC_PORT}"
+    echo "ircd: up on ${IRC_HOST}:${IRC_PORT}"
   else
     echo "ircd: DOWN (start: cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml)"
   fi

--- a/bin/roost
+++ b/bin/roost
@@ -94,7 +94,7 @@ EOF
 }
 
 require_ircd() {
-  if ! nc -z -w 2 "${IRC_HOST}" "${IRC_PORT}" >/dev/null 2>&1; then
+  if ! (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "error: no IRC daemon listening on ${IRC_HOST}:${IRC_PORT}" >&2
     echo "  start ergo with:" >&2
     echo "    cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml" >&2
@@ -376,7 +376,7 @@ cmd_tail() {
 }
 
 cmd_status() {
-  if nc -z -w 2 "${IRC_HOST}" "${IRC_PORT}" >/dev/null 2>&1; then
+  if (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "ircd: up on ${IRC_HOST}:${IRC_PORT}"
   else
     echo "ircd: DOWN (start: cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml)"

--- a/bin/roost
+++ b/bin/roost
@@ -94,7 +94,7 @@ EOF
 }
 
 require_ircd() {
-  if ! lsof -nP -iTCP:${IRC_PORT} -sTCP:LISTEN >/dev/null 2>&1; then
+  if ! nc -z -w 2 "${IRC_HOST}" "${IRC_PORT}" >/dev/null 2>&1; then
     echo "error: no IRC daemon listening on ${IRC_HOST}:${IRC_PORT}" >&2
     echo "  start ergo with:" >&2
     echo "    cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml" >&2
@@ -376,7 +376,7 @@ cmd_tail() {
 }
 
 cmd_status() {
-  if lsof -nP -iTCP:${IRC_PORT} -sTCP:LISTEN >/dev/null 2>&1; then
+  if nc -z -w 2 "${IRC_HOST}" "${IRC_PORT}" >/dev/null 2>&1; then
     echo "ircd: up on ${IRC_HOST}:${IRC_PORT}"
   else
     echo "ircd: DOWN (start: cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml)"

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -13,7 +13,7 @@
  * each get their own MCP subprocess and therefore their own nick.
  *
  * Configuration (env vars):
- *   ROOST_IRC_SERVER     IRC server (default: 127.0.0.1)
+ *   ROOST_IRC_SERVER     IRC server (default: 127.0.0.1; set by bin/roost)
  *   ROOST_IRC_PORT       IRC port   (default: 6667)
  *   ROOST_IRC_NICK       Nick       (REQUIRED, no default)
  *   ROOST_IRC_REALNAME   Realname   (default: same as nick)


### PR DESCRIPTION
Closes #144.

`bin/roost` now reads `ROOST_IRC_SERVER` (defaulting to `127.0.0.1`) into a local `IRC_HOST` variable and uses it everywhere — error messages, startup output, and both child-process env injections (`ROOST_IRC_SERVER` for the MCP, `ROOST_PERM_HOST` for permbot). Previously the MCP server fell back to its own hardcoded default with no connection to what `bin/roost` was using.

[worker-144] 🤖 Generated with [Claude Code](https://claude.com/claude-code)