### PR TITLE
fix(test): wait for second multiline before history fetch (#252)

### DIFF
--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -228,7 +228,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     await peer.joinChannel('#ip-histshape5')
 
     peer.say('#ip-histshape5', 'line one\nline two')
-    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape5' && n.content.includes('line one'))
+    await mcp.waitForNotification(n => n.meta.channel === '#ip-histshape5' && n.content.includes('line two'))
 
     const hist = await mcp.client.callTool({ name: 'channel_history', arguments: { channel: '#ip-histshape5' } })
     const text = toolText(hist)

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -65,11 +65,11 @@ describe.if(isErgoAvailable())('outbound message tools', () => {
     const sender = await startMcpInProcess(ergo, 'ip-out-mcp4')
     const receiver = await startMcpInProcess(ergo, 'ip-out-mcp5')
 
-    await Promise.all([
-      sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } }),
-      receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } }),
-    ])
-    // wait for sender to see receiver's JOIN so channelUsers reflects 2 members
+    // Sequence the joins: sender joins first, then receiver, so sender deterministically
+    // sees receiver's JOIN event. Promise.all races the joins and if receiver wins, sender
+    // arrives into an already-populated channel and never sees the JOIN it's waiting for.
+    await sender.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } })
+    await receiver.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-out-ml' } })
     await sender.waitForNotification(n => n.meta.event === 'join' && n.meta.channel === '#ip-out-ml' && n.meta.sender === 'ip-out-mcp5')
 
     const longText = 'a'.repeat(150) + '\n' + 'b'.repeat(150) + '\n' + 'c'.repeat(50)


### PR DESCRIPTION
Closes #252

## Summary
Two test races, both surfaced by coverage instrumentation timing.

**Race 1 — channel_history multiline shape (irc-server.test.ts)**: test waited for `line one` arrival before calling `channel_history`, then asserted on the full multiline body. Under coverage, `line two` sometimes hadn't been recorded yet. Fixed by waiting for `line two` — both lines are in the same batch, so once the second arrives we know the full multiline is in the buffer.

**Race 2 — long multiline reassemble (outbound.test.ts)**: the test used `Promise.all` to dispatch sender and receiver joins concurrently, then awaited sender seeing receiver's JOIN event. If receiver won the race, sender arrived into an already-populated channel and never saw the JOIN — predicate unsatisfiable, 15s timeout. Coverage shifted timing enough to make receiver win reliably. Sequence the joins.

## Test plan
- [x] Targeted tests pass 5/5 in isolation under coverage
- [x] Full suite passes 299/0 under coverage
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)