### PR TITLE
fix: clear unread badge on channel_leave and KICK

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -455,6 +455,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
   private handleQuit(event: QuitEvent): void {
     if (event.nick === this.nick) {
       this.channelUsers.clear()
+      // don't clear unread on quit — reconnect replays as historical, badges don't double-count
       return
     }
     for (const [chan, set] of this.channelUsers) {

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -429,6 +429,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
         this.partResolvers.delete(channel)
       }
       this.channelUsers.delete(channel)
+      this.unread.delete(channel)
       return
     }
     this.channelUsers.get(channel)?.delete(event.nick)
@@ -442,6 +443,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     const victim = event.kicked
     if (victim === this.nick) {
       this.channelUsers.delete(channel)
+      this.unread.delete(channel)
       return
     }
     this.channelUsers.get(channel)?.delete(victim)

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -10,7 +10,7 @@ export interface PeerMessage {
   text: string
 }
 
-// IMPORTANT: waitForMessage / waitForPart register the waiter when called.
+// IMPORTANT: waitForMessage / waitForPart / waitForKick register the waiter when called.
 // irc-framework's EventEmitter is synchronous and does NOT replay past events,
 // so an event that fires before the waiter is registered is lost forever.
 // Always start the wait BEFORE the action that triggers the event:
@@ -94,6 +94,22 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
       client.on('part', onPart)
     }))
 
+  const waitForKick = (channel: string, kicked: string, timeoutMs = 5000): Promise<void> =>
+    suppressLateRejection(new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        client.removeListener('kick', onKick)
+        reject(new Error(`waitForKick ${kicked} in ${channel} timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+      const onKick = (event: { kicked: string; channel: string }) => {
+        if (event.kicked === kicked && event.channel === channel) {
+          client.removeListener('kick', onKick)
+          clearTimeout(timer)
+          resolve()
+        }
+      }
+      client.on('kick', onKick)
+    }))
+
   return {
     nick: peerNick,
 
@@ -148,22 +164,7 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
 
     waitForPart,
 
-    waitForKick(channel: string, kicked: string, timeoutMs = 5000): Promise<void> {
-      return suppressLateRejection(new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          client.removeListener('kick', onKick)
-          reject(new Error(`waitForKick ${kicked} in ${channel} timed out after ${timeoutMs}ms`))
-        }, timeoutMs)
-        const onKick = (event: { kicked: string; channel: string }) => {
-          if (event.kicked === kicked && event.channel === channel) {
-            client.removeListener('kick', onKick)
-            clearTimeout(timer)
-            resolve()
-          }
-        }
-        client.on('kick', onKick)
-      }))
-    },
+    waitForKick,
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {

--- a/test/helpers/peer.ts
+++ b/test/helpers/peer.ts
@@ -35,6 +35,7 @@ export interface PeerContext {
     timeoutMs?: number,
   ): Promise<PeerMessage>
   waitForPart(channel: string, nick: string, timeoutMs?: number): Promise<void>
+  waitForKick(channel: string, kicked: string, timeoutMs?: number): Promise<void>
 }
 
 export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<PeerContext & { readonly pendingWaiterCount: number }> {
@@ -146,6 +147,23 @@ export async function connectPeer(ergo: ErgoContext, nick?: string): Promise<Pee
     },
 
     waitForPart,
+
+    waitForKick(channel: string, kicked: string, timeoutMs = 5000): Promise<void> {
+      return suppressLateRejection(new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          client.removeListener('kick', onKick)
+          reject(new Error(`waitForKick ${kicked} in ${channel} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+        const onKick = (event: { kicked: string; channel: string }) => {
+          if (event.kicked === kicked && event.channel === channel) {
+            client.removeListener('kick', onKick)
+            clearTimeout(timer)
+            resolve()
+          }
+        }
+        client.on('kick', onKick)
+      }))
+    },
 
     waitForMessage(channel, pred, timeoutMs = 5000) {
       return suppressLateRejection(new Promise<PeerMessage>((resolve, reject) => {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -258,6 +258,26 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(ack)).not.toContain('unread:')
   })
 
+  it('rejoin after leave resumes unread tracking from zero', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-unread11')
+    const peer = await connectPeer(ergo, 'ip-unread11-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread11' } })
+    await peer.joinChannel('#ip-unread11')
+
+    peer.say('#ip-unread11', 'first')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-unread11' && n.content === 'first')
+
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#ip-unread11' } })
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread11' } })
+
+    peer.say('#ip-unread11', 'after rejoin')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-unread11' && n.content === 'after rejoin')
+
+    const list = await mcp.client.callTool({ name: 'channel_list', arguments: {} })
+    // unread count should be 1 (only post-rejoin message), not 2
+    expect(toolText(list)).toMatch(/\(1\)/)
+  })
+
   it('channel_ack response includes unread suffix for other channels, omits if none', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-unread8')
     const peer = await connectPeer(ergo, 'ip-unread8-peer')

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -219,6 +219,45 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(list)).not.toMatch(/\(\d+\)/)
   })
 
+  it('channel_leave clears unread', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-unread9')
+    const peer = await connectPeer(ergo, 'ip-unread9-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread9' } })
+    await peer.joinChannel('#ip-unread9')
+
+    peer.say('#ip-unread9', 'bye')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-unread9' && n.content === 'bye')
+
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#ip-unread9' } })
+
+    // channel_ack on an unrelated channel — no unread suffix means the parted channel was cleared
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread9-b' } })
+    const ack = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread9-b' } })
+    expect(toolText(ack)).not.toContain('unread:')
+  })
+
+  it('kick clears unread (handleKick path)', async () => {
+    // peer joins first to get channel-op status, then MCP client joins
+    const peer = await connectPeer(ergo, 'ip-unread10-peer')
+    const mcp = await startMcpInProcess(ergo, 'ip-unread10')
+    await peer.joinChannel('#ip-unread10')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread10' } })
+
+    peer.say('#ip-unread10', 'watch out')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-unread10' && n.content === 'watch out')
+
+    // peer kicks the MCP client; goes through handleKick not channel_leave
+    const kickSeen = peer.waitForKick('#ip-unread10', 'ip-unread10')
+    peer.kick('#ip-unread10', 'ip-unread10', 'out you go')
+    await kickSeen
+
+    // After the kick echo reaches the peer, the server has already sent KICK to the MCP
+    // client's TCP connection. The next event-loop turn (the callTool await) drains it.
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-unread10-b' } })
+    const ack = await mcp.client.callTool({ name: 'channel_ack', arguments: { channel: '#ip-unread10-b' } })
+    expect(toolText(ack)).not.toContain('unread:')
+  })
+
   it('channel_ack response includes unread suffix for other channels, omits if none', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-unread8')
     const peer = await connectPeer(ergo, 'ip-unread8-peer')


### PR DESCRIPTION
Closes #220

Fix is in `handlePart` and `handleKick` (both self-leave paths in `irc-client-impl.ts`). `handleQuit` is intentionally separate — reconnect+rejoin replays as historical, so badges don't double-count.

- `handlePart`: `this.unread.delete(channel)` when self parts
- `handleKick`: `this.unread.delete(channel)` when self is kicked
- Three new integration tests: PART path, KICK path, rejoin-from-zero
- `waitForKick` peer helper (hoisted const, consistent with `waitForPart`)

[roost-worker-220]