### PR TITLE
fix: reliable watcher/dispatcher startup

### DIFF
--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -1,6 +1,6 @@
 {
   "project": "roost",
-  "repo": "AlexSc/roost",
+  "repo": "AvesAlight/roost",
   "agent_logins": ["TeakBuilds"],
   "irc": {
     "nick": "roost-dispatcher",

--- a/bin/roost
+++ b/bin/roost
@@ -559,7 +559,7 @@ cmd_spawn() {
   # `zsh -l` (login shell) ensures .zprofile runs before claude — required for
   # RVM / nvm / shell-rc-managed toolchains. Env vars go through tmux -e so
   # the inner command stays a clean single-quoted string.
-  local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}")
+  local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}" -e "ROOST_DIR=${ROOST_DIR}")
   tmux_env+=(-e "ROOST_IRC_SERVER=${IRC_HOST}")
   if [ -n "${perm_sock}" ]; then
     tmux_env+=(-e "ROOST_PERM_SOCK=${perm_sock}" -e "ROOST_PERM_HOST=${IRC_HOST}" -e "ROOST_PERM_PORT=${IRC_PORT}")

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -46,7 +46,15 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** run `ROOST_ROOT="$(roost root)" && nohup "$ROOST_ROOT/bin/dispatcher" --daemon --config-dir "$3" &` to ensure the dispatcher daemon is up. (Without `--daemon` the orchestrator is one-shot and exits.)
+- **On boot, first action:** start and verify the dispatcher daemon. Run this Bash block:
+  ```bash
+  nohup "$ROOST_DIR/bin/dispatcher" --daemon --config-dir "$3" >> "$3/dispatcher-boot.log" 2>&1 &
+  DISP_PID=$!
+  # 2s catches immediate failures (missing config, env, syntax); steady-state crashes are visible in daemon.log
+  sleep 2
+  kill -0 "$DISP_PID" 2>/dev/null && echo "dispatcher ok (pid $DISP_PID)" || echo "FAIL"
+  ```
+  If output contains `FAIL`, post to #$0-leads: `dispatcher failed to start — check $3/dispatcher-boot.log`. Then continue accepting watch commands normally (degraded mode; dispatcher may recover). Without `--daemon` the orchestrator is one-shot and exits.
 - Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -46,7 +46,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** start and verify the dispatcher daemon. Run this Bash block:
+- **On boot, first action:** start and verify the dispatcher daemon (`--daemon` keeps it running; without it the orchestrator exits after one tick). Run this Bash block:
   ```bash
   nohup "$ROOST_DIR/bin/dispatcher" --daemon --config-dir "$3" >> "$3/dispatcher-boot.log" 2>&1 &
   DISP_PID=$!
@@ -54,7 +54,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
   sleep 2
   kill -0 "$DISP_PID" 2>/dev/null && echo "dispatcher ok (pid $DISP_PID)" || echo "FAIL"
   ```
-  If output contains `FAIL`, post to #$0-leads: `dispatcher failed to start — check $3/dispatcher-boot.log`. Then continue accepting watch commands normally (degraded mode; dispatcher may recover). Without `--daemon` the orchestrator is one-shot and exits.
+  If output contains `FAIL`, post to #$0-leads: `dispatcher failed to start — check $3/dispatcher-boot.log`. Then continue accepting watch commands normally (degraded mode; dispatcher may recover).
 - Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.


### PR DESCRIPTION
Closes #258

Three root causes of the silent dispatcher startup failure:

**(a) wrong invocation** — watcher called `roost root` (CLI) but a Haiku model sometimes invoked the `roost` skill instead. Fix: pass `ROOST_DIR` via tmux env in `bin/roost cmd_spawn()` so watcher uses it directly, no CLI call needed.

**(b) silent stderr** — boot failures (missing config, bad env, syntax error) had nowhere to land. Fix: redirect to `$config_dir/dispatcher-boot.log`, separate from the daemon's steady-state `daemon.log`.

**(c) no verification** — `nohup ... &` always exits 0. Fix: capture PID, `kill -0` after 2s (catches immediate exits), post failure notice to `#leads` and continue in degraded mode.

No new tests — this is prompt + spawn config, not logic. Existing `cwd-default.test.ts` covers the dispatcher's loud-fail exit path (the part testable at all); the watcher prompt behavior (PID capture, kill-0, conditional IRC post) isn't unit-testable.