### PR TITLE
feat: unify channel_history output shape with live <channel> envelope

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -248,13 +248,14 @@ export class RoostIrcClientImpl implements RoostIrcClient {
 
   // Record a message in history and dedupe set; increment unread unless historical.
   // Empty-sender messages (server NOTICEs) are recorded to history/fingerprint but excluded from unread.
-  // Returns whether the message is a text-body mention (nick word-boundary match). Always false for historical.
+  // Returns whether the message body contains a nick mention (text-only; callers OR with isDirect for wire attr).
   private recordMessage(msg: IrcMessage, historical = false): boolean {
+    const isMention = this.nickMentionRegex.test(msg.text)
+    msg.mention = isMention
     this.pushHistory(msg.channel, msg)
     this.addFingerprint(msg)
     if (!historical && msg.sender !== '') {
       const prev = this.unread.get(msg.channel)
-      const isMention = this.nickMentionRegex.test(msg.text)
       this.unread.set(msg.channel, {
         count: (prev?.count ?? 0) + 1,
         lastSender: msg.sender,

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -246,9 +246,9 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     return set
   }
 
-  // Record a message in history and dedupe set; increment unread unless historical.
-  // Empty-sender messages (server NOTICEs) are recorded to history/fingerprint but excluded from unread.
-  // Returns whether the message body contains a nick mention (text-only; callers OR with isDirect for wire attr).
+  // Record a message in history and dedupe set. Always sets msg.mention (text-only regex).
+  // Increments unread only for non-historical, non-empty-sender messages.
+  // Returns true iff the message body contains a nick mention (same value as msg.mention after the call).
   private recordMessage(msg: IrcMessage, historical = false): boolean {
     const isMention = this.nickMentionRegex.test(msg.text)
     msg.mention = isMention
@@ -543,7 +543,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
         continue
       }
       this.recordMessage(msg, true)
-      this.emitMessage(msg, { historical: true })
+      this.emitMessage(msg, { historical: true, mention: msg.mention })
     }
   }
 

--- a/src/irc-lib.ts
+++ b/src/irc-lib.ts
@@ -6,6 +6,7 @@ export interface IrcMessage {
   text: string
   ts: string
   isDirect: boolean
+  /** Memoized result of the nick mention regex (text-only). Set by recordMessage; OR'd with isDirect at wire-emit time. */
   mention?: boolean
 }
 

--- a/src/irc-lib.ts
+++ b/src/irc-lib.ts
@@ -6,6 +6,7 @@ export interface IrcMessage {
   text: string
   ts: string
   isDirect: boolean
+  mention?: boolean
 }
 
 // Split at natural boundaries when possible — prefer sentence end, then any

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -209,6 +209,10 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
     })
   }
 
+  const escAttr = (s: string) => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/'/g, '&#39;')
+  const escBody = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  const wireMention = (msg: { mention?: boolean; isDirect: boolean }) => msg.mention || msg.isDirect
+
   const formatUnreadLine = (ch: string, info: UnreadInfo, previewLength = 40): string => {
     const hasMention = info.mentionCount > 0
     const [sender, preview] = hasMention
@@ -241,7 +245,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       if (meta.chunkCount && meta.chunkCount > 1) metaRecord.chunkCount = String(meta.chunkCount)
     }
     if (meta.historical) metaRecord.historical = 'true'
-    if (meta.mention || msg.isDirect) metaRecord.mention = 'true'
+    if (wireMention({ mention: meta.mention, isDirect: msg.isDirect })) metaRecord.mention = 'true'
 
     pushNotification(msg.text, metaRecord)
     process.stderr.write(
@@ -347,11 +351,9 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         const limit = (args.limit as number | undefined) ?? 20
         client.ackUnread(key)
         const slice = client.getHistory(key, limit)
-        if (slice.length === 0) return { content: [{ type: 'text', text: `no history for ${key} (since this MCP started)` }] }
-        const escAttr = (s: string) => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/'/g, '&#39;')
-        const escBody = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        if (slice.length === 0) return { content: [{ type: 'text', text: `<channel event="no-history" channel="${escAttr(key)}">no history for ${key} (since this MCP started)</channel>` }] }
         const lines = slice.map(m => {
-          const mention = (m.mention || m.isDirect) ? ' mention="true"' : ''
+          const mention = wireMention(m) ? ' mention="true"' : ''
           return `<channel sender="${escAttr(m.sender)}" channel="${escAttr(m.channel)}" isDirect="${m.isDirect}" ts="${escAttr(m.ts)}" event="message" historical="true"${mention}>${escBody(m.text)}</channel>`
         })
         return { content: [{ type: 'text', text: lines.join('\n') }] }

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -193,7 +193,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -348,7 +348,12 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         client.ackUnread(key)
         const slice = client.getHistory(key, limit)
         if (slice.length === 0) return { content: [{ type: 'text', text: `no history for ${key} (since this MCP started)` }] }
-        const lines = slice.map(m => `[${m.ts}] ${m.isDirect ? `(DM from ${m.sender})` : `${m.channel} <${m.sender}>`} ${m.text}`)
+        const escAttr = (s: string) => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/'/g, '&#39;')
+        const escBody = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        const lines = slice.map(m => {
+          const mention = (m.mention || m.isDirect) ? ' mention="true"' : ''
+          return `<channel sender="${escAttr(m.sender)}" channel="${escAttr(m.channel)}" isDirect="${m.isDirect}" ts="${escAttr(m.ts)}" event="message" historical="true"${mention}>${escBody(m.text)}</channel>`
+        })
         return { content: [{ type: 'text', text: lines.join('\n') }] }
       }
       case 'channel_list': {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -156,6 +156,85 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(toolText(hist)).toContain('no history')
   })
 
