### PR TITLE
feat: SessionStart-compact hook for IRC-reply directive

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -507,9 +507,10 @@ cmd_spawn() {
   fi
 
   # Write per-session roost-settings.json with hooks that need to be active
-  # for all roost sessions. PreCompact is always present; PermissionRequest is
-  # added when --perm-irc is passed. Cleaned up implicitly when data_dir is
-  # rm -rf'd on shutdown. ROOST_DIR is cd-derived (no spaces/backslashes).
+  # for all roost sessions. PreCompact, PostCompact, and SessionStart-compact
+  # are always present; PermissionRequest is added when --perm-irc is passed.
+  # Cleaned up implicitly when data_dir is rm -rf'd on shutdown. ROOST_DIR is
+  # cd-derived (no spaces/backslashes).
   local perm_sock=""
   local perm_hook_json=""
   if [ "${perm_irc}" -eq 1 ]; then

--- a/bin/roost
+++ b/bin/roost
@@ -517,7 +517,7 @@ cmd_spawn() {
     perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]"
   fi
   local ROOST_SETTINGS="${ROOST_DATA_DIR}/roost-settings.json"
-  printf '%s\n' "{\"hooks\":{\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-compact-hook\"}]}],\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-post-compact-hook\"}]}]${perm_hook_json}}}" > "${ROOST_SETTINGS}"
+  printf '%s\n' "{\"hooks\":{\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-compact-hook\"}]}],\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-session-start-hook\"}]}]${perm_hook_json}}}" > "${ROOST_SETTINGS}"
 
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode}, cwd: ${cwd})"
   [ -n "${extra_str}" ] && echo "  extra claude args:${extra_str}"

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -1,32 +1,23 @@
-#!/usr/bin/env python3
-"""
-PreCompact hook — signals the roost IRC MCP to clear its replay dedupe seen-set.
-
-Fired by Claude Code before context compaction. Sends SIGUSR1 to the MCP
-process so that the next chathistory backfill (after any reconnect) delivers
-messages that were compacted out of the agent's context window.
-
-Wired by bin/roost at spawn time via roost-settings.json; never exits
-non-zero so a hook failure doesn't block compaction.
-"""
-import os
-import signal
-import sys
-
-data_dir = os.environ.get("ROOST_DATA_DIR", "")
-if not data_dir:
-    sys.stderr.write("roost-compact-hook: ROOST_DATA_DIR not set, skipping\n")
-    sys.exit(0)
-
-pid_path = os.path.join(data_dir, "mcp.pid")
-if not os.path.exists(pid_path):
-    sys.stderr.write(f"roost-compact-hook: {pid_path} not found, skipping\n")
-    sys.exit(0)
-
-try:
-    pid = int(open(pid_path).read().strip())
-    os.kill(pid, signal.SIGUSR1)
-    sys.stderr.write(f"roost-compact-hook: sent SIGUSR1 to MCP pid {pid}\n")
-except Exception as e:
-    sys.stderr.write(f"roost-compact-hook: failed: {e}\n")
-    sys.exit(0)
+#!/bin/sh
+# PreCompact hook — signal MCP to clear replay dedupe (SIGUSR1) so the next
+# chathistory backfill after reconnect delivers messages compacted out of
+# the agent's context window.
+#
+# Wired by bin/roost at spawn time via roost-settings.json. Never exits
+# non-zero — a hook failure must not block compaction.
+if [ -z "$ROOST_DATA_DIR" ]; then
+  echo "roost-compact-hook: ROOST_DATA_DIR not set, skipping" >&2
+  exit 0
+fi
+pid_file="$ROOST_DATA_DIR/mcp.pid"
+if [ ! -f "$pid_file" ]; then
+  echo "roost-compact-hook: $pid_file not found, skipping" >&2
+  exit 0
+fi
+pid=$(cat "$pid_file")
+if kill -USR1 "$pid" 2>/dev/null; then
+  echo "roost-compact-hook: sent SIGUSR1 to MCP pid $pid" >&2
+else
+  echo "roost-compact-hook: kill -USR1 $pid failed" >&2
+fi
+exit 0

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -15,9 +15,15 @@ if [ ! -f "$pid_file" ]; then
   exit 0
 fi
 pid=$(cat "$pid_file")
+case "$pid" in
+  ''|*[!0-9]*)
+    echo "roost-compact-hook: malformed pid in $pid_file: '$pid', skipping" >&2
+    exit 0
+    ;;
+esac
 if kill -USR1 "$pid" 2>/dev/null; then
   echo "roost-compact-hook: sent SIGUSR1 to MCP pid $pid" >&2
 else
