### PR TITLE
feat: broadcast hint — [#channel: N members] on channel_message

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -193,7 +193,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message responses include a [#channel: N members] line after the body showing current channel membership from the local cache — this is a broadcast reminder, not a live query. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message responses always include a [#channel: N members] line after the body — current member count from the local cache, not a live query. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -294,7 +294,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
 
   // ---- Tool definitions --------------------------------------------------
 
-  const handleSay = (target: string, text: string, label: string, broadcastChannel?: string) => {
+  const handleSay = (target: string, text: string, label: string) => {
     const { chunks, mode } = client.say(target, text)
     client.ackUnread(target)
     const suffix = unreadSuffix()
@@ -303,8 +303,8 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       : chunks > 1 ? ` (split into ${chunks} chunks for IRC line cap)`
       : ''
     const preview = text.length > 120 ? text.slice(0, 117) + '...' : text
-    const memberHint = broadcastChannel && client.isJoined(broadcastChannel)
-      ? `\n[${broadcastChannel}: ${client.getUsers(broadcastChannel).length} members]`
+    const memberHint = target.startsWith('#')
+      ? `\n[${target}: ${client.getUsers(target).length} members]`
       : ''
     return { content: [{ type: 'text', text: `${label}: ${preview}${note}${memberHint}${suffix}` }] }
   }
@@ -325,7 +325,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       case 'channel_message': {
         const ch = args.channel as string
         const text = args.text as string
-        return handleSay(ch, text, `sent to ${ch}`, ch)
+        return handleSay(ch, text, `sent to ${ch}`)
       }
       case 'direct_message': {
         const nick = args.nick as string

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -193,7 +193,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
         tools: {},
         experimental: { 'claude/channel': {} },
       },
-      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
+      instructions: `roost IRC MCP. You are connected to IRC as nick "${NICK}". This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message responses include a [#channel: N members] line after the body showing current channel membership from the local cache — this is a broadcast reminder, not a live query. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}.`,
     },
   )
 
@@ -294,7 +294,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
 
   // ---- Tool definitions --------------------------------------------------
 
-  const handleSay = (target: string, text: string, label: string) => {
+  const handleSay = (target: string, text: string, label: string, broadcastChannel?: string) => {
     const { chunks, mode } = client.say(target, text)
     client.ackUnread(target)
     const suffix = unreadSuffix()
@@ -303,7 +303,10 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       : chunks > 1 ? ` (split into ${chunks} chunks for IRC line cap)`
       : ''
     const preview = text.length > 120 ? text.slice(0, 117) + '...' : text
-    return { content: [{ type: 'text', text: `${label}: ${preview}${note}${suffix}` }] }
+    const memberHint = broadcastChannel && client.isJoined(broadcastChannel)
+      ? `\n[${broadcastChannel}: ${client.getUsers(broadcastChannel).length} members]`
+      : ''
+    return { content: [{ type: 'text', text: `${label}: ${preview}${note}${memberHint}${suffix}` }] }
   }
 
   mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))
@@ -322,7 +325,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       case 'channel_message': {
         const ch = args.channel as string
         const text = args.text as string
-        return handleSay(ch, text, `sent to ${ch}`)
+        return handleSay(ch, text, `sent to ${ch}`, ch)
       }
       case 'direct_message': {
         const nick = args.nick as string

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -69,6 +69,8 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
       sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } }),
       receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } }),
     ])
+    // wait for sender to see receiver's JOIN so channelUsers reflects 2 members
+    await sender.waitForNotification(n => n.meta.event === 'join' && n.meta.channel === '#ip-out-ml' && n.meta.sender === 'ip-out-mcp5')
 
     const longText = 'a'.repeat(150) + '\n' + 'b'.repeat(150) + '\n' + 'c'.repeat(50)
     // 352 bytes total, two embedded newlines — forces draft/multiline batch
@@ -79,6 +81,7 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     })
     expect(result.isError).toBeFalsy()
     expect(toolText(result)).toContain('draft/multiline batch')
