### PR TITLE
weechat notifier: drop per-notification debug chatter

### DIFF
--- a/extras/weechat/notification_center.py
+++ b/extras/weechat/notification_center.py
@@ -97,8 +97,6 @@ def _post(title, body, group, sound, activate, debug_on):
 	cmd = [TERMINAL_NOTIFIER, '-title', title, '-group', group, '-appIcon', WEECHAT_ICON, '-activate', activate]
 	if sound:
 		cmd += ['-sound', sound]
-	if debug_on:
-		weechat.prnt('', '[notif] cmd=%r body=%r' % (cmd, body))
 	try:
 		proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5, input=body)
 		if debug_on and proc.returncode != 0:


### PR DESCRIPTION
Closes #268

Drop the `[notif] cmd=%r body=%r` line that fired on every notification (even in debug mode — real chatter). Keep:
- `rc=%d stdout=%r stderr=%r` gated behind `debug_on`, fires only on command failure
- `subprocess raised: %r` unconditional, so exceptions surface when notifications silently break

With `debug=off`: zero output for all paths (healthy or not, short of subprocess exceptions).