-  echo "roost-compact-hook: kill -USR1 $pid failed" >&2
+  echo "roost-compact-hook: kill -USR1 $pid failed (no such process?)" >&2
 fi
 exit 0

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -13,9 +13,15 @@ if [ ! -f "$pid_file" ]; then
   exit 0
 fi
 pid=$(cat "$pid_file")
+case "$pid" in
+  ''|*[!0-9]*)
+    echo "roost-post-compact-hook: malformed pid in $pid_file: '$pid', skipping" >&2
+    exit 0
+    ;;
+esac
 if kill -USR2 "$pid" 2>/dev/null; then
   echo "roost-post-compact-hook: sent SIGUSR2 to MCP pid $pid" >&2
 else
-  echo "roost-post-compact-hook: kill -USR2 $pid failed" >&2
+  echo "roost-post-compact-hook: kill -USR2 $pid failed (no such process?)" >&2
 fi
 exit 0

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -1,21 +1,21 @@
-#!/usr/bin/env python3
-import os
-import signal
-import sys
-
-data_dir = os.environ.get("ROOST_DATA_DIR", "")
-if not data_dir:
-    sys.stderr.write("roost-post-compact-hook: ROOST_DATA_DIR not set, skipping\n")
-    sys.exit(0)
-
-pid_path = os.path.join(data_dir, "mcp.pid")
-if not os.path.exists(pid_path):
-    sys.stderr.write(f"roost-post-compact-hook: {pid_path} not found, skipping\n")
-    sys.exit(0)
-
-try:
-    pid = int(open(pid_path).read().strip())
-    os.kill(pid, signal.SIGUSR2)
-    sys.stderr.write(f"roost-post-compact-hook: sent SIGUSR2 to MCP pid {pid}\n")
-except Exception as e:
-    sys.stderr.write(f"roost-post-compact-hook: failed: {e}\n")
+#!/bin/sh
+# PostCompact hook — signal MCP to replay missed messages (SIGUSR2).
+#
+# Wired by bin/roost at spawn time via roost-settings.json. Never exits
+# non-zero — a hook failure must not block compaction.
+if [ -z "$ROOST_DATA_DIR" ]; then
+  echo "roost-post-compact-hook: ROOST_DATA_DIR not set, skipping" >&2
+  exit 0
+fi
+pid_file="$ROOST_DATA_DIR/mcp.pid"
+if [ ! -f "$pid_file" ]; then
+  echo "roost-post-compact-hook: $pid_file not found, skipping" >&2
+  exit 0
+fi
+pid=$(cat "$pid_file")
+if kill -USR2 "$pid" 2>/dev/null; then
+  echo "roost-post-compact-hook: sent SIGUSR2 to MCP pid $pid" >&2
+else
+  echo "roost-post-compact-hook: kill -USR2 $pid failed" >&2
+fi
+exit 0

--- a/bin/roost-session-start-hook
+++ b/bin/roost-session-start-hook
@@ -1,5 +1,10 @@
 #!/bin/sh
 # SessionStart hook (matcher="compact") — inject IRC-reply directive after compaction.
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"You are running on the Roost IRC harness. Substantive replies belong in IRC, not your local text buffer — humans cannot see your buffer. When responding to a channel message or DM, post via channel_message or direct_message. Brief tool-narration is fine to keep in the buffer.\n\nYou are returning from a context compaction. Note in IRC that you're coming back from a compaction so the humans you're working with know."}}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "You are running on the Roost IRC harness. Substantive replies belong in IRC, not your local text buffer — humans cannot see your buffer. When responding to a channel message or DM, post via channel_message or direct_message. Brief tool-narration is fine to keep in the buffer.\n\nYou are returning from a context compaction. Note in IRC that you're coming back from a compaction so the humans you're working with know."
+  }
+}
 EOF

--- a/bin/roost-session-start-hook
+++ b/bin/roost-session-start-hook
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-"""
-SessionStart hook (matcher="compact") — injects an IRC-reply directive into
-the agent's view after Claude Code finishes compacting context.
-
-Without this, post-compact agents tend to reply in their own text buffer
-instead of via channel_message/direct_message — the human on IRC sees
-silence. PostCompact is too late (the new session is already initialized),
-so we hook SessionStart with matcher="compact" instead.
-
-Wired by bin/roost at spawn time via roost-settings.json. Never exits
-non-zero — a hook failure must not block session start.
-"""
+"""SessionStart hook (matcher="compact") — inject IRC-reply directive after compaction."""
 import json
