### PR TITLE
feat: add hint to unread postfix explaining how to clear

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -40,6 +40,7 @@ export const NOT_READY_SENTINEL = 'IRC client not ready (still connecting).'
 const PASSIVE_SENTINEL = 'roost-irc MCP is passive: a sibling MCP in the same ROOST_DATA_DIR already owns this nick. Tools are disabled in this instance.'
 
 const REPLY_REMINDER = 'Substantive replies should be posted to IRC.'
+const UNREAD_HINT = '(post a message to those channels/peers or call channel_ack to clear)'
 // 1/7 — midpoint of the 1/5–1/10 range from #136. Random rate avoids the
 // pattern-match-and-ignore failure mode of a fixed cadence.
 const REMINDER_PROBABILITY = 1 / 7
@@ -222,7 +223,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
     const unread = client.getUnread()
     if (unread.size === 0) return ''
     return '\nunread:\n' + [...unread.entries()].map(([ch, i]) => `  ${formatUnreadLine(ch, i)}`).join('\n') +
-      '\n(post a message to that channel/peer or call channel_ack to clear)'
+      `\n${UNREAD_HINT}`
   }
 
   // ---- Typed event subscriptions -----------------------------------------
@@ -377,7 +378,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       text = '[roost] all caught up — no unread messages'
     } else {
       const lines = entries.map(([ch, info]) => `  ${formatUnreadLine(ch, info)}`)
-      text = `[roost] unread activity:\n${lines.join('\n')}\n(post a message to that channel/peer or call channel_ack to clear)`
+      text = `[roost] unread activity:\n${lines.join('\n')}\n${UNREAD_HINT}`
     }
     process.stderr.write(`roost-irc[${NICK}]: unread summary emitted (${entries.length} channels with unread)\n`)
     return pushNotification(text, { event: 'unread-summary', channel: '', sender: '', isDirect: 'false', ts: new Date().toISOString() })

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -221,7 +221,8 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
   const unreadSuffix = (): string => {
     const unread = client.getUnread()
     if (unread.size === 0) return ''
-    return '\nunread:\n' + [...unread.entries()].map(([ch, i]) => `  ${formatUnreadLine(ch, i)}`).join('\n')
+    return '\nunread:\n' + [...unread.entries()].map(([ch, i]) => `  ${formatUnreadLine(ch, i)}`).join('\n') +
+      '\n(post a message to that channel/peer or call channel_ack to clear)'
   }
 
   // ---- Typed event subscriptions -----------------------------------------
@@ -376,7 +377,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       text = '[roost] all caught up — no unread messages'
     } else {
       const lines = entries.map(([ch, info]) => `  ${formatUnreadLine(ch, info)}`)
-      text = `[roost] unread activity:\n${lines.join('\n')}`
+      text = `[roost] unread activity:\n${lines.join('\n')}\n(post a message to that channel/peer or call channel_ack to clear)`
     }
     process.stderr.write(`roost-irc[${NICK}]: unread summary emitted (${entries.length} channels with unread)\n`)
     return pushNotification(text, { event: 'unread-summary', channel: '', sender: '', isDirect: 'false', ts: new Date().toISOString() })

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -231,12 +231,13 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     peer.say('#ip-unread8-b', 'check this out')
     await mcp.waitForNotification(n => n.meta.channel === '#ip-unread8-b' && n.content === 'check this out')
 
-    // Acking A should report B as unread
+    // Acking A should report B as unread, including the hint
     const ack = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread8-a' } })
     expect(toolText(ack)).toContain('acked #ip-unread8-a')
     expect(toolText(ack)).toContain('unread:')
     expect(toolText(ack)).toContain('#ip-unread8-b')
     expect(toolText(ack)).toContain('check this out')
+    expect(toolText(ack)).toContain('channel_ack to clear')
 
     // Acking B clears the last unread — no suffix
     const ack2 = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread8-b' } })
@@ -264,6 +265,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(nDirty.content).toContain('#ip-unread5')
     expect(nDirty.content).toContain('ip-unread5-peer')
     expect(nDirty.content).toContain('pending message')
+    expect(nDirty.content).toContain('channel_ack to clear')
   })
 
   it('send reply includes unread nudge for other channels, omits if none', async () => {


### PR DESCRIPTION
Closes #216

Agents were getting repeated unread reminders without any hint about how to act on them. Both the inline `unread:` postfix (appended to channel_message / channel_ack / direct_message responses) and the `unread-summary` push notification now end with:

> (post a message to that channel/peer or call channel_ack to clear)

Covers channel and DM peers. No new tests needed — existing `toContain` assertions all still pass (269/269).