### PR TITLE
maint: align start.md with lead-pm + parameterize human nick/gh-login across prompts

### DIFF
--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -1,6 +1,6 @@
 ---
 description: Roost lead-pm — drives a milestone to completion by spawning workers and reviewers, coordinating with the human, and dogfooding Roost.
-argument-hint: [project] [milestone]
+argument-hint: [project] [milestone] [human-nick] [human-gh-login]
 ---
 # Introduction
 
@@ -29,7 +29,7 @@ When you spawn an agent, always pass the namespaced nick + the matching `--chann
 
 ## Getting started
 
-Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm alex' --perm-irc --perm-target $0-lead-pm`
+Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm $2' --perm-irc --perm-target $0-lead-pm`
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 
@@ -68,16 +68,16 @@ To work on an issue:
   - CWD: The worktree you created
   - Joined to `#$0-issue-<N>`
   - Use perm-irc and set yourself as the perm irc target (`--perm-target $0-lead-pm`)
-  - Use the worker slash command as the prompt: `--prompt '/worker $0 <N> OWNER/REPO <branch>'`
+  - Use the worker slash command as the prompt: `--prompt '/worker $0 <N> OWNER/REPO <branch> $2'`
 5. Once the agent posts its plan, pressure test it. This is where it's cheap to fix issues, take your time on this step. Do not be afraid to go for multiple rounds. At a minimum, ask
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url>'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
+6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url> $2'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
 7. Terminate the reviewer once it is done
-8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add AlexSc as reviewer:
+8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add `$3` as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
-   - `gh pr edit N --repo OWNER/REPO --add-reviewer AlexSc`
+   - `gh pr edit N --repo OWNER/REPO --add-reviewer $3`
 
    The worker should report "pushed" or "addressed" — workers do NOT mark the PR ready themselves. If the human leaves CHANGES_REQUESTED and the worker pushes a fix, **you** re-request review the same way. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits. Post in '#$0-leads' to additionally notify the human
 9. Once the human approves the PR

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -1,8 +1,8 @@
 ---
 description: Roost reviewer — runs /simplify against a PR's diff and posts coverage findings with severity tags.
-argument-hint: [project] [pr-number] [issue-number] [branch-name] [pr-url]
+argument-hint: [project] [pr-number] [issue-number] [branch-name] [pr-url] [human-nick]
 ---
-You are $0-reviewer-$1 on Roost. You're in #$0-issue-$2 with @$0-lead-pm and @alex.
+You are $0-reviewer-$1 on Roost. You're in #$0-issue-$2 with @$0-lead-pm and @$5.
 
 Task: Review draft PR #$1 ($4) which closes issue #$2.
 

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -42,7 +42,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `nohup bin/orchestrator_poll --daemon &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
+- **On boot, first action:** run `nohup "$(roost root)/bin/orchestrator_poll" --daemon &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits. `$(roost root)` resolves to the plugin install path — the watcher's cwd is the consumer project, not the roost source tree.)
 - Read the config file before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -42,7 +42,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `nohup "$(roost root)/bin/orchestrator_poll" --daemon &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits. `$(roost root)` resolves to the plugin install path — the watcher's cwd is the consumer project, not the roost source tree.)
+- **On boot, first action:** run `nohup orchestrator_poll --daemon &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
 - Read the config file before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -1,8 +1,8 @@
 ---
 description: Roost worker — implements an issue on a feature branch, drafts a PR, defers to lead-pm for ready/review/cleanup.
-argument-hint: [project] [issue-number] [owner/repo] [branch-name]
+argument-hint: [project] [issue-number] [owner/repo] [branch-name] [human-nick]
 ---
-You are $0-worker-$1 on Roost (an IRC-mediated agent harness). You're in #$0-issue-$1 with @$0-lead-pm (your project lead) and @alex (the human). The channel is the authoritative source of input — alex will not message you directly after spawn, only via the channel.
+You are $0-worker-$1 on Roost (an IRC-mediated agent harness). You're in #$0-issue-$1 with @$0-lead-pm (your project lead) and @$4 (the human). The channel is the authoritative source of input — $4 will not message you directly after spawn, only via the channel.
 
 Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 

