### PR TITLE
maint: reconcile permission-prompt / pretooluse-prompt asymmetries (#278)

### DIFF
--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -15,6 +15,7 @@ const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
 // 570s default — just under Claude Code's 600s hook timeout. Override via
 // ROOST_PERM_TIMEOUT_SECS for tests that need to exercise the timeout path
 // without waiting nine minutes.
+// keep in sync with src/pretooluse-prompt.ts (SOCKET_SAFETY_TIMEOUT)
 const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOST_PERM_TIMEOUT_SECS'] ?? '570')))
 
 const PASSTHROUGH_PREFIXES = ['mcp__roost-irc__', 'mcp__plugin_roost_roost-irc__']

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -12,7 +12,10 @@ const PERM_HOST   = process.env['ROOST_PERM_HOST'] ?? '127.0.0.1'
 const PERM_PORT   = Number(process.env['ROOST_PERM_PORT'] ?? '6667')
 const DATA_DIR    = process.env['ROOST_DATA_DIR'] ?? ''
 const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
-const SOCKET_SAFETY_TIMEOUT = 570 // just under Claude Code's 600s hook default
+// 570s default — just under Claude Code's 600s hook timeout. Override via
+// ROOST_PERM_TIMEOUT_SECS for tests that need to exercise the timeout path
+// without waiting nine minutes.
+const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOST_PERM_TIMEOUT_SECS'] ?? '570')))
 
 const PASSTHROUGH_PREFIXES = ['mcp__roost-irc__', 'mcp__plugin_roost_roost-irc__']
 
@@ -241,8 +244,8 @@ if (import.meta.main) {
   const parts = reply!.trim().split(/\s+/, 2)
   const norm = (parts[0] ?? '').toLowerCase()
   const msg  = parts[1] ?? ''
-  if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) emit('allow', msg)
-  if (['n', 'no', 'deny', 'block'].includes(norm)) emit('deny', msg)
+  if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) emit('allow', msg || 'operator approved via IRC')
+  if (['n', 'no', 'deny', 'block'].includes(norm)) emit('deny', msg || 'operator denied via IRC')
   await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(reply)}`)
   emit('ask', `unrecognized reply ${JSON.stringify(reply)}; falling back to terminal`)
 }

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -32,6 +32,7 @@ const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
 // 570s default — just under Claude Code's 600s hook timeout. Override via
 // ROOST_PERM_TIMEOUT_SECS for tests that need to exercise the timeout path
 // without waiting nine minutes.
+// keep in sync with src/permission-prompt.ts (SOCKET_SAFETY_TIMEOUT)
 const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOST_PERM_TIMEOUT_SECS'] ?? '570')))
 
 // bashMissKind labels lifted from the 2.1.139 binary (issue #276). These are

--- a/test/irc-permission-prompt.test.ts
+++ b/test/irc-permission-prompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'bun:test'
 import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { join } from 'node:path'
 
 const HOOK = join(import.meta.dirname, '../src/permission-prompt.ts')
@@ -45,14 +47,43 @@ function captureIRC(): Promise<{ port: number; lines: () => Promise<string[]> }>
   })
 }
 
-async function runHook(env: Record<string, string>): Promise<void> {
+async function runHook(env: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
   const proc = Bun.spawn(['bun', HOOK], {
     env: { PATH: process.env.PATH ?? '/usr/bin:/bin', ...env },
     stdin: new TextEncoder().encode(PAYLOAD),
     stdout: 'pipe',
     stderr: 'pipe',
   })
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
   await proc.exited
+  return { stdout, stderr }
+}
+
+function makeSock(): string {
+  return path.join(os.tmpdir(), `irc-perm-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
+}
+
+function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
+  let onReady!: () => void
+  const ready = new Promise<void>(r => { onReady = r })
+  let onDone!: () => void
+  const done = new Promise<void>(r => { onDone = r })
+  const server = net.createServer((sock) => {
+    let buf = ''
+    sock.on('data', (d) => {
+      buf += d.toString('utf8')
+      if (!buf.includes('\n')) return
+      sock.write(JSON.stringify(reply) + '\n')
+      sock.end()
+      server.close()
+      onDone()
+    })
+  })
+  server.listen(sockPath, () => { onReady() })
+  return { ready, done }
 }
 
 describe('irc-permission-prompt fallback DM', () => {
@@ -72,6 +103,29 @@ describe('irc-permission-prompt fallback DM', () => {
     expect(privmsgs.length).toBeGreaterThan(0)
     expect(privmsgs.some(m => m.includes('fallback'))).toBe(true)
     expect(privmsgs.some(m => m.includes('Bash'))).toBe(true)
+  }, 15_000)
+
+  it('sends fallback DM when operator reply is unrecognized', async () => {
+    const sockPath = makeSock()
+    const stub = startPermbotStub(sockPath, { reply: 'maybe' })
+    await stub.ready
+
+    const { port, lines } = await captureIRC()
+    const [received] = await Promise.all([
+      lines(),
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_TARGET: 'operator',
+        ROOST_PERM_HOST: '127.0.0.1',
+        ROOST_PERM_PORT: String(port),
+        ROOST_PERM_SOCK: sockPath,
+      }),
+      stub.done,
+    ])
+
+    const privmsgs = received.filter(l => l.startsWith('PRIVMSG operator :'))
+    expect(privmsgs.length).toBeGreaterThan(0)
+    expect(privmsgs.some(m => m.includes('unrecognized'))).toBe(true)
   }, 15_000)
 
   it('skips DM when ROOST_PERM_TARGET not set', async () => {

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -210,18 +210,44 @@ const PAYLOAD = JSON.stringify({
   transcript_path: '',
 })
 
-async function runHook(env: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
+async function runHook(env: Record<string, string>): Promise<{ stdout: string; stderr: string; exit: number }> {
   const proc = Bun.spawn(['bun', HOOK], {
     env: { PATH: process.env.PATH ?? '/usr/bin:/bin', ...env },
     stdin: new TextEncoder().encode(PAYLOAD),
     stdout: 'pipe',
     stderr: 'pipe',
   })
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
   await proc.exited
-  return {
-    stdout: await new Response(proc.stdout).text(),
-    stderr: await new Response(proc.stderr).text(),
-  }
+  return { stdout, stderr, exit: proc.exitCode ?? 0 }
+}
+
+/** Minimal permbot socket stub: reads one JSON line, responds immediately. */
+function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
+  let onReady!: () => void
+  const ready = new Promise<void>(r => { onReady = r })
+  let onDone!: () => void
+  const done = new Promise<void>(r => { onDone = r })
+  const server = net.createServer((sock) => {
+    let buf = ''
+    sock.on('data', (d) => {
+      buf += d.toString('utf8')
+      if (!buf.includes('\n')) return
+      sock.write(JSON.stringify(reply) + '\n')
+      sock.end()
+      server.close()
+      onDone()
+    })
+  })
+  server.listen(sockPath, () => { onReady() })
+  return { ready, done }
+}
+
+function makeSock(): string {
+  return path.join(os.tmpdir(), `perm-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
 }
 
 describe('permission-prompt hook', () => {
@@ -263,6 +289,85 @@ describe('permission-prompt hook', () => {
     const { stderr } = await runHook({ ROOST_IRC_NICK: 'worker-test' })
     expect(stderr).toContain('deferring to terminal')
   })
+
+  it('allow carries default reason when operator replies with bare y', async () => {
+    const sockPath = makeSock()
+    const stub = startPermbotStub(sockPath, { reply: 'y' })
+    await stub.ready
+
+    const [{ stdout }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+      }),
+      stub.done,
+    ])
+
+    const out = JSON.parse(stdout.trim()) as { hookSpecificOutput: { decision: { behavior: string; message?: string } } }
+    expect(out.hookSpecificOutput.decision.behavior).toBe('allow')
+    expect(out.hookSpecificOutput.decision.message).toBe('operator approved via IRC')
+  }, 10_000)
+
+  it('deny carries default reason when operator replies with bare n', async () => {
+    const sockPath = makeSock()
+    const stub = startPermbotStub(sockPath, { reply: 'n' })
+    await stub.ready
+
+    const [{ stdout }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+      }),
+      stub.done,
+    ])
+
+    const out = JSON.parse(stdout.trim()) as { hookSpecificOutput: { decision: { behavior: string; message?: string } } }
+    expect(out.hookSpecificOutput.decision.behavior).toBe('deny')
+    expect(out.hookSpecificOutput.decision.message).toBe('operator denied via IRC')
+  }, 10_000)
+
+  it('emits ask when operator reply is unrecognized', async () => {
+    const sockPath = makeSock()
+    const stub = startPermbotStub(sockPath, { reply: 'maybe later' })
+    await stub.ready
+
+    const [{ stderr }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+        // No PERM_HOST/PORT → fallback DM fails silently; contract under test is ask emission.
+      }),
+      stub.done,
+    ])
+
+    expect(stderr).toContain('unrecognized')
+    expect(stderr).toContain('deferring to terminal')
+  }, 10_000)
+
+  it('emits ask when permbot times out', async () => {
+    const sockPath = makeSock()
+    // Stub accepts connection but never responds — exercises the timeout path.
+    const server = net.createServer(() => {})
+    await new Promise<void>(r => server.listen(sockPath, r))
+
+    try {
+      const { stderr } = await runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+        ROOST_PERM_TIMEOUT_SECS: '1',
+        // No PERM_HOST/PORT → fallback DM fails silently.
+      })
+      expect(stderr).toContain('timed out')
+      expect(stderr).toContain('deferring to terminal')
+    } finally {
+      server.close()
+      try { fs.unlinkSync(sockPath) } catch { /* ignore */ }
+    }
+  }, 15_000)
 
   it('owner-gate short-circuits before any socket touch when nested (#188)', async () => {
     // Owner.session is held by sess-A; this hook run carries CLAUDE_CODE_SESSION_ID=sess-B,

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -4,6 +4,7 @@ import * as net from 'node:net'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { summarize, extractIntent, resolveTranscriptPath } from '../src/permission-prompt.js'
+import { suppressLateRejection } from './helpers/tool.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/permission-prompt.ts')
 
@@ -333,7 +334,7 @@ describe('permission-prompt hook', () => {
     const stub = startPermbotStub(sockPath, { reply: 'maybe later' })
     await stub.ready
 
-    const [{ stderr }] = await Promise.all([
+    const [{ stderr, exit }] = await Promise.all([
       runHook({
         ROOST_IRC_NICK: 'worker-test',
         ROOST_PERM_SOCK: sockPath,
@@ -345,16 +346,17 @@ describe('permission-prompt hook', () => {
 
     expect(stderr).toContain('unrecognized')
     expect(stderr).toContain('deferring to terminal')
+    expect(exit).toBe(0)
   }, 10_000)
 
   it('emits ask when permbot times out', async () => {
     const sockPath = makeSock()
     // Stub accepts connection but never responds — exercises the timeout path.
     const server = net.createServer(() => {})
-    await new Promise<void>(r => server.listen(sockPath, r))
+    await suppressLateRejection(new Promise<void>(r => server.listen(sockPath, r)))
 
     try {
-      const { stderr } = await runHook({
+      const { stderr, exit } = await runHook({
         ROOST_IRC_NICK: 'worker-test',
         ROOST_PERM_SOCK: sockPath,
         ROOST_PERM_TARGET: 'operator',
@@ -363,6 +365,7 @@ describe('permission-prompt hook', () => {
       })
       expect(stderr).toContain('timed out')
       expect(stderr).toContain('deferring to terminal')
+      expect(exit).toBe(0)
     } finally {
       server.close()
       try { fs.unlinkSync(sockPath) } catch { /* ignore */ }


### PR DESCRIPTION
Closes #278

Reconciles the two asymmetries called out in the issue and fills the test gap.

**src/permission-prompt.ts**
- `ROOST_PERM_TIMEOUT_SECS` override: replaces hard-coded 570 with the same clamped env-read as `pretooluse-prompt.ts` (copy-pasted character-for-character so grep verifies parity)
- Bare y/n default reason: `emit('allow', msg || 'operator approved via IRC')` / `emit('deny', msg || 'operator denied via IRC')` — matches pretooluse behavior and the spec example in the issue

**test/permission-prompt.test.ts**
- Adds `startPermbotStub` / `makeSock` helpers (mirrored from pretooluse test)
- Updates `runHook` to expose exit code
- Four new subprocess tests: allow default reason, deny default reason, unrecognized reply → ask, timeout (ROOST_PERM_TIMEOUT_SECS=1) → ask

**test/irc-permission-prompt.test.ts**
- Updates `runHook` to capture stdout/stderr
- Adds: unrecognized reply → fallback DM is sent (permbot stub replies `maybe`, IRC stub captures the PRIVMSG)

352/352 tests pass.