### PR TITLE
fix: pass --plugin-dir to claude on spawn

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -553,7 +553,11 @@ cmd_spawn() {
     mcp_flag=" --mcp-config ${mcp_config}"
     channel_server="server:roost-irc"
   fi
-  local inner_cmd="claude --model ${model} --permission-mode ${permission_mode}${mcp_flag} --settings ${ROOST_SETTINGS} --dangerously-load-development-channels ${channel_server}${extra_str}"
+  # --plugin-dir points claude at the resolved plugin tree (dev checkout
+  # OR brew cellar — ROOST_DIR walks symlinks). Without it, --dangerously-
+  # load-development-channels server:plugin:roost:roost-irc has nothing to
+  # find unless the plugin's been installed into claude's registry.
+  local inner_cmd="claude --model ${model} --permission-mode ${permission_mode}${mcp_flag} --settings ${ROOST_SETTINGS} --plugin-dir ${ROOST_DIR} --dangerously-load-development-channels ${channel_server}${extra_str}"
   if [ -n "${prompt_file}" ]; then
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary
- `bin/roost spawn` invokes claude with `--dangerously-load-development-channels server:plugin:roost:roost-irc` but no `--plugin-dir`. That works in a dev checkout (since the plugin's auto-discovered from cwd / there's a `.claude-plugin/`), but breaks in the brew-install flow where the plugin lives at `<brew-cellar>/Cellar/roost/<v>/` and isn't registered with claude.
- Adding `--plugin-dir ${ROOST_DIR}` makes both flows work uniformly. ROOST_DIR walks symlinks (#207), so it correctly resolves to the cellar path under brew or the checkout path in dev.

## Test plan
- [x] `shellcheck bin/roost` clean
- [x] `bun run lint` / `bun run typecheck` clean
- [ ] Live: spawn an agent from a brew-installed roost; confirm the roost-irc MCP loads in the spawned claude session

🤖 Generated with [Claude Code](https://claude.com/claude-code)