### PR TITLE
permbot: collapse into MCP process + owner-gate via session id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ A Claude Code plugin to allow teams of agents (and humans!) to communicate over 
 Delivers
 - A CLI for spawning new Claude code instances (see `bin/roost`)
 - An MCP server to let Claude work with IRC and receive IRC messages (see `src/irc-server.ts`)
-- A hook to proxy permissions requests over IRC (see `bin/irc-permission-prompt` and `bin/roost-permbot`)
+- A hook to proxy permissions requests over IRC (see `bin/irc-permission-prompt`; the permbot routing daemon runs in-process inside `src/irc-server.ts`)
 
 Intended to ride ergo for IRCv3 (multiline and chathistory) support.
 
@@ -29,7 +29,7 @@ Use `script/worktree <branch> [--from <base>] [path]` to bootstrap a new worktre
 
 ## Plugin vs. project file layout
 
-Roost is a Claude Code plugin. Hook scripts live in `bin/` inside the plugin root and are wired by `bin/roost` at spawn time (written to `${ROOST_DATA_DIR}/roost-settings.json` and passed via `--settings`). They are **not** configured in `.claude/settings.json` — that file is project-local and not part of the plugin. Same pattern as `bin/irc-permission-prompt` / `bin/roost-permbot`.
+Roost is a Claude Code plugin. Hook scripts live in `bin/` inside the plugin root and are wired by `bin/roost` at spawn time (written to `${ROOST_DATA_DIR}/roost-settings.json` and passed via `--settings`). They are **not** configured in `.claude/settings.json` — that file is project-local and not part of the plugin. Same pattern as `bin/irc-permission-prompt`.
 
 ## Committing
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ When a Claude Code session loads `roost-irc` as an MCP and connects:
 /plugin install roost@roost
 ```
 
-This puts `roost`, `roost-permbot`, and `irc-permission-prompt` on
-your PATH and auto-loads the `roost-irc` MCP for every session.
+This puts `roost` and `irc-permission-prompt` on your PATH and
+auto-loads the `roost-irc` MCP for every session. The permbot
+routing daemon (used by `--perm-irc`) runs in-process inside the
+MCP — no separate launcher.
 
 After installing, pull dependencies:
 
@@ -137,9 +139,9 @@ irssi -c 127.0.0.1 -n myname
 
 ## IRC permission oversight (--perm-irc)
 
-`--perm-irc` starts a side daemon (`roost-permbot`) alongside the
-worker. The daemon holds a stable IRC nick `permbot-{worker}` and
-serializes the worker's PreToolUse permission prompts as DMs to
+`--perm-irc` runs a permbot routing module inside the worker's MCP
+process. The module holds a second IRC connection on a stable nick
+`permbot-{worker}` and serializes the worker's PreToolUse permission prompts as DMs to
 `--perm-target` (required). The operator replies `y` / `n` / `yes` /
 `no` / `allow` / `deny`; anything else or a 30s timeout falls through
 to the terminal prompt.
@@ -225,7 +227,6 @@ roost/
 ├── bin/
 │   ├── roost               Wrapper: spawn / shutdown / list / attach / tail / status / root.
 │   ├── roost-irc-server    PATH-resolvable launcher for the MCP server.
-│   ├── roost-permbot       IRC permission oversight daemon.
 │   └── irc-permission-prompt  PermissionRequest hook (thin socket client, loaded per-session by --perm-irc).
 ├── etc/ergo.yaml           Sample ergo IRC server config.
 ├── extras/weechat/         Optional weechat notification script.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ When a Claude Code session loads `roost-irc` as an MCP and connects:
 ```
 
 This puts `roost` and `irc-permission-prompt` on your PATH and
-auto-loads the `roost-irc` MCP for every session. The permbot
-routing daemon (used by `--perm-irc`) runs in-process inside the
-MCP — no separate launcher.
+auto-loads the `roost-irc` MCP for every session.
 
 After installing, pull dependencies:
 
@@ -141,7 +139,7 @@ irssi -c 127.0.0.1 -n myname
 
 `--perm-irc` runs a permbot routing module inside the worker's MCP
 process. The module holds a second IRC connection on a stable nick
-`permbot-{worker}` and serializes the worker's PreToolUse permission prompts as DMs to
+`permbot-{worker}` and serializes the worker's PermissionRequest prompts as DMs to
 `--perm-target` (required). The operator replies `y` / `n` / `yes` /
 `no` / `allow` / `deny`; anything else or a 30s timeout falls through
 to the terminal prompt.

--- a/bin/roost
+++ b/bin/roost
@@ -51,11 +51,11 @@ Options:
   -c, --channels CHANS       Comma-separated channels to auto-join.
                              Default: #roost
   -m, --model MODEL          Override --model. Default: opus.
-  --perm-irc                 Start a permbot side daemon that surfaces this
-                             worker's tool-permission prompts as DMs to
-                             --perm-target. Useful for non-Opus models that
-                             can't use auto mode. Spawned as a child of the
-                             MCP server and dies with it.
+  --perm-irc                 Run an in-process permbot inside the worker's
+                             MCP server. It surfaces this worker's
+                             tool-permission prompts as DMs to --perm-target.
+                             Useful for non-Opus models that can't use auto
+                             mode. Lifecycle = MCP lifecycle.
   --perm-target NICK         Operator nick to DM for permission prompts.
                              Required when --perm-irc is set.
   --permission-mode MODE     Override --permission-mode passed to claude.
