### PR TITLE
permbot: show sub-agent prompt instead of stale parent intent

### DIFF
--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -113,6 +113,30 @@ export function extractIntent(transcriptPath: string): string {
   const rawLines = text.split('\n')
   // first line after a mid-file seek is likely truncated; drop it
   const lines = text.length < 200_000 ? rawLines : rawLines.slice(1)
+
+  // Pass 1: collect tool_use ids that have completed (have a matching tool_result).
+  const completedIds = new Set<string>()
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let turn: unknown
+    try { turn = JSON.parse(trimmed) } catch { continue }
+    if (typeof turn !== 'object' || turn === null) continue
+    const t = turn as Record<string, unknown>
+    if (t['type'] !== 'user') continue
+    const content = (t['message'] as Record<string, unknown> | undefined)?.['content']
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (typeof block !== 'object' || block === null) continue
+      const b = block as Record<string, unknown>
+      if (b['type'] === 'tool_result') {
+        const id = String(b['tool_use_id'] ?? '')
+        if (id) completedIds.add(id)
+      }
+    }
+  }
+
+  // Pass 2: scan backwards for the most recent active sub-agent or last parent text.
   let fallbackThinking = ''
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim()
@@ -124,17 +148,36 @@ export function extractIntent(transcriptPath: string): string {
     if (t['type'] !== 'assistant') continue
     const content = (t['message'] as Record<string, unknown> | undefined)?.['content']
     if (!Array.isArray(content)) continue
+
+    let foundText = ''
+    let activeAgent: { prompt: string; desc: string } | null = null
     for (const block of content) {
       if (typeof block !== 'object' || block === null) continue
       const b = block as Record<string, unknown>
-      if (b['type'] === 'text') {
+      if (b['type'] === 'tool_use' && b['name'] === 'Agent') {
+        const id = String(b['id'] ?? '')
+        if (!completedIds.has(id)) {
+          const input = b['input'] as Record<string, unknown> | undefined
+          activeAgent = {
+            prompt: String(input?.['prompt'] ?? '').trim(),
+            desc: String(input?.['description'] ?? '').trim(),
+          }
+        }
+      } else if (b['type'] === 'text') {
         const txt = String(b['text'] ?? '').trim()
-        if (txt) return clip(txt, 400)
+        if (txt && !foundText) foundText = txt
       } else if (b['type'] === 'thinking' && !fallbackThinking) {
         const think = String(b['thinking'] ?? '').trim()
         if (think) fallbackThinking = clip(think, 400)
       }
     }
+
+    if (activeAgent !== null) {
+      const label = activeAgent.desc ? `[sub-agent: ${activeAgent.desc}]` : '[sub-agent]'
+      if (activeAgent.prompt) return `${label} ${clip(activeAgent.prompt, 400 - label.length - 1)}`
+      return label
+    }
+    if (foundText) return clip(foundText, 400)
   }
   return fallbackThinking
 }

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -2,6 +2,7 @@
 
 import * as fs from 'node:fs'
 import * as net from 'node:net'
+import * as path from 'node:path'
 
 const WORKER      = process.env['ROOST_IRC_NICK'] ?? 'unknown'
 const SOCK_PATH   = process.env['ROOST_PERM_SOCK'] ?? ''
