### PR TITLE
feat(#196): namespace nicks and channels per project

### DIFF
--- a/.orchestrator/config.example.json
+++ b/.orchestrator/config.example.json
@@ -1,9 +1,10 @@
 {
+  "project": "your-project",
   "repo": "your-org/your-repo",
   "agent_logins": [],
   "irc": {
-    "nick": "dispatcher",
-    "project_channel": "#your-project",
+    "nick": "your-project-dispatcher",
+    "project_channel": "#your-project-leads",
     "server": "127.0.0.1",
     "port": 6667,
     "interval_seconds": 60

--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -1,9 +1,10 @@
 {
+  "project": "roost",
   "repo": "AlexSc/roost",
   "agent_logins": ["TeakBuilds"],
   "irc": {
-    "nick": "dispatcher-roost",
-    "project_channel": "#leads-roost-dev",
+    "nick": "roost-dispatcher",
+    "project_channel": "#roost-leads",
     "server": "127.0.0.1",
     "port": 6667,
     "interval_seconds": 10

--- a/README.md
+++ b/README.md
@@ -172,18 +172,22 @@ roost spawn scratch-h -c '#sandbox' -m haiku \
 ## Project dispatcher (example poller)
 
 `bin/orchestrator_poll` is a reference dispatcher that polls GitHub for
-changes to watched issues / PRs and posts events into `#issue-N` channels,
-waking the agents listening there. Run it from a Roost clone (or fork) and
-point its config at your own repo.
+changes to watched issues / PRs and posts events into `#<project>-issue-N`
+channels, waking the agents listening there. Run it from a Roost clone (or
+fork) and point its config at your own repo.
 
 Quickstart:
 
 ```bash
 cp .orchestrator/config.example.json .orchestrator/config.json
-# edit repo, irc.nick, irc.project_channel, watched_prs, watched_issues
+# edit project, repo, irc.nick, irc.project_channel, watched_prs, watched_issues
 bin/orchestrator_poll --seed     # seed state, no events emitted
 bin/orchestrator_poll --daemon   # production loop
 ```
+
+`project` namespaces every per-project artifact (`<project>-worker-N` nicks,
+`#<project>-issue-N` channels, etc.) so multiple projects can share one ergo.
+See [`docs/ORCHESTRATOR.md`](docs/ORCHESTRATOR.md) for the convention.
 
 Run the daemon under whatever supervisor your project already uses (tmux,
 systemd, launchd). Full field reference, event list, and plugin extension

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -11,8 +11,9 @@ receive dispatcher messages exactly like any other channel message.
 This ships as an example. Run it from a Roost clone (or fork) and point the
 config at your own repo / channel set.
 
-Each watched item routes to `#issue-{number}`. The project channel is a
-fallback for errors and project-level events.
+Each watched item routes to `#<project>-issue-{number}`. The project channel
+(default `#<project>-leads`) is a fallback for errors and project-level events.
+See `src/orchestrator/naming.ts` for the full namespacing convention (#196).
 
 ## Setup
 
@@ -26,18 +27,19 @@ Fields:
 
 | Field | Meaning |
 |---|---|
+| `project` | Lowercase slug used to namespace IRC nicks/channels (`<project>-worker-N`, `#<project>-issue-N`). Falls back to the basename of `repo`. Must match `^[a-z0-9][a-z0-9-]*$`. |
 | `repo` | Default `OWNER/NAME` for watched items. Per-entry `repo` overrides. |
 | `agent_logins` | GitHub logins whose comments are tagged `is_worker_reply: true` (informational). |
-| `irc.nick` | Nick the dispatcher uses on the IRC server. |
-| `irc.project_channel` | Fallback channel for errors and project-level events. |
+| `irc.nick` | Nick the dispatcher uses on the IRC server. Convention: `<project>-dispatcher`. |
+| `irc.project_channel` | Fallback channel for errors and project-level events. Defaults to `#<project>-leads`. |
 | `irc.server` / `irc.port` | IRCv3 server address. Defaults to `127.0.0.1:6667`. |
 | `irc.interval_seconds` | Tick interval. Min 5s; 60s is sane for most repos. |
 | `watched_prs` | `[{"number": N, "repo"?: "OWNER/NAME", "channels"?: [...]}]` |
 | `watched_issues` | Same shape as `watched_prs`. |
 
 For watched entries, `repo` defaults to the top-level value. `channels` adds
-destinations on top of the auto-routed `#issue-N` (PR events also go to
-`#issue-N` for each linked issue).
+destinations on top of the auto-routed `#<project>-issue-N` (PR events also go
+to `#<project>-issue-N` for each linked issue).
 
 ## Running
 

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -1,20 +1,33 @@
 ---
 description: Roost lead-pm — drives a milestone to completion by spawning workers and reviewers, coordinating with the human, and dogfooding Roost.
-argument-hint: [milestone]
+argument-hint: [project] [milestone]
 ---
 # Introduction
 
 Hello. You are the lead project manager for Roost. You value quick and efficient project execution with a minimum of rework and code duplication.
 
-You have been automatically joined to Roost in #leads-roost-dev
+You are `$0-lead-pm`. You have been automatically joined to Roost in #$0-leads.
 
-Your job is to get the $0 milestone over the line. Use the github-management skill to list issues to identify what issues are for the $0 milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blockedBy relationships are highly informative for this and are surfaced by the github-management skill.
+Your job is to get the $1 milestone over the line. Use the github-management skill to list issues to identify what issues are for the $1 milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blockedBy relationships are highly informative for this and are surfaced by the github-management skill.
 
-The primary goal of the $0 milestone is to make Roost usable for development by other humans. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #leads-roost-dev.
+The primary goal of the $1 milestone is to make Roost usable for development by other humans. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #$0-leads.
+
+## Naming convention (multi-project, #196)
+
+Every per-project artifact carries a `$0-` prefix so multiple projects can share one ergo without collision:
+
+- Leads channel: `#$0-leads`
+- Issue channel: `#$0-issue-<N>`
+- Worker nick: `$0-worker-<N>`
+- Reviewer nick: `$0-reviewer-<N>`
+- Watcher nick: `$0-watcher`
+- Dispatcher nick: `$0-dispatcher` (set in `.orchestrator/config.json`)
+
+When you spawn an agent, compute the namespaced nick + channel and pass them explicitly via `roost spawn` flags. The orchestrator daemon's `naming.ts` is the source of truth — keep prompt-side strings in sync.
 
 ## Getting started
 
-Spawn the watcher: `roost spawn watcher --model haiku --channels '#leads-roost-dev' --prompt '/watcher lead-pm alex' --perm-irc --perm-target lead-pm`
+Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm alex' --perm-irc --perm-target $0-lead-pm`
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 
@@ -26,7 +39,7 @@ The watcher is an agent in roost. You can DM it to control what issues and PRs w
 - `watch list` — reply with current contents of both lists, including channel attachments
 - `help` — short usage reminder
 
-Each watched item routes to `#issue-{number}` automatically; entry-attached channels are unioned in. The project channel is a fallback for errors and project-level events. For PRs the issue is determined by the PR's linked_issues.
+Each watched item routes to `#$0-issue-{number}` automatically; entry-attached channels are unioned in. The project channel is a fallback for errors and project-level events. For PRs the issue is determined by the PR's linked_issues.
 
 ## Working In Roost
 
@@ -36,35 +49,35 @@ When the dispatcher relays a PR comment to the channel, the body is truncated to
 
 You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to acknowledge moving something to a followup issue. You may also remain silent.
 
-If you comment on GitHub, prefix your comment with your name [lead-pm]
+If you comment on GitHub, prefix your comment with your name [$0-lead-pm]
 
 ## Working With A Team
 
 To work on an issue:
-1. Join #issue-<N> on Roost
+1. Join #$0-issue-<N> on Roost
 2. Message the watcher to watch the issue
 3. Create a new branch and worktree for the issue. Install dependencies in the worktree (bun or yarn)
 
-   Before continuing: read the issue. If the body is < ~3 sentences or scope-ambiguous, ask the human in #leads-roost-dev for a one-line clarification before spawning the worker — much cheaper than a full PR rewrite after the worker builds the wrong thing.
+   Before continuing: read the issue. If the body is < ~3 sentences or scope-ambiguous, ask the human in #$0-leads for a one-line clarification before spawning the worker — much cheaper than a full PR rewrite after the worker builds the wrong thing.
 
 4. Start a new agent with Roost using
   - Model: Consider the issue complexity. For routine work, use Sonnet. For advanced work, anything requiring considerable design or cross cutting concerns, use Opus.
-  - Name: worker-<N>
+  - Name: `$0-worker-<N>`
   - CWD: The worktree you created
-  - Joined to #issue-<N>
-  - Use perm-irc and set yourself as the perm irc target
-  - Use the worker slash command as the prompt: `--prompt '/worker <N> OWNER/REPO <branch>'`
+  - Joined to `#$0-issue-<N>`
+  - Use perm-irc and set yourself as the perm irc target (`--perm-target $0-lead-pm`)
+  - Use the worker slash command as the prompt: `--prompt '/worker $0 <N> OWNER/REPO <branch>'`
 5. Once the agent posts its plan, pressure test it. This is where it's cheap to fix issues, take your time on this step. Do not be afraid to go for multiple rounds. At a minimum, ask
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent with `--prompt '/reviewer <PR> <ISSUE> <branch> <pr-url>'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
+6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url>'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
 7. Terminate the reviewer once it is done
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add AlexSc as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
    - `gh pr edit N --repo OWNER/REPO --add-reviewer AlexSc`
 
-   The worker should report "pushed" or "addressed" — workers do NOT mark the PR ready themselves. If the human leaves CHANGES_REQUESTED and the worker pushes a fix, **you** re-request review the same way. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits. Post in '#leads-roost-dev' to additionally notify the human
+   The worker should report "pushed" or "addressed" — workers do NOT mark the PR ready themselves. If the human leaves CHANGES_REQUESTED and the worker pushes a fix, **you** re-request review the same way. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits. Post in '#$0-leads' to additionally notify the human
 9. Once the human approves the PR
   - Terminate the worker
   - Part the channel
@@ -72,16 +85,16 @@ To work on an issue:
   - Pull main in the primary repo
   - Clean up the worktree
   - Unwatch the issue and the PR by dm'ing watcher
-10. Post a postmortem in '#leads-roost-dev' about how the issue went. Come with suggestions about how to make the next issue easier.
+10. Post a postmortem in '#$0-leads' about how the issue went. Come with suggestions about how to make the next issue easier.
 
 Before merging a PR or removing a worktree, confirm: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
 
 ## Ready?
 
-Post a message in #leads-roost-dev with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you begin you may proceed autonomously and spawn new workers as needed.
+Post a message in #$0-leads with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you begin you may proceed autonomously and spawn new workers as needed.
 
-Post in #leads-roost-dev each time you start work on a new issue.
+Post in #$0-leads each time you start work on a new issue.
 
 ## Things that come up in the work
 
-You may be asked to "self compact". That means using `roost send` to send your own `/compact` prompt with instructions about what to focus on retaining through compaction. At a minimum, you must include a directive to read `prompts/lead-pm.md` and to post in `#leads-roost-dev` on start.
+You may be asked to "self compact". That means using `roost send` to send your own `/compact` prompt with instructions about what to focus on retaining through compaction. At a minimum, you must include a directive to read `prompts/lead-pm.md` and to post in `#$0-leads` on start.

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -14,7 +14,7 @@ The primary goal of the $1 milestone is to make Roost usable for development by 
 
 ## Naming convention (multi-project, #196)
 
-Every per-project artifact carries a `$0-` prefix so multiple projects can share one ergo without collision:
+Every per-project artifact carries a `$0-` prefix:
 
 - Leads channel: `#$0-leads`
 - Issue channel: `#$0-issue-<N>`
@@ -23,7 +23,9 @@ Every per-project artifact carries a `$0-` prefix so multiple projects can share
 - Watcher nick: `$0-watcher`
 - Dispatcher nick: `$0-dispatcher` (set in `.orchestrator/config.json`)
 
-When you spawn an agent, compute the namespaced nick + channel and pass them explicitly via `roost spawn` flags. The orchestrator daemon's `naming.ts` is the source of truth — keep prompt-side strings in sync.
+The prefix exists for **IRC nick uniqueness** across projects sharing one ergo, and for **GitHub comment attribution** (agents share one GH account, so `[$0-worker-N]` disambiguates which project the comment came from). It is *not* an in-chat speaker label — IRC nicks already show who said what.
+
+When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the watcher to add a watch — pass the explicit channel rather than relying on dispatcher defaults. Namespacing in spawn args + watch commands is the lead's job.
 
 ## Getting started
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -1,16 +1,16 @@
 ---
 description: Roost reviewer — runs /simplify against a PR's diff and posts coverage findings with severity tags.
-argument-hint: [pr-number] [issue-number] [branch-name] [pr-url]
+argument-hint: [project] [pr-number] [issue-number] [branch-name] [pr-url]
 ---
-You are reviewer-$0 on Roost. You're in #issue-$1 with @lead-pm and @alex.
+You are $0-reviewer-$1 on Roost. You're in #$0-issue-$2 with @$0-lead-pm and @alex.
 
-Task: Review draft PR #$0 ($3) which closes issue #$1.
+Task: Review draft PR #$1 ($4) which closes issue #$2.
 
 Process:
 1. Read the diff and the surrounding code in each modified file before forming an opinion. /simplify alone won't pull in enough context.
-2. Run /simplify against the changed code on the current branch ($2)
-3. Post every finding you identify as a single comment on PR #$0, prefixed [reviewer-$0]. Tag each finding with severity (blocker / nit / fyi) and confidence so the reader can filter. Be terse per finding — IRC tone — but report coverage, not a curated subset.
+2. Run /simplify against the changed code on the current branch ($3)
+3. Post every finding you identify as a single comment on PR #$1, prefixed [$0-reviewer-$1]. Tag each finding with severity (blocker / nit / fyi) and confidence so the reader can filter. Be terse per finding — IRC tone — but report coverage, not a curated subset.
 4. Do NOT make edits — review only
-5. Once posted, report 'review complete' in #issue-$1 and stop
+5. Once posted, report 'review complete' in #$0-issue-$2 and stop
 
 Focus areas: code reuse, quality, efficiency, dead code, premature abstraction, style smells.

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -1,10 +1,10 @@
 ---
 description: Roost watcher haiku — supervises the orchestrator and mutates the watch list in response to channel/DM commands.
-argument-hint: [lead-nick] [human-nick]
+argument-hint: [project] [lead-nick] [human-nick]
 ---
-You are `watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #leads-roost-dev. The lead PM is @$0 and the human is @$1.
+You are `$0-watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #$0-leads. The lead PM is @$1 and the human is @$2.
 
-You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #leads-roost-dev or as DMs from @$0 or @$1, and mutate `.orchestrator/config.json` (relative to your working directory) accordingly. The orchestrator daemon re-reads config each tick (~60s).
+You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #$0-leads or as DMs from @$1 or @$2, and mutate `.orchestrator/config.json` (relative to your working directory) accordingly. The orchestrator daemon re-reads config each tick (~60s).
 
 ## IMPORTANT — tooling
 
@@ -16,11 +16,11 @@ You have IRC tools as MCP. Use them. Do NOT use Bash/nc/raw IRC protocol.
 
 ## Config shape (#116)
 
-`watched_prs` and `watched_issues` are arrays of `{number, channels?}` objects. Each entry's optional `channels` list adds destinations on top of the default `#issue-N` routing. There is no bare-int form.
+`watched_prs` and `watched_issues` are arrays of `{number, channels?}` objects. Each entry's optional `channels` list adds destinations on top of the default `#$0-issue-N` routing. There is no bare-int form.
 
 ```json
 {
-  "watched_prs": [{"number": 25, "channels": ["#issue-14"]}],
+  "watched_prs": [{"number": 25, "channels": ["#$0-issue-14"]}],
   "watched_issues": [{"number": 30}]
 }
 ```
@@ -46,5 +46,5 @@ A single message may contain multiple commands, separated by newlines, semicolon
 - Read the config file before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.
-- Only respond to messages addressed to you (`watcher: <cmd>`) in the channel, OR any message in a DM.
+- Only respond to messages addressed to you (`$0-watcher: <cmd>`) in the channel, OR any message in a DM.
 - Do not initiate other work. Do not spawn other agents. Do not push to git. Edit only that one config file.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -1,16 +1,16 @@
 ---
 description: Roost worker — implements an issue on a feature branch, drafts a PR, defers to lead-pm for ready/review/cleanup.
-argument-hint: [issue-number] [owner/repo] [branch-name]
+argument-hint: [project] [issue-number] [owner/repo] [branch-name]
 ---
-You are worker-$0 on Roost (an IRC-mediated agent harness). You're in #issue-$0 with @lead-pm (your project lead) and @alex (the human). The channel is the authoritative source of input — alex will not message you directly after spawn, only via the channel.
+You are $0-worker-$1 on Roost (an IRC-mediated agent harness). You're in #$0-issue-$1 with @$0-lead-pm (your project lead) and @alex (the human). The channel is the authoritative source of input — alex will not message you directly after spawn, only via the channel.
 
-Your task: GitHub issue $1#$0. Branch `$2` is checked out here.
+Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 
 Process:
-1. Read the issue using the `github-management` skill (`scripts/view-issue.sh $0` from its base dir) — that pulls body, comments, labels, milestones, and blocking relationships in one shot. Plain `gh issue view` skips comments, which often carry the actual scope. Then read any relevant code.
-2. Post your implementation plan in #issue-$0 and wait for lead-pm's approval before coding
-3. When done, open a *draft* PR and post the link in #issue-$0
-4. Prefix all GitHub comments with [worker-$0]
+1. Read the issue using the `github-management` skill (`scripts/view-issue.sh $1` from its base dir) — that pulls body, comments, labels, milestones, and blocking relationships in one shot. Plain `gh issue view` skips comments, which often carry the actual scope. Then read any relevant code.
+2. Post your implementation plan in #$0-issue-$1 and wait for lead-pm's approval before coding
+3. When done, open a *draft* PR and post the link in #$0-issue-$1
+4. Prefix all GitHub comments with [$0-worker-$1]
 5. Defer to lead-pm for marking the PR ready, tagging reviewers, and creating followup issues
 
 Don't mark the PR ready yourself.

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -119,13 +119,19 @@ Stop with `pkill -f 'ergo run.*roost/etc/ergo.yaml'`.
 
 ## Naming conventions
 
+When a project sits under the orchestrator (i.e. has `.orchestrator/config.json`
+with a `project` slug), every per-project nick + channel carries the project
+prefix to keep multiple projects from colliding on a shared ergo. See
+`src/orchestrator/naming.ts` for the formal convention (#196).
+
 - **Standing agents** — stable nicks for long-lived roles. One instance
-  per role.
-- **Per-PR workers** — `worker-<PR>-<rev>`, e.g. `worker-123-A`.
+  per role. In a project: `<project>-lead-pm`, `<project>-watcher`,
+  `<project>-dispatcher`.
+- **Per-issue workers** — `<project>-worker-<N>`, e.g. `roost-worker-196`.
   Ephemeral; join their channel on assignment, leave on completion.
-- **Per-PR reviewers** — `reviewer-<PR>`, e.g. `reviewer-123`.
+- **Per-PR reviewers** — `<project>-reviewer-<PR>`, e.g. `roost-reviewer-123`.
   Join on CI green, leave on conclude.
-- **Watchers / observers** — descriptive (`ci-watcher`, `metrics-A`).
+- **Watchers / observers (ad-hoc)** — descriptive (`ci-watcher`, `metrics-A`).
 - **Permbot routing connections** — `permbot-{worker}`, automatically
   named by `--perm-irc` (don't pick a worker nick that would collide
   with an existing `permbot-*` nick). These are second IRC
@@ -142,8 +148,10 @@ with `roost status` (which lists running tmux sessions).
 - `#roost` — default landing channel. Cross-cutting only; no
   persistent per-PR worker traffic.
 - `#staff` — standing senior agents (cross-cutting team).
-- `#pr-NNN` — one per active PR. Created on first JOIN; dissolves
-  when the last member leaves (or on merge cleanup).
+- `#<project>-leads` — per-project leads channel for project-scoped
+  coordination. Lead-pm + watcher live here.
+- `#<project>-issue-N` — one per active issue. Created on first JOIN;
+  dissolves when the last member leaves.
 - `#sandbox` — ad-hoc testing / demos / one-off coordination.
 
 ## Lifecycle = channel membership

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -119,17 +119,16 @@ Stop with `pkill -f 'ergo run.*roost/etc/ergo.yaml'`.
 
 ## Naming conventions
 
-When a project sits under the orchestrator (i.e. has `.orchestrator/config.json`
-with a `project` slug), every per-project nick + channel carries the project
-prefix to keep multiple projects from colliding on a shared ergo. See
-`src/orchestrator/naming.ts` for the formal convention (#196).
+Multiple projects can share one ergo. To avoid IRC nick + channel
+collisions, every per-project nick + channel carries a project prefix
+(the project's lowercase slug, matching `^[a-z0-9][a-z0-9-]*$`):
 
 - **Standing agents** — stable nicks for long-lived roles. One instance
   per role. In a project: `<project>-lead-pm`, `<project>-watcher`,
   `<project>-dispatcher`.
-- **Per-issue workers** — `<project>-worker-<N>`, e.g. `roost-worker-196`.
+- **Per-issue workers** — `<project>-worker-<N>`, e.g. `myproj-worker-196`.
   Ephemeral; join their channel on assignment, leave on completion.
-- **Per-PR reviewers** — `<project>-reviewer-<PR>`, e.g. `roost-reviewer-123`.
+- **Per-PR reviewers** — `<project>-reviewer-<PR>`, e.g. `myproj-reviewer-123`.
   Join on CI green, leave on conclude.
 - **Watchers / observers (ad-hoc)** — descriptive (`ci-watcher`, `metrics-A`).
 - **Permbot routing connections** — `permbot-{worker}`, automatically
@@ -137,6 +136,10 @@ prefix to keep multiple projects from colliding on a shared ergo. See
   with an existing `permbot-*` nick). These are second IRC
   connections opened by the worker's MCP process — not standalone
   daemons.
+
+The prefix is for IRC nick uniqueness and GitHub comment attribution
+when agents share one GH account. It is not an in-chat speaker label —
+IRC nicks already show who said what.
 
 Ergo refuses nick collisions, so two agents trying the same nick
 will fail. The wrapper doesn't enforce uniqueness for you — pick

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -18,13 +18,9 @@ import {
 import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js'
 import { GitHubPrsPlugin } from './orchestrator/plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './orchestrator/plugins/github/issues-plugin.js'
-import { defaultProject, leadsChannel } from './orchestrator/naming.js'
+import { resolveProjectChannel } from './orchestrator/naming.js'
 import type { Plugin, TaggedEvent } from './orchestrator/plugin.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
-
-function resolveProjectChannel(config: OrchestratorConfig): string {
-  return config.irc?.project_channel ?? leadsChannel(defaultProject(config))
-}
 
 // ---- Path setup ------------------------------------------------------------
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -18,8 +18,13 @@ import {
 import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js'
 import { GitHubPrsPlugin } from './orchestrator/plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './orchestrator/plugins/github/issues-plugin.js'
+import { defaultProject, leadsChannel } from './orchestrator/naming.js'
 import type { Plugin, TaggedEvent } from './orchestrator/plugin.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
+
+function resolveProjectChannel(config: OrchestratorConfig): string {
+  return config.irc?.project_channel ?? leadsChannel(defaultProject(config))
+}
 
 // ---- Path setup ------------------------------------------------------------
 
@@ -104,7 +109,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   const ircCfg = config.irc ?? {}
   const nick = ircCfg.nick
   if (!nick) throw new Error('daemon mode requires irc.nick in config')
-  const projectChannel = ircCfg.project_channel ?? '#general'
+  const projectChannel = resolveProjectChannel(config)
   const server = ircCfg.server ?? '127.0.0.1'
   const port = ircCfg.port ?? 6667
   const interval = Math.max(5, ircCfg.interval_seconds ?? 60) * 1000
@@ -204,7 +209,7 @@ async function runDispatchIrc(stateDir: string, seed: boolean): Promise<void> {
   const ircCfg = config.irc ?? {}
   const nick = ircCfg.nick
   if (!nick) throw new Error('--dispatch-irc requires irc.nick in config')
-  const projectChannel = ircCfg.project_channel ?? '#general'
+  const projectChannel = resolveProjectChannel(config)
   const server = ircCfg.server ?? '127.0.0.1'
   const port = ircCfg.port ?? 6667
 
@@ -264,7 +269,7 @@ async function main(): Promise<void> {
 
     // One-shot: fetch + diff, print events JSON
     const config = await loadConfig(stateDir)
-    const projectChannel = config.irc?.project_channel ?? '#general'
+    const projectChannel = resolveProjectChannel(config)
     const plugins = buildPlugins(projectChannel)
     const result = await runOneTick(stateDir, config, plugins, {
       seed: values['seed'] as boolean,

--- a/src/orchestrator/__tests__/naming.test.ts
+++ b/src/orchestrator/__tests__/naming.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  defaultProject,
+  validateProject,
+  issueChannel,
+  leadsChannel,
+  workerNick,
+  reviewerNick,
+  leadPmNick,
+  watcherNick,
+  dispatcherNick,
+} from '../naming.js'
+
+describe('validateProject', () => {
+  it.each(['roost', 'my-project', 'a1b2', 'p'])('accepts %p', (s) => {
+    expect(() => validateProject(s)).not.toThrow()
+  })
+
+  it.each(['', 'Foo', 'foo bar', '-foo', 'foo!', 'a/b'])('rejects %p', (s) => {
+    expect(() => validateProject(s)).toThrow(/invalid project/)
+  })
+})
+
+describe('defaultProject', () => {
+  it('returns the explicit project when set', () => {
+    expect(defaultProject({ project: 'roost', repo: 'AlexSc/roost' })).toBe('roost')
+  })
+
+  it('falls back to lowercased basename of repo', () => {
+    expect(defaultProject({ repo: 'AlexSc/Roost' })).toBe('roost')
+  })
+
+  it('throws when project invalid', () => {
+    expect(() => defaultProject({ project: 'BAD NAME' })).toThrow(/invalid project/)
+  })
+
+  it('throws when no project and no parseable repo', () => {
+    expect(() => defaultProject({})).toThrow(/no project/)
+  })
+})
+
+describe('name helpers', () => {
+  it('format names with the project prefix', () => {
+    expect(issueChannel('roost', 196)).toBe('#roost-issue-196')
+    expect(leadsChannel('roost')).toBe('#roost-leads')
+    expect(workerNick('roost', 196)).toBe('roost-worker-196')
+    expect(reviewerNick('roost', 200)).toBe('roost-reviewer-200')
+    expect(leadPmNick('roost')).toBe('roost-lead-pm')
+    expect(watcherNick('roost')).toBe('roost-watcher')
+    expect(dispatcherNick('roost')).toBe('roost-dispatcher')
+  })
+})

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -12,6 +12,10 @@ export interface WatchedEntry {
 }
 
 export interface OrchestratorConfig {
+  // Lowercase slug used as the prefix for namespaced nicks/channels
+  // (`<project>-worker-N`, `#<project>-issue-N`). Optional: falls back to
+  // the basename of `repo` if missing. See src/orchestrator/naming.ts.
+  project?: string
   repo?: string
   agent_logins?: string[]
   irc?: {

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -12,9 +12,7 @@ export interface WatchedEntry {
 }
 
 export interface OrchestratorConfig {
-  // Lowercase slug used as the prefix for namespaced nicks/channels
-  // (`<project>-worker-N`, `#<project>-issue-N`). Optional: falls back to
-  // the basename of `repo` if missing. See src/orchestrator/naming.ts.
+  // See src/orchestrator/naming.ts for shape + fallback rules.
   project?: string
   repo?: string
   agent_logins?: string[]

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -9,6 +9,10 @@
 
 import type { OrchestratorConfig } from './config.js'
 
+export function resolveProjectChannel(config: OrchestratorConfig): string {
+  return config.irc?.project_channel ?? leadsChannel(defaultProject(config))
+}
+
 const PROJECT_PATTERN = /^[a-z0-9][a-z0-9-]*$/
 
 export function validateProject(project: string): void {

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -1,0 +1,62 @@
+// Project-namespaced names for the roost conventions. Multi-project hygiene
+// requires every per-project artifact (IRC nick, IRC channel, tmux session)
+// to carry a project prefix so two projects sharing one ergo + one tmux do
+// not collide. Single source of truth for the prefix shape.
+//
+// Format choice (#196): project-first (`#<project>-leads`, `#<project>-issue-N`,
+// `<project>-worker-N`). Project-first groups every channel for one project
+// together in irssi/weechat `/list`, which is the dogfooding ergonomic.
+
+import type { OrchestratorConfig } from './config.js'
+
+const PROJECT_PATTERN = /^[a-z0-9][a-z0-9-]*$/
+
+export function validateProject(project: string): void {
+  if (!PROJECT_PATTERN.test(project)) {
+    throw new Error(
+      `invalid project name "${project}": must match ${PROJECT_PATTERN} (lowercase, digits, dashes; must start with a letter or digit)`
+    )
+  }
+}
+
+// Falls back to the basename of `repo` if `project` is unset, so existing
+// configs with `repo: "Owner/name"` keep working without a hand-edit.
+export function defaultProject(config: OrchestratorConfig): string {
+  if (config.project) {
+    validateProject(config.project)
+    return config.project
+  }
+  if (config.repo) {
+    const base = config.repo.split('/').pop()?.toLowerCase() ?? ''
+    if (PROJECT_PATTERN.test(base)) return base
+  }
+  throw new Error('no project: set `project` (or a parseable `repo`) in config.json')
+}
+
+export function issueChannel(project: string, n: number): string {
+  return `#${project}-issue-${n}`
+}
+
+export function leadsChannel(project: string): string {
+  return `#${project}-leads`
+}
+
+export function workerNick(project: string, n: number): string {
+  return `${project}-worker-${n}`
+}
+
+export function reviewerNick(project: string, n: number): string {
+  return `${project}-reviewer-${n}`
+}
+
+export function leadPmNick(project: string): string {
+  return `${project}-lead-pm`
+}
+
+export function watcherNick(project: string): string {
+  return `${project}-watcher`
+}
+
+export function dispatcherNick(project: string): string {
+  return `${project}-dispatcher`
+}

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -39,15 +39,16 @@ describe('GitHubPrsPlugin.runTick', () => {
     })
     try {
       const cfg: OrchestratorConfig = {
+        project: 'proj',
         repo: 'org/repo',
         watched_prs: [{ number: 25, channels: ['#extra'] }],
         watched_issues: [],
       }
       const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
       expect(result.taggedEvents).toHaveLength(1)
-      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#extra', '#issue-14'])
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#extra', '#proj-issue-14'])
       expect(result.taggedEvents[0]?.payload.kind).toBe('multiline')
-      expect(result.channels).toContain('#issue-14')
+      expect(result.channels).toContain('#proj-issue-14')
       expect(result.channels).toContain('#extra')
     } finally { spy.mockRestore() }
   })
@@ -58,6 +59,7 @@ describe('GitHubPrsPlugin.runTick', () => {
     })
     try {
       const cfg: OrchestratorConfig = {
+        project: 'proj',
         repo: 'org/repo',
         watched_prs: [{ number: 25 }],
         watched_issues: [],
@@ -65,7 +67,7 @@ describe('GitHubPrsPlugin.runTick', () => {
       const result = await new GitHubPrsPlugin('#proj').runTick(cfg, null)
       const state = result.state as { prs: Record<string, PrSnap> }
       expect(state.prs['org/repo#25']?.linked_issues).toEqual([7])
-      expect(result.channels).toContain('#issue-7')
+      expect(result.channels).toContain('#proj-issue-7')
     } finally { spy.mockRestore() }
   })
 
@@ -77,7 +79,7 @@ describe('GitHubPrsPlugin.runTick', () => {
       snap: fakePrSnap(), events: [seedEv],
     })
     try {
-      const cfg: OrchestratorConfig = { repo: 'org/repo', watched_prs: [{ number: 25 }] }
+      const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', watched_prs: [{ number: 25 }] }
       const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
       expect(result.taggedEvents).toHaveLength(0)
     } finally { spy.mockRestore() }
@@ -98,34 +100,45 @@ describe('GitHubIssuesPlugin.runTick', () => {
     })
     try {
       const cfg: OrchestratorConfig = {
+        project: 'proj',
         repo: 'org/repo',
         watched_prs: [],
         watched_issues: [{ number: 50, channels: ['#leads'] }],
       }
       const result = await new GitHubIssuesPlugin('#proj').runTick(cfg, { issues: {} })
       expect(result.taggedEvents).toHaveLength(1)
-      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#issue-50', '#leads'])
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#leads', '#proj-issue-50'])
     } finally { spy.mockRestore() }
   })
 })
 
 describe('desiredChannels', () => {
-  it('PrsPlugin includes #issue-N + entry channels for watched_prs only', () => {
+  it('PrsPlugin includes #<project>-issue-N + entry channels for watched_prs only', () => {
     const cfg: OrchestratorConfig = {
+      project: 'proj',
       repo: 'org/repo',
       watched_prs: [{ number: 25, channels: ['#extra'] }],
       watched_issues: [{ number: 14 }],
     }
-    expect(new GitHubPrsPlugin('#proj').desiredChannels(cfg).sort()).toEqual(['#extra', '#issue-25'])
+    expect(new GitHubPrsPlugin('#proj').desiredChannels(cfg).sort()).toEqual(['#extra', '#proj-issue-25'])
   })
 
-  it('IssuesPlugin includes #issue-N + entry channels for watched_issues only', () => {
+  it('IssuesPlugin includes #<project>-issue-N + entry channels for watched_issues only', () => {
     const cfg: OrchestratorConfig = {
+      project: 'proj',
       repo: 'org/repo',
       watched_prs: [{ number: 25 }],
       watched_issues: [{ number: 14, channels: ['#extra', '#more'] }],
     }
-    expect(new GitHubIssuesPlugin('#proj').desiredChannels(cfg).sort()).toEqual(['#extra', '#issue-14', '#more'])
+    expect(new GitHubIssuesPlugin('#proj').desiredChannels(cfg).sort()).toEqual(['#extra', '#more', '#proj-issue-14'])
+  })
+
+  it('falls back to repo basename when project is unset', () => {
+    const cfg: OrchestratorConfig = {
+      repo: 'org/myrepo',
+      watched_issues: [{ number: 7 }],
+    }
+    expect(new GitHubIssuesPlugin('#proj').desiredChannels(cfg)).toEqual(['#myrepo-issue-7'])
   })
 
   it('returns empty when no watches configured', () => {

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -1,10 +1,11 @@
 // GhBase — shared scaffolding for the two GitHub plugins (PRs, issues).
 // Owns nothing except a tiny ergonomic surface: agent-login set, default repo,
-// and a shared helper for collecting `#issue-N + entry.channels` from a
+// and a shared helper for collecting `<issue-channel> + entry.channels` from a
 // WatchedEntry list. Channel resolution + default-channel fallback come from
 // BasePlugin.
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
+import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin } from '../../plugin.js'
 
 export abstract class GhBase extends BasePlugin {
@@ -12,13 +13,17 @@ export abstract class GhBase extends BasePlugin {
     return new Set(config.agent_logins ?? [])
   }
 
-  // Static channel set for a list of watched entries: `#issue-N` for each
-  // entry, plus the entry's declared channels. Used for boot-time joins.
-  protected entryChannels(entries: WatchedEntry[] | undefined, defaultRepo: string | undefined): string[] {
+  // Static channel set for a list of watched entries: project-namespaced
+  // issue channel for each entry, plus the entry's declared channels.
+  // Used for boot-time joins. No watches → no project lookup (avoids
+  // requiring `project`/`repo` on minimal configs).
+  protected entryChannels(config: OrchestratorConfig, entries: WatchedEntry[] | undefined): string[] {
+    if (!entries?.length) return []
+    const project = defaultProject(config)
     const chans = new Set<string>()
-    for (const entry of entries ?? []) {
-      const { number, channels } = resolveRepoEntry(entry, defaultRepo)
-      chans.add(`#issue-${number}`)
+    for (const entry of entries) {
+      const { number, channels } = resolveRepoEntry(entry, config.repo)
+      chans.add(issueChannel(project, number))
       for (const c of channels) chans.add(c)
     }
     return [...chans]

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -13,10 +13,8 @@ export abstract class GhBase extends BasePlugin {
     return new Set(config.agent_logins ?? [])
   }
 
-  // Static channel set for a list of watched entries: project-namespaced
-  // issue channel for each entry, plus the entry's declared channels.
-  // Used for boot-time joins. No watches → no project lookup (avoids
-  // requiring `project`/`repo` on minimal configs).
+  // No watches → no project lookup (avoids requiring `project`/`repo` on
+  // minimal configs).
   protected entryChannels(config: OrchestratorConfig, entries: WatchedEntry[] | undefined): string[] {
     if (!entries?.length) return []
     const project = defaultProject(config)

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -1,5 +1,6 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
+import { defaultProject, issueChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { scrapeIssue } from './scraper.js'
@@ -11,18 +12,19 @@ export class GitHubIssuesPlugin extends GhBase {
   readonly name = 'github-issues'
 
   desiredChannels(config: OrchestratorConfig): string[] {
-    return this.entryChannels(config.watched_issues, config.repo)
+    return this.entryChannels(config, config.watched_issues)
   }
 
   // Auto-detected channel for an issue event: the issue's own channel.
-  private static issueEventChannels(event: OrchestratorEvent): string[] {
-    return event.issue != null ? [`#issue-${event.issue}`] : []
+  private static issueEventChannels(project: string, event: OrchestratorEvent): string[] {
+    return event.issue != null ? [issueChannel(project, event.issue)] : []
   }
 
   async runTick(
     config: OrchestratorConfig,
     prevState: unknown
   ): Promise<PluginTickResult> {
+    const project = defaultProject(config)
     const defaultRepo = config.repo
     const watched = config.watched_issues ?? []
     const agentLogins = this.agentLogins(config)
@@ -47,7 +49,7 @@ export class GitHubIssuesPlugin extends GhBase {
       for (const event of events) {
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubIssuesPlugin.issueEventChannels(event), entryChannels),
+          channels: this.resolveChannels(GitHubIssuesPlugin.issueEventChannels(project, event), entryChannels),
           payload: formatPayload(event),
         })
       }

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -1,5 +1,6 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
+import { defaultProject, issueChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { scrapePr } from './scraper.js'
@@ -11,21 +12,24 @@ export class GitHubPrsPlugin extends GhBase {
   readonly name = 'github-prs'
 
   desiredChannels(config: OrchestratorConfig): string[] {
-    return this.entryChannels(config.watched_prs, config.repo)
+    return this.entryChannels(config, config.watched_prs)
   }
 
   // Auto-detected channels for a PR event: linked-issue channels, or its own
-  // #issue-N if no linked issues.
-  private static prEventChannels(event: OrchestratorEvent): string[] {
+  // issue channel if no linked issues.
+  private static prEventChannels(project: string, event: OrchestratorEvent): string[] {
     if (event.pr == null) return []
     const linked = event.linked_issues ?? []
-    return linked.length ? linked.map(n => `#issue-${n}`) : [`#issue-${event.pr}`]
+    return linked.length
+      ? linked.map(n => issueChannel(project, n))
+      : [issueChannel(project, event.pr)]
   }
 
   async runTick(
     config: OrchestratorConfig,
     prevState: unknown
   ): Promise<PluginTickResult> {
+    const project = defaultProject(config)
     const defaultRepo = config.repo
     const watched = config.watched_prs ?? []
     const agentLogins = this.agentLogins(config)
@@ -51,7 +55,7 @@ export class GitHubPrsPlugin extends GhBase {
       for (const event of events) {
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(event), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(project, event), entryChannels),
           payload: formatPayload(event),
         })
       }
@@ -61,7 +65,7 @@ export class GitHubPrsPlugin extends GhBase {
     // discovered during scrape).
     const channels = new Set<string>(this.desiredChannels(config))
     for (const snap of Object.values(curState.prs)) {
-      for (const n of snap.linked_issues ?? []) channels.add(`#issue-${n}`)
+      for (const n of snap.linked_issues ?? []) channels.add(issueChannel(project, n))
     }
 
     return { state: curState, taggedEvents, channels: [...channels] }

--- a/start.md
+++ b/start.md
@@ -10,7 +10,7 @@ The primary goal of the alpha milestone is to make Roost usable for development 
 
 ## Naming convention (multi-project, #196)
 
-Every per-project artifact carries a `roost-` prefix so multiple projects can share one ergo without collision:
+Every per-project artifact carries a `roost-` prefix:
 
 - Leads channel: `#roost-leads`
 - Issue channel: `#roost-issue-<N>`
@@ -19,7 +19,9 @@ Every per-project artifact carries a `roost-` prefix so multiple projects can sh
 - Watcher nick: `roost-watcher`
 - Dispatcher nick: `roost-dispatcher` (set in `.orchestrator/config.json`)
 
-When you spawn an agent, compute the namespaced nick + channel and pass them explicitly via `roost spawn` flags. The orchestrator daemon's `naming.ts` is the source of truth.
+The prefix exists for **IRC nick uniqueness** across projects sharing one ergo, and for **GitHub comment attribution** (agents share one GH account, so `[roost-worker-N]` disambiguates which project the comment came from). It is *not* an in-chat speaker label — IRC nicks already show who said what.
+
+When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the watcher to add a watch — pass the explicit channel rather than relying on dispatcher defaults.
 
 ## Getting started
 

--- a/start.md
+++ b/start.md
@@ -2,15 +2,28 @@
 
 Hello. You are the lead project manager for Roost. You value quick and efficient project execution with a minimum of rework and code duplication.
 
-You have been automatically joined to Roost in #leads-roost-dev
+You are `roost-lead-pm`. You have been automatically joined to Roost in #roost-leads.
 
-Your job is to get the alpha milestone over the line. Use the github-management skill to list issues to identify what issues are for the alpha milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blcoked by relationships are highly informative for this and are surfaced by the github-management skill.
+Your job is to get the alpha milestone over the line. Use the github-management skill to list issues to identify what issues are for the alpha milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blockedBy relationships are highly informative for this and are surfaced by the github-management skill.
 
-The primary goal of the alpha milestone is to make Roost usable for development by the human and agents who have built it. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #leads-roost-dev.
+The primary goal of the alpha milestone is to make Roost usable for development by the human and agents who have built it. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #roost-leads.
+
+## Naming convention (multi-project, #196)
+
+Every per-project artifact carries a `roost-` prefix so multiple projects can share one ergo without collision:
+
+- Leads channel: `#roost-leads`
+- Issue channel: `#roost-issue-<N>`
+- Worker nick: `roost-worker-<N>`
+- Reviewer nick: `roost-reviewer-<N>`
+- Watcher nick: `roost-watcher`
+- Dispatcher nick: `roost-dispatcher` (set in `.orchestrator/config.json`)
+
+When you spawn an agent, compute the namespaced nick + channel and pass them explicitly via `roost spawn` flags. The orchestrator daemon's `naming.ts` is the source of truth.
 
 ## Getting started
 
-Spawn the watcher: `roost spawn watcher --model haiku --channels '#leads-roost-dev' --prompt '/watcher lead-pm alex' --perm-irc --perm-target lead-pm`
+Spawn the watcher: `roost spawn roost-watcher --model haiku --channels '#roost-leads' --prompt '/watcher roost roost-lead-pm alex' --perm-irc --perm-target roost-lead-pm`
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 
@@ -22,7 +35,7 @@ The watcher is an agent in roost. You can DM it to control what issues and PRs w
 - `watch list` — reply with current contents of both lists, including channel attachments
 - `help` — short usage reminder
 
-Each watched item routes to `#issue-{number}` automatically; entry-attached channels are unioned in. The project channel is a fallback for errors and project-level events. For PRs the issue is determined by the PR's linked_issues.
+Each watched item routes to `#roost-issue-{number}` automatically; entry-attached channels are unioned in. The project channel is a fallback for errors and project-level events. For PRs the issue is determined by the PR's linked_issues.
 
 ## Working In Roost
 
@@ -32,37 +45,37 @@ When the dispatcher relays a PR comment to the channel, the body is truncated to
 
 You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to acknowledge moving something to a followup issue. You may also remain silent.
 
-If you comment on GitHub, prefix your comment with your name [lead-pm]
+If you comment on GitHub, prefix your comment with your name [roost-lead-pm]
 
 ## Working With A Team
 
 To work on an issue:
-1. Join #issue-<N> on Roost
+1. Join #roost-issue-<N> on Roost
 2. Message the watcher to watch the issue
 3. Create a new branch and worktree for the issue. Install dependencies in the worktree (bun or yarn)
 
-   Before continuing: read the issue. If the body is < ~3 sentences or scope-ambiguous, ask the human in #leads-roost-dev for a one-line clarification before spawning the worker — much cheaper than a full PR rewrite after the worker builds the wrong thing.
+   Before continuing: read the issue. If the body is < ~3 sentences or scope-ambiguous, ask the human in #roost-leads for a one-line clarification before spawning the worker — much cheaper than a full PR rewrite after the worker builds the wrong thing.
 
 4. Start a new agent with Roost using
   - Model: Consider the issue complexity. For routine work, use Sonnet. For advanced work, anything requiring considerable design or cross cutting concerns, use Opus.
-  - Name: worker-<N>
+  - Name: `roost-worker-<N>`
   - CWD: The worktree you created
-  - Joined to #issue-<N>
-  - Use perm-irc and set yourself as the perm irc target
+  - Joined to `#roost-issue-<N>`
+  - Use perm-irc and set yourself as the perm irc target (`--perm-target roost-lead-pm`)
   - Minimal initial prompt
     - Give the agent a quick introduction to Roost
-      - It's in the issue channel. You are @lead-pm, the human is @alex
+      - It's in the issue channel. You are @roost-lead-pm, the human is @alex
       - The channel is the authoritative source of user input, and the user will _not_ provide direct Claude Code input after the initial prompt.
     - Tell the agent what issue it's working on. Do not paste into the prompt, let the agent read the issue itself from Github.
     - Instruct the agent to present its implementation plan in the channel first and wait for your approval before beginning.
     - Instruct the agent that once it's done it should open a _draft_ pr and post a link in the channel
-    - Instruct the agent to prefix its comments on github with its name, [worker-N]
+    - Instruct the agent to prefix its comments on github with its name, [roost-worker-N]
     - Instruct the agent to defer to you for marking PRs as ready for review, tagging reviewers, and creating followup issues
 5. Once the agent posts its plan, pressure test it. This is where it's cheap to fix issues, take your time on this step. Do not be afraid to go for multiple rounds. At a minimum, ask
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent and task it with using /simplify, and instructions to post its findings to the PR. The reviewer should be instructed to not make edits. The reviewer should prefix its comment with its name, [reviewer-N]. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
+6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `roost-reviewer-<PR>` and task it with using /simplify, and instructions to post its findings to the PR. The reviewer should be instructed to not make edits. The reviewer should prefix its comment with its name, [roost-reviewer-N]. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
 7. Terminate the reviewer once it is done
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add AlexSc as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
@@ -81,10 +94,10 @@ Run as many workers as you can.
 
 ## Ready?
 
-Post a message in #leads-roost-dev with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you being you may proceed autonomously and spawn new workers as needed.
+Post a message in #roost-leads with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you begin you may proceed autonomously and spawn new workers as needed.
 
-Post in #leads-roost-dev each time you start work on a new issue.
+Post in #roost-leads each time you start work on a new issue.
 
 ## Things that come up in the work
 
-You may be asked to "self compact". That means using `roost send` to send your own `/compact` prompt with instructions about what to focus on retaining through compaction. At a minimum, you must include a directive to read `start.md` and to post in `#leads-roost-dev` on start.
+You may be asked to "self compact". That means using `roost send` to send your own `/compact` prompt with instructions about what to focus on retaining through compaction. At a minimum, you must include a directive to read `start.md` and to post in `#roost-leads` on start.


### PR DESCRIPTION
Closes #196.

## Summary

- Adds optional `project` slug to `OrchestratorConfig` (falls back to lowercased basename of `repo` when unset).
- New `src/orchestrator/naming.ts` is the single source of truth for project-prefixed nicks (`<project>-worker-N`, `<project>-lead-pm`, `<project>-reviewer-N`, `<project>-watcher`, `<project>-dispatcher`) and channels (`#<project>-leads`, `#<project>-issue-N`).
- Orchestrator plugins (`GhBase`, `prs-plugin`, `issues-plugin`) and the dispatcher's `project_channel` default consume the helper.
- Prompts (`worker`, `reviewer`, `lead-pm`, `watcher`) take `<project>` as their first slash arg and render the namespaced nicks/channels. `lead-pm.md` documents the convention so the lead is the human-readable source of truth at spawn time.
- tmux session names become `roost-<project>-<nick>` for free via existing `SESSION_PREFIX` + nick concat — no `bin/roost` wrapper changes (per @lead-pm's reframe: lead-pm passes channels/nicks explicitly to `roost spawn`).
- This repo's `.orchestrator/config.json` flips to `project: "roost"` (`#roost-leads`, `roost-dispatcher`).
- Format choice: project-first (`#<project>-leads`, `#<project>-issue-N`) for irssi/weechat sortability — all of one project's channels group together.

Validates `^[a-z0-9][a-z0-9-]*$` so the slug stays IRC-safe.

## Behavior changes

- `irc.project_channel` default was `#general`; now defaults to `#<project>-leads`. All real configs set `project_channel` explicitly today, so this is unobservable in practice.
- `defaultProject()` throws when both `project` and parseable `repo` are missing. Previously the dispatcher would have silently routed to `#general`. All real configs have `repo`, so safe in practice — but flagging for explicitness.

## Migration

Stop-the-world cutover: terminate lead-pm + watcher + workers + dispatcher, merge, respawn under new names, alex re-attaches to `#roost-leads`. Channel scrollback in irssi does not survive the rename.

## Followups (out of scope)

- Watcher could accept both `watcher:` (short) and `<project>-watcher:` (full) trigger forms for ergonomics. Currently the prompt requires the full form.
- `@alex` is hardcoded in `worker.md` / `watcher.md`. Fine if alex is the human across every project; refactor needed if a different human ever runs a roost.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 159 pass / 0 fail (new `naming.test.ts` covers helper + validation; existing plugin tests updated for new channel format)
- [x] `bin/orchestrator_poll --dry-run` boots cleanly against the updated config
- [ ] Post-merge: cutover, verify a fresh roost-lead-pm boots, watcher joins, second project comes up cleanly under its own prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)