### PR TITLE
feat: extract dispatcher boot+verify into bin/start-dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 
+      - name: Shellcheck
+        run: shellcheck bin/*
+
       - name: Lint
         run: bun run lint
 

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# start-dispatcher <config-dir>
+#
+# Starts the roost dispatcher daemon for the given config directory and
+# verifies it is alive after a 2-second boot window.
+#
+# Exits 0 on success. Exits 1 on failure with a diagnostic on stderr
+# prefixed "start-dispatcher: FAIL: <reason>".
+#
+# Idempotency: no existing-PID guard. If a dispatcher is already running
+# for this config-dir a second copy will start. The watcher calls this
+# once on boot; avoiding double-starts is the caller's responsibility.
+
+set -uo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "start-dispatcher: usage: start-dispatcher <config-dir>" >&2
+  exit 1
+fi
+
+CONFIG_DIR="$1"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+nohup "$DIR/dispatcher" --daemon --config-dir "$CONFIG_DIR" >> "$CONFIG_DIR/dispatcher-boot.log" 2>&1 &
+DISP_PID=$!
+
+# 2s catches immediate failures (missing config, env, syntax);
+# steady-state crashes are visible in daemon.log
+sleep 2
+
+if kill -0 "$DISP_PID" 2>/dev/null; then
+  echo "dispatcher ok (pid $DISP_PID)"
+else
+  echo "start-dispatcher: FAIL: dispatcher (pid $DISP_PID) exited within 2s — see $CONFIG_DIR/dispatcher-boot.log" >&2
+  exit 1
+fi

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -11,7 +11,7 @@
 # for this config-dir a second copy will start. The watcher calls this
 # once on boot; avoiding double-starts is the caller's responsibility.
 
-set -uo pipefail
+set -euo pipefail
 
 if [ "$#" -lt 1 ]; then
   echo "start-dispatcher: usage: start-dispatcher <config-dir>" >&2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "bun test",
-    "lint": "eslint src/ test/",
+    "lint": "eslint src/ test/ && shellcheck bin/*",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -46,7 +46,7 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** start and verify the dispatcher daemon (`--daemon` keeps it running; without it the orchestrator exits after one tick):
+- **On boot, first action:** start and verify the dispatcher daemon:
   ```bash
   "$ROOST_DIR/bin/start-dispatcher" "$3"
   ```

--- a/prompts/watcher.md
+++ b/prompts/watcher.md
@@ -46,15 +46,11 @@ A single message may contain multiple commands, separated by newlines, semicolon
 
 ## Behavior rules
 
-- **On boot, first action:** start and verify the dispatcher daemon (`--daemon` keeps it running; without it the orchestrator exits after one tick). Run this Bash block:
+- **On boot, first action:** start and verify the dispatcher daemon (`--daemon` keeps it running; without it the orchestrator exits after one tick):
   ```bash
-  nohup "$ROOST_DIR/bin/dispatcher" --daemon --config-dir "$3" >> "$3/dispatcher-boot.log" 2>&1 &
-  DISP_PID=$!
-  # 2s catches immediate failures (missing config, env, syntax); steady-state crashes are visible in daemon.log
-  sleep 2
-  kill -0 "$DISP_PID" 2>/dev/null && echo "dispatcher ok (pid $DISP_PID)" || echo "FAIL"
+  "$ROOST_DIR/bin/start-dispatcher" "$3"
   ```
-  If output contains `FAIL`, post to #$0-leads: `dispatcher failed to start — check $3/dispatcher-boot.log`. Then continue accepting watch commands normally (degraded mode; dispatcher may recover).
+  If it exits non-zero, post to #$0-leads: `dispatcher failed to start — check $3/dispatcher-boot.log`. Then continue accepting watch commands normally (degraded mode; dispatcher may recover).
 - Read `$3/config.json` before each mutation (don't cache).
 - Pretty-print JSON on write (2-space indent, trailing newline).
 - If you don't recognize a command, ignore it silently.


### PR DESCRIPTION
Closes #260

Extracts the inline bash block from `prompts/watcher.md` into `bin/start-dispatcher <config-dir>`.

- Exits 0 if dispatcher is alive after the 2s boot window
- Exits 1 with `start-dispatcher: FAIL: <reason>` on stderr if not
- Owns the `dispatcher-boot.log` redirect
- No idempotency guard (documented in script header) — watcher calls this once on boot

Watcher prompt is now one line instead of an inline bash block. The brittle verification logic lives in deterministic shell, not prompt text.

Homebrew formula bundles `bin/` wholesale via `libexec.install Dir["*", ".[!.]*"]` — no formula changes needed.