### PR TITLE
fix: watcher uses roost root to locate dispatcher binary

### DIFF
--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -35,6 +35,8 @@ CONFIG_DIR="$(pwd)/.orchestrator"
 roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt "/watcher $0 $0-lead-pm $2 $CONFIG_DIR" --perm-irc --perm-target $0-lead-pm
 ```
 
+The watcher starts the dispatcher daemon automatically on boot — you don't need to start it manually.
+
 The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
 
 - `watch <N>` — add N to `watched_issues` (idempotent)

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -44,7 +44,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `nohup "$(roost root)/bin/dispatcher" --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
+- **On boot, first action:** run `ROOST_ROOT="$(roost root)" && nohup "$ROOST_ROOT/bin/dispatcher" --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
 - Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -44,7 +44,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `nohup bin/dispatcher --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
+- **On boot, first action:** run `nohup "$(roost root)/bin/dispatcher" --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
 - Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.


### PR DESCRIPTION
Closes #219

`bin/dispatcher` in the watcher boot action was a relative path from the watcher's CWD (the user's project root, not the roost plugin tree) — so the daemon never started.

Fix: use `$(roost root)/bin/dispatcher`, which resolves the absolute plugin path via the same symlink-walking logic that `roost` itself uses. `roost root` is on PATH in any session where `roost spawn` was used.

Also adds a note to the lead-pm prompt so leads know the watcher handles dispatcher startup automatically.

**Known followup (out of scope here):** if the watcher restarts mid-session, it'd spawn a second daemon → unix-socket conflict. Should add a pid-file or liveness check before the `nohup`.