### PR TITLE
prompts: lead-pm — engage on self-authored PRs same as worker PRs

### DIFF
--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -102,7 +102,7 @@ Before merging a PR or removing a worktree, confirm: the PR is approved by the h
 
 Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself, but **treat it the same as a worker-authored PR for engagement**:
 
-- Bootstrap a sibling worktree with `script/worktree <branch>` (yes, for one-line changes too — keeps the main worktree free for other in-flight work). Commit, push, open the PR from the worktree
+- Same setup as a worker PR (step 3): new branch + worktree, even for a one-liner. Keeps the primary worktree free for other in-flight work. Commit, push, open the PR from there
 - Add `$3` as reviewer immediately when you open the PR: `gh pr edit <N> --repo OWNER/REPO --add-reviewer $3`. Self-authored PRs aren't draft + ready toggled, so the request-review step doesn't happen automatically — you have to do it explicitly
 - DM the watcher to watch it: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
 - Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget. If the human leaves CHANGES_REQUESTED and you push a fix, re-request review the same way (`--add-reviewer $3`)

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -102,7 +102,7 @@ Before merging a PR or removing a worktree, confirm: the PR is approved by the h
 
 Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself, but **treat it the same as a worker-authored PR for engagement**:
 
-- Branch off main, commit, push, open the PR (don't push directly to main, even for one-line changes)
+- Bootstrap a sibling worktree with `script/worktree <branch>` (yes, for one-line changes too — keeps the main worktree free for other in-flight work). Commit, push, open the PR from the worktree
 - Add `$3` as reviewer immediately when you open the PR: `gh pr edit <N> --repo OWNER/REPO --add-reviewer $3`. Self-authored PRs aren't draft + ready toggled, so the request-review step doesn't happen automatically — you have to do it explicitly
 - DM the watcher to watch it: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
 - Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget. If the human leaves CHANGES_REQUESTED and you push a fix, re-request review the same way (`--add-reviewer $3`)

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -108,8 +108,6 @@ Some changes are small enough that spawning a worker is overhead — a doc tweak
 - Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget. If the human leaves CHANGES_REQUESTED and you push a fix, re-request review the same way (`--add-reviewer $3`)
 - After human approval, merge follows the same flow as step 9: terminate-N/A, merge `--merge`, pull main, clean up branch, unwatch
 
-The temptation to skip the watch step "because it's just a small docs change" is the failure mode. Channel routing is what tells you when the human reviewed.
-
 ## Ready?
 
 Post a message in #$0-leads with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you begin you may proceed autonomously and spawn new workers as needed.

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -98,6 +98,17 @@ To work on an issue:
 
 Before merging a PR or removing a worktree, confirm: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
 
+## When you author a PR yourself
+
+Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself, but **treat it the same as a worker-authored PR for engagement**:
+
+- Branch off main, commit, push, open the PR (don't push directly to main, even for one-line changes)
+- DM the watcher to watch it: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
+- Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget
+- After human approval, merge follows the same flow as step 9: terminate-N/A, merge `--merge`, pull main, clean up branch, unwatch
+
+The temptation to skip the watch step "because it's just a small docs change" is the failure mode. Channel routing is what tells you when the human reviewed.
+
 ## Ready?
 
 Post a message in #$0-leads with your starting strategy. Wait until the human pressure tests and approves your plan before beginning the first wave. Once you begin you may proceed autonomously and spawn new workers as needed.

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -103,8 +103,9 @@ Before merging a PR or removing a worktree, confirm: the PR is approved by the h
 Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself, but **treat it the same as a worker-authored PR for engagement**:
 
 - Branch off main, commit, push, open the PR (don't push directly to main, even for one-line changes)
+- Add `$3` as reviewer immediately when you open the PR: `gh pr edit <N> --repo OWNER/REPO --add-reviewer $3`. Self-authored PRs aren't draft + ready toggled, so the request-review step doesn't happen automatically — you have to do it explicitly
 - DM the watcher to watch it: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
-- Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget
+- Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget. If the human leaves CHANGES_REQUESTED and you push a fix, re-request review the same way (`--add-reviewer $3`)
 - After human approval, merge follows the same flow as step 9: terminate-N/A, merge `--merge`, pull main, clean up branch, unwatch
 
 The temptation to skip the watch step "because it's just a small docs change" is the failure mode. Channel routing is what tells you when the human reviewed.


### PR DESCRIPTION
## Summary

- Adds a new `## When you author a PR yourself` section to `prompts/lead-pm.md`
- Spells out that small lead-authored PRs (doc tweaks, prompt updates, one-line fixes) follow the same watch + engage flow as worker-authored PRs
- Suggests `watch pr <N> #$0-leads` as the right route since there's no `#$0-issue-N` for self-authored PRs

## Why

Live failure mode caught by alex during the #213 dogfooding session: I authored PR #221 (small CLAUDE.md tweak), opened it, and then mentally fire-and-forgot. Alex reviewed it without me watching. The lead-pm prompt covers worker-authored PR flow in detail but said nothing about lead-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)