+    expect(toolText(result)).toContain('[#ip-out-ml: 2 members]')
 
     const n = await receiver.waitForNotification(
       n => n.meta.channel === '#ip-out-ml' && n.meta.sender === 'ip-out-mcp4' && n.meta.event === 'message',
@@ -104,19 +107,18 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     expect(toolText(result)).toContain('[#ip-out-bcast: 2 members]')
   })
 
-  it('channel_message: no member hint when not joined', async () => {
+  it('channel_message: shows 0 members when not joined', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-out-bcast-mcp2')
 
     const result = await mcp.client.callTool({
       name: 'channel_message',
-      arguments: { channel: '#ip-out-bcast-nojoin', text: 'should have no hint' },
+      arguments: { channel: '#ip-out-bcast-nojoin', text: 'not joined' },
     })
-    expect(toolText(result)).not.toContain('[#ip-out-bcast-nojoin:')
+    expect(toolText(result)).toContain('[#ip-out-bcast-nojoin: 0 members]')
   })
 
   it('direct_message: response has no member hint', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-out-bcast-mcp3')
-    const peer = await connectPeer(ergo, 'ip-out-bcast-peer3')
 
     const result = await mcp.client.callTool({
       name: 'direct_message',
@@ -124,7 +126,6 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     })
     expect(result.isError).toBeFalsy()
     expect(toolText(result)).not.toMatch(/\[.*members\]/)
-    void peer
   })
 
   it('channel_join: cache hit — second join returns ok without IRC round-trip', async () => {

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -86,6 +86,47 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     expect(n.content).toBe(longText)
   })
 
+  it('channel_message: response includes [#channel: N members] suffix', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-out-bcast-mcp1')
+    const peer = await connectPeer(ergo, 'ip-out-bcast-peer1')
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-bcast' } })
+    await peer.joinChannel('#ip-out-bcast')
+    // wait for MCP to process peer's JOIN so channelUsers cache reflects 2 members
+    await mcp.waitForNotification(n => n.meta.event === 'join' && n.meta.channel === '#ip-out-bcast' && n.meta.sender === 'ip-out-bcast-peer1')
+
+    const result = await mcp.client.callTool({
+      name: 'channel_message',
+      arguments: { channel: '#ip-out-bcast', text: 'broadcast test' },
+    })
+    expect(result.isError).toBeFalsy()
+    // mcp + peer = 2 members
+    expect(toolText(result)).toContain('[#ip-out-bcast: 2 members]')
+  })
+
+  it('channel_message: no member hint when not joined', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-out-bcast-mcp2')
+
+    const result = await mcp.client.callTool({
+      name: 'channel_message',
+      arguments: { channel: '#ip-out-bcast-nojoin', text: 'should have no hint' },
+    })
+    expect(toolText(result)).not.toContain('[#ip-out-bcast-nojoin:')
+  })
+
+  it('direct_message: response has no member hint', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-out-bcast-mcp3')
+    const peer = await connectPeer(ergo, 'ip-out-bcast-peer3')
+
+    const result = await mcp.client.callTool({
+      name: 'direct_message',
+      arguments: { nick: 'ip-out-bcast-peer3', text: 'dm no hint' },
+    })
+    expect(result.isError).toBeFalsy()
+    expect(toolText(result)).not.toMatch(/\[.*members\]/)
+    void peer
+  })
+
   it('channel_join: cache hit — second join returns ok without IRC round-trip', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-out-cache1')
 


### PR DESCRIPTION
Closes #235

Appends `[#channel: N members]` to every `channel_message` tool response, between the send confirmation and the `unread:` block. Always-on per spec — `getUsers()` returns 0 when not joined (rare edge case, self-correcting noise). DMs unchanged.

One call to `getUsers()` drives both the presence check and the count; `target.startsWith('#')` distinguishes channels from DMs without a separate param.

Docs: updated the MCP `instructions` string to describe the always-on hint.

Tests: count accuracy (waits for JOIN to settle cache), 0-member when not joined, no hint on DM, hint present alongside multiline chunk note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)