### PR TITLE
maint: flip repo URLs from AlexSc/roost to AvesAlight/roost

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "roost",
   "owner": {
-    "name": "Alex Scarborough"
+    "name": "Aves Alight"
   },
   "description": "IRC-based multi-agent coordination for Claude Code.",
   "plugins": [
@@ -9,7 +9,7 @@
       "name": "roost",
       "source": {
         "source": "github",
-        "repo": "AlexSc/roost"
+        "repo": "AvesAlight/roost"
       },
       "description": "IRC-based multi-agent coordination for Claude Code. Run a local IRC server and coordinate multiple Claude sessions via named channels a human operator can join with any IRC client."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,6 +5,6 @@
   "author": {
     "name": "Alex Scarborough"
   },
-  "repository": "https://github.com/AlexSc/roost",
+  "repository": "https://github.com/AvesAlight/roost",
   "license": "Apache-2.0"
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When a Claude Code session loads `roost-irc` as an MCP and connects:
 ### 1. Install the plugin
 
 ```
-/plugin marketplace add https://github.com/AlexSc/roost
+/plugin marketplace add https://github.com/AvesAlight/roost
 /plugin install roost@roost
 ```
 

--- a/src/orchestrator/__tests__/naming.test.ts
+++ b/src/orchestrator/__tests__/naming.test.ts
@@ -23,11 +23,11 @@ describe('validateProject', () => {
 
 describe('defaultProject', () => {
   it('returns the explicit project when set', () => {
-    expect(defaultProject({ project: 'roost', repo: 'AlexSc/roost' })).toBe('roost')
+    expect(defaultProject({ project: 'roost', repo: 'AvesAlight/roost' })).toBe('roost')
   })
 
   it('falls back to lowercased basename of repo', () => {
-    expect(defaultProject({ repo: 'AlexSc/Roost' })).toBe('roost')
+    expect(defaultProject({ repo: 'AvesAlight/Roost' })).toBe('roost')
   })
 
   it('throws when project invalid', () => {


### PR DESCRIPTION
closes #209

four files updated:
- `.claude-plugin/plugin.json` — repository URL
- `.claude-plugin/marketplace.json` — owner.name (publisher) + source.repo
- `README.md` — marketplace install URL
- `src/orchestrator/__tests__/naming.test.ts` — test fixtures

`plugin.json:author.name` left as "Alex Scarborough" per issue spec. lint/typecheck/test all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)