### PR TITLE
feat: roost init — bootstrap .orchestrator/config.json

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -53,10 +53,10 @@ Options:
   --repo OWNER/REPO      GitHub repo (default: parsed from git origin remote).
   --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
                          Default: current gh user.
-  --force                Overwrite existing .orchestrator/config.json and
-                         .orchestrator/.gitignore.
-  --force-prompts        Overwrite existing .claude/commands/ prompt copies.
-                         Independent of --force; does not touch config.json.
+  --force                Overwrite everything: config.json, .gitignore, and
+                         .claude/commands/ prompt copies.
+  --force-prompts        Overwrite only .claude/commands/ prompt copies.
+                         Does not touch config.json or .gitignore.
   --no-prompts           Skip copying prompts to .claude/commands/.
   --dry-run              Print what would be written; do not write files.
 
@@ -348,7 +348,7 @@ cmd_init() {
     for _pf in "${prompt_files[@]}"; do
       local _dst
       _dst="${commands_dir}/$(basename "$_pf" .md).md"
-      if [ ! -f "$_dst" ] || [ "$force_prompts" -eq 1 ]; then
+      if [ ! -f "$_dst" ] || [ "$force_prompts" -eq 1 ] || [ "$force" -eq 1 ]; then
         cp "$_pf" "$_dst"
         echo "Wrote ${_dst}"
         wrote_prompts=1

--- a/bin/roost
+++ b/bin/roost
@@ -355,9 +355,9 @@ cmd_init() {
       fi
     done
     if [ "$wrote_prompts" -eq 1 ]; then
-      printf '\nTip: prompts under %s/ are project-local copies. Edit them\n' "$commands_dir"
-      printf '     to fit your conventions, or delete a file to fall back to the\n'
-      printf "     plugin default. Re-run \`roost init --force-prompts\` to refresh.\n"
+      printf '\nTip: prompts under %s/ are project-local copies of the roost\n' "$commands_dir"
+      printf '     defaults. Edit them to fit your conventions. Re-run\n'
+      printf "     \`roost init --force-prompts\` to refresh from the plugin tree.\n"
     fi
   fi
 

--- a/bin/roost
+++ b/bin/roost
@@ -52,7 +52,11 @@ Options:
   --repo OWNER/REPO      GitHub repo (default: parsed from git origin remote).
   --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
                          Default: current gh user.
-  --force                Overwrite existing .orchestrator/config.json.
+  --force                Overwrite existing .orchestrator/config.json and
+                         .orchestrator/.gitignore.
+  --force-prompts        Overwrite existing .claude/commands/ prompt copies.
+                         Independent of --force; does not touch config.json.
+  --no-prompts           Skip copying prompts to .claude/commands/.
   --dry-run              Print what would be written; do not write files.
 
 Examples:
@@ -60,6 +64,8 @@ Examples:
   roost init --project myapp --repo Owner/myapp
   roost init --agent-login alice --agent-login bob
   roost init --force
+  roost init --force-prompts
+  roost init --no-prompts
 EOF
 }
 
@@ -205,16 +211,20 @@ cmd_init() {
   local repo=""
   local agent_logins=()
   local force=0
+  local force_prompts=0
+  local no_prompts=0
   local dry_run=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --project)     project="$2";              shift 2 ;;
-      --repo)        repo="$2";                 shift 2 ;;
-      --agent-login) agent_logins+=("$2");      shift 2 ;;
-      --force)       force=1;                   shift ;;
-      --dry-run)     dry_run=1;                 shift ;;
-      -h|--help)     usage_init;                exit 0 ;;
+      --project)       project="$2";         shift 2 ;;
+      --repo)          repo="$2";            shift 2 ;;
+      --agent-login)   agent_logins+=("$2"); shift 2 ;;
+      --force)         force=1;              shift ;;
+      --force-prompts) force_prompts=1;      shift ;;
+      --no-prompts)    no_prompts=1;         shift ;;
+      --dry-run)       dry_run=1;            shift ;;
+      -h|--help)       usage_init;           exit 0 ;;
       *) echo "error: unknown init option: $1" >&2; exit 1 ;;
     esac
   done
