### PR TITLE
feat: pin watcher config dir via explicit arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,11 @@ transitions, PR comments, issue updates) into the right
 ```bash
 cd ~/Dev/myproject
 roost init                              # first-time: writes .orchestrator/config.json + prompts
+CONFIG_DIR="$(pwd)/.orchestrator"
 roost spawn myproject-watcher -m haiku \
   --channels '#myproject-leads' \
-  --prompt '/watcher'
+  --prompt "/watcher myproject myproject-lead-pm <your-nick> $CONFIG_DIR" \
+  --perm-irc --perm-target myproject-lead-pm
 ```
 
 `project` namespaces every per-project artifact (`<project>-worker-N` nicks,

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -29,7 +29,7 @@ When you spawn an agent, always pass the namespaced nick + the matching `--chann
 
 ## Getting started
 
-Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm $2' --perm-irc --perm-target $0-lead-pm`
+Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm $2 $(pwd)/.orchestrator' --perm-irc --perm-target $0-lead-pm`
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -29,7 +29,11 @@ When you spawn an agent, always pass the namespaced nick + the matching `--chann
 
 ## Getting started
 
-Spawn the watcher: `roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt '/watcher $0 $0-lead-pm $2 $(pwd)/.orchestrator' --perm-irc --perm-target $0-lead-pm`
+Spawn the watcher — pre-expand the config dir so the absolute path is baked in at spawn time:
+```bash
+CONFIG_DIR="$(pwd)/.orchestrator"
+roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt "/watcher $0 $0-lead-pm $2 $CONFIG_DIR" --perm-irc --perm-target $0-lead-pm
+```
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -1,10 +1,12 @@
 ---
 description: Roost watcher haiku — supervises the orchestrator and mutates the watch list in response to channel/DM commands.
-argument-hint: [project] [lead-nick] [human-nick]
+argument-hint: [project] [lead-nick] [human-nick] [config-dir]
 ---
 You are `$0-watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #$0-leads. The lead PM is @$1 and the human is @$2.
 
-You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #$0-leads or as DMs from @$1 or @$2, and mutate `.orchestrator/config.json` (relative to your working directory) accordingly. The orchestrator daemon re-reads config each tick (~60s).
+Your config dir is `$3` (the `.orchestrator` directory for this project). All config reads and writes target `$3/config.json`. This path is explicit — do not fall back to cwd-relative paths.
+
+You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #$0-leads or as DMs from @$1 or @$2, and mutate `$3/config.json` accordingly. The orchestrator daemon re-reads config each tick (~60s).
 
 ## IMPORTANT — tooling
 
@@ -42,8 +44,8 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `nohup bin/dispatcher --daemon &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
-- Read the config file before each mutation (don't cache).
+- **On boot, first action:** run `nohup bin/dispatcher --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
+- Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.
 - Only respond to messages addressed to you (`$0-watcher: <cmd>`) in the channel, OR any message in a DM.

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -4,7 +4,7 @@ argument-hint: [project] [lead-nick] [human-nick] [config-dir]
 ---
 You are `$0-watcher`, a small haiku agent on the local Roost (ergo on 127.0.0.1:6667). You are joined to #$0-leads. The lead PM is @$1 and the human is @$2.
 
-Your config dir is `$3` (the `.orchestrator` directory for this project). All config reads and writes target `$3/config.json`. This path is explicit — do not fall back to cwd-relative paths.
+Your config dir is `$3` (the `.orchestrator` directory for this project). All config reads and writes target `$3/config.json`. Use `$3` as given — do not compute your own cwd-relative config path.
 
 You exist as a throwaway scaffold. Your single responsibility: listen for watch-list commands in #$0-leads or as DMs from @$1 or @$2, and mutate `$3/config.json` accordingly. The orchestrator daemon re-reads config each tick (~60s).
 

--- a/start.md
+++ b/start.md
@@ -25,7 +25,11 @@ When you spawn an agent, always pass the namespaced nick + the matching `--chann
 
 ## Getting started
 
-Spawn the watcher: `roost spawn roost-watcher --model haiku --channels '#roost-leads' --prompt '/watcher roost roost-lead-pm alex' --perm-irc --perm-target roost-lead-pm`
+Spawn the watcher:
+```bash
+CONFIG_DIR="$(pwd)/.orchestrator"
+roost spawn roost-watcher --model haiku --channels '#roost-leads' --prompt "/watcher roost roost-lead-pm alex $CONFIG_DIR" --perm-irc --perm-target roost-lead-pm
+```
 
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 


### PR DESCRIPTION
Closes #224

watcher accepts a 4th positional arg (`config-dir`) and uses it for both config reads/writes and for starting the dispatcher daemon with `--config-dir`. lead-pm's spawn command passes `$(pwd)/.orchestrator` to pin the path at spawn time, removing the ambient cwd dependency.

`.claude/commands/{watcher,lead-pm}.md` are symlinks into `prompts/` so they pick up the changes automatically.