### PR TITLE
maint: bump version to 0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,18 @@ roost/
 
 Roost is a Claude Code plugin. Hook scripts live in `bin/` inside the plugin root and are wired by `bin/roost` at spawn time (written to `${ROOST_DATA_DIR}/roost-settings.json` and passed via `--settings`). They are **not** configured in `.claude/settings.json` — that file is project-local and not part of the plugin. Same pattern as `bin/irc-permission-prompt`.
 
+## Releasing
+
+To cut a release:
+
+1. Bump `package.json` version on a `maint/bump-version-X.Y.Z` branch, PR, merge.
+2. From main, after the bump merges: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. The tag fires `.github/workflows/release.yml` — creates the GitHub release and opens a formula-bump PR against `AvesAlight/homebrew-tap`.
+4. Watch the tap repo for the bump PR: `gh pr list --repo AvesAlight/homebrew-tap` (or the web UI). Merge it once it lands.
+5. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code.
+
+The version bump and the tag are separate steps — the workflow only fires on tag push, and only tags that don't contain a hyphen (so `v1.0.0-rc1` is skipped).
+
 ## Committing
 
 When making a commit, ensure you include a human/claude interaction log. This is mandatory, and captures the human intent of actions you perform. Make the humans accountable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ To cut a release:
 
 1. Bump `package.json` version on a `maint/bump-version-X.Y.Z` branch, PR, merge.
 2. From main, after the bump merges: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-3. The tag fires `.github/workflows/release.yml` — creates the GitHub release and opens a formula-bump PR against `AvesAlight/homebrew-tap`.
-4. Watch the tap repo for the bump PR: `gh pr list --repo AvesAlight/homebrew-tap` (or the web UI). Merge it once it lands.
+3. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
+4. Watch the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI).
 5. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code.
 
 The version bump and the tag are separate steps — the workflow only fires on tag push, and only tags that don't contain a hyphen (so `v1.0.0-rc1` is skipped).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
0.3.0 release. Two commits:
1. Version bump in package.json
2. New "Releasing" section in CLAUDE.md documenting the bump→tag→tap-PR→upgrade flow (per alex request)

## Headliners since 0.2.0
- #253 — pluggable orchestrator seams (registry + per-plugin config)
- #251 — watcher auto-starts dispatcher
- #244/#248/#249 — channel-meta wire-shape unification (event=message, mention=true, historical=true)
- #250 — broadcast member-count hint
- #252 — multiline-history race + JOIN-order race
- #247 — now-watching event

## Test plan
- [x] one-line version bump in package.json
- [x] release-workflow docs added to CLAUDE.md
- [ ] CI green