@@ -277,6 +287,9 @@ cmd_init() {
 
   local config_path=".orchestrator/config.json"
   local gitignore_path=".orchestrator/.gitignore"
+  local prompts_dir="${ROOST_DIR}/prompts"
+  local commands_dir=".claude/commands"
+  local prompt_names=(lead-pm worker reviewer watcher)
 
   if [ "$dry_run" -eq 1 ]; then
     echo "--- ${config_path} ---"
@@ -284,6 +297,12 @@ cmd_init() {
       "$project" "$repo" "$logins_json"
     echo "--- ${gitignore_path} ---"
     printf 'state.json\nlast-tick.txt\nlast-error.txt\n'
+    if [ "$no_prompts" -eq 0 ]; then
+      for name in "${prompt_names[@]}"; do
+        local src="${prompts_dir}/${name}.md"
+        [ -f "$src" ] && echo "--- ${commands_dir}/${name}.md ---"
+      done
+    fi
     exit 0
   fi
 
@@ -300,6 +319,29 @@ cmd_init() {
     printf 'state.json\nlast-tick.txt\nlast-error.txt\n' > "$gitignore_path"
     echo "Wrote ${gitignore_path}"
   fi
+
+  local wrote_prompts=0
+  if [ "$no_prompts" -eq 0 ]; then
+    mkdir -p "$commands_dir"
+    for name in "${prompt_names[@]}"; do
+      local src="${prompts_dir}/${name}.md"
+      local dst="${commands_dir}/${name}.md"
+      if [ ! -f "$src" ]; then
+        continue
+      fi
+      if [ ! -f "$dst" ] || [ "$force_prompts" -eq 1 ]; then
+        cp "$src" "$dst"
+        echo "Wrote ${dst}"
+        wrote_prompts=1
+      fi
+    done
+    if [ "$wrote_prompts" -eq 1 ]; then
+      printf '\nTip: prompts under %s/ are project-local copies. Edit them\n' "$commands_dir"
+      printf '     to fit your conventions, or delete a file to fall back to the\n'
+      printf "     plugin default. Re-run \`roost init --force-prompts\` to refresh.\n"
+    fi
+  fi
+
   printf '\nNext step:\n'
   printf '  roost spawn %s-lead-pm \\\n' "$project"
   printf "    --channels '#%s-leads' \\\n" "$project"

--- a/bin/roost
+++ b/bin/roost
@@ -26,7 +26,7 @@ usage() {
 Usage: roost <command> [args]
 
 Commands:
-  init                     Bootstrap .orchestrator/config.json for a project.
+  init                     Bootstrap config, .gitignore, and copy prompts.
   spawn <nick> [options]   Bring up a Claude session on the roost.
   shutdown <nick>          Kill the tmux session for that nick.
   list                     Show all roost-prefixed tmux sessions.
@@ -44,8 +44,9 @@ usage_init() {
   cat <<EOF
 Usage: roost init [options]
 
-Bootstrap .orchestrator/config.json for a new project. Autodetects project
-name, repo, and GitHub user; each value can be overridden with a flag.
+Bootstrap .orchestrator/config.json + .gitignore for a new project and copy
+roost prompt templates to .claude/commands/ for local customization.
+Autodetects project name, repo, and GitHub user; each value can be overridden.
 
 Options:
   --project NAME         Project name (default: basename of cwd, lowercased).
@@ -304,17 +305,25 @@ cmd_init() {
   local gitignore_path=".orchestrator/.gitignore"
   local prompts_dir="${ROOST_DIR}/prompts"
   local commands_dir=".claude/commands"
-  local prompt_names=(lead-pm worker reviewer watcher)
+
+  # Discover prompt files from the plugin tree at runtime so new prompts
+  # added to prompts/ flow through automatically.
+  local prompt_files=()
+  local _pf
+  for _pf in "${prompts_dir}"/*.md; do
+    [ -f "$_pf" ] && prompt_files+=("$_pf")
+  done
 
   if [ "$dry_run" -eq 1 ]; then
     echo "--- ${config_path} ---"
     _init_config_json "$project" "$repo" "$logins_json"
     echo "--- ${gitignore_path} ---"
     _init_gitignore
-    if [ "$no_prompts" -eq 0 ]; then
-      for name in "${prompt_names[@]}"; do
-        local src="${prompts_dir}/${name}.md"
-        [ -f "$src" ] && echo "--- ${commands_dir}/${name}.md (copied verbatim from plugin prompts/${name}.md) ---"
+    if [ "$no_prompts" -eq 0 ] && [ "${#prompt_files[@]}" -gt 0 ]; then
+      for _pf in "${prompt_files[@]}"; do
+        local _name
+        _name="$(basename "$_pf" .md)"
+        echo "--- ${commands_dir}/${_name}.md (copied verbatim from plugin prompts/${_name}.md) ---"
       done
     fi
     exit 0
@@ -334,17 +343,14 @@ cmd_init() {
   fi
 
   local wrote_prompts=0
-  if [ "$no_prompts" -eq 0 ]; then
+  if [ "$no_prompts" -eq 0 ] && [ "${#prompt_files[@]}" -gt 0 ]; then
     mkdir -p "$commands_dir"
-    for name in "${prompt_names[@]}"; do
-      local src="${prompts_dir}/${name}.md"
-      local dst="${commands_dir}/${name}.md"
-      if [ ! -f "$src" ]; then
-        continue
-      fi
-      if [ ! -f "$dst" ] || [ "$force_prompts" -eq 1 ]; then
-        cp "$src" "$dst"
-        echo "Wrote ${dst}"
+    for _pf in "${prompt_files[@]}"; do
+      local _dst
+      _dst="${commands_dir}/$(basename "$_pf" .md).md"
+      if [ ! -f "$_dst" ] || [ "$force_prompts" -eq 1 ]; then
+        cp "$_pf" "$_dst"
+        echo "Wrote ${_dst}"
         wrote_prompts=1
       fi
     done

--- a/bin/roost
+++ b/bin/roost
@@ -278,11 +278,6 @@ cmd_init() {
   local config_path=".orchestrator/config.json"
   local gitignore_path=".orchestrator/.gitignore"
 
-  if [ -f "$config_path" ] && [ "$force" -eq 0 ]; then
-    echo "error: ${config_path} already exists — pass \`--force\` to overwrite" >&2
-    exit 1
-  fi
-
   if [ "$dry_run" -eq 1 ]; then
     echo "--- ${config_path} ---"
     printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
@@ -292,13 +287,19 @@ cmd_init() {
     exit 0
   fi
 
+  if [ -f "$config_path" ] && [ "$force" -eq 0 ]; then
+    echo "error: ${config_path} already exists — pass \`--force\` to overwrite" >&2
+    exit 1
+  fi
+
   mkdir -p .orchestrator
   printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
     "$project" "$repo" "$logins_json" > "$config_path"
-  printf 'state.json\nlast-tick.txt\nlast-error.txt\n' > "$gitignore_path"
-
   echo "Wrote ${config_path}"
-  echo "Wrote ${gitignore_path}"
+  if [ ! -f "$gitignore_path" ] || [ "$force" -eq 1 ]; then
+    printf 'state.json\nlast-tick.txt\nlast-error.txt\n' > "$gitignore_path"
+    echo "Wrote ${gitignore_path}"
+  fi
   printf '\nNext step:\n'
   printf '  roost spawn %s-lead-pm \\\n' "$project"
   printf "    --channels '#%s-leads' \\\n" "$project"

--- a/bin/roost
+++ b/bin/roost
@@ -2,6 +2,7 @@
 # roost — manage roost-irc Claude sessions in tmux.
 #
 # Subcommands:
+#   init                    — bootstrap .orchestrator/config.json for a project
 #   spawn <nick> [options]  — bring up a Claude session on the roost
 #   shutdown <nick>         — kill the tmux session for that nick
 #   list                    — show all roost-prefixed tmux sessions
@@ -25,6 +26,7 @@ usage() {
 Usage: roost <command> [args]
 
 Commands:
+  init                     Bootstrap .orchestrator/config.json for a project.
   spawn <nick> [options]   Bring up a Claude session on the roost.
   shutdown <nick>          Kill the tmux session for that nick.
   list                     Show all roost-prefixed tmux sessions.
@@ -35,6 +37,29 @@ Commands:
   send <nick> <message...> Inject text into a nick's tmux pane.
 
 Run 'roost <command> --help' for per-command usage.
+EOF
+}
+
+usage_init() {
+  cat <<EOF
+Usage: roost init [options]
+
+Bootstrap .orchestrator/config.json for a new project. Autodetects project
+name, repo, and GitHub user; each value can be overridden with a flag.
+
+Options:
+  --project NAME         Project name (default: basename of cwd, lowercased).
+  --repo OWNER/REPO      GitHub repo (default: parsed from git origin remote).
+  --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
+                         Default: current gh user.
+  --force                Overwrite existing .orchestrator/config.json.
+  --dry-run              Print what would be written; do not write files.
+
+Examples:
+  roost init
+  roost init --project myapp --repo Owner/myapp
+  roost init --agent-login alice --agent-login bob
+  roost init --force
 EOF
 }
 
@@ -173,6 +198,111 @@ Print the roost plugin root directory.
 Example:
   roost root
 EOF
+}
+
+cmd_init() {
+  local project=""
+  local repo=""
+  local agent_logins=()
+  local force=0
+  local dry_run=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project)     project="$2";              shift 2 ;;
+      --repo)        repo="$2";                 shift 2 ;;
+      --agent-login) agent_logins+=("$2");      shift 2 ;;
+      --force)       force=1;                   shift ;;
+      --dry-run)     dry_run=1;                 shift ;;
+      -h|--help)     usage_init;                exit 0 ;;
+      *) echo "error: unknown init option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "error: not inside a git repo — run \`git init\` first or \`cd\` to a git repo" >&2
+    exit 1
+  fi
+
+  if ! gh auth status &>/dev/null; then
+    echo "error: gh is not authenticated — run \`gh auth login\` first" >&2
+    exit 1
+  fi
+
+  if [ -z "$project" ]; then
+    project="$(basename "$PWD" | tr '[:upper:]' '[:lower:]')"
+  fi
+
+  local project_re='^[a-z0-9][a-z0-9-]*$'
+  if [[ ! "$project" =~ $project_re ]]; then
+    echo "error: invalid project name \"${project}\": must match ^[a-z0-9][a-z0-9-]*$ (lowercase, digits, dashes; must start with a letter or digit)" >&2
+    exit 1
+  fi
+
+  if [ -z "$repo" ]; then
+    local url
+    if ! url="$(git remote get-url origin 2>/dev/null)"; then
+      echo "error: no \`origin\` remote and no \`--repo\` flag — pass \`--repo Owner/repo\` or run \`git remote add origin ...\`" >&2
+      exit 1
+    fi
+    url="${url%.git}"
+    repo="$(printf '%s' "$url" | sed -E 's|.*[:/]([^/:]+/[^/]+)$|\1|')"
+    if [ "$repo" = "$url" ]; then
+      echo "error: could not parse Owner/repo from remote URL: ${url} — pass \`--repo Owner/repo\` explicitly" >&2
+      exit 1
+    fi
+  fi
+
+  if ! gh repo view "$repo" &>/dev/null; then
+    echo "error: repo \`${repo}\` not reachable via gh — check the repo name + your gh auth" >&2
+    exit 1
+  fi
+
+  if [ "${#agent_logins[@]}" -eq 0 ]; then
+    local login
+    if ! login="$(gh api user --jq .login 2>/dev/null)"; then
+      echo "error: could not get gh user login — run \`gh auth login\` first" >&2
+      exit 1
+    fi
+    agent_logins=("$login")
+  fi
+
+  local logins_json='['
+  local sep=''
+  for l in "${agent_logins[@]}"; do
+    logins_json="${logins_json}${sep}\"${l}\""
+    sep=','
+  done
+  logins_json="${logins_json}]"
+
+  local config_path=".orchestrator/config.json"
+  local gitignore_path=".orchestrator/.gitignore"
+
+  if [ -f "$config_path" ] && [ "$force" -eq 0 ]; then
+    echo "error: ${config_path} already exists — pass \`--force\` to overwrite" >&2
+    exit 1
+  fi
+
+  if [ "$dry_run" -eq 1 ]; then
+    echo "--- ${config_path} ---"
+    printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
+      "$project" "$repo" "$logins_json"
+    echo "--- ${gitignore_path} ---"
+    printf 'state.json\nlast-tick.txt\nlast-error.txt\n'
+    exit 0
+  fi
+
+  mkdir -p .orchestrator
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
+    "$project" "$repo" "$logins_json" > "$config_path"
+  printf 'state.json\nlast-tick.txt\nlast-error.txt\n' > "$gitignore_path"
+
+  echo "Wrote ${config_path}"
+  echo "Wrote ${gitignore_path}"
+  printf '\nNext step:\n'
+  printf '  roost spawn %s-lead-pm \\\n' "$project"
+  printf "    --channels '#%s-leads' \\\n" "$project"
+  printf "    --prompt '/lead-pm %s <milestone> <your-irc-nick> <your-gh-login>'\n" "$project"
 }
 
 require_tmux() {
@@ -516,6 +646,7 @@ shift
 case "${1:-}" in
   -h|--help)
     case "${cmd}" in
+      init)     usage_init ;;
       spawn)    usage_spawn ;;
       shutdown) usage_shutdown ;;
       list)     usage_list ;;
@@ -530,6 +661,7 @@ case "${1:-}" in
     ;;
 esac
 case "${cmd}" in
+  init)     cmd_init "$@" ;;
   spawn)    cmd_spawn "$@" ;;
   shutdown) cmd_shutdown "$@" ;;
   list)     cmd_list "$@" ;;

--- a/bin/roost
+++ b/bin/roost
@@ -206,10 +206,20 @@ Example:
 EOF
 }
 
+_init_config_json() {
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
+    "$1" "$2" "$3"
+}
+
+_init_gitignore() {
+  printf 'state.json\nlast-tick.txt\nlast-error.txt\n'
+}
+
 cmd_init() {
   local project=""
   local repo=""
   local agent_logins=()
+  local login_re='^[a-zA-Z0-9][a-zA-Z0-9-]*$'
   local force=0
   local force_prompts=0
   local no_prompts=0
@@ -219,7 +229,12 @@ cmd_init() {
     case "$1" in
       --project)       project="$2";         shift 2 ;;
       --repo)          repo="$2";            shift 2 ;;
-      --agent-login)   agent_logins+=("$2"); shift 2 ;;
+      --agent-login)
+        if [[ ! "$2" =~ $login_re ]]; then
+          echo "error: invalid --agent-login \"$2\": must match ^[a-zA-Z0-9][a-zA-Z0-9-]*$" >&2
+          exit 1
+        fi
+        agent_logins+=("$2");               shift 2 ;;
       --force)         force=1;              shift ;;
       --force-prompts) force_prompts=1;      shift ;;
       --no-prompts)    no_prompts=1;         shift ;;
@@ -293,14 +308,13 @@ cmd_init() {
 
   if [ "$dry_run" -eq 1 ]; then
     echo "--- ${config_path} ---"
-    printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
-      "$project" "$repo" "$logins_json"
+    _init_config_json "$project" "$repo" "$logins_json"
     echo "--- ${gitignore_path} ---"
-    printf 'state.json\nlast-tick.txt\nlast-error.txt\n'
+    _init_gitignore
     if [ "$no_prompts" -eq 0 ]; then
       for name in "${prompt_names[@]}"; do
         local src="${prompts_dir}/${name}.md"
-        [ -f "$src" ] && echo "--- ${commands_dir}/${name}.md ---"
+        [ -f "$src" ] && echo "--- ${commands_dir}/${name}.md (copied verbatim from plugin prompts/${name}.md) ---"
       done
     fi
     exit 0
@@ -312,11 +326,10 @@ cmd_init() {
   fi
 
   mkdir -p .orchestrator
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "watched_issues": [],\n  "watched_prs": []\n}\n' \
-    "$project" "$repo" "$logins_json" > "$config_path"
+  _init_config_json "$project" "$repo" "$logins_json" > "$config_path"
   echo "Wrote ${config_path}"
   if [ ! -f "$gitignore_path" ] || [ "$force" -eq 1 ]; then
-    printf 'state.json\nlast-tick.txt\nlast-error.txt\n' > "$gitignore_path"
+    _init_gitignore > "$gitignore_path"
     echo "Wrote ${gitignore_path}"
   fi
 

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -40,15 +40,6 @@ roost_init() {
   PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init "$@"
 }
 
-assert_json() {
-  local file="$1" field="$2" expected="$3"
-  local actual
-  actual="$(grep "\"${field}\"" "$file" | sed 's/.*: //' | tr -d ' ,')"
-  if [ "$actual" = "$expected" ]; then return 0; fi
-  echo "  expected ${field}=${expected}, got ${actual}" >&2
-  return 1
-}
-
 # --- URL parsing: all four remote shapes ---
 
 for shape in \
@@ -137,11 +128,27 @@ teardown
 
 setup "https://github.com/TestOwner/myproject.git"
 cd "$TDIR"
-if roost_init --dry-run 2>/dev/null | grep -q '"project"' \
+dry_out="$(roost_init --dry-run 2>/dev/null)"
+if echo "$dry_out" | grep -q '"project"' \
     && [ ! -f "${TDIR}/.orchestrator/config.json" ]; then
   ok "--dry-run: no files written, content printed"
 else
   fail "--dry-run: no files written, content printed"
+fi
+cd - >/dev/null
+teardown
+
+# --- --dry-run on existing config: works without --force ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .orchestrator
+echo '{"old": true}' > .orchestrator/config.json
+dry_out="$(roost_init --dry-run 2>/dev/null)"
+if echo "$dry_out" | grep -q '"project"'; then
+  ok "--dry-run: bypasses existing-config guard"
+else
+  fail "--dry-run: bypasses existing-config guard"
 fi
 cd - >/dev/null
 teardown

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -275,6 +275,23 @@ fi
 cd - >/dev/null
 teardown
 
+# --- prompts: --force overwrites (implies --force-prompts) ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .claude/commands .orchestrator
+echo '{"old": true}' > .orchestrator/config.json
+echo 'custom content' > .claude/commands/worker.md
+if roost_init --force >/dev/null 2>&1 \
+    && ! grep -q 'custom content' "${TDIR}/.claude/commands/worker.md" \
+    && grep -q 'description' "${TDIR}/.claude/commands/worker.md"; then
+  ok "prompts: --force overwrites prompts"
+else
+  fail "prompts: --force overwrites prompts"
+fi
+cd - >/dev/null
+teardown
+
 # --- prompts: --force-prompts overwrites ---
 
 setup "https://github.com/TestOwner/myproject.git"

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Tests for `roost init`. Plain bash, no bats required.
+# Run: bash test/init_test.sh
+set -uo pipefail
+
+ROOST_BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/bin/roost"
+PASS=0
+FAIL=0
+TDIR=""
+STUBS=""
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+setup() {
+  local remote_url="${1:-}"
+  # Template uses only dashes so basename matches the project-name regex.
+  TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
+  git -C "$TDIR" init -q
+  if [ -n "$remote_url" ]; then
+    git -C "$TDIR" remote add origin "$remote_url"
+  fi
+  STUBS="${TDIR}/.stubs"
+  mkdir -p "$STUBS"
+  cat > "${STUBS}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "auth status")  exit 0 ;;
+  "api user")     echo "testuser" ;;
+  "repo view")    exit 0 ;;
+  *)              echo "gh-stub: unhandled: $*" >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "${STUBS}/gh"
+}
+
+teardown() { rm -rf "$TDIR"; }
+
+roost_init() {
+  PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init "$@"
+}
+
+assert_json() {
+  local file="$1" field="$2" expected="$3"
+  local actual
+  actual="$(grep "\"${field}\"" "$file" | sed 's/.*: //' | tr -d ' ,')"
+  if [ "$actual" = "$expected" ]; then return 0; fi
+  echo "  expected ${field}=${expected}, got ${actual}" >&2
+  return 1
+}
+
+# --- URL parsing: all four remote shapes ---
+
+for shape in \
+  "git@github.com:TestOwner/myproject.git" \
+  "https://github.com/TestOwner/myproject.git" \
+  "https://github.com/TestOwner/myproject" \
+  "ssh://git@github.com/TestOwner/myproject.git"; do
+  setup "$shape"
+  cd "$TDIR"
+  if roost_init >/dev/null 2>&1 \
+      && grep -q '"repo": "TestOwner/myproject"' "${TDIR}/.orchestrator/config.json"; then
+    ok "url-parse: ${shape}"
+  else
+    fail "url-parse: ${shape}"
+  fi
+  cd - >/dev/null
+  teardown
+done
+
+# --- agent_logins: autodetected (single) ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init >/dev/null 2>&1 \
+    && grep -q '"agent_logins": \["testuser"\]' "${TDIR}/.orchestrator/config.json"; then
+  ok "agent_logins: autodetected"
+else
+  fail "agent_logins: autodetected"
+fi
+cd - >/dev/null
+teardown
+
+# --- agent_logins: single --agent-login ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init --agent-login alice >/dev/null 2>&1 \
+    && grep -q '"agent_logins": \["alice"\]' "${TDIR}/.orchestrator/config.json"; then
+  ok "agent_logins: single flag"
+else
+  fail "agent_logins: single flag"
+fi
+cd - >/dev/null
+teardown
+
+# --- agent_logins: multiple --agent-login ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init --agent-login alice --agent-login bob >/dev/null 2>&1 \
+    && grep -q '"agent_logins": \["alice","bob"\]' "${TDIR}/.orchestrator/config.json"; then
+  ok "agent_logins: multiple flags"
+else
+  fail "agent_logins: multiple flags"
+fi
+cd - >/dev/null
+teardown
+
+# --- --project override ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init --project custom-name >/dev/null 2>&1 \
+    && grep -q '"project": "custom-name"' "${TDIR}/.orchestrator/config.json"; then
+  ok "--project override"
+else
+  fail "--project override"
+fi
+cd - >/dev/null
+teardown
+
+# --- --repo override (no remote needed) ---
+
+setup ""
+cd "$TDIR"
+if roost_init --repo "SomeOwner/other-repo" >/dev/null 2>&1 \
+    && grep -q '"repo": "SomeOwner/other-repo"' "${TDIR}/.orchestrator/config.json"; then
+  ok "--repo override"
+else
+  fail "--repo override"
+fi
+cd - >/dev/null
+teardown
+
+# --- --dry-run: prints content, writes nothing ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init --dry-run 2>/dev/null | grep -q '"project"' \
+    && [ ! -f "${TDIR}/.orchestrator/config.json" ]; then
+  ok "--dry-run: no files written, content printed"
+else
+  fail "--dry-run: no files written, content printed"
+fi
+cd - >/dev/null
+teardown
+
+# --- --force: overwrites existing config ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .orchestrator
+echo '{"old": true}' > .orchestrator/config.json
+if roost_init --force >/dev/null 2>&1 \
+    && grep -q '"project"' "${TDIR}/.orchestrator/config.json" \
+    && ! grep -q '"old"' "${TDIR}/.orchestrator/config.json"; then
+  ok "--force: overwrites existing"
+else
+  fail "--force: overwrites existing"
+fi
+cd - >/dev/null
+teardown
+
+# --- .gitignore written ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+roost_init >/dev/null 2>&1
+if grep -q 'state.json'     "${TDIR}/.orchestrator/.gitignore" \
+    && grep -q 'last-tick.txt'  "${TDIR}/.orchestrator/.gitignore" \
+    && grep -q 'last-error.txt' "${TDIR}/.orchestrator/.gitignore"; then
+  ok ".gitignore: correct entries"
+else
+  fail ".gitignore: correct entries"
+fi
+cd - >/dev/null
+teardown
+
+# --- error: existing config without --force ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .orchestrator
+echo '{}' > .orchestrator/config.json
+if ! roost_init >/dev/null 2>&1; then
+  ok "error: existing config rejected without --force"
+else
+  fail "error: existing config rejected without --force"
+fi
+cd - >/dev/null
+teardown
+
+# --- error: not a git repo ---
+
+TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
+STUBS="${TDIR}/.stubs"
+mkdir -p "$STUBS"
+# gh stub not needed — should fail before gh is called
+cd "$TDIR"
+if ! "${ROOST_BIN}" init >/dev/null 2>&1; then
+  ok "error: not a git repo"
+else
+  fail "error: not a git repo"
+fi
+cd - >/dev/null
+rm -rf "$TDIR"
+
+# --- error: no origin remote without --repo ---
+
+setup ""
+cd "$TDIR"
+if ! roost_init >/dev/null 2>&1; then
+  ok "error: no origin remote"
+else
+  fail "error: no origin remote"
+fi
+cd - >/dev/null
+teardown
+
+# --- summary ---
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -16,6 +16,8 @@ setup() {
   local remote_url="${1:-}"
   # Template uses only dashes so basename matches the project-name regex.
   TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
+  # Cleanup on exit in case a test panics before teardown.
+  trap 'cd / 2>/dev/null; rm -rf "$TDIR"' EXIT
   git -C "$TDIR" init -q
   if [ -n "$remote_url" ]; then
     git -C "$TDIR" remote add origin "$remote_url"
@@ -165,6 +167,23 @@ if roost_init --force >/dev/null 2>&1 \
   ok "--force: overwrites existing"
 else
   fail "--force: overwrites existing"
+fi
+cd - >/dev/null
+teardown
+
+# --- --force: also overwrites .gitignore ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .orchestrator
+echo '{"old": true}' > .orchestrator/config.json
+printf 'old-entry\n' > .orchestrator/.gitignore
+if roost_init --force >/dev/null 2>&1 \
+    && ! grep -q 'old-entry' "${TDIR}/.orchestrator/.gitignore" \
+    && grep -q 'state.json' "${TDIR}/.orchestrator/.gitignore"; then
+  ok "--force: overwrites .gitignore"
+else
+  fail "--force: overwrites .gitignore"
 fi
 cd - >/dev/null
 teardown

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -225,6 +225,67 @@ fi
 cd - >/dev/null
 teardown
 
+# --- prompts: fresh copy ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+if roost_init >/dev/null 2>&1 \
+    && [ -f "${TDIR}/.claude/commands/worker.md" ] \
+    && [ -f "${TDIR}/.claude/commands/lead-pm.md" ] \
+    && [ -f "${TDIR}/.claude/commands/reviewer.md" ] \
+    && [ -f "${TDIR}/.claude/commands/watcher.md" ]; then
+  ok "prompts: fresh copy to .claude/commands/"
+else
+  fail "prompts: fresh copy to .claude/commands/"
+fi
+cd - >/dev/null
+teardown
+
+# --- prompts: skip existing (idempotent) ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .claude/commands
+echo 'custom content' > .claude/commands/worker.md
+roost_init >/dev/null 2>&1
+if grep -q 'custom content' "${TDIR}/.claude/commands/worker.md"; then
+  ok "prompts: existing file not overwritten without --force-prompts"
+else
+  fail "prompts: existing file not overwritten without --force-prompts"
+fi
+cd - >/dev/null
+teardown
+
+# --- prompts: --force-prompts overwrites ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .claude/commands
+echo 'custom content' > .claude/commands/worker.md
+roost_init --force-prompts >/dev/null 2>&1
+if ! grep -q 'custom content' "${TDIR}/.claude/commands/worker.md" \
+    && grep -q 'description' "${TDIR}/.claude/commands/worker.md"; then
+  ok "prompts: --force-prompts overwrites existing"
+else
+  fail "prompts: --force-prompts overwrites existing"
+fi
+cd - >/dev/null
+teardown
+
+# --- prompts: --no-prompts skips copy ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+roost_init --no-prompts >/dev/null 2>&1
+if [ ! -d "${TDIR}/.claude/commands" ] \
+    || [ ! -f "${TDIR}/.claude/commands/worker.md" ]; then
+  ok "prompts: --no-prompts skips copy"
+else
+  fail "prompts: --no-prompts skips copy"
+fi
+cd - >/dev/null
+teardown
+
 # --- summary ---
 
 echo ""


### PR DESCRIPTION
Closes #202.

Adds `roost init` as a bash subcommand of `bin/roost`. No new deps.

**What it writes:**
- `.orchestrator/config.json` — project/repo/agent_logins/watched_issues/watched_prs (no irc fields; defaults in naming.ts)
- `.orchestrator/.gitignore` — state.json, last-tick.txt, last-error.txt
- `.claude/commands/{lead-pm,worker,reviewer,watcher}.md` — project-local prompt copies for customization

**Autodetect:** project from cwd basename, repo from git origin (`.git`-stripped, then `sed`-parsed), agent_login from `gh api user`. All overridable via flag.

**Preconditions:** git repo, gh auth, repo reachable via gh, project name matches `^[a-z0-9][a-z0-9-]*$`. All exit non-zero with actionable hints.

**Flags:**
- `--force` — overwrite config.json + .gitignore
- `--force-prompts` — overwrite existing prompt copies (independent of `--force`)
- `--no-prompts` — skip prompt copy entirely
- `--dry-run` — preview without writing (bypasses existing-config guard)

**Prompt copy:** idempotent by default (existing files skipped). Success output lists copied files + tip about customization and `--force-prompts`. No in-file banner — tip goes to stdout only.

**Tests:** `test/init_test.sh` — 20 cases: all four remote URL shapes, 0/1/2+ agent_logins, flag overrides, --force, --dry-run (including on existing config), prompt fresh-copy, skip-existing, --force-prompts overwrite, --no-prompts. Uses real git; stubs `gh` via PATH. shellcheck clean.

[roost-worker-202]