### PR TITLE
maint: bump package.json to 0.2.0 ahead of v0.2.0 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Aligns `package.json` with the imminent `v0.2.0` release. Pre-existing drift (package.json at `0.0.1`, latest tag `v0.1.1`) flagged in #230 review.

Workflow keys off the git tag, not `package.json`, so this is cosmetic — but tidier for `v0.2.0` to actually be `0.2.0` in `package.json`.

Once merged, tag + push `v0.2.0` to exercise the release loop from #230.