@@ -113,28 +114,6 @@ export function extractIntent(transcriptPath: string): string {
   const rawLines = text.split('\n')
   // first line after a mid-file seek is likely truncated; drop it
   const lines = text.length < 200_000 ? rawLines : rawLines.slice(1)
-
-  const completedIds = new Set<string>()
-  for (const line of lines) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    let turn: unknown
-    try { turn = JSON.parse(trimmed) } catch { continue }
-    if (typeof turn !== 'object' || turn === null) continue
-    const t = turn as Record<string, unknown>
-    if (t['type'] !== 'user') continue
-    const content = (t['message'] as Record<string, unknown> | undefined)?.['content']
-    if (!Array.isArray(content)) continue
-    for (const block of content) {
-      if (typeof block !== 'object' || block === null) continue
-      const b = block as Record<string, unknown>
-      if (b['type'] === 'tool_result') {
-        const id = String(b['tool_use_id'] ?? '')
-        if (id) completedIds.add(id)
-      }
-    }
-  }
-
   let fallbackThinking = ''
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim()
@@ -146,38 +125,27 @@ export function extractIntent(transcriptPath: string): string {
     if (t['type'] !== 'assistant') continue
     const content = (t['message'] as Record<string, unknown> | undefined)?.['content']
     if (!Array.isArray(content)) continue
-
-    let foundText = ''
-    let activeAgent: { prompt: string; desc: string } | null = null
     for (const block of content) {
       if (typeof block !== 'object' || block === null) continue
       const b = block as Record<string, unknown>
-      if (b['type'] === 'tool_use' && b['name'] === 'Agent') {
-        const id = String(b['id'] ?? '')
-        if (!completedIds.has(id)) {
-          const input = b['input'] as Record<string, unknown> | undefined
-          activeAgent = {
-            prompt: String(input?.['prompt'] ?? '').trim(),
-            desc: String(input?.['description'] ?? '').trim(),
-          }
-        }
-      } else if (b['type'] === 'text') {
+      if (b['type'] === 'text') {
         const txt = String(b['text'] ?? '').trim()
-        if (txt && !foundText) foundText = txt
+        if (txt) return clip(txt, 400)
       } else if (b['type'] === 'thinking' && !fallbackThinking) {
         const think = String(b['thinking'] ?? '').trim()
         if (think) fallbackThinking = clip(think, 400)
       }
     }
-
-    if (activeAgent !== null) {
-      const label = activeAgent.desc ? `[sub-agent: ${activeAgent.desc}]` : '[sub-agent]'
-      if (activeAgent.prompt) return `${label} ${clip(activeAgent.prompt, 400 - label.length - 1)}`
-      return label
-    }
-    if (foundText) return clip(foundText, 400)
   }
   return fallbackThinking
+}
+
+export function resolveTranscriptPath(transcriptPath: string, agentId: string): string {
+  if (!agentId) return transcriptPath
+  if (transcriptPath.includes('/subagents/')) return transcriptPath
+  const sessionDir = transcriptPath.replace(/\.jsonl$/, '')
+  const subPath = path.join(sessionDir, 'subagents', `agent-${agentId}.jsonl`)
+  return fs.existsSync(subPath) ? subPath : transcriptPath
 }
 
 // ---- Socket round-trip to permbot daemon ------------------------------------
@@ -271,12 +239,16 @@ if (import.meta.main) {
   const toolName      = String(payload!['tool_name'] ?? '')
   const toolInput     = (payload!['tool_input'] as Record<string, unknown> | null) ?? {}
   const transcriptPath = String(payload!['transcript_path'] ?? '')
+  const agentId        = String(payload!['agent_id'] ?? '')
 
   if (PASSTHROUGH_PREFIXES.some(p => toolName.startsWith(p))) emit('allow', 'roost-irc passthrough')
 
-  const intent = extractIntent(transcriptPath)
+  const intent = extractIntent(resolveTranscriptPath(transcriptPath, agentId))
   const summaryLines = summarize(toolName, toolInput)
-  if (intent) summaryLines.push(`intent: ${intent}`)
+  if (intent) {
+    summaryLines.push(`last narration: ${intent}`)
+    summaryLines.push(`(also check the agent's recent IRC messages)`)
+  }
   const summary = summaryLines.join('\n')
 
   const reply = await askDaemon(summary)

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -114,7 +114,6 @@ export function extractIntent(transcriptPath: string): string {
   // first line after a mid-file seek is likely truncated; drop it
   const lines = text.length < 200_000 ? rawLines : rawLines.slice(1)
 
-  // Pass 1: collect tool_use ids that have completed (have a matching tool_result).
   const completedIds = new Set<string>()
   for (const line of lines) {
     const trimmed = line.trim()
@@ -136,7 +135,6 @@ export function extractIntent(transcriptPath: string): string {
     }
   }
 
-  // Pass 2: scan backwards for the most recent active sub-agent or last parent text.
   let fallbackThinking = ''
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim()

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs'
 import * as net from 'node:net'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { summarize, extractIntent } from '../src/permission-prompt.js'
+import { summarize, extractIntent, resolveTranscriptPath } from '../src/permission-prompt.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/permission-prompt.ts')
 
@@ -128,78 +128,37 @@ describe('extractIntent', () => {
     }
   })
 
