### PR TITLE
maint: bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
0.3.1 point release covering #258 (watcher/dispatcher reliability).

## Headliners since 0.3.0
- #258 / PR #259 — watcher/dispatcher reliability: ROOST_DIR via tmux env, boot stderr → dispatcher-boot.log, post-launch PID verification

## Test plan
- [x] one-line version bump in package.json
- [ ] CI green
- [ ] after merge: tag v0.3.1, watch release workflow fire, watch tap repo bump commit land

🤖 Generated with [Claude Code](https://claude.com/claude-code)