+  it('channel_history returns <channel> XML elements with historical="true"', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-histshape1')
+    const peer = await connectPeer(ergo, 'ip-histshape1-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-histshape1' } })
+    await peer.joinChannel('#ip-histshape1')
+
+    peer.say('#ip-histshape1', 'shape-test-msg')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape1' && n.content === 'shape-test-msg')
+
+    const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-histshape1' } })
+    const text = toolText(hist)
+    expect(text).toMatch(/^<channel /)
+    expect(text).toContain('sender="ip-histshape1-peer"')
+    expect(text).toContain('channel="#ip-histshape1"')
+    expect(text).toContain('isDirect="false"')
+    expect(text).toContain('event="message"')
+    expect(text).toContain('historical="true"')
+    expect(text).toContain('>shape-test-msg<')
+    expect(text).not.toContain('mention="true"')
+  })
+
+  it('channel_history emits mention="true" for DMs', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-histshape2')
+    const peer = await connectPeer(ergo, 'ip-histshape2-peer')
+
+    peer.say('ip-histshape2', 'hi directly')
+    await mcp.waitForNotification(n => n.meta.isDirect === 'true' && n.content === 'hi directly')
+
+    const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: 'ip-histshape2-peer' } })
+    const text = toolText(hist)
+    expect(text).toContain('isDirect="true"')
+    expect(text).toContain('mention="true"')
+  })
+
+  it('channel_history emits mention="true" for nick mention in channel', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-histshape3')
+    const peer = await connectPeer(ergo, 'ip-histshape3-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-histshape3' } })
+    await peer.joinChannel('#ip-histshape3')
+
+    peer.say('#ip-histshape3', 'hey ip-histshape3 are you there?')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape3' && n.meta.mention === 'true')
+
+    const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-histshape3' } })
+    expect(toolText(hist)).toContain('mention="true"')
+  })
+
+  it('channel_history XML-escapes special characters in body and attrs', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-histshape4')
+    const peer = await connectPeer(ergo, 'ip-histshape4-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-histshape4' } })
+    await peer.joinChannel('#ip-histshape4')
+
+    peer.say('#ip-histshape4', 'a <b> & "c"')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape4' && n.content.includes('<b>'))
+
+    const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-histshape4' } })
+    const text = toolText(hist)
+    expect(text).toContain('&lt;b&gt;')
+    expect(text).toContain('&amp;')
+    expect(text).not.toMatch(/<b>/)
+  })
+
+  it('channel_history handles multiline message body', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-histshape5')
+    const peer = await connectPeer(ergo, 'ip-histshape5-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-histshape5' } })
+    await peer.joinChannel('#ip-histshape5')
+
+    peer.say('#ip-histshape5', 'line one\nline two')
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape5' && n.content.includes('line one'))
+
+    const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-histshape5' } })
+    const text = toolText(hist)
+    expect(text).toContain('line one')
+    expect(text).toContain('line two')
+    expect(text).toMatch(/historical="true"/)
+  })
+
   // ---- Unread tracking (issue #9) ----------------------------------------
 
   it('inbound message increments unread; channel_list shows sender+preview', async () => {

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -153,7 +153,9 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     const mcp = await startMcpInProcess(ergo, 'ip-hist2')
     await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-hist2' } })
     const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-hist2' } })
-    expect(toolText(hist)).toContain('no history')
+    const text = toolText(hist)
+    expect(text).toContain('event="no-history"')
+    expect(text).toContain('no history')
   })
 
   it('channel_history returns <channel> XML elements with historical="true"', async () => {


### PR DESCRIPTION
Closes #239

channel_history now returns `<channel>` XML elements matching the live notification shape, with `historical="true"` to distinguish from real-time arrivals.

## Shape

```xml
<channel sender="nick" channel="#chan" isDirect="false" ts="…" event="message" historical="true">body</channel>
```

`mention="true"` emitted iff body nick-matches or the message is a DM — same composition as live events.

## What changed

- `IrcMessage` gains optional `mention?: boolean` (text-only regex result, set at record time)
- `recordMessage` stashes the mention result on the message before pushing to history — single source of truth, no per-read recompute, no semantic drift vs unread `mentionCount`
- `channel_history` handler emits XML instead of `[ts] #chan <nick> body` plain text; XML-escapes attrs (`& " < > '`) and body (`& < >`)
- MCP instructions string updated to document the new history shape
- 5 new tests: shape verification, DM mention, channel nick mention, XML escape, multiline body

[roost-worker-239]