-import sys
 
 DIRECTIVE = (
     "You are running on the Roost IRC harness. Substantive replies belong "
@@ -23,13 +11,9 @@ DIRECTIVE = (
     "coming back from a compaction so the humans you're working with know."
 )
 
-try:
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": "SessionStart",
-            "additionalContext": DIRECTIVE,
-        }
-    }))
-except Exception as e:
-    sys.stderr.write(f"roost-session-start-hook: failed: {e}\n")
-    sys.exit(0)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": DIRECTIVE,
+    }
+}))

--- a/bin/roost-session-start-hook
+++ b/bin/roost-session-start-hook
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook (matcher="compact") — injects an IRC-reply directive into
+the agent's view after Claude Code finishes compacting context.
+
+Without this, post-compact agents tend to reply in their own text buffer
+instead of via channel_message/direct_message — the human on IRC sees
+silence. PostCompact is too late (the new session is already initialized),
+so we hook SessionStart with matcher="compact" instead.
+
+Wired by bin/roost at spawn time via roost-settings.json. Never exits
+non-zero — a hook failure must not block session start.
+"""
+import json
+import sys
+
+DIRECTIVE = (
+    "You are running on the Roost IRC harness. Substantive replies belong "
+    "in IRC, not your local text buffer — humans cannot see your buffer. "
+    "When responding to a channel message or DM, post via channel_message "
+    "or direct_message. Brief tool-narration is fine to keep in the buffer.\n\n"
+    "You are returning from a context compaction. Note in IRC that you're "
+    "coming back from a compaction so the humans you're working with know."
+)
+
+try:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": DIRECTIVE,
+        }
+    }))
+except Exception as e:
+    sys.stderr.write(f"roost-session-start-hook: failed: {e}\n")
+    sys.exit(0)

--- a/bin/roost-session-start-hook
+++ b/bin/roost-session-start-hook
@@ -1,19 +1,5 @@
-#!/usr/bin/env python3
-"""SessionStart hook (matcher="compact") — inject IRC-reply directive after compaction."""
-import json
-
-DIRECTIVE = (
-    "You are running on the Roost IRC harness. Substantive replies belong "
-    "in IRC, not your local text buffer — humans cannot see your buffer. "
-    "When responding to a channel message or DM, post via channel_message "
-    "or direct_message. Brief tool-narration is fine to keep in the buffer.\n\n"
-    "You are returning from a context compaction. Note in IRC that you're "
-    "coming back from a compaction so the humans you're working with know."
-)
-
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "SessionStart",
-        "additionalContext": DIRECTIVE,
-    }
-}))
+#!/bin/sh
+# SessionStart hook (matcher="compact") — inject IRC-reply directive after compaction.
+cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"You are running on the Roost IRC harness. Substantive replies belong in IRC, not your local text buffer — humans cannot see your buffer. When responding to a channel message or DM, post via channel_message or direct_message. Brief tool-narration is fine to keep in the buffer.\n\nYou are returning from a context compaction. Note in IRC that you're coming back from a compaction so the humans you're working with know."}}
+EOF


### PR DESCRIPTION
## Summary
- After context compaction, agents tend to reply in their own text buffer instead of posting to IRC. The human sees silence. This wires up a SessionStart hook (matcher="compact") that injects a short directive reminding the agent that substantive replies belong in IRC, and to note in IRC that it's resuming from compaction.
- PostCompact can't carry the directive — by the time it fires, the new session is already initialized, so `additionalContext` from there never reaches Claude. SessionStart with `matcher="compact"` is the documented injection point.
- While here, ported all three roost hook scripts from python to shell (PreCompact, PostCompact, SessionStart). Drops the python interpreter dep from the hook hot path; existing Pre/PostCompact hooks keep their SIGUSR1/2 roles.

## Test plan
- [x] `bin/roost-session-start-hook` prints valid JSON with `hookSpecificOutput.hookEventName="SessionStart"` and a non-empty `additionalContext`
- [x] Assembled `roost-settings.json` (in `bin/roost`) parses as valid JSON with all three hook entries (PreCompact, PostCompact, SessionStart-compact) plus optional PermissionRequest
- [x] All three shell hooks: shellcheck clean, exit 0 in missing-env / missing-pidfile cases, send signal correctly when env+pidfile present
- [ ] Live: spawn a roost agent, trigger `/compact`, confirm the agent's first post-compact action mentions resumption in IRC

🤖 Generated with [Claude Code](https://claude.com/claude-code)