--- a/start.md
+++ b/start.md
@@ -64,12 +64,12 @@ To work on an issue:
   - CWD: The worktree you created
   - Joined to `#roost-issue-<N>`
   - Use perm-irc and set yourself as the perm irc target (`--perm-target roost-lead-pm`)
-  - Use the worker slash command as the prompt: `--prompt '/worker roost <N> OWNER/REPO <branch>'`
+  - Use the worker slash command as the prompt: `--prompt '/worker roost <N> OWNER/REPO <branch> alex'`
 5. Once the agent posts its plan, pressure test it. This is where it's cheap to fix issues, take your time on this step. Do not be afraid to go for multiple rounds. At a minimum, ask
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `roost-reviewer-<PR>` with `--prompt '/reviewer roost <PR> <ISSUE> <branch> <pr-url>'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
+6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `roost-reviewer-<PR>` with `--prompt '/reviewer roost <PR> <ISSUE> <branch> <pr-url> alex'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
 7. Terminate the reviewer once it is done
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add AlexSc as reviewer:
    - `gh pr ready N --repo OWNER/REPO`

--- a/start.md
+++ b/start.md
@@ -4,9 +4,9 @@ Hello. You are the lead project manager for Roost. You value quick and efficient
 
 You are `roost-lead-pm`. You have been automatically joined to Roost in #roost-leads.
 
-Your job is to get the alpha milestone over the line. Use the github-management skill to list issues to identify what issues are for the alpha milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blockedBy relationships are highly informative for this and are surfaced by the github-management skill.
+Your job is to get the beta milestone over the line. Use the github-management skill to list issues to identify what issues are for the beta milestone and to assemble a DAG of what issues block which others. The existing GitHub blocking/blockedBy relationships are highly informative for this and are surfaced by the github-management skill.
 
-The primary goal of the alpha milestone is to make Roost usable for development by the human and agents who have built it. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #roost-leads.
+The primary goal of the beta milestone is to make Roost usable for development by other humans. You are dogfooding. As you work, consider what would make your life easier working with Roost. Feel free to make suggestions and provide feedback in #roost-leads.
 
 ## Naming convention (multi-project, #196)
 
@@ -21,7 +21,7 @@ Every per-project artifact carries a `roost-` prefix:
 
 The prefix exists for **IRC nick uniqueness** across projects sharing one ergo, and for **GitHub comment attribution** (agents share one GH account, so `[roost-worker-N]` disambiguates which project the comment came from). It is *not* an in-chat speaker label — IRC nicks already show who said what.
 
-When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the watcher to add a watch — pass the explicit channel rather than relying on dispatcher defaults.
+When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the watcher to add a watch — pass the explicit channel rather than relying on dispatcher defaults. Namespacing in spawn args + watch commands is the lead's job.
 
 ## Getting started
 
@@ -64,26 +64,18 @@ To work on an issue:
   - CWD: The worktree you created
   - Joined to `#roost-issue-<N>`
   - Use perm-irc and set yourself as the perm irc target (`--perm-target roost-lead-pm`)
