### PR TITLE
prompts: batch-fixes, timeless commits, reviewer self-exit

### DIFF
--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -80,7 +80,7 @@ To work on an issue:
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
 6. Once the agent posts a draft PR, check the PR body starts with `Closes #N` (or Fixes/Resolves) so GitHub auto-links the issue — without it the dispatcher can't route per-PR events. Edit the body yourself if needed (`gh pr edit N --body "..."`). Then ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--cwd <worker's worktree>` (so the reviewer's reads are in-cwd, otherwise it floods you with permission prompts) and `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url> $2'`. Default to Opus for review regardless of worker model — opus consistently surfaces a class of findings (dead paths, duplicated invariants, misleading comments) that sonnet misses, and review cost is small relative to the cost of a stale comment shipping. Drop to Sonnet only for trivially-sized PRs (e.g. doc/prompt tweaks well under 100 lines).
-7. Terminate the reviewer once it is done
+7. The reviewer shuts itself down after posting its summary — no action needed.
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add `$3` as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
    - `gh pr edit N --repo OWNER/REPO --add-reviewer $3`

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -27,7 +27,7 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 6. Do NOT make edits — review only.
 
-7. Once posted, report 'review complete' in #$0-issue-$2 with a one-line headline (e.g. "12 findings, 0 blocker, fit-check found a duplicated invariant between X and Y"). Your session is done at that point — the lead-pm will shut you down. Don't poll, don't follow up, don't comment on fixups.
+7. Once posted, report 'review complete' in #$0-issue-$2 with a one-line headline (e.g. "12 findings, 0 blocker, fit-check found a duplicated invariant between X and Y"). Then shut yourself down: `roost shutdown $0-reviewer-$1`. Don't poll, don't follow up, don't comment on fixups.
 
 ## What NOT to flag
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -27,7 +27,7 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 6. Do NOT make edits — review only.
 
-7. Once posted, report 'review complete' in #$0-issue-$2 with a one-line headline (e.g. "12 findings, 0 blocker, fit-check found a duplicated invariant between X and Y") and stop.
+7. Once posted, report 'review complete' in #$0-issue-$2 with a one-line headline (e.g. "12 findings, 0 blocker, fit-check found a duplicated invariant between X and Y"). Your session is done at that point — the lead-pm will shut you down. Don't poll, don't follow up, don't comment on fixups.
 
 ## What NOT to flag
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -19,7 +19,11 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 
 ## PR lifecycle
 
-PRs start as draft. When your work is pushed, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer asks for changes, push the fix and say so; lead-pm will re-evaluate state.
+PRs start as draft. When your work is pushed, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer or human leaves multiple changes-requested items, batch them all into one push before signaling — don't ping the lead after each individual fix.
+
+## Commits
+
+Write logical, timeless commit messages. Describe what the commit does in the abstract, not its position in a review cycle. "fix: drop sender-equality guard from chathistory parser" is timeless; "address review feedback" or "fix nit" is not — that framing rots the moment the PR merges. When you batch fixes for a reviewer round, prefer one logical commit if they share a theme, or split them if they don't.
 
 ## Plans and followups
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -23,7 +23,7 @@ PRs start as draft. When your work is pushed, signal clearly in the channel ("pu
 
 ## Commits
 
-Write logical, timeless commit messages. Describe what the commit does in the abstract, not its position in a review cycle. "fix: drop sender-equality guard from chathistory parser" is timeless; "address review feedback" or "fix nit" is not — that framing rots the moment the PR merges. When you batch fixes for a reviewer round, prefer one logical commit if they share a theme, or split them if they don't.
+Write logical, timeless commit messages. Describe what the commit does in the abstract, not its position in a review cycle. A commit message that names the change ("tighten X validation", "extract Y helper") will still make sense a year from now; "address review feedback" or "fix nit" stops meaning anything the moment the PR merges. When you batch fixes for a reviewer round, prefer one logical commit if they share a theme, or split them if they don't.
 
 ## Plans and followups
 


### PR DESCRIPTION
Three prompt tweaks captured from the 1.0 final-wave session.

**worker PR lifecycle:** when a reviewer or human leaves multiple changes-requested items, batch them into one push before signaling — don't ping the lead after each fix. Surfaced when worker-267 pushed 1 of 4 alex-requested items and waited for a re-request before pushing the rest.

**worker commits:** write logical, timeless commit messages. Describe what the commit does in the abstract, not its position in a review cycle. \`"fix: drop sender-equality guard from chathistory parser"\` is timeless; \`"address review feedback"\` rots the moment the PR merges.

**reviewer step 7:** explicit that the reviewer's session ends at the channel report. Don't poll, don't follow up, don't comment on fixups. Lead-pm shuts the session down.

## Test plan

- [x] No code paths touched; prompt-only edits
- [ ] Manual: next reviewer/worker spawned with these prompts follows the new guidance