### PR TITLE
feat: warn once when watched PR has empty linked_issues

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/diff.test.ts
@@ -203,8 +203,9 @@ describe('diffPr — pr_no_linked_issues', () => {
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
   })
 
-  it('warns again after linked_issues cleared (warned_no_linked reset to false)', () => {
-    const prev: PrSnap = { ...basePrSnap({ linked_issues: [], warned_no_linked: false }) }
+  it('warns again after linked_issues cleared ([N] → [] transition)', () => {
+    // prev had linked issues so warned_no_linked was reset to false
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [42], warned_no_linked: false }) }
     const cur = basePrSnap({ linked_issues: [] })
     const events = diffPr(prev, cur)
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
@@ -221,22 +222,25 @@ describe('diffPr — pr_no_linked_issues', () => {
 })
 
 describe('computePrEvents — pr_no_linked_issues', () => {
-  it('emits pr_no_linked_issues for new PR with empty linked_issues', () => {
+  it('emits pr_no_linked_issues and sets nextWarnedNoLinked for new PR with empty linked_issues', () => {
     const snap = basePrSnap({ linked_issues: [] })
-    const events = computePrEvents(snap, null, new Set())
+    const { events, nextWarnedNoLinked } = computePrEvents(snap, null, new Set())
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
+    expect(nextWarnedNoLinked).toBe(true)
   })
 
-  it('does not emit pr_no_linked_issues for new PR with linked issues', () => {
+  it('does not emit pr_no_linked_issues and clears flag for new PR with linked issues', () => {
     const snap = basePrSnap({ linked_issues: [5] })
-    const events = computePrEvents(snap, null, new Set())
+    const { events, nextWarnedNoLinked } = computePrEvents(snap, null, new Set())
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
+    expect(nextWarnedNoLinked).toBe(false)
   })
 
-  it('does not emit for seeding tick (prevSnap undefined)', () => {
+  it('does not emit for seeding tick (prevSnap undefined), nextWarnedNoLinked false', () => {
     const snap = basePrSnap({ linked_issues: [] })
-    const events = computePrEvents(snap, undefined, new Set())
+    const { events, nextWarnedNoLinked } = computePrEvents(snap, undefined, new Set())
     expect(events).toHaveLength(0)
+    expect(nextWarnedNoLinked).toBe(false)
   })
 })
 

--- a/src/orchestrator/plugins/github/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { diffPr, diffIssue, shouldPush, formatCommentEvent } from '../diff.js'
+import { computePrEvents } from '../scraper.js'
 import type { PrSnap, IssueSnap } from '../types.js'
 import type { PrSnapInternal, IssueSnapInternal } from '../snapshot.js'
 
@@ -177,6 +178,71 @@ describe('shouldPush', () => {
 
   it('does not push issue_state_changed to open', () => {
     expect(shouldPush({ kind: 'issue_state_changed', from: 'closed', to: 'open' })).toBe(false)
+  })
+})
+
+describe('diffPr — pr_no_linked_issues', () => {
+  it('emits pr_no_linked_issues when linked_issues is empty and not yet warned', () => {
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [], warned_no_linked: false }) }
+    const cur = basePrSnap({ linked_issues: [] })
+    const events = diffPr(prev, cur)
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
+  })
+
+  it('does not re-emit pr_no_linked_issues when already warned', () => {
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [], warned_no_linked: true }) }
+    const cur = basePrSnap({ linked_issues: [] })
+    const events = diffPr(prev, cur)
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
+  })
+
+  it('does not emit pr_no_linked_issues when linked_issues is non-empty', () => {
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [] }) }
+    const cur = basePrSnap({ linked_issues: [42] })
+    const events = diffPr(prev, cur)
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
+  })
+
+  it('warns again after linked_issues cleared (warned_no_linked reset to false)', () => {
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [], warned_no_linked: false }) }
+    const cur = basePrSnap({ linked_issues: [] })
+    const events = diffPr(prev, cur)
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
+  })
+
+  it('treats absent warned_no_linked as false (warns on upgrade)', () => {
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [] }) }
+    // warned_no_linked is undefined (absent from old snapshot)
+    delete (prev as Partial<PrSnap>).warned_no_linked
+    const cur = basePrSnap({ linked_issues: [] })
+    const events = diffPr(prev, cur)
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
+  })
+})
+
+describe('computePrEvents — pr_no_linked_issues', () => {
+  it('emits pr_no_linked_issues for new PR with empty linked_issues', () => {
+    const snap = basePrSnap({ linked_issues: [] })
+    const events = computePrEvents(snap, null, new Set())
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
+  })
+
+  it('does not emit pr_no_linked_issues for new PR with linked issues', () => {
+    const snap = basePrSnap({ linked_issues: [5] })
+    const events = computePrEvents(snap, null, new Set())
+    expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
+  })
+
+  it('does not emit for seeding tick (prevSnap undefined)', () => {
+    const snap = basePrSnap({ linked_issues: [] })
+    const events = computePrEvents(snap, undefined, new Set())
+    expect(events).toHaveLength(0)
+  })
+})
+
+describe('shouldPush — pr_no_linked_issues', () => {
+  it('pushes pr_no_linked_issues', () => {
+    expect(shouldPush({ kind: 'pr_no_linked_issues', pr: 5 })).toBe(true)
   })
 })
 

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -71,6 +71,23 @@ describe('GitHubPrsPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 
+  it('routes pr_no_linked_issues to project channel', async () => {
+    const warningEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues',
+      repo: 'org/repo', pr: 25, url: 'https://example.com/p/25', title: 'P',
+    } as OrchestratorEvent
+    const spy = spyOn(scraper, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }),
+      events: [warningEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', watched_prs: [{ number: 25 }] }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toContain('#proj-leads')
+    } finally { spy.mockRestore() }
+  })
+
   it('filters non-pushable events (e.g. pr_added_to_watch) before tagging', async () => {
     const seedEv: OrchestratorEvent = {
       kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',

--- a/src/orchestrator/plugins/github/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/scraper.test.ts
@@ -43,51 +43,53 @@ function baseIssueInternal(overrides: Partial<IssueSnapInternal> = {}): IssueSna
 
 describe('computePrEvents — seeding tick (prevSnap = undefined)', () => {
   it('returns no events on a seeding tick', () => {
-    expect(computePrEvents(basePrInternal(), undefined, new Set())).toEqual([])
+    const { events, nextWarnedNoLinked } = computePrEvents(basePrInternal(), undefined, new Set())
+    expect(events).toEqual([])
+    expect(nextWarnedNoLinked).toBe(false)
   })
 })
 
 describe('computePrEvents — new watch entry (prevSnap = null)', () => {
   it('emits pr_added_to_watch', () => {
-    const events = computePrEvents(basePrInternal(), null, new Set())
+    const { events } = computePrEvents(basePrInternal(), null, new Set())
     expect(events.some(e => e.kind === 'pr_added_to_watch')).toBe(true)
   })
 
   it('includes linked_issues in seed event when present', () => {
     const snap = basePrInternal({ linked_issues: [5, 6] })
-    const events = computePrEvents(snap, null, new Set())
+    const { events } = computePrEvents(snap, null, new Set())
     const ev = events.find(e => e.kind === 'pr_added_to_watch') as { linked_issues?: number[] } | undefined
     expect(ev?.linked_issues).toEqual([5, 6])
   })
 
   it('emits pr_has_existing_comments when review comments exist', () => {
     const snap = basePrInternal({ seen_review_comment_ids: [1, 2] })
-    const events = computePrEvents(snap, null, new Set())
+    const { events } = computePrEvents(snap, null, new Set())
     const ev = events.find(e => e.kind === 'pr_has_existing_comments') as { review_comment_count?: number } | undefined
     expect(ev?.review_comment_count).toBe(2)
   })
 
   it('emits pr_has_existing_comments when conversation comments exist', () => {
     const snap = basePrInternal({ seen_conversation_comment_ids: [3] })
-    const events = computePrEvents(snap, null, new Set())
+    const { events } = computePrEvents(snap, null, new Set())
     const ev = events.find(e => e.kind === 'pr_has_existing_comments') as { conversation_comment_count?: number } | undefined
     expect(ev?.conversation_comment_count).toBe(1)
   })
 
   it('does not emit pr_has_existing_comments when no existing comments', () => {
-    const events = computePrEvents(basePrInternal(), null, new Set())
+    const { events } = computePrEvents(basePrInternal(), null, new Set())
     expect(events.some(e => e.kind === 'pr_has_existing_comments')).toBe(false)
   })
 
   it('emits pr_has_existing_ci_state for terminal CI', () => {
     const snap = basePrInternal({ ci_state: 'SUCCESS' })
-    const events = computePrEvents(snap, null, new Set())
+    const { events } = computePrEvents(snap, null, new Set())
     expect(events.some(e => e.kind === 'pr_has_existing_ci_state')).toBe(true)
   })
 
   it('does not emit pr_has_existing_ci_state for PENDING CI', () => {
     const snap = basePrInternal({ ci_state: 'PENDING' })
-    const events = computePrEvents(snap, null, new Set())
+    const { events } = computePrEvents(snap, null, new Set())
     expect(events.some(e => e.kind === 'pr_has_existing_ci_state')).toBe(false)
   })
 })
@@ -96,7 +98,7 @@ describe('computePrEvents — normal diff (prevSnap = PrSnap)', () => {
   it('delegates to diffPr and returns change events', () => {
     const prev: PrSnap = { ...basePrInternal(), is_draft: true }
     const cur = basePrInternal({ is_draft: false })
-    const events = computePrEvents(cur, prev, new Set())
+    const { events } = computePrEvents(cur, prev, new Set())
     expect(events.some(e => e.kind === 'pr_ready_for_review')).toBe(true)
   })
 })

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -70,6 +70,7 @@ export interface SeedEvent extends BaseEvent {
     | 'pr_returned_to_draft'
     | 'pr_merged'
     | 'pr_closed'
+    | 'pr_no_linked_issues'
   review_comment_count?: number
   conversation_comment_count?: number
   comment_count?: number
@@ -92,6 +93,7 @@ const ALWAYS_PUSH_KINDS = new Set([
   'pr_has_existing_ci_state',
   'issue_has_existing_comments',
   'dispatcher_error',
+  'pr_no_linked_issues',
 ])
 const MEANINGFUL_LABEL_PREFIXES = ['phase:', 'plan:']
 const MEANINGFUL_LABELS_EXACT = new Set(['ready-for-merge'])
@@ -180,6 +182,8 @@ export function diffPr(
   const repo = cur.repo
   const linked = cur.linked_issues ?? []
   const base = { repo, pr: n, url: cur.url ?? '', title: cur.title ?? '', ...(linked.length ? { linked_issues: linked } : {}) }
+
+  if (linked.length === 0 && !prev.warned_no_linked) events.push({ kind: 'pr_no_linked_issues', ...base })
 
   if (prev.is_draft && !cur.is_draft) events.push({ kind: 'pr_ready_for_review', ...base })
   if (!prev.is_draft && cur.is_draft) events.push({ kind: 'pr_returned_to_draft', ...base })

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -105,6 +105,10 @@ export function formatEvent(event: OrchestratorEvent): string {
     return `Issue ${tag} BACKLOG: ${ev.comment_count ?? 0} comments existed before watch — scan manually: ${event.url ?? ''}`
   }
 
+  if (kind === 'pr_no_linked_issues') {
+    return `⚠️ PR ${tag} has no linked issues — events won't be routed. Add Closes #N (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
+  }
+
   if (kind === 'dispatcher_error') {
     const ev = event as SeedEvent
     const tb = (ev.stderr ?? '').trim().split('\n')

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -106,7 +106,7 @@ export function formatEvent(event: OrchestratorEvent): string {
   }
 
   if (kind === 'pr_no_linked_issues') {
-    return `⚠️ PR ${tag} has no linked issues — events won't be routed. Add Closes #<issue> (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
+    return `WARN PR ${tag} has no linked issues — events won't be routed. Add Closes #<issue> (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
   }
 
   if (kind === 'dispatcher_error') {

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -106,7 +106,7 @@ export function formatEvent(event: OrchestratorEvent): string {
   }
 
   if (kind === 'pr_no_linked_issues') {
-    return `⚠️ PR ${tag} has no linked issues — events won't be routed. Add Closes #N (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
+    return `⚠️ PR ${tag} has no linked issues — events won't be routed. Add Closes #<issue> (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
   }
 
   if (kind === 'dispatcher_error') {

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -1,6 +1,6 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
-import { defaultProject, issueChannel } from '../../naming.js'
+import { defaultProject, issueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { scrapePr } from './scraper.js'
@@ -15,10 +15,11 @@ export class GitHubPrsPlugin extends GhBase {
     return this.entryChannels(config, config.watched_prs)
   }
 
-  // Auto-detected channels for a PR event: linked-issue channels, or its own
-  // issue channel if no linked issues.
-  private static prEventChannels(project: string, event: OrchestratorEvent): string[] {
+  // Auto-detected channels for a PR event: linked-issue channels, project
+  // channel for no-linked-issues warnings, or PR's own issue channel as fallback.
+  private static prEventChannels(project: string, event: OrchestratorEvent, projectChannel: string): string[] {
     if (event.pr == null) return []
+    if (event.kind === 'pr_no_linked_issues') return [projectChannel]
     const linked = event.linked_issues ?? []
     return linked.length
       ? linked.map(n => issueChannel(project, n))
@@ -30,6 +31,7 @@ export class GitHubPrsPlugin extends GhBase {
     prevState: unknown
   ): Promise<PluginTickResult> {
     const project = defaultProject(config)
+    const projectChannel = resolveProjectChannel(config)
     const defaultRepo = config.repo
     const watched = config.watched_prs ?? []
     const agentLogins = this.agentLogins(config)
@@ -55,7 +57,7 @@ export class GitHubPrsPlugin extends GhBase {
       for (const event of events) {
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(project, event), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(project, event, projectChannel), entryChannels),
           payload: formatPayload(event),
         })
       }

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -20,12 +20,16 @@ export function computePrEvents(
   snap: PrSnapInternal,
   prevSnap: PrSnap | null | undefined,
   agentLogins: Set<string>
-): OrchestratorEvent[] {
-  if (prevSnap === undefined) return []   // seeding tick — no events
-  if (prevSnap !== null) return diffPr(prevSnap, snap, agentLogins)
+): { events: OrchestratorEvent[], nextWarnedNoLinked: boolean } {
+  const linked = snap.linked_issues ?? []
+
+  if (prevSnap === undefined) return { events: [], nextWarnedNoLinked: false }  // seeding tick
+
+  if (prevSnap !== null) {
+    return { events: diffPr(prevSnap, snap, agentLogins), nextWarnedNoLinked: linked.length === 0 }
+  }
 
   // New PR added to watch list
-  const linked = snap.linked_issues ?? []
   const base = { repo: snap.repo, pr: snap.number, url: snap.url ?? '', title: snap.title ?? '', ...(linked.length ? { linked_issues: linked } : {}) }
   const events: OrchestratorEvent[] = [{ kind: 'pr_added_to_watch', ...base }]
   if (linked.length === 0) events.push({ kind: 'pr_no_linked_issues', ...base })
@@ -37,7 +41,7 @@ export function computePrEvents(
   if (snap.ci_state === 'SUCCESS' || snap.ci_state === 'FAILURE') {
     events.push({ kind: 'pr_has_existing_ci_state', ci_state: snap.ci_state, ...base })
   }
-  return events
+  return { events, nextWarnedNoLinked: linked.length === 0 }
 }
 
 export function computeIssueEvents(
@@ -65,16 +69,9 @@ export async function scrapePr(
   agentLogins: Set<string>
 ): Promise<ScrapeResult<PrSnap>> {
   const snap = await snapshotPr(repo, number, prevSnap ?? undefined)
-  const events = computePrEvents(snap, prevSnap, agentLogins)
+  const { events, nextWarnedNoLinked } = computePrEvents(snap, prevSnap, agentLogins)
   const stripped = stripInternals(snap) as PrSnap
-  const linked = stripped.linked_issues ?? []
-  if (linked.length > 0) {
-    stripped.warned_no_linked = false
-  } else if (events.some(e => e.kind === 'pr_no_linked_issues')) {
-    stripped.warned_no_linked = true
-  } else {
-    stripped.warned_no_linked = prevSnap?.warned_no_linked ?? false
-  }
+  stripped.warned_no_linked = nextWarnedNoLinked
   return { snap: stripped, events }
 }
 

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -28,6 +28,7 @@ export function computePrEvents(
   const linked = snap.linked_issues ?? []
   const base = { repo: snap.repo, pr: snap.number, url: snap.url ?? '', title: snap.title ?? '', ...(linked.length ? { linked_issues: linked } : {}) }
   const events: OrchestratorEvent[] = [{ kind: 'pr_added_to_watch', ...base }]
+  if (linked.length === 0) events.push({ kind: 'pr_no_linked_issues', ...base })
   const existingRev = snap.seen_review_comment_ids.length
   const existingConv = snap.seen_conversation_comment_ids.length
   if (existingRev || existingConv) {
@@ -64,7 +65,17 @@ export async function scrapePr(
   agentLogins: Set<string>
 ): Promise<ScrapeResult<PrSnap>> {
   const snap = await snapshotPr(repo, number, prevSnap ?? undefined)
-  return { snap: stripInternals(snap) as PrSnap, events: computePrEvents(snap, prevSnap, agentLogins) }
+  const events = computePrEvents(snap, prevSnap, agentLogins)
+  const stripped = stripInternals(snap) as PrSnap
+  const linked = stripped.linked_issues ?? []
+  if (linked.length > 0) {
+    stripped.warned_no_linked = false
+  } else if (events.some(e => e.kind === 'pr_no_linked_issues')) {
+    stripped.warned_no_linked = true
+  } else {
+    stripped.warned_no_linked = prevSnap?.warned_no_linked ?? false
+  }
+  return { snap: stripped, events }
 }
 
 export async function scrapeIssue(

--- a/src/orchestrator/plugins/github/types.ts
+++ b/src/orchestrator/plugins/github/types.ts
@@ -14,6 +14,7 @@ export interface PrSnap {
   seen_review_comment_ids: number[]
   seen_conversation_comment_ids: number[]
   seen_review_ids: number[]
+  warned_no_linked?: boolean
 }
 
 export interface IssueSnap {

--- a/src/orchestrator/plugins/github/types.ts
+++ b/src/orchestrator/plugins/github/types.ts
@@ -14,6 +14,10 @@ export interface PrSnap {
   seen_review_comment_ids: number[]
   seen_conversation_comment_ids: number[]
   seen_review_ids: number[]
+  // Mute flag: set after pr_no_linked_issues warning, cleared when
+  // linked_issues becomes non-empty so a subsequent loss re-warns.
+  // Absent in old snapshots (pre-upgrade) — !undefined is true, so upgrade
+  // path warns on first tick without any special handling.
   warned_no_linked?: boolean
 }
 


### PR DESCRIPTION
Closes #227

When a watched PR has no closing keyword, GitHub returns empty `linked_issues` and the dispatcher silently drops events (including CHANGES_REQUESTED reviews). This gives lead-pm a signal to act on.

## What changed

- `PrSnap` gets `warned_no_linked?: boolean` — set after warning, cleared when `linked_issues` becomes non-empty, absent=false (warns on first tick after upgrade)
- New `pr_no_linked_issues` event kind routed to the project channel (e.g. `#proj-leads`) instead of a PR-number-as-issue-channel fallback
- Warning emitted in `diffPr` (normal ticks) and `computePrEvents` (new PR added to watch)
- Format: `⚠️ PR org/repo#N has no linked issues — events won't be routed. Add Closes #N (or Fixes/Resolves) to the PR body: <url>`

## Tests

40 tests pass. New coverage: `diffPr — pr_no_linked_issues` (5 cases including upgrade/reset semantics), `computePrEvents — pr_no_linked_issues` (3 cases), `shouldPush`, and plugin routing to project channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)