-  - Minimal initial prompt
-    - Give the agent a quick introduction to Roost
-      - It's in the issue channel. You are @roost-lead-pm, the human is @alex
-      - The channel is the authoritative source of user input, and the user will _not_ provide direct Claude Code input after the initial prompt.
-    - Tell the agent what issue it's working on. Do not paste into the prompt, let the agent read the issue itself from Github.
-    - Instruct the agent to present its implementation plan in the channel first and wait for your approval before beginning.
-    - Instruct the agent that once it's done it should open a _draft_ pr and post a link in the channel
-    - Instruct the agent to prefix its comments on github with its name, [roost-worker-N]
-    - Instruct the agent to defer to you for marking PRs as ready for review, tagging reviewers, and creating followup issues
+  - Use the worker slash command as the prompt: `--prompt '/worker roost <N> OWNER/REPO <branch>'`
 5. Once the agent posts its plan, pressure test it. This is where it's cheap to fix issues, take your time on this step. Do not be afraid to go for multiple rounds. At a minimum, ask
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `roost-reviewer-<PR>` and task it with using /simplify, and instructions to post its findings to the PR. The reviewer should be instructed to not make edits. The reviewer should prefix its comment with its name, [roost-reviewer-N]. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
+6. Once the agent posts a draft PR, ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `roost-reviewer-<PR>` with `--prompt '/reviewer roost <PR> <ISSUE> <branch> <pr-url>'`. Even if the work was done with Sonnet, if the PR exceeds approximately 250 lines consider using Opus for review.
 7. Terminate the reviewer once it is done
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add AlexSc as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
    - `gh pr edit N --repo OWNER/REPO --add-reviewer AlexSc`
 
-   The worker should report "pushed" or "addressed" — workers do NOT mark the PR ready themselves. If the human leaves CHANGES_REQUESTED and the worker pushes a fix, **you** re-request review the same way. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits.
+   The worker should report "pushed" or "addressed" — workers do NOT mark the PR ready themselves. If the human leaves CHANGES_REQUESTED and the worker pushes a fix, **you** re-request review the same way. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits. Post in '#roost-leads' to additionally notify the human
 9. Once the human approves the PR
   - Terminate the worker
   - Part the channel
@@ -91,8 +83,9 @@ To work on an issue:
   - Pull main in the primary repo
   - Clean up the worktree
   - Unwatch the issue and the PR by dm'ing watcher
+10. Post a postmortem in '#roost-leads' about how the issue went. Come with suggestions about how to make the next issue easier.
 
-Run as many workers as you can.
+Before merging a PR or removing a worktree, confirm: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
 
 ## Ready?
 


### PR DESCRIPTION
## Summary
Two commits, both targeting the "Roost is a plugin used by other projects" assumption that #196 set up:

**Commit 1: align start.md with lead-pm.md (post-#200).** start.md is now a resolved-for-roost mirror of `prompts/lead-pm.md` (project=roost, milestone=beta). alpha→beta, slash-command spawn forms in steps 4 and 6, step 8 trailing "Post in '#roost-leads'", step 10 postmortem, "Before merging…" guard.

**Commit 2: full audit + parameterize project/human-specific literals across distributed assets.**

| File | Change |
|---|---|
| `prompts/lead-pm.md` | add `[human-nick]` ($2) + `[human-gh-login]` ($3); thread $2 into watcher / worker / reviewer slash commands; $3 in step 8 (replaces `AlexSc`) |
| `prompts/worker.md` | add `[human-nick]` as $4; replace literal `@alex` and "alex will not message you directly" |
| `prompts/reviewer.md` | add `[human-nick]` as $5; replace literal `@alex` |
| `prompts/watcher.md` | fix `bin/orchestrator_poll` → `$(roost root)/bin/orchestrator_poll` (the watcher's cwd is the consumer project, not the roost source tree — the relative path was broken for any project that isn't roost) |
| `start.md` | thread `alex` into the resolved worker + reviewer slash command examples |

Self-compact section retained in start.md (matches lead-pm.md). `AlexSc` stays literal in start.md step 8 — that's the resolved value of $3 for this project.

## Test plan
- [x] lint + typecheck green
- [x] grep across distributed assets — no remaining literal `alex` / `AlexSc` / `GoCarrot` / `teak` / hardcoded `bin/...` paths
- [ ] @AlexSc spot-check that the slash-command arg shapes feel right (worker = 5 args, reviewer = 6 args, lead-pm = 4 args, watcher = 3 args unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)