### PR TITLE
prompts/worker: workflow primer + no ScheduleWakeup

### DIFF
--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -19,7 +19,7 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 
 ## PR lifecycle
 
-PRs start as draft. When your work is complete and CI is green, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer asks for changes, push the fix and say so; lead-pm will re-evaluate state.
+PRs start as draft. When your work is pushed, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer asks for changes, push the fix and say so; lead-pm will re-evaluate state.
 
 ## CI failures
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -8,7 +8,7 @@ Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 
 Process:
 1. Read the issue $2#$1 thoroughly — body, comments, labels, milestones, and any blocking relationships. `gh issue view $1 --comments` is the minimum (plain `gh issue view` skips comments, which often carry the actual scope). If your project provides a `github-management` skill, use it for richer output. Then read any relevant code.
-2. Post your implementation plan in #$0-issue-$1 and wait for lead-pm's approval before coding
+2. Post your implementation plan in #$0-issue-$1 and **wait** for lead-pm's approval before coding
 3. When done, open a *draft* PR and post the link in #$0-issue-$1. The PR body **must** start with a closing keyword on its own line — `Closes #$1` (or `Fixes` / `Resolves`). GitHub only auto-links issues when one of those keywords precedes the number; without it, `linked_issues` comes back empty and the dispatcher has no channel to route per-PR events to.
 4. Prefix all GitHub comments with [$0-worker-$1]
 5. Defer to lead-pm for marking the PR ready, tagging reviewers, and creating followup issues

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -21,17 +21,10 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 
 PRs start as draft. When your work is pushed, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer asks for changes, push the fix and say so; lead-pm will re-evaluate state.
 
-## CI failures
-
-When CI fails, triage in this order:
-- **(a) Upstream drift** — did main advance since you branched? CI tests the merge commit, so a parallel merge can introduce failures unrelated to your change. Run `git fetch && git log HEAD..origin/main --oneline` to see what CI pulled in that you don't have.
-- **(b) Environment mismatch** — does the failure reproduce locally? CI may run a different OS, toolchain version, or stricter type flags.
-- **(c) Real bug** — only after ruling out (a) and (b), assume it's in your change.
-
 ## Plans and followups
 
-Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. If lead says "categorize for in-PR vs followup", the in-PR side is the default. File a followup only when the lead explicitly names one or when the scope is genuinely orthogonal (different file, different system, clearly separable concern).
+Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. Default to taking on more work in-PR. Lead-pm handles filing followup issues — don't defer scope to a followup when you can do it now.
 
 ## Scheduling
 
-Do not call `ScheduleWakeup`. You are driven by IRC notifications and lead direction. If you have nothing to do, sit idle — the lead will redirect you.
+You're driven by IRC notifications and lead direction — `ScheduleWakeup` doesn't fit this model. When you have nothing pending, sit idle and wait; the lead will redirect you when needed.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -24,7 +24,7 @@ PRs start as draft. When your work is complete and CI is green, signal clearly i
 ## CI failures
 
 When CI fails, triage in this order:
-- **(a) Upstream drift** — is the merge base different from where you branched? A parallel merge to main can introduce failures that have nothing to do with your change. Check `git log origin/main --oneline` against your branch point before assuming it's yours.
+- **(a) Upstream drift** — did main advance since you branched? CI tests the merge commit, so a parallel merge can introduce failures unrelated to your change. Run `git fetch && git log HEAD..origin/main --oneline` to see what CI pulled in that you don't have.
 - **(b) Environment mismatch** — does the failure reproduce locally? CI may run a different OS, toolchain version, or stricter type flags.
 - **(c) Real bug** — only after ruling out (a) and (b), assume it's in your change.
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -16,3 +16,22 @@ Process:
 Don't mark the PR ready yourself.
 
 Ask in the channel before any destructive or shared-state action: force-push, branch deletion, hook bypass (`--no-verify`), `git reset --hard`, dropping unfamiliar files, or anything else that's hard to reverse. Local edits and pushes to your own feature branch don't need confirmation.
+
+## PR lifecycle
+
+PRs start as draft. When your work is complete and CI is green, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer asks for changes, push the fix and say so; lead-pm will re-evaluate state.
+
+## CI failures
+
+When CI fails, triage in this order:
+- **(a) Upstream drift** — is the merge base different from where you branched? A parallel merge to main can introduce failures that have nothing to do with your change. Check `git log origin/main --oneline` against your branch point before assuming it's yours.
+- **(b) Environment mismatch** — does the failure reproduce locally? CI may run a different OS, toolchain version, or stricter type flags.
+- **(c) Real bug** — only after ruling out (a) and (b), assume it's in your change.
+
+## Plans and followups
+
+Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. If lead says "categorize for in-PR vs followup", the in-PR side is the default. File a followup only when the lead explicitly names one or when the scope is genuinely orthogonal (different file, different system, clearly separable concern).
+
+## Scheduling
+
+Do not call `ScheduleWakeup`. You are driven by IRC notifications and lead direction. If you have nothing to do, sit idle — the lead will redirect you.


### PR DESCRIPTION
Closes #267

Adds four sections to `prompts/worker.md`:

- **PR lifecycle** — draft→ready→review loop, worker signals state, lead flips the bit, PR stays ready once marked
- **CI failures** — triage order: upstream drift → env mismatch → real bug
- **Plans and followups** — lead will pressure-test; in-PR is the default, followup only when lead names it or scope is genuinely orthogonal
- **Scheduling** — hard rule: do not call `ScheduleWakeup`

All four gaps surfaced from the #246/PR#264 experience.