-  it('returns Agent prompt prefixed with label when sub-agent is active (same turn as text)', () => {
-    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa1.jsonl`)
-    const turn = {
-      type: 'assistant',
-      message: {
-        content: [
-          { type: 'text', text: 'Now spawning the Haiku agent.' },
-          { type: 'tool_use', id: 'tu_001', name: 'Agent', input: { prompt: 'Run the test suite and report failures.', description: 'run tests' } },
-        ],
-      },
-    }
-    fs.writeFileSync(tmp, JSON.stringify(turn) + '\n')
+})
+
+// ---- resolveTranscriptPath() ------------------------------------------------
+
+describe('resolveTranscriptPath', () => {
+  it('returns transcript_path unchanged when no agent_id', () => {
+    expect(resolveTranscriptPath('/path/to/session.jsonl', '')).toBe('/path/to/session.jsonl')
+  })
+
+  it('returns transcript_path unchanged when path already contains /subagents/', () => {
+    const p = '/path/to/session/subagents/agent-abc.jsonl'
+    expect(resolveTranscriptPath(p, 'abc')).toBe(p)
+  })
+
+  it('derives sub-agent path when agent_id present and file exists', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rtp-'))
+    const sessionJsonl = path.join(tmp, 'session.jsonl')
+    const subDir = path.join(tmp, 'session', 'subagents')
+    fs.mkdirSync(subDir, { recursive: true })
+    fs.writeFileSync(sessionJsonl, '')
+    const subFile = path.join(subDir, 'agent-deadbeef.jsonl')
+    fs.writeFileSync(subFile, '')
     try {
-      const result = extractIntent(tmp)
-      expect(result).toContain('[sub-agent: run tests]')
-      expect(result).toContain('Run the test suite')
-      expect(result).not.toContain('Now spawning')
+      expect(resolveTranscriptPath(sessionJsonl, 'deadbeef')).toBe(subFile)
     } finally {
-      fs.unlinkSync(tmp)
+      fs.rmSync(tmp, { recursive: true, force: true })
     }
   })
 
-  it('returns Agent prompt when active Agent is in a more recent turn than last text', () => {
-    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa2.jsonl`)
-    const lines = [
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Doing analysis.' }] } }),
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tu_002', name: 'Agent', input: { prompt: 'Investigate the crash logs.', description: 'crash investigation' } }] } }),
-    ]
-    fs.writeFileSync(tmp, lines.join('\n') + '\n')
-    try {
-      const result = extractIntent(tmp)
-      expect(result).toContain('[sub-agent: crash investigation]')
-      expect(result).toContain('Investigate the crash logs')
-    } finally {
-      fs.unlinkSync(tmp)
-    }
-  })
-
-  it('falls back to parent text when Agent tool_use has a matching tool_result (completed)', () => {
-    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa3.jsonl`)
-    const lines = [
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Spawning agent to check docs.' }, { type: 'tool_use', id: 'tu_003', name: 'Agent', input: { prompt: 'Summarize the README.' } }] } }),
-      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'tu_003', content: 'done' }] } }),
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Now writing the report.' }] } }),
-    ]
-    fs.writeFileSync(tmp, lines.join('\n') + '\n')
-    try {
-      const result = extractIntent(tmp)
-      expect(result).toBe('Now writing the report.')
-      expect(result).not.toContain('sub-agent')
-    } finally {
-      fs.unlinkSync(tmp)
-    }
-  })
-
-  it('uses [sub-agent] label without description when Agent input has no description', () => {
-    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa4.jsonl`)
-    const turn = {
-      type: 'assistant',
-      message: {
-        content: [
-          { type: 'tool_use', id: 'tu_004', name: 'Agent', input: { prompt: 'Do the work.' } },
-        ],
-      },
-    }
-    fs.writeFileSync(tmp, JSON.stringify(turn) + '\n')
-    try {
-      const result = extractIntent(tmp)
-      expect(result).toMatch(/^\[sub-agent\] Do the work\./)
-    } finally {
-      fs.unlinkSync(tmp)
-    }
+  it('falls back to parent transcript when sub-agent file does not exist', () => {
+    expect(resolveTranscriptPath('/nonexistent/session.jsonl', 'deadbeef')).toBe('/nonexistent/session.jsonl')
   })
 })
 

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -127,6 +127,80 @@ describe('extractIntent', () => {
       fs.unlinkSync(tmp)
     }
   })
