### PR TITLE
irc-server: add mention="true" to channel event metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ hello world
 </channel>
 ```
 
+`mention="true"` is added when the message body contains your nick (word-boundary, case-insensitive) or when the message is a DM (`isDirect="true"`). Absent on non-mention channel messages.
+
+```xml
+<channel event="message" sender="alex" channel="#roost"
+         isDirect="false" ts="2026-04-28T05:30:00.000Z" seq="43" mention="true">
+roost-worker-1: can you check the build?
+</channel>
+```
+
 **Membership events** (JOIN, PART, KICK, NICK):
 
 ```xml

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -448,6 +448,9 @@ long-run side-effect.
   Resolved (#237): event meta field — `mention="true"` on the
   `event="message"` notification when body contains agent's nick
   (word-boundary) or message is a DM. Absent otherwise.
+  Note: `UnreadInfo.mentionCount` (client layer) is text-match only — a DM
+  body that doesn't contain the nick scores 0. The wire attribute is
+  text-OR-isDirect. They are intentionally different and should stay so.
 - One MCP per session (configured at launch with nick + connection),
   or shared MCP service all sessions connect to? Per-session is simpler;
   shared is one process but couples lifecycles. Per-session seems

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -443,10 +443,11 @@ long-run side-effect.
 - IRC server choice: ngircd default. solanum if we want SASL/services
   *and* IRCv3 message-tags (Finding E); bouncer integration question
   for replay-on-reconnect.
-- Mention/highlight semantics: separate channel source
-  (`irc-mention` vs `irc-ambient`), event meta field, or convention?
-  Affects how agents behave on noisy channels — wake on every CI tick
-  on `#dispatch-feed`, or only when addressed?
+- ~~Mention/highlight semantics: separate channel source
+  (`irc-mention` vs `irc-ambient`), event meta field, or convention?~~
+  Resolved (#237): event meta field — `mention="true"` on the
+  `event="message"` notification when body contains agent's nick
+  (word-boundary) or message is a DM. Absent otherwise.
 - One MCP per session (configured at launch with nick + connection),
   or shared MCP service all sessions connect to? Per-session is simpler;
   shared is one process but couples lifecycles. Per-session seems

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -248,7 +248,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   // Record a message in history and dedupe set; increment unread unless historical.
   // Empty-sender messages (server NOTICEs) are recorded to history/fingerprint but excluded from unread.
-  private recordMessage(msg: IrcMessage, historical = false): void {
+  // Returns whether the message is a text-body mention (nick word-boundary match). Always false for historical.
+  private recordMessage(msg: IrcMessage, historical = false): boolean {
     this.pushHistory(msg.channel, msg)
     this.addFingerprint(msg)
     if (!historical && msg.sender !== '') {
@@ -262,7 +263,9 @@ export class RoostIrcClientImpl implements RoostIrcClient {
         lastMentionSender: isMention ? msg.sender : (prev?.lastMentionSender ?? ''),
         lastMentionPreview: isMention ? msg.text : (prev?.lastMentionPreview ?? ''),
       })
+      return isMention
     }
+    return false
   }
 
   // ---- Typed event emitters ----------------------------------------------
@@ -508,8 +511,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     const channel = isDirect ? event.nick.toLowerCase() : event.target.toLowerCase()
     const ts = event.tags?.['time'] ?? new Date().toISOString()
     const msg: IrcMessage = { channel, sender: event.nick, text: event.message, ts, isDirect }
-    this.recordMessage(msg)
-    this.emitMessage(msg, {})
+    const mention = this.recordMessage(msg)
+    this.emitMessage(msg, mention ? { mention: true } : {})
   }
 
   private handleMultilineBatch(event: BatchEndEvent): void {
@@ -525,8 +528,8 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     const serverTimeMs = cmds[0].getServerTime?.()
     const ts = (serverTimeMs ? new Date(serverTimeMs) : new Date()).toISOString()
     const msg: IrcMessage = { channel, sender, text, ts, isDirect }
-    this.recordMessage(msg)
-    this.emitMessage(msg, { buffered: cmds.length > 1, chunkCount: cmds.length })
+    const mention = this.recordMessage(msg)
+    this.emitMessage(msg, { buffered: cmds.length > 1, chunkCount: cmds.length, ...(mention ? { mention: true } : {}) })
   }
 
   private handleChathistoryBatch(event: BatchEndEvent): void {

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -26,6 +26,7 @@ export interface MessageMeta {
   buffered?: boolean
   chunkCount?: number
   historical?: boolean
+  mention?: boolean
 }
 
 // Extras on membership events from join/part/kick/quit/nick.

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -149,6 +149,7 @@ export interface CreateMcpOptions {
 // → ircClient.connect.
 export function createMcpServer(client: RoostIrcClient, config: ClientConfig, options: CreateMcpOptions = {}): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
   const { nick: NICK, autoJoin: AUTO_JOIN } = config
+  const mentionRegex = new RegExp(`\\b${NICK.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
 
   // ---- Passive short-circuit ---------------------------------------------
   // Lost the owner race in claimOwnership(). Build a minimal MCP that errors
@@ -193,7 +194,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events also carry mention="true" when the message body contains your nick (word-boundary match) or the message is a DM (isDirect="true") — absent when not a mention. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -241,6 +242,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       if (meta.chunkCount && meta.chunkCount > 1) metaRecord.chunkCount = String(meta.chunkCount)
     }
     if (meta.historical) metaRecord.historical = 'true'
+    if (msg.isDirect || mentionRegex.test(msg.text)) metaRecord.mention = 'true'
 
     pushNotification(msg.text, metaRecord)
     process.stderr.write(

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -149,7 +149,6 @@ export interface CreateMcpOptions {
 // → ircClient.connect.
 export function createMcpServer(client: RoostIrcClient, config: ClientConfig, options: CreateMcpOptions = {}): { server: Server; clearDedupeCache: () => void; emitUnreadSummary: () => Promise<void> } {
   const { nick: NICK, autoJoin: AUTO_JOIN } = config
-  const mentionRegex = new RegExp(`\\b${NICK.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
 
   // ---- Passive short-circuit ---------------------------------------------
   // Lost the owner race in claimOwnership(). Build a minimal MCP that errors
@@ -194,7 +193,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events also carry mention="true" when the message body contains your nick (word-boundary match) or the message is a DM (isDirect="true") — absent when not a mention. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -242,7 +241,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       if (meta.chunkCount && meta.chunkCount > 1) metaRecord.chunkCount = String(meta.chunkCount)
     }
     if (meta.historical) metaRecord.historical = 'true'
-    if (msg.isDirect || mentionRegex.test(msg.text)) metaRecord.mention = 'true'
+    if (meta.mention || msg.isDirect) metaRecord.mention = 'true'
 
     pushNotification(msg.text, metaRecord)
     process.stderr.write(

--- a/test/inbound.test.ts
+++ b/test/inbound.test.ts
@@ -205,4 +205,52 @@ describe.if(isErgoAvailable())('inbound notifications', () => {
     expect(summary.content).toContain('ip-in-peer9b (1)')
     expect(summary.content).not.toContain('ip-in-peer9 (')
   })
+
+  // ---- mention="true" attribute (issue #237) --------------------------------
+
+  it('channel message containing own nick carries mention="true"', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-ment1')
+    const peer = await connectPeer(ergo, 'ip-in-ment1-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-in-ment1' } })
+    await peer.joinChannel('#ip-in-ment1')
+
+    peer.say('#ip-in-ment1', 'ip-in-ment1: are you there?')
+    const n = await mcp.waitForNotification(n => n.meta.channel === '#ip-in-ment1' && n.content === 'ip-in-ment1: are you there?')
+
+    expect(n.meta.mention).toBe('true')
+  })
+
+  it('channel message not containing own nick has no mention attribute', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-ment2')
+    const peer = await connectPeer(ergo, 'ip-in-ment2-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-in-ment2' } })
+    await peer.joinChannel('#ip-in-ment2')
+
+    peer.say('#ip-in-ment2', 'just chatting')
+    const n = await mcp.waitForNotification(n => n.meta.channel === '#ip-in-ment2' && n.content === 'just chatting')
+
+    expect(n.meta.mention).toBeUndefined()
+  })
+
+  it('word-boundary: nick as prefix of longer word does not set mention', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-ment3')
+    const peer = await connectPeer(ergo, 'ip-in-ment3-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-in-ment3' } })
+    await peer.joinChannel('#ip-in-ment3')
+
+    peer.say('#ip-in-ment3', 'ip-in-ment3x is not the target nick')
+    const n = await mcp.waitForNotification(n => n.meta.channel === '#ip-in-ment3' && n.content === 'ip-in-ment3x is not the target nick')
+
+    expect(n.meta.mention).toBeUndefined()
+  })
+
+  it('DM always carries mention="true"', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-ment4')
+    const peer = await connectPeer(ergo, 'ip-in-ment4-peer')
+
+    peer.say('ip-in-ment4', 'hey there')
+    const n = await mcp.waitForNotification(n => n.meta.isDirect === 'true' && n.content === 'hey there')
+
+    expect(n.meta.mention).toBe('true')
+  })
 })


### PR DESCRIPTION
Closes #237

Agents currently have to scan every message body to detect whether they're being addressed. This adds `mention="true"` to the `event="message"` notification metadata so agents can cheaply triage directed messages.

**When it's set:** body contains the agent's nick (word-boundary, case-insensitive) OR the message is a DM (`isDirect="true"`). Absent otherwise.

**Scope:** only `event="message"` — membership events untouched.

**Docs updated:** README example, MCP instructions string, LEARNINGS.md open question closed.

**Tests:** 4 new cases in `inbound.test.ts` — channel mention, non-mention, word-boundary false positive, DM always-mention. Full suite 291/291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)