### PR TITLE
maint: bump package.json to 0.4.0 ahead of v0.4.0 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump ahead of cutting v0.4.0.

## Changes since v0.3.1
- #258 reliable watcher/dispatcher startup (shipped in 0.3.1; included here for context)
- #246 test-suite fragility hardening: typed `WireMessageMeta` discriminated union, CI workflow timeout, shellcheck wired into `bun run lint` and CI, `messagePredicate`/`assertChannelMessage`/`eventPredicate`/`expectEvent` helpers
- #262 chathistory backfill no longer filters own-nick messages
- #260 `bin/start-dispatcher` extracted from watcher boot logic
- #267 worker prompt: workflow primer, CI triage, batch fixes, timeless commits, suppress proactive ScheduleWakeup
- #268 weechat notifier debug chatter removed
- #270 worker prompt followups (cut CI-green qualifier, bold "wait", outdated `--daemon` note dropped)
- #272 reviewer self-shutdown, generic commit-message example
- #273 `roost init --force-prompts` works against existing config, `--dry-run` reflects flags

## Test plan
- [x] CI green on bump branch
- [ ] After merge: tag `v0.4.0` and push to fire `release.yml`
- [ ] Confirm formula bump lands in `AvesAlight/homebrew-tap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)