@@ -188,8 +188,8 @@ require_ircd() {
 # spawn time (ROOST_DATA_DIR). The dir is stored in the tmux session env so
 # shutdown can find it:
 #   tmux show-environment -t roost-<nick> ROOST_DATA_DIR
-# Permbot (when --perm-irc is on) is spawned as a child of the MCP server in
-# src/irc-server.ts and dies with it — no lifecycle management here.
+# Permbot (when --perm-irc is on) runs in-process inside the MCP server
+# (src/irc-server.ts) — no separate process to manage here.
 
 cmd_spawn() {
   local nick=""
@@ -398,8 +398,8 @@ cmd_shutdown() {
   data_dir="$(tmux show-environment -t "${session_name}" ROOST_DATA_DIR 2>/dev/null | sed 's/^ROOST_DATA_DIR=//')"
   tmux kill-session -t "${session_name}"
   echo "killed ${session_name}"
-  # MCP exits with the tmux pane → permbot reparents → permbot exits via
-  # its own ppid watcher. We just clean up the per-session data dir.
+  # MCP (which hosts the in-process permbot) exits with the tmux pane.
+  # We just clean up the per-session data dir.
   if [ -n "${data_dir}" ] && [ -d "${data_dir}" ]; then
     rm -rf "${data_dir}"
   fi

--- a/bin/roost-permbot
+++ b/bin/roost-permbot
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Thin launcher — delegates to the TypeScript implementation.
-ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-exec bun "${ROOST_DIR}/src/permbot.ts"

--- a/docs/audit-2026-05-mcp.md
+++ b/docs/audit-2026-05-mcp.md
@@ -400,6 +400,11 @@ substrate swap may bring different canonicalization rules.
 
 ## Findings — `bin/roost-permbot` (318 LOC)
 
+> **Update (#188):** the standalone `bin/roost-permbot` launcher has been
+> deleted. Permbot now runs as a module (`src/permbot.ts`) loaded by
+> `src/irc-server.ts`. D2–D4 below are obsolete; L9 is moot since the
+> module rewrite is in TypeScript with named tuples.
+
 ### D2-D4. Dead state — delete · low · −6 LOC
 
 Three small dead bindings on the same wrapper class:

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -61,13 +61,14 @@ claude flag the wrapper doesn't otherwise know about.
 
 ## IRC permission oversight (--perm-irc)
 
-`--perm-irc` starts a side daemon (`bin/roost-permbot`) alongside the
-worker. The daemon holds a stable IRC nick `permbot-{worker}` and
-serializes the worker's PreToolUse permission prompts as DMs to
-`--perm-target` (required). The operator replies `y` / `n` /
-`yes` / `no` / `allow` / `deny` (case-insensitive); anything else or a
-30s timeout falls through to the regular terminal prompt as a safety
-net. `roost shutdown` reaps the daemon and its socket/pidfile.
+`--perm-irc` runs a permbot routing module inside the worker's MCP
+process. It opens a second IRC connection on the stable nick
+`permbot-{worker}` and serializes the worker's PreToolUse permission
+prompts as DMs to `--perm-target` (required). The operator replies
+`y` / `n` / `yes` / `no` / `allow` / `deny` (case-insensitive); anything
+else or a 30s timeout falls through to the regular terminal prompt as
+a safety net. Permbot lifecycle is the MCP's lifecycle — `roost
+shutdown` reaps it along with the worker.
 
 Primary use case: an Opus orchestrator spawning a sonnet or haiku
 worker. Non-Opus workers default to `acceptEdits` (edits auto-approved;
@@ -125,9 +126,11 @@ Stop with `pkill -f 'ergo run.*roost/etc/ergo.yaml'`.
 - **Per-PR reviewers** — `reviewer-<PR>`, e.g. `reviewer-123`.
   Join on CI green, leave on conclude.
 - **Watchers / observers** — descriptive (`ci-watcher`, `metrics-A`).
-- **Permbot side daemons** — `permbot-{worker}`, automatically named
-  by `--perm-irc` (don't pick a worker nick that would collide with an
-  existing `permbot-*` nick).
+- **Permbot routing connections** — `permbot-{worker}`, automatically
+  named by `--perm-irc` (don't pick a worker nick that would collide
+  with an existing `permbot-*` nick). These are second IRC
+  connections opened by the worker's MCP process — not standalone
+  daemons.
 
 Ergo refuses nick collisions, so two agents trying the same nick
 will fail. The wrapper doesn't enforce uniqueness for you — pick

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -63,12 +63,12 @@ claude flag the wrapper doesn't otherwise know about.
 
 `--perm-irc` runs a permbot routing module inside the worker's MCP
 process. It opens a second IRC connection on the stable nick
-`permbot-{worker}` and serializes the worker's PreToolUse permission
+`permbot-{worker}` and serializes the worker's PermissionRequest
 prompts as DMs to `--perm-target` (required). The operator replies
 `y` / `n` / `yes` / `no` / `allow` / `deny` (case-insensitive); anything
-else or a 30s timeout falls through to the regular terminal prompt as
-a safety net. Permbot lifecycle is the MCP's lifecycle — `roost
-shutdown` reaps it along with the worker.
+else falls through to the regular terminal prompt as a safety net.
+Permbot lifecycle is the MCP's lifecycle — `roost shutdown` reaps it
+along with the worker.
 
 Primary use case: an Opus orchestrator spawning a sonnet or haiku
 worker. Non-Opus workers default to `acceptEdits` (edits auto-approved;

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -23,6 +23,7 @@
  *   ROOST_IRC_JOIN_HISTORY_MINUTES Time window for join history in minutes (default: 30)
  */
 
+import * as path from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
@@ -30,10 +31,13 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { RoostIrcClient, ClientConfig, UnreadInfo } from './irc-client.js'
+import { startPermbot, type PermbotConfig } from './permbot.js'
+import { claimOwnership } from './owner-gate.js'
 
 const SOURCE_NAME = 'roost-irc'
 
 export const NOT_READY_SENTINEL = 'IRC client not ready (still connecting).'
+export const PASSIVE_SENTINEL = 'roost-irc MCP is passive: a sibling MCP in the same ROOST_DATA_DIR already owns this nick. Tools are disabled in this instance.'
 
 const REPLY_REMINDER = 'Substantive replies should be posted to IRC.'
 // 1/7 — midpoint of the 1/5–1/10 range from #136. Random rate avoids the
@@ -131,12 +135,20 @@ const TOOL_SCHEMAS = [
   },
 ]
 
+export interface CreateMcpOptions {
+  // Passive MCPs (lost the owner race in claimOwnership) keep the stdio
+  // transport up so claude doesn't see a crashed plugin, but every tool
+  // call short-circuits with PASSIVE_SENTINEL. No IRC events are wired.
+  passive?: boolean
+}
+
 // Wire the MCP server and subscribe to typed IRC events. Does NOT connect to
 // any transport or start the IRC connection — the caller does both after
 // createMcpServer returns. Call order: createMcpServer → server.connect(transport)
 // → ircClient.connect.
-export function createMcpServer(client: RoostIrcClient, config: ClientConfig): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
+export function createMcpServer(client: RoostIrcClient, config: ClientConfig, options: CreateMcpOptions = {}): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
   const { nick: NICK, autoJoin: AUTO_JOIN } = config
+  const passive = options.passive === true
 
   // Per-MCP monotonic receive counter — gives downstream consumers a
   // strictly-monotonic ordering even when two events resolve to the same
@@ -186,6 +198,23 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig): {
     const unread = client.getUnread()
     if (unread.size === 0) return ''
     return '\nunread:\n' + [...unread.entries()].map(([ch, i]) => `  ${formatUnreadLine(ch, i)}`).join('\n')
+  }
+
+  // ---- Passive short-circuit ---------------------------------------------
+  // No event subscriptions in passive mode — we never connect the client,
+  // so they'd never fire anyway, but skipping makes intent explicit.
+
+  if (passive) {
+    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))
+    mcp.setRequestHandler(CallToolRequestSchema, async () => ({
+      content: [{ type: 'text', text: PASSIVE_SENTINEL }],
+      isError: true,
+    }))
+    return {
+      server: mcp,
+      clearDedupeCache: () => { /* no-op */ },
+      emitUnreadSummary: async () => { /* no-op */ },
+    }
   }
 
   // ---- Typed event subscriptions -----------------------------------------
@@ -374,51 +403,13 @@ if (import.meta.main) {
     .map(s => s.trim())
     .filter(Boolean)
 
-  // Write our PID so the PreCompact hook can signal us. Only when ROOST_DATA_DIR
-  // is set — that's always true for sessions spawned by bin/roost.
+  // Owner gate: nested claudes (e.g. `claude -p ...` from a Bash tool call)
+  // inherit ROOST_DATA_DIR via tmux env and would otherwise spawn a duplicate
+  // MCP that collides with the owner's IRC nick. First MCP to start wins;
+  // later starters detect the mismatch and stay passive.
   const DATA_DIR = process.env['ROOST_DATA_DIR'] ?? ''
-  if (DATA_DIR) {
-    try {
-      await Bun.write(`${DATA_DIR}/mcp.pid`, String(process.pid))
-    } catch (e) {
-      process.stderr.write(`roost-irc[${NICK}]: warn: could not write pidfile: ${e}\n`)
-    }
-  }
-
-  // Spawn permbot as our child when the side-daemon is requested. Permbot's
-  // lifecycle then rides this MCP's lifecycle: when claude exits, we exit
-  // (stdio EOF), permbot detects ppid change and exits. No external pidfiles,
-  // no stale-reap on next spawn.
-  const PERM_SOCK = process.env['ROOST_PERM_SOCK'] ?? ''
-  const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''
-  let permbotProc: import('bun').Subprocess | null = null
-  if (PERM_SOCK && PERM_TARGET) {
-    const permbotPath = new URL('./permbot.ts', import.meta.url).pathname
-    // ROOST_PERM_SOCK / ROOST_PERM_TARGET are already in process.env (set by
-    // bin/roost via tmux -e). ROOST_PERM_WORKER and ROOST_PERM_DEBUG_LOG
-    // default sensibly inside permbot.ts (worker = nick minus 'permbot-',
-    // log = dirname(sock)/permbot.log). Only ROOST_PERM_NICK needs explicit
-    // setting — the prefix convention lives in one place: here.
-    // stdout=ignore: MCP owns parent stdout for JSON-RPC protocol; permbot
-    // writes there would corrupt it. stderr=inherit lets permbot logs surface
-    // alongside MCP logs in the tmux pane.
-    permbotProc = Bun.spawn([process.execPath, permbotPath], {
-      env: { ...process.env, ROOST_PERM_NICK: `permbot-${NICK}` } as Record<string, string>,
-      stdin: 'ignore',
-      stdout: 'ignore',
-      stderr: 'inherit',
-    })
-    process.stderr.write(`roost-irc[${NICK}]: spawned permbot child (pid ${permbotProc.pid})\n`)
-  }
-
-  const killPermbot = () => {
-    if (permbotProc && permbotProc.exitCode === null) {
-      try { permbotProc.kill('SIGTERM') } catch { /* ignore */ }
-    }
-  }
-  process.on('exit', killPermbot)
-  process.on('SIGINT', () => { killPermbot(); process.exit(130) })
-  process.on('SIGTERM', () => { killPermbot(); process.exit(143) })
+  const SESSION_ID = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
+  const ownership = (DATA_DIR && SESSION_ID) ? claimOwnership(DATA_DIR, SESSION_ID) : 'owner'
 
   const clientConfig: ClientConfig = {
     nick: NICK,
@@ -428,8 +419,71 @@ if (import.meta.main) {
     joinHistoryMinutes: numericEnv('ROOST_IRC_JOIN_HISTORY_MINUTES', 30),
   }
 
+  if (ownership === 'passive') {
+    process.stderr.write(`roost-irc[${NICK}]: passive — owner.session held by sibling MCP, skipping IRC connect / permbot / pidfile\n`)
+    const ircClient = new RoostIrcClientImpl(clientConfig)
+    const { server: mcp } = createMcpServer(ircClient, clientConfig, { passive: true })
+    await mcp.connect(new StdioServerTransport())
+    process.stderr.write(`roost-irc[${NICK}]: passive MCP transport up at ${new Date().toISOString()}\n`)
+  } else {
+
+  // Owner path: write pidfile so the PreCompact hook can signal us, then
+  // bring up worker IRC + (optional) in-process permbot.
+  if (DATA_DIR) {
+    try {
+      await Bun.write(`${DATA_DIR}/mcp.pid`, String(process.pid))
+    } catch (e) {
+      process.stderr.write(`roost-irc[${NICK}]: warn: could not write pidfile: ${e}\n`)
+    }
+  }
+
   const ircClient = new RoostIrcClientImpl(clientConfig)
   const { server: mcp, clearDedupeCache, emitUnreadSummary } = createMcpServer(ircClient, clientConfig)
+
+  // Permbot runs in-process when --perm-irc is on. Same MCP, second IRC
+  // connection on nick `permbot-${NICK}`. Lifecycle = MCP lifecycle, so a
+  // crashed nested-claude spawn can no longer kick the worker's permbot
+  // off via nick collision (#188). The hook stays a separate process and
+  // talks to us over the unix socket as before.
+  const PERM_SOCK = process.env['ROOST_PERM_SOCK'] ?? ''
+  const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''
+  let permbotStop: (() => void) | null = null
+  if (PERM_SOCK && PERM_TARGET) {
+    const permbotNick = `permbot-${NICK}`
+    const permbotClient = new RoostIrcClientImpl({
+      nick: permbotNick,
+      autoJoin: [],
+      historySize: 0,
+      joinHistoryLines: 0,
+      joinHistoryMinutes: 0,
+    })
+    const permbotConfig: PermbotConfig = {
+      nick: permbotNick,
+      sockPath: PERM_SOCK,
+      target: PERM_TARGET,
+      worker: NICK,
+      debugLog: path.join(path.dirname(PERM_SOCK), 'permbot.log'),
+    }
+    const { stop } = startPermbot(permbotConfig, permbotClient)
+    permbotStop = stop
+    permbotClient.connect({
+      host: SERVER,
+      port: PORT,
+      nick: permbotNick,
+      username: permbotNick,
+      gecos: 'roost-permbot',
+      autoReconnect: true,
+      autoReconnectMaxRetries: 10,
+    })
+    process.stderr.write(`roost-irc[${NICK}]: started in-process permbot (nick ${permbotNick}, sock ${PERM_SOCK})\n`)
+  }
+
+  const shutdown = (code: number) => {
+    if (permbotStop) { try { permbotStop() } catch { /* ignore */ } }
+    process.exit(code)
+  }
+  process.on('SIGINT', () => shutdown(130))
+  process.on('SIGTERM', () => shutdown(143))
 
   // SIGUSR1: PreCompact hook fires this to clear the seen-set. Next backfill
   // after reconnect re-delivers messages compacted out of the agent's context.
@@ -453,4 +507,6 @@ if (import.meta.main) {
     autoReconnectMaxRetries: 10,
   })
   process.stderr.write(`roost-irc[${NICK}]: connecting to ${SERVER}:${PORT}...\n`)
+
+  } // end owner branch
 }

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -23,7 +23,6 @@
  *   ROOST_IRC_JOIN_HISTORY_MINUTES Time window for join history in minutes (default: 30)
  */
 
-import * as path from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
@@ -37,7 +36,7 @@ import { claimOwnership } from './owner-gate.js'
 const SOURCE_NAME = 'roost-irc'
 
 export const NOT_READY_SENTINEL = 'IRC client not ready (still connecting).'
-export const PASSIVE_SENTINEL = 'roost-irc MCP is passive: a sibling MCP in the same ROOST_DATA_DIR already owns this nick. Tools are disabled in this instance.'
+const PASSIVE_SENTINEL = 'roost-irc MCP is passive: a sibling MCP in the same ROOST_DATA_DIR already owns this nick. Tools are disabled in this instance.'
 
 const REPLY_REMINDER = 'Substantive replies should be posted to IRC.'
 // 1/7 — midpoint of the 1/5–1/10 range from #136. Random rate avoids the
@@ -148,7 +147,31 @@ export interface CreateMcpOptions {
 // → ircClient.connect.
 export function createMcpServer(client: RoostIrcClient, config: ClientConfig, options: CreateMcpOptions = {}): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
   const { nick: NICK, autoJoin: AUTO_JOIN } = config
-  const passive = options.passive === true
+
+  // ---- Passive short-circuit ---------------------------------------------
+  // Lost the owner race in claimOwnership(). Build a minimal MCP that errors
+  // every tool call so claude doesn't see a crashed plugin. No state, no
+  // event subscriptions, no IRC client interaction.
+
+  if (options.passive === true) {
+    const mcp = new Server(
+      { name: SOURCE_NAME, version: '0.0.1' },
+      {
+        capabilities: { tools: {} },
+        instructions: `roost IRC MCP (passive instance for nick "${NICK}"). All tool calls error.`,
+      },
+    )
+    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))
+    mcp.setRequestHandler(CallToolRequestSchema, async () => ({
+      content: [{ type: 'text', text: PASSIVE_SENTINEL }],
+      isError: true,
+    }))
+    return {
+      server: mcp,
+      clearDedupeCache: () => { /* no-op */ },
+      emitUnreadSummary: async () => { /* no-op */ },
+    }
+  }
 
   // Per-MCP monotonic receive counter — gives downstream consumers a
   // strictly-monotonic ordering even when two events resolve to the same
@@ -198,23 +221,6 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
     const unread = client.getUnread()
     if (unread.size === 0) return ''
     return '\nunread:\n' + [...unread.entries()].map(([ch, i]) => `  ${formatUnreadLine(ch, i)}`).join('\n')
-  }
-
-  // ---- Passive short-circuit ---------------------------------------------
-  // No event subscriptions in passive mode — we never connect the client,
-  // so they'd never fire anyway, but skipping makes intent explicit.
-
-  if (passive) {
-    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))
-    mcp.setRequestHandler(CallToolRequestSchema, async () => ({
-      content: [{ type: 'text', text: PASSIVE_SENTINEL }],
-      isError: true,
-    }))
-    return {
-      server: mcp,
-      clearDedupeCache: () => { /* no-op */ },
-      emitUnreadSummary: async () => { /* no-op */ },
-    }
   }
 
   // ---- Typed event subscriptions -----------------------------------------
@@ -426,9 +432,24 @@ if (import.meta.main) {
     await mcp.connect(new StdioServerTransport())
     process.stderr.write(`roost-irc[${NICK}]: passive MCP transport up at ${new Date().toISOString()}\n`)
   } else {
+    await runOwnerMcp({ NICK, REALNAME, SERVER, PORT, DATA_DIR, clientConfig, RoostIrcClientImpl })
+  }
+}
 
-  // Owner path: write pidfile so the PreCompact hook can signal us, then
-  // bring up worker IRC + (optional) in-process permbot.
+// Owner path: pidfile + worker IRC + (optional) in-process permbot.
+// Extracted from the if-block to keep the entrypoint flat — the passive
+// branch returns early; this is the rest.
+async function runOwnerMcp(args: {
+  NICK: string
+  REALNAME: string
+  SERVER: string
+  PORT: number
+  DATA_DIR: string
+  clientConfig: ClientConfig
+  RoostIrcClientImpl: typeof import('./irc-client-impl.js').RoostIrcClientImpl
+}): Promise<void> {
+  const { NICK, REALNAME, SERVER, PORT, DATA_DIR, clientConfig, RoostIrcClientImpl } = args
+
   if (DATA_DIR) {
     try {
       await Bun.write(`${DATA_DIR}/mcp.pid`, String(process.pid))
@@ -462,7 +483,6 @@ if (import.meta.main) {
       sockPath: PERM_SOCK,
       target: PERM_TARGET,
       worker: NICK,
-      debugLog: path.join(path.dirname(PERM_SOCK), 'permbot.log'),
     }
     const { stop } = startPermbot(permbotConfig, permbotClient)
     permbotStop = stop
@@ -477,7 +497,7 @@ if (import.meta.main) {
   }
 
   const shutdown = (code: number) => {
-    if (permbotStop) { try { permbotStop() } catch { /* ignore */ } }
+    try { permbotStop?.() } catch { /* ignore */ }
     process.exit(code)
   }
   process.on('SIGINT', () => shutdown(130))
@@ -505,6 +525,4 @@ if (import.meta.main) {
     autoReconnectMaxRetries: 10,
   })
   process.stderr.write(`roost-irc[${NICK}]: connecting to ${SERVER}:${PORT}...\n`)
-
-  } // end owner branch
 }

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -472,8 +472,6 @@ if (import.meta.main) {
       nick: permbotNick,
       username: permbotNick,
       gecos: 'roost-permbot',
-      autoReconnect: true,
-      autoReconnectMaxRetries: 10,
     })
     process.stderr.write(`roost-irc[${NICK}]: started in-process permbot (nick ${permbotNick}, sock ${PERM_SOCK})\n`)
   }

--- a/src/owner-gate.ts
+++ b/src/owner-gate.ts
@@ -1,0 +1,46 @@
+// Owner-gate: ensures only one MCP per ROOST_DATA_DIR claims the IRC nick
+// and binds the permbot socket. Nested claudes (e.g. `claude -p ...` from
+// inside a Bash tool call) inherit the same DATA_DIR via tmux env and would
+// otherwise spawn a duplicate MCP that collides with the owner's IRC nick.
+//
+// First MCP to start atomic-creates `${dataDir}/owner.session` with its
+// CLAUDE_CODE_SESSION_ID. Later starters compare; mismatch → passive.
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+export type Ownership = 'owner' | 'passive'
+
+const FILE = 'owner.session'
+
+// Atomic claim — used by the MCP at startup. Writes our session id if the
+// file is absent; on EEXIST, compares and returns 'passive' on mismatch.
+// Same session re-running (e.g. after a transient crash) re-acquires owner.
+export function claimOwnership(dataDir: string, sessionId: string): Ownership {
+  const p = path.join(dataDir, FILE)
+  try {
+    const fd = fs.openSync(p, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600)
+    try { fs.writeSync(fd, sessionId) } finally { fs.closeSync(fd) }
+    return 'owner'
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e
+    const existing = fs.readFileSync(p, 'utf8').trim()
+    return existing === sessionId ? 'owner' : 'passive'
+  }
+}
+
+// Read-only check — used by the permission-prompt hook. Returns 'no-gate'
+// when the file is absent or env vars are missing, so callers can fall back
+// to legacy behavior. Returns 'passive' iff the file exists with a session
+// id different from ours.
+export function checkOwnership(dataDir: string, sessionId: string): Ownership | 'no-gate' {
+  if (!dataDir || !sessionId) return 'no-gate'
+  const p = path.join(dataDir, FILE)
+  let existing: string
+  try {
+    existing = fs.readFileSync(p, 'utf8').trim()
+  } catch {
+    return 'no-gate'
+  }
+  return existing === sessionId ? 'owner' : 'passive'
+}

--- a/src/owner-gate.ts
+++ b/src/owner-gate.ts
@@ -16,11 +16,17 @@ const FILE = 'owner.session'
 // Atomic claim — used by the MCP at startup. Writes our session id if the
 // file is absent; on EEXIST, compares and returns 'passive' on mismatch.
 // Same session re-running (e.g. after a transient crash) re-acquires owner.
+//
+// Stale-file note: nothing deletes owner.session by itself; `roost shutdown`
+// rms the whole data dir. If the data dir survives an abnormal exit (manual
+// tmux kill, crash mid-session) and a *different* CLAUDE_CODE_SESSION_ID
+// boots later in the same dir, that starter goes passive against the stale
+// file. Same-session re-acquires fine. In practice we always start fresh
+// dirs via `roost spawn`, so this is a known edge, not a recurring bug.
 export function claimOwnership(dataDir: string, sessionId: string): Ownership {
   const p = path.join(dataDir, FILE)
   try {
-    const fd = fs.openSync(p, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600)
-    try { fs.writeSync(fd, sessionId) } finally { fs.closeSync(fd) }
+    fs.writeFileSync(p, sessionId, { flag: 'wx', mode: 0o600 })
     return 'owner'
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'node:fs'
 import * as net from 'node:net'
+import * as path from 'node:path'
 import type { IrcMessage, RoostIrcClient } from './irc-client.js'
 
 // ---- Types ------------------------------------------------------------------
@@ -14,7 +15,9 @@ export interface PermbotConfig {
   sockPath: string
   target: string
   worker: string
-  debugLog: string
+  // Defaults to <dirname(sockPath)>/permbot.log when omitted. Pass '/dev/null'
+  // in tests to silence file output.
+  debugLog?: string
   nudgeAfterMs?: number  // default: 5 minutes; exposed for testing
 }
 
@@ -46,7 +49,8 @@ export function startPermbot(
   config: PermbotConfig,
   client: RoostIrcClient,
 ): { stop: () => void; ready: Promise<void> } {
-  const { nick, sockPath, target, worker, debugLog } = config
+  const { nick, sockPath, target, worker } = config
+  const debugLog = config.debugLog ?? path.join(path.dirname(sockPath), 'permbot.log')
   const nudgeAfterMs = config.nudgeAfterMs ?? 5 * 60 * 1000
   const log = (msg: string) => dlog(debugLog, nick, msg)
 

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -175,11 +175,13 @@ export function startPermbot(
       log('FATAL nick registration failure, shutting down')
       stop()
     } else if (kind === 'disconnected') {
-      // The IRC client auto-reconnects; lifecycle is the MCP process. Log
-      // and let the next 'reconnected' system event resume the y/n flow.
-      log('IRC connection lost (transient — auto-reconnect in progress)')
-    } else if (kind === 'reconnected') {
-      log('IRC reconnected')
+      // Tear down on disconnect. The hook's askDaemon detects the missing
+      // socket and falls back to a transient-DM + emit('ask'), so the
+      // worker degrades cleanly. Owner-gate eliminates the collision-driven
+      // disconnect that motivated #188; if a real network drop becomes a
+      // recurring failure mode, add auto-reconnect as a followup.
+      log('IRC connection lost, shutting down')
+      stop()
     } else if (kind === 'cap-missing') {
       log('cap-missing (ignored)')
     }

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -1,8 +1,10 @@
-#!/usr/bin/env bun
+// Permbot: queues permission-prompt summaries from the worker's hook,
+// DMs them to the operator, and routes the y/n reply back over the unix
+// socket. Loaded as a module by irc-server.ts — owns one of the two IRC
+// connections held by the MCP process.
 
 import * as fs from 'node:fs'
 import * as net from 'node:net'
-import * as path from 'node:path'
 import type { IrcMessage, RoostIrcClient } from './irc-client.js'
 
 // ---- Types ------------------------------------------------------------------
@@ -51,7 +53,6 @@ export function startPermbot(
   const queue: QueueEntry[] = []
   let inFlight: InFlight | null = null
   let shuttingDown = false
-  let ppidTimer: ReturnType<typeof setInterval> | null = null
 
   function respond(socket: net.Socket, payload: object): void {
     try { socket.write(JSON.stringify(payload) + '\n') } catch { /* ignore */ }
@@ -105,7 +106,6 @@ export function startPermbot(
     }
     for (const e of queue) respond(e.socket, { error: 'daemon shutting down' })
     queue.length = 0
-    if (ppidTimer !== null) clearInterval(ppidTimer)
     try { client.quit() } catch { /* ignore */ }
     server.close()
     try { fs.unlinkSync(sockPath) } catch { /* ignore */ }
@@ -175,65 +175,15 @@ export function startPermbot(
       log('FATAL nick registration failure, shutting down')
       stop()
     } else if (kind === 'disconnected') {
-      log('IRC connection lost, shutting down')
-      stop()
+      // The IRC client auto-reconnects; lifecycle is the MCP process. Log
+      // and let the next 'reconnected' system event resume the y/n flow.
+      log('IRC connection lost (transient — auto-reconnect in progress)')
+    } else if (kind === 'reconnected') {
+      log('IRC reconnected')
     } else if (kind === 'cap-missing') {
       log('cap-missing (ignored)')
     }
   })
 
-  // ---- Parent reparent watcher ---------------------------------------------
-  // Capture initial ppid (the spawning process — typically the MCP server).
-  // When it dies, kernel reparents us to init/launchd → ppid changes → exit.
-  // Bounds orphan window to one poll interval; no env-var config needed.
-
-  const initialPpid = process.ppid
-  ppidTimer = setInterval(() => {
-    if (process.ppid !== initialPpid) {
-      log(`parent reparented (${initialPpid} → ${process.ppid}), shutting down`)
-      stop()
-    }
-  }, 1000)
-  ppidTimer.unref?.()
-
   return { stop, ready }
-}
-
-// ---- Entrypoint -------------------------------------------------------------
-
-if (import.meta.main) {
-  const env = (k: string, def?: string): string | undefined => process.env[k] ?? def
-  const required = (k: string): string => {
-    const v = process.env[k]
-    if (!v) { process.stderr.write(`roost-permbot: FATAL: ${k} required\n`); process.exit(2) }
-    return v
-  }
-
-  const NICK     = required('ROOST_PERM_NICK')
-  const SOCK     = required('ROOST_PERM_SOCK')
-  const TARGET   = required('ROOST_PERM_TARGET')
-  const HOST     = env('ROOST_PERM_HOST', '127.0.0.1')!
-  const PORT     = Number(env('ROOST_PERM_PORT', '6667'))
-  const WORKER   = env('ROOST_PERM_WORKER') ?? NICK.replace(/^permbot-/, '')
-  const LOG      = env('ROOST_PERM_DEBUG_LOG') ?? path.join(path.dirname(SOCK), 'permbot.log')
-
-  const { RoostIrcClientImpl } = await import('./irc-client-impl.js')
-  const client = new RoostIrcClientImpl({
-    nick: NICK,
-    autoJoin: [],
-    historySize: 0,
-    joinHistoryLines: 0,
-    joinHistoryMinutes: 0,
-  })
-
-  const config: PermbotConfig = {
-    nick: NICK, sockPath: SOCK, target: TARGET,
-    worker: WORKER, debugLog: LOG,
-  }
-
-  const { stop } = startPermbot(config, client)
-  client.connect({ host: HOST, port: PORT, nick: NICK, username: NICK, gecos: 'roost-permbot' })
-
-  process.on('SIGTERM', stop)
-  process.on('SIGINT', stop)
 }

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -3,12 +3,15 @@
 import * as fs from 'node:fs'
 import * as net from 'node:net'
 import * as path from 'node:path'
+import { checkOwnership } from './owner-gate.js'
 
 const WORKER      = process.env['ROOST_IRC_NICK'] ?? 'unknown'
 const SOCK_PATH   = process.env['ROOST_PERM_SOCK'] ?? ''
 const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''
 const PERM_HOST   = process.env['ROOST_PERM_HOST'] ?? '127.0.0.1'
 const PERM_PORT   = Number(process.env['ROOST_PERM_PORT'] ?? '6667')
+const DATA_DIR    = process.env['ROOST_DATA_DIR'] ?? ''
+const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
 const SOCKET_SAFETY_TIMEOUT = 570 // just under Claude Code's 600s hook default
 
 const PASSTHROUGH_PREFIXES = ['mcp__roost-irc__', 'mcp__plugin_roost_roost-irc__']
@@ -242,6 +245,16 @@ if (import.meta.main) {
   const agentId        = String(payload!['agent_id'] ?? '')
 
   if (PASSTHROUGH_PREFIXES.some(p => toolName.startsWith(p))) emit('allow', 'roost-irc passthrough')
+
+  // Owner-gate short-circuit (#188): nested claudes inherit the parent's
+  // ROOST_DATA_DIR via tmux env, so the unix socket path resolves to the
+  // owner's permbot. Routing a nested-claude's prompt there would DM the
+  // operator about a tool call they didn't initiate. Defer to the local
+  // terminal prompt before touching the socket at all.
+  if (DATA_DIR && SESSION_ID) {
+    const ownership = checkOwnership(DATA_DIR, SESSION_ID)
+    if (ownership === 'passive') emit('ask', 'nested claude (non-owner session) — local prompt')
+  }
 
   const intent = extractIntent(resolveTranscriptPath(transcriptPath, agentId))
   const summaryLines = summarize(toolName, toolInput)

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -244,6 +244,9 @@ if (import.meta.main) {
   const transcriptPath = String(payload!['transcript_path'] ?? '')
   const agentId        = String(payload!['agent_id'] ?? '')
 
+  // Passthrough check runs BEFORE the owner gate: roost-irc tool calls are
+  // safe from any session (worker, nested, owner) and we never want to ask
+  // the operator to approve them. Anything else falls through to the gate.
   if (PASSTHROUGH_PREFIXES.some(p => toolName.startsWith(p))) emit('allow', 'roost-irc passthrough')
 
   // Owner-gate short-circuit (#188): nested claudes inherit the parent's

--- a/test/helpers/mcp.ts
+++ b/test/helpers/mcp.ts
@@ -16,11 +16,18 @@ let instanceCounter = 0
 export async function startMcp(ergo: ErgoContext, nick?: string, extraEnv?: Record<string, string>): Promise<McpHandle> {
   const clientNick = nick ?? `mcp${++instanceCounter}`
 
+  // Scrub roost-related env from the parent process so the subprocess
+  // doesn't inherit a real worker's ROOST_DATA_DIR / ROOST_PERM_* and
+  // accidentally bind a test permbot on top of the operator's live socket.
+  const scrubbed = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith('ROOST_')),
+  )
+
   const transport = new StdioClientTransport({
     command: 'bun',
     args: ['run', join(ROOST_ROOT, 'src', 'irc-server.ts')],
     env: {
-      ...process.env,
+      ...scrubbed,
       ROOST_IRC_SERVER: ergo.host,
       ROOST_IRC_PORT: String(ergo.port),
       ROOST_IRC_NICK: clientNick,

--- a/test/owner-gate.test.ts
+++ b/test/owner-gate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { claimOwnership, checkOwnership } from '../src/owner-gate.js'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* ignore */ }
+  dirs.length = 0
+})
+
+function tmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'owner-gate-test-'))
+  dirs.push(d)
+  return d
+}
+
+describe('claimOwnership', () => {
+  it('first claimer wins and writes the session file', () => {
+    const d = tmpDir()
+    expect(claimOwnership(d, 'sess-1')).toBe('owner')
+    expect(fs.readFileSync(path.join(d, 'owner.session'), 'utf8').trim()).toBe('sess-1')
+  })
+
+  it('same session re-claiming returns owner (idempotent restart)', () => {
+    const d = tmpDir()
+    expect(claimOwnership(d, 'sess-1')).toBe('owner')
+    expect(claimOwnership(d, 'sess-1')).toBe('owner')
+  })
+
+  it('second claimer with a different session goes passive', () => {
+    const d = tmpDir()
+    expect(claimOwnership(d, 'sess-A')).toBe('owner')
+    expect(claimOwnership(d, 'sess-B')).toBe('passive')
+    // owner.session is unchanged
+    expect(fs.readFileSync(path.join(d, 'owner.session'), 'utf8').trim()).toBe('sess-A')
+  })
+})
+
+describe('checkOwnership', () => {
+  it('returns no-gate when env-derived inputs are blank', () => {
+    expect(checkOwnership('', 'sess-1')).toBe('no-gate')
+    expect(checkOwnership(tmpDir(), '')).toBe('no-gate')
+  })
+
+  it('returns no-gate when owner.session does not exist', () => {
+    expect(checkOwnership(tmpDir(), 'sess-1')).toBe('no-gate')
+  })
+
+  it('returns owner when session matches owner.session', () => {
+    const d = tmpDir()
+    claimOwnership(d, 'sess-1')
+    expect(checkOwnership(d, 'sess-1')).toBe('owner')
+  })
+
+  it('returns passive when session differs from owner.session', () => {
+    const d = tmpDir()
+    claimOwnership(d, 'sess-A')
+    expect(checkOwnership(d, 'sess-B')).toBe('passive')
+  })
+
+  it('does not write owner.session as a side effect', () => {
+    const d = tmpDir()
+    expect(checkOwnership(d, 'sess-1')).toBe('no-gate')
+    expect(fs.existsSync(path.join(d, 'owner.session'))).toBe(false)
+  })
+})

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -263,4 +263,32 @@ describe('permission-prompt hook', () => {
     const { stderr } = await runHook({ ROOST_IRC_NICK: 'worker-test' })
     expect(stderr).toContain('deferring to terminal')
   })
+
+  it('owner-gate short-circuits before any socket touch when nested (#188)', async () => {
+    // Owner.session is held by sess-A; this hook run carries CLAUDE_CODE_SESSION_ID=sess-B,
+    // so checkOwnership() must short-circuit BEFORE askDaemon connects to the unix socket.
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-hook-test-'))
+    const sockPath = path.join(dataDir, 'permbot.sock')
+    fs.writeFileSync(path.join(dataDir, 'owner.session'), 'sess-A')
+
+    let connected = false
+    const sockServer = net.createServer((s) => { connected = true; s.destroy() })
+    await new Promise<void>(r => sockServer.listen(sockPath, () => r()))
+
+    try {
+      const { stdout, stderr } = await runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_DATA_DIR: dataDir,
+        CLAUDE_CODE_SESSION_ID: 'sess-B',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+      })
+      expect(connected).toBe(false)
+      expect(stderr).toContain('nested claude')
+      expect(stdout).toBe('')  // emit('ask') is a no-stdout exit
+    } finally {
+      await new Promise<void>(r => sockServer.close(() => r()))
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- **Collapse permbot into the MCP process.** `src/permbot.ts` becomes a module loaded by `src/irc-server.ts`; the MCP now holds two `RoostIrcClientImpl`s (worker + `permbot-${NICK}`). Drops the `Bun.spawn(permbot.ts)` block, the standalone `bin/roost-permbot` launcher, and the parent-reparent watcher.
- **Owner gate via `CLAUDE_CODE_SESSION_ID`.** New `src/owner-gate.ts`. First MCP per `ROOST_DATA_DIR` atomic-creates `owner.session` (`O_EXCL`); later starters with a mismatching session id stay passive (no IRC nick claim, no permbot, no socket bind, no pidfile write — tools return `PASSIVE_SENTINEL`). The `irc-permission-prompt` hook does the same compare and short-circuits to `emit('ask', ...)` BEFORE any socket touch, so nested claudes get the normal terminal prompt instead of DMing the parent's operator.

closes #188.

## Why

Root cause from #188 (lead-pm + alex): nested claudes inherit the worker's `ROOST_DATA_DIR`/`ROOST_PERM_SOCK`/`ROOST_IRC_NICK` via tmux env. The user-installed roost plugin in the nested claude auto-spawned a second MCP, which spawned a second permbot with the same `permbot-${NICK}` — ergo kicked the original off via nick collision and the worker was permbot-less for the rest of the session. Heartbeat/reconnect treats the symptom; the real fix is making duplicate MCPs benign.

## Test plan

- [x] `bun test` (216 pass, 0 fail; ergo-driven integration tests pass)
- [x] `bun tsc --noEmit` clean
- [x] new `test/owner-gate.test.ts` — claim/check matrix incl. EEXIST-with-different-session goes passive
- [x] new case in `test/permission-prompt.test.ts` — owner-gate short-circuits hook BEFORE binding a unix listener (asserts no client connection observed on the listener)
- [x] existing `test/permbot.test.ts` unchanged and still passes (it always tested `startPermbot()` against a mock client — that's the public surface)

Drive-by: `test/helpers/mcp.ts` now scrubs `ROOST_*` env vars from the spawned subprocess so test runs from inside a live worker session don't accidentally bind a test permbot on top of the operator's real socket. Pre-existing leak; surfaced once permbot ran in-process and logged through the same nick.

## Notes for review

- Open Q from plan: claude's behavior on a crashed MCP (auto-restart? loop?) is unverified — defaulted to passive-stay-alive per lead-pm's pressure. If the next nested-claude scenario shows passive is overkill, can switch to exit-at-startup.
- `bin/roost-permbot` deleted (no back-compat per CLAUDE.md).
- audit doc (`docs/audit-2026-05-mcp.md`) section "Findings — bin/roost-permbot" gets a "resolved by #188" note rather than rewriting; the line refs were already stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)