### PR TITLE
fix: include own-nick messages in chathistory backfill

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -553,7 +553,7 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     for (const c of commands) {
       if (c.command !== 'PRIVMSG') continue
       const sender = c.nick
-      if (!sender || sender === this.nick) continue
+      if (!sender) continue
       const text = c.params[c.params.length - 1] ?? ''
       const isDirect = target === this.nick
       const channel = isDirect ? sender.toLowerCase() : target.toLowerCase()

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -106,6 +106,38 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     expect(idx2).toBeGreaterThan(idx1)
   })
 
+  it('own-nick messages sent before join appear as historical on join', async () => {
+    const peer = await connectPeer(ergo, 'ip-own-peer1')
+    const mcp = await startMcpInProcess(ergo, 'ip-own-mcp1')
+
+    // MCP joins, sends a message, then parts
+    await peer.joinChannel('#ip-hist-own1')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-hist-own1' } })
+    await mcp.client.callTool({ name: 'channel_message', arguments: { channel: '#ip-hist-own1', text: 'own-msg-before-part' } })
+    await sleep(100)
+    await mcp.client.callTool({ name: 'channel_leave', arguments: { channel: '#ip-hist-own1' } })
+
+    // Rejoin — own message must appear in chathistory backfill
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-hist-own1' } })
+    await mcp.waitForNotification(n => n.meta.historical === 'true' && n.content === 'own-msg-before-part')
+  })
+
+  it('own-nick messages sent while joined do not produce live notifications', async () => {
+    const peer = await connectPeer(ergo, 'ip-own-peer2')
+    const mcp = await startMcpInProcess(ergo, 'ip-own-mcp2')
+
+    await peer.joinChannel('#ip-hist-own2')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-hist-own2' } })
+    await mcp.client.callTool({ name: 'channel_message', arguments: { channel: '#ip-hist-own2', text: 'own-live-msg' } })
+    await sleep(200)
+
+    // Must not arrive as a live notification
+    const live = mcp.notifications.filter(
+      n => n.content === 'own-live-msg' && n.meta.historical !== 'true',
+    )
+    expect(live).toHaveLength(0)
+  })
+
   it('live messages are not re-emitted as historical on part+rejoin', async () => {
     const peer = await connectPeer(ergo, 'ip-dedup-peer1')
     const mcp = await startMcpInProcess(ergo, 'ip-dedup-mcp1')

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -131,6 +131,7 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     await mcp.client.callTool({ name: 'channel_message', arguments: { channel: '#ip-hist-own2', text: 'own-live-msg' } })
     await sleep(200)
 
+    // Tests the no-echo protocol guarantee (ergo doesn't echo without echo-message cap); to cover the line 508 guard directly, echo-message would need to be negotiated.
     // Must not arrive as a live notification
     const live = mcp.notifications.filter(
       n => n.content === 'own-live-msg' && n.meta.historical !== 'true',


### PR DESCRIPTION
Closes #262

one-liner in `parseChathistoryBatch` — remove `sender === this.nick` guard so own messages aren't stripped from join-history replay.

live-path guards (`handleMessage`, `handleMultilineBatch`) untouched. `historical: true` stamped by the caller, not the parser.

two new tests: own messages appear as historical on rejoin; live own messages don't produce notifications.