### PR TITLE
fix: orchestrator state dir defaults to cwd, not install path

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -24,8 +24,7 @@ import { RoostIrcClientImpl } from './irc-client-impl.js'
 
 // ---- Path setup ------------------------------------------------------------
 
-const REPO_ROOT = new URL('../', import.meta.url).pathname.replace(/\/$/, '')
-const DEFAULT_STATE_DIR = join(REPO_ROOT, '.orchestrator')
+const DEFAULT_STATE_DIR = join(process.cwd(), '.orchestrator')
 
 // ---- Tick ------------------------------------------------------------------
 

--- a/src/orchestrator/__tests__/cwd-default.test.ts
+++ b/src/orchestrator/__tests__/cwd-default.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const POLL_BIN = join(import.meta.dir, '../../../bin/orchestrator_poll')
+
+async function runPoll(cwd: string, args: string[] = []): Promise<{ stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([POLL_BIN, ...args], { cwd, stderr: 'pipe', stdout: 'pipe' })
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+  return { stderr, exitCode }
+}
+
+describe('orchestrator cwd-default', () => {
+  it('defaults state dir to <cwd>/.orchestrator', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'roost-test-'))
+    try {
+      const { stderr, exitCode } = await runPoll(tmp)
+      expect(exitCode).toBe(3)
+      expect(stderr).toContain(join(tmp, '.orchestrator', 'config.json'))
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('--config-dir overrides the default', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'roost-test-'))
+    const override = await mkdtemp(join(tmpdir(), 'roost-override-'))
+    try {
+      const { stderr, exitCode } = await runPoll(tmp, ['--config-dir', override])
+      expect(exitCode).toBe(3)
+      expect(stderr).toContain(join(override, 'config.json'))
+      expect(stderr).not.toContain(join(tmp, '.orchestrator'))
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+      await rm(override, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/orchestrator/__tests__/cwd-default.test.ts
+++ b/src/orchestrator/__tests__/cwd-default.test.ts
@@ -3,10 +3,10 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-const POLL_BIN = join(import.meta.dir, '../../../bin/orchestrator_poll')
+const POLL_BIN = join(import.meta.dirname, '../../../bin/orchestrator_poll')
 
 async function runPoll(cwd: string, args: string[] = []): Promise<{ stderr: string; exitCode: number }> {
-  const proc = Bun.spawn([POLL_BIN, ...args], { cwd, stderr: 'pipe', stdout: 'pipe' })
+  const proc = Bun.spawn([POLL_BIN, ...args], { cwd, stderr: 'pipe', stdout: 'ignore' })
   const stderr = await new Response(proc.stderr).text()
   const exitCode = await proc.exited
   return { stderr, exitCode }


### PR DESCRIPTION
Fixes #218.

`DEFAULT_STATE_DIR` was built from `import.meta.url`, which after a brew install resolves to the install path rather than the project working directory. The watcher writes `.orchestrator/config.json` cwd-relative, so the dispatcher was reading a stale config — root cause of the missed PR review comment relay in #213.

## Changes

- `src/orchestrator.ts`: `process.cwd()` replaces the `import.meta.url`-based path; drop unused `REPO_ROOT` constant
- `src/orchestrator/__tests__/cwd-default.test.ts`: spawns `bin/orchestrator_poll` from a tmpdir, asserts the config-missing error names the cwd path; second case covers `--config-dir` override

236 pass, 0 fail.

[roost-worker-218]