### PR TITLE
fix: resolve bin/roost symlinks before computing ROOST_DIR

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -16,10 +16,8 @@
 
 set -uo pipefail
 
-# Resolve BASH_SOURCE through any symlinks before computing ROOST_DIR, so
-# Homebrew's `bin.install_symlink libexec/"bin/roost"` (or any other
-# /opt/homebrew/bin/roost → cellar/bin/roost shim) lands at the real plugin
-# tree, not the symlink's parent.
+# Walk symlinks so ROOST_DIR resolves to the real plugin tree, not the
+# parent of a /usr/local/bin/roost-style shim.
 _src="${BASH_SOURCE[0]}"
 while [ -L "$_src" ]; do
   _dir="$( cd -P "$( dirname "$_src" )" && pwd )"

--- a/bin/roost
+++ b/bin/roost
@@ -16,7 +16,18 @@
 
 set -uo pipefail
 
-ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+# Resolve BASH_SOURCE through any symlinks before computing ROOST_DIR, so
+# Homebrew's `bin.install_symlink libexec/"bin/roost"` (or any other
+# /opt/homebrew/bin/roost → cellar/bin/roost shim) lands at the real plugin
+# tree, not the symlink's parent.
+_src="${BASH_SOURCE[0]}"
+while [ -L "$_src" ]; do
+  _dir="$( cd -P "$( dirname "$_src" )" && pwd )"
+  _src="$( readlink "$_src" )"
+  case "$_src" in /*) ;; *) _src="$_dir/$_src" ;; esac
+done
+ROOST_DIR="$( cd -P "$( dirname "$_src" )/.." && pwd )"
+unset _src _dir
 IRC_HOST="${ROOST_IRC_SERVER:-127.0.0.1}"
 IRC_PORT=6667
 SESSION_PREFIX="roost-"


### PR DESCRIPTION
## Summary
- `bin/roost` derives `ROOST_DIR` via `cd $(dirname $BASH_SOURCE[0])/..`. When the script is invoked through a symlink (e.g. `/opt/homebrew/bin/roost` → `<cellar>/libexec/bin/roost`), `BASH_SOURCE[0]` is the symlink path, so ROOST_DIR ends up at `/opt/homebrew` instead of the plugin tree.
- Fix: walk symlinks (standard `while [ -L "$src" ]` idiom) before computing the directory.
- Unblocks the homebrew tap formula being able to use `bin.install_symlink libexec/"bin/roost"` instead of a shell-shim wrapper.

## Test plan
- [x] `shellcheck bin/roost` clean
- [x] `bin/roost root` (direct) returns the plugin dir
- [x] `<symlinked-bin>/roost root` (via symlink) returns the same plugin dir
- [x] Existing `bun run lint` / `bun run typecheck` clean
- [ ] Live: spawn a roost agent from a brew-installed `bin.install_symlink` setup; confirm hooks fire and the MCP boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)