### PR TITLE
docs: add 'previewing assets' tip to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,16 @@ Requires ergo (IRCv3 server). Install with `bin/install-ergo` or set `ERGO_BIN` 
 
 Use `script/worktree <branch> [--from <base>] [path]` to bootstrap a new worktree — it creates the sibling worktree, runs `bun install`, and copies `.claude/settings.local.json` from the main worktree so spawned workers don't hit a permission-prompt flood.
 
+## Previewing assets
+
+IRC has no inline image preview, and human reviewers run weechat in tmux. When sharing a rendered asset, post the path as text and let the human view it with OS tools:
+
+- macOS: `qlmanage -p path/to/file.png` (Quick Look popup, space to dismiss)
+- Linux: `xdg-open path/to/file.png`
+- Cross-platform: `feh path/to/file.png` if installed
+
+The render → post path → human-views-externally → reply round-trip is the floor of working in this medium, congruent with the brand. Don't bolt new abstractions onto IRC to bridge it.
+
 ## Layout
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,7 @@ Use `script/worktree <branch> [--from <base>] [path]` to bootstrap a new worktre
 
 ## Previewing assets
 
-IRC has no inline image preview, and human reviewers run weechat in tmux. When sharing a rendered asset, post the path as text and let the human view it with OS tools:
-
-- macOS: `qlmanage -p path/to/file.png` (Quick Look popup, space to dismiss)
-- Linux: `xdg-open path/to/file.png`
-- Cross-platform: `feh path/to/file.png` if installed
+IRC has no inline image preview, and human reviewers run weechat in tmux. When sharing a rendered asset, post the path as text and let the human view it with their OS tools (e.g. macOS Quick Look via `qlmanage -p path/to/file.png`).
 
 The render → post path → human-views-externally → reply round-trip is the floor of working in this medium, congruent with the brand. Don't bolt new abstractions onto IRC to bridge it.
 


### PR DESCRIPTION
## Summary

- Adds a `## Previewing assets` section to roost's CLAUDE.md
- Documents the macOS / Linux / cross-platform OS tools for viewing files when sharing assets over IRC (qlmanage / xdg-open / feh)
- Mirrors the matching section just added to the brand repo's CLAUDE.md

## Why

From the #213 dogfooding postmortem: visual-context-over-text is real strain in IRC, and we briefly considered building a `channel_image` MCP / static-server bridge before alex pointed out IRC clients in tmux don't inline-preview anything. The right answer is to use the operator's existing OS tools, not bolt new abstractions onto IRC. The round-trip cost is congruent with the brand.

## Test plan

- [ ] CLAUDE.md renders cleanly on GitHub
- [ ] No other content shifted

🤖 Generated with [Claude Code](https://claude.com/claude-code)