+
+  it('returns Agent prompt prefixed with label when sub-agent is active (same turn as text)', () => {
+    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa1.jsonl`)
+    const turn = {
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'Now spawning the Haiku agent.' },
+          { type: 'tool_use', id: 'tu_001', name: 'Agent', input: { prompt: 'Run the test suite and report failures.', description: 'run tests' } },
+        ],
+      },
+    }
+    fs.writeFileSync(tmp, JSON.stringify(turn) + '\n')
+    try {
+      const result = extractIntent(tmp)
+      expect(result).toContain('[sub-agent: run tests]')
+      expect(result).toContain('Run the test suite')
+      expect(result).not.toContain('Now spawning')
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+
+  it('returns Agent prompt when active Agent is in a more recent turn than last text', () => {
+    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa2.jsonl`)
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Doing analysis.' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tu_002', name: 'Agent', input: { prompt: 'Investigate the crash logs.', description: 'crash investigation' } }] } }),
+    ]
+    fs.writeFileSync(tmp, lines.join('\n') + '\n')
+    try {
+      const result = extractIntent(tmp)
+      expect(result).toContain('[sub-agent: crash investigation]')
+      expect(result).toContain('Investigate the crash logs')
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+
+  it('falls back to parent text when Agent tool_use has a matching tool_result (completed)', () => {
+    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa3.jsonl`)
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Spawning agent to check docs.' }, { type: 'tool_use', id: 'tu_003', name: 'Agent', input: { prompt: 'Summarize the README.' } }] } }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'tu_003', content: 'done' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Now writing the report.' }] } }),
+    ]
+    fs.writeFileSync(tmp, lines.join('\n') + '\n')
+    try {
+      const result = extractIntent(tmp)
+      expect(result).toBe('Now writing the report.')
+      expect(result).not.toContain('sub-agent')
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+
+  it('uses [sub-agent] label without description when Agent input has no description', () => {
+    const tmp = path.join(os.tmpdir(), `transcript-${process.pid}-sa4.jsonl`)
+    const turn = {
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tu_004', name: 'Agent', input: { prompt: 'Do the work.' } },
+        ],
+      },
+    }
+    fs.writeFileSync(tmp, JSON.stringify(turn) + '\n')
+    try {
+      const result = extractIntent(tmp)
+      expect(result).toMatch(/^\[sub-agent\] Do the work\./)
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
 })
 
 // ---- hook integration (subprocess) -----------------------------------------


### PR DESCRIPTION
fixes #82

when a sub-agent is active, `extractIntent` now returns the Agent tool's `input.prompt` (labelled `[sub-agent: <description>]`) instead of the parent worker's stale last text.

**how**: two-pass transcript scan — pass 1 collects completed `tool_use` ids (matched `tool_result`s in user turns), pass 2 scans backwards for the most recent Agent tool_use with no matching result. falls back to normal parent text when no active sub-agent found.

agent prompt wins over parent text in the same turn — parent narration ("spawning haiku agent") is less useful than the brief the sub-agent actually has to work with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)