### PR TITLE
fix: waitForMessage timeout cleanup never found the waiter (#172)

### DIFF
--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -41,7 +41,7 @@ describe.if(isErgoAvailable())('test helpers', () => {
     expect(mcp.waiterCount()).toBe(0)
   })
 
-  it('waitForMessage removes waiter on timeout — issue #172 regression', async () => {
+  it('waitForMessage removes waiter on timeout', async () => {
     const peer = await connectPeer(ergo, 'wfm-timeout-peer')
     await peer.joinChannel('#wfm-timeout')
     await expect(peer.waitForMessage('#wfm-timeout', () => false, 50)).rejects.toThrow('timed out')

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -41,6 +41,24 @@ describe.if(isErgoAvailable())('test helpers', () => {
     expect(mcp.waiterCount()).toBe(0)
   })
 
+  it('waitForMessage removes waiter on timeout — issue #172 regression', async () => {
+    const peer = await connectPeer(ergo, 'wfm-timeout-peer')
+    await peer.joinChannel('#wfm-timeout')
+    await expect(peer.waitForMessage('#wfm-timeout', () => false, 50)).rejects.toThrow('timed out')
+    expect(peer.pendingWaiterCount).toBe(0)
+  })
+
+  it('waitForMessage removes waiter on success', async () => {
+    const sender = await connectPeer(ergo, 'wfm-success-sender')
+    const receiver = await connectPeer(ergo, 'wfm-success-receiver')
+    await sender.joinChannel('#wfm-success')
+    await receiver.joinChannel('#wfm-success')
+    const msgP = receiver.waitForMessage('#wfm-success', m => m.text === 'wfm-probe')
+    sender.say('#wfm-success', 'wfm-probe')
+    await msgP
+    expect(receiver.pendingWaiterCount).toBe(0)
+  })
+
   it('waitForNotification removes waiter on success', async () => {
     const mcp = await startMcpInProcess(ergo, 'waiter-success-mcp')
     const peer = await connectPeer(ergo, 'waiter-success-peer')

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -35,6 +35,7 @@ export interface PeerContext {
     timeoutMs?: number,
   ): Promise<PeerMessage>
   waitForPart(channel: string, nick: string, timeoutMs?: number): Promise<void>
+  pendingWaiterCount: number
 }
 
 export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext> {
@@ -149,8 +150,9 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {
+        const wrappedResolve = (msg: PeerMessage) => { clearTimeout(timer); resolve(msg) }
         const timer = setTimeout(() => {
-          const idx = messageWaiters.findIndex(w => w.resolve === resolve)
+          const idx = messageWaiters.findIndex(w => w.resolve === wrappedResolve)
           if (idx !== -1) messageWaiters.splice(idx, 1)
           reject(new Error(`waitForMessage on ${channel} timed out after ${timeoutMs}ms`))
         }, timeoutMs)
@@ -158,10 +160,12 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
         messageWaiters.push({
           channel,
           pred,
-          resolve: (msg) => { clearTimeout(timer); resolve(msg) },
+          resolve: wrappedResolve,
           reject,
         })
       }))
     },
+
+    get pendingWaiterCount() { return messageWaiters.length },
   }
 }

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -35,10 +35,9 @@ export interface PeerContext {
     timeoutMs?: number,
   ): Promise<PeerMessage>
   waitForPart(channel: string, nick: string, timeoutMs?: number): Promise<void>
-  pendingWaiterCount: number
 }
 
-export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext> {
+export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext & { readonly pendingWaiterCount: number }> {
   const peerNick = nick ?? `peer${++peerCounter}`
 
   const client = new IRC.Client()
@@ -150,8 +149,9 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {
+        let timer: ReturnType<typeof setTimeout>
         const wrappedResolve = (msg: PeerMessage) => { clearTimeout(timer); resolve(msg) }
-        const timer = setTimeout(() => {
+        timer = setTimeout(() => {
           const idx = messageWaiters.findIndex(w => w.resolve === wrappedResolve)
           if (idx !== -1) messageWaiters.splice(idx, 1)
           reject(new Error(`waitForMessage on ${channel} timed out after ${timeoutMs}ms`))

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -149,9 +149,8 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {
-        let timer: ReturnType<typeof setTimeout>
         const wrappedResolve = (msg: PeerMessage) => { clearTimeout(timer); resolve(msg) }
-        timer = setTimeout(() => {
+        const timer = setTimeout(() => {
           const idx = messageWaiters.findIndex(w => w.resolve === wrappedResolve)
           if (idx !== -1) messageWaiters.splice(idx, 1)
           reject(new Error(`waitForMessage on ${channel} timed out after ${timeoutMs}ms`))


### PR DESCRIPTION
closes #172

`findIndex` compared against raw `resolve` but the pushed entry stored a wrapped function — always -1, so the waiter leaked on timeout. Fix: extract `wrappedResolve`, use it in both the push and the findIndex.

Also adds `pendingWaiterCount` to `PeerContext` and two regression tests in `helpers.test.ts` (timeout path + success path).

218/218 tests pass.