### PR TITLE
dispatcher: emit now-watching confirmation on watch-add

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/diff.test.ts
@@ -148,10 +148,6 @@ describe('diffIssue', () => {
 })
 
 describe('shouldPush', () => {
-  it('skips pr_added_to_watch', () => {
-    expect(shouldPush({ kind: 'pr_added_to_watch' })).toBe(false)
-  })
-
   it('pushes pr_merged', () => {
     expect(shouldPush({ kind: 'pr_merged' })).toBe(true)
   })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -88,7 +88,7 @@ describe('GitHubPrsPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('filters non-pushable events (e.g. pr_added_to_watch) before tagging', async () => {
+  it('suppresses now-watching when pr_added_to_watch has no linked issues', async () => {
     const seedEv: OrchestratorEvent = {
       kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
     } as OrchestratorEvent
@@ -101,9 +101,88 @@ describe('GitHubPrsPlugin.runTick', () => {
       expect(result.taggedEvents).toHaveLength(0)
     } finally { spy.mockRestore() }
   })
+
+  it('emits now-watching to project channel when pr_added_to_watch has linked issues', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
+      linked_issues: [7, 14],
+    } as OrchestratorEvent
+    const spy = spyOn(scraper, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [7, 14] }), events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', watched_prs: [{ number: 25 }] }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'now watching PR org/repo#25 — routing events to #proj-issue-7, #proj-issue-14',
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('includes entry channels in now-watching routing list', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
+      linked_issues: [7],
+    } as OrchestratorEvent
+    const spy = spyOn(scraper, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [7] }), events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', watched_prs: [{ number: 25, channels: ['#extra'] }] }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('#proj-issue-7')
+      expect(text).toContain('#extra')
+    } finally { spy.mockRestore() }
+  })
 })
 
 describe('GitHubIssuesPlugin.runTick', () => {
+  it('emits now-watching to project channel on issue_added_to_watch', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'issue_added_to_watch', repo: 'org/repo', issue: 50, url: 'u', title: 't',
+    } as OrchestratorEvent
+    const spy = spyOn(scraper, 'scrapeIssue').mockResolvedValue({
+      snap: fakeIssueSnap(), events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', watched_issues: [{ number: 50 }] }
+      const result = await new GitHubIssuesPlugin('#proj').runTick(cfg, { issues: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'now watching issue org/repo#50 — routing events to #proj-issue-50',
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('includes entry channels in now-watching routing list for issues', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'issue_added_to_watch', repo: 'org/repo', issue: 50, url: 'u', title: 't',
+    } as OrchestratorEvent
+    const spy = spyOn(scraper, 'scrapeIssue').mockResolvedValue({
+      snap: fakeIssueSnap(), events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        watched_issues: [{ number: 50, channels: ['#extra'] }],
+      }
+      const result = await new GitHubIssuesPlugin('#proj').runTick(cfg, { issues: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('#proj-issue-50')
+      expect(text).toContain('#extra')
+    } finally { spy.mockRestore() }
+  })
+
   it('routes an issue comment to its own channel unioned with entry channels', async () => {
     const issueEv: OrchestratorEvent = {
       kind: 'issue_comment',

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -83,7 +83,6 @@ export type OrchestratorEvent = BaseEvent | LabelEvent | CiEvent | CommentEvent 
 
 // ---- Classification --------------------------------------------------------
 
-const SKIP_KINDS = new Set(['pr_added_to_watch', 'issue_added_to_watch'])
 const ALWAYS_PUSH_KINDS = new Set([
   'pr_ready_for_review',
   'pr_returned_to_draft',
@@ -100,7 +99,6 @@ const MEANINGFUL_LABELS_EXACT = new Set(['ready-for-merge'])
 
 export function shouldPush(event: OrchestratorEvent): boolean {
   const kind = event.kind
-  if (SKIP_KINDS.has(kind)) return false
   if (ALWAYS_PUSH_KINDS.has(kind)) return true
   if (['pr_review_comment', 'pr_conversation_comment', 'issue_comment', 'pr_review_submitted'].includes(kind)) return true
   if (kind === 'ci_transitioned') {

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -53,7 +53,7 @@ export class GitHubIssuesPlugin extends GhBase {
           const routingChannels = this.resolveChannels(
             GitHubIssuesPlugin.issueEventChannels(project, event),
             entryChannels
-          )
+          ).filter(ch => ch !== projectChannel)
           taggedEvents.push({
             channels: [projectChannel],
             payload: { kind: 'oneline', text: `now watching issue ${key} — routing events to ${routingChannels.join(', ')}` },

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -49,6 +49,7 @@ export class GitHubIssuesPlugin extends GhBase {
       curState.issues[key] = snap
       for (const event of events) {
         if (event.kind === 'issue_added_to_watch') {
+          // Issues always get a confirmation — no no-linked-issues analogue here.
           const routingChannels = this.resolveChannels(
             GitHubIssuesPlugin.issueEventChannels(project, event),
             entryChannels

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -1,6 +1,6 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
-import { defaultProject, issueChannel } from '../../naming.js'
+import { defaultProject, issueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { scrapeIssue } from './scraper.js'
@@ -25,6 +25,7 @@ export class GitHubIssuesPlugin extends GhBase {
     prevState: unknown
   ): Promise<PluginTickResult> {
     const project = defaultProject(config)
+    const projectChannel = resolveProjectChannel(config)
     const defaultRepo = config.repo
     const watched = config.watched_issues ?? []
     const agentLogins = this.agentLogins(config)
@@ -47,6 +48,17 @@ export class GitHubIssuesPlugin extends GhBase {
     for (const { key, snap, events, entryChannels } of scraped) {
       curState.issues[key] = snap
       for (const event of events) {
+        if (event.kind === 'issue_added_to_watch') {
+          const routingChannels = this.resolveChannels(
+            GitHubIssuesPlugin.issueEventChannels(project, event),
+            entryChannels
+          )
+          taggedEvents.push({
+            channels: [projectChannel],
+            payload: { kind: 'oneline', text: `now watching issue ${key} — routing events to ${routingChannels.join(', ')}` },
+          })
+          continue
+        }
         if (!shouldPush(event)) continue
         taggedEvents.push({
           channels: this.resolveChannels(GitHubIssuesPlugin.issueEventChannels(project, event), entryChannels),

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -57,6 +57,8 @@ export class GitHubPrsPlugin extends GhBase {
       for (const event of events) {
         if (event.kind === 'pr_added_to_watch') {
           const linked = event.linked_issues ?? []
+          // Suppress when no linked issues — pr_no_linked_issues already fires
+          // with the clearer "events won't be routed" message on the same tick.
           if (linked.length > 0) {
             const routingChannels = this.resolveChannels(
               GitHubPrsPlugin.prEventChannels(project, event, projectChannel),

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -59,11 +59,11 @@ export class GitHubPrsPlugin extends GhBase {
           const linked = event.linked_issues ?? []
           // Suppress when no linked issues — pr_no_linked_issues already fires
           // with the clearer "events won't be routed" message on the same tick.
-          if (linked.length > 0) {
+          if (linked.length) {
             const routingChannels = this.resolveChannels(
               GitHubPrsPlugin.prEventChannels(project, event, projectChannel),
               entryChannels
-            )
+            ).filter(ch => ch !== projectChannel)
             taggedEvents.push({
               channels: [projectChannel],
               payload: { kind: 'oneline', text: `now watching PR ${key} — routing events to ${routingChannels.join(', ')}` },

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -55,6 +55,20 @@ export class GitHubPrsPlugin extends GhBase {
     for (const { key, snap, events, entryChannels } of scraped) {
       curState.prs[key] = snap
       for (const event of events) {
+        if (event.kind === 'pr_added_to_watch') {
+          const linked = event.linked_issues ?? []
+          if (linked.length > 0) {
+            const routingChannels = this.resolveChannels(
+              GitHubPrsPlugin.prEventChannels(project, event, projectChannel),
+              entryChannels
+            )
+            taggedEvents.push({
+              channels: [projectChannel],
+              payload: { kind: 'oneline', text: `now watching PR ${key} — routing events to ${routingChannels.join(', ')}` },
+            })
+          }
+          continue
+        }
         if (!shouldPush(event)) continue
         taggedEvents.push({
           channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(project, event, projectChannel), entryChannels),


### PR DESCRIPTION
Closes #243

When a PR or issue is first added to the watch list, emit a oneline confirmation to the project channel listing the IRC channels events will route to.

**PR**: only when `linked_issues` is non-empty. When empty, `pr_no_linked_issues` already fires with the clearer "events won't be routed" message, so we suppress to avoid contradiction.

**Issue**: always emit; routes to `#proj-issue-N` + any entry channels.

Synthesized in plugin `runTick` before `shouldPush()` — routing channel computation naturally lives where routing is decided, not pushed down into `format.ts` where the context isn't available.

4 new tests added; 288/288 pass.