### PR TITLE
resolve spawn hook paths via shim at exec time

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -423,6 +423,19 @@ require_ircd() {
   fi
 }
 
+# Write a thin resolver shim to DIR/NAME. The shim re-resolves the plugin
+# root via `roost root` at exec time so Cellar-dir rotation after a
+# `brew upgrade roost` doesn't break wired hook commands.
+_write_shim() {
+  local name="$1"
+  local dest="$2/${name}"
+  # intentionally single-quoted: $() and $@ are shell syntax written to the
+  # shim file, not expanded here.
+  # shellcheck disable=SC2016
+  printf '#!/bin/sh\nexec "$(roost root)/bin/%s" "$@"\n' "${name}" > "${dest}"
+  chmod 755 "${dest}"
+}
+
 # All per-session files live under a mktemp-generated directory created at
 # spawn time (ROOST_DATA_DIR). The dir is stored in the tmux session env so
 # shutdown can find it:
@@ -569,17 +582,26 @@ cmd_spawn() {
   if [ "${perm_irc}" -eq 1 ] || [ "${ask_routing}" -eq 1 ]; then
     perm_sock="${ROOST_DATA_DIR}/permbot.sock"
   fi
+  # Write resolver shims to ROOST_DATA_DIR. Shims re-resolve the plugin root
+  # via `roost root` at exec time so Cellar-dir rotation (brew upgrade roost)
+  # doesn't invalidate hook paths baked at spawn time.
+  _write_shim roost-compact-hook "${ROOST_DATA_DIR}"
+  _write_shim roost-post-compact-hook "${ROOST_DATA_DIR}"
+  _write_shim roost-session-start-hook "${ROOST_DATA_DIR}"
   if [ "${perm_irc}" -eq 1 ]; then
-    perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-permission-prompt\"}]}]"
+    _write_shim irc-permission-prompt "${ROOST_DATA_DIR}"
+    perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-permission-prompt\"}]}]"
   fi
   # PreToolUse may hold up to two matcher entries: Bash (--perm-irc; closes the
   # safety-analyzer bypass from #276) and AskUserQuestion (--ask-irc / --ask-target).
   local pretooluse_entries=()
   if [ "${perm_irc}" -eq 1 ]; then
-    pretooluse_entries+=("{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-pretooluse-prompt\"}]}")
+    _write_shim irc-pretooluse-prompt "${ROOST_DATA_DIR}"
+    pretooluse_entries+=("{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-pretooluse-prompt\"}]}")
   fi
   if [ "${ask_routing}" -eq 1 ]; then
-    pretooluse_entries+=("{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/irc-ask-question\"}]}")
+    _write_shim irc-ask-question "${ROOST_DATA_DIR}"
+    pretooluse_entries+=("{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-ask-question\"}]}")
   fi
   if [ "${#pretooluse_entries[@]}" -gt 0 ]; then
     local _ptu_joined=""
@@ -591,7 +613,7 @@ cmd_spawn() {
     pretooluse_hook_json=",\"PreToolUse\":[${_ptu_joined}]"
   fi
   local ROOST_SETTINGS="${ROOST_DATA_DIR}/roost-settings.json"
-  printf '%s\n' "{\"hooks\":{\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-compact-hook\"}]}],\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DIR}/bin/roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}}" > "${ROOST_SETTINGS}"
+  printf '%s\n' "{\"hooks\":{\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-compact-hook\"}]}],\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}}" > "${ROOST_SETTINGS}"
 
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode}, cwd: ${cwd})"
   [ -n "${extra_str}" ] && echo "  extra claude args:${extra_str}"

--- a/bin/roost
+++ b/bin/roost
@@ -571,7 +571,7 @@ cmd_spawn() {
   # are always present; PermissionRequest and PreToolUse:Bash are added when
   # --perm-irc is passed; PreToolUse:AskUserQuestion is added when --ask-irc
   # or --ask-target is set. Cleaned up implicitly when data_dir is rm -rf'd
-  # on shutdown. ROOST_DIR is cd-derived (no spaces/backslashes).
+  # on shutdown. ROOST_DATA_DIR is mktemp-derived (no spaces/backslashes).
   local perm_sock=""
   local perm_hook_json=""
   local pretooluse_hook_json=""
@@ -810,6 +810,7 @@ cmd_send() {
   tmux delete-buffer -b "${buf}" 2>/dev/null || true
 }
 
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 if [ "$#" -eq 0 ]; then
   usage
   exit 0
@@ -846,3 +847,4 @@ case "${cmd}" in
   -h|--help|help) usage ;;
   *) echo "error: unknown command: ${cmd}" >&2; usage; exit 1 ;;
 esac
+fi

--- a/test/spawn-shim.test.ts
+++ b/test/spawn-shim.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const HOOK_NAME = 'roost-compact-hook'
+
+describe('spawn shim', () => {
+  let tmpDir: string
+  let shimPath: string
+  let stubsDir: string
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'roost-shim-test-'))
+    stubsDir = join(tmpDir, 'stubs')
+    mkdirSync(stubsDir, { recursive: true })
+
+    // Write a shim with the same content _write_shim produces in bin/roost
+    shimPath = join(tmpDir, HOOK_NAME)
+    writeFileSync(shimPath, `#!/bin/sh\nexec "$(roost root)/bin/${HOOK_NAME}" "$@"\n`)
+    chmodSync(shimPath, 0o755)
+  })
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  async function runShimWithRoot(root: string): Promise<string> {
+    mkdirSync(join(root, 'bin'), { recursive: true })
+    // Stub hook echoes its root path so we can verify which root was reached
+    writeFileSync(join(root, 'bin', HOOK_NAME), `#!/bin/sh\necho "${root}"\n`)
+    chmodSync(join(root, 'bin', HOOK_NAME), 0o755)
+    // Stub `roost`: `roost root` returns the given root path
+    writeFileSync(join(stubsDir, 'roost'), `#!/bin/sh\necho "${root}"\n`)
+    chmodSync(join(stubsDir, 'roost'), 0o755)
+
+    const proc = Bun.spawn([shimPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, PATH: `${stubsDir}:${process.env.PATH ?? ''}` },
+    })
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ])
+    expect(exitCode).toBe(0)
+    return stdout.trim()
+  }
+
+  it('re-resolves roost root at exec time, not at shim-write time', async () => {
+    const rootA = join(tmpDir, 'root-a')
+    const rootB = join(tmpDir, 'root-b')
+
+    // Same shim file; swapping what `roost root` returns routes to a different hook binary
+    expect(await runShimWithRoot(rootA)).toBe(rootA)
+    expect(await runShimWithRoot(rootB)).toBe(rootB)
+  })
+})

--- a/test/spawn-shim.test.ts
+++ b/test/spawn-shim.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
-import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, chmodSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
+const BIN_DIR = join(import.meta.dirname, '../bin')
 const HOOK_NAME = 'roost-compact-hook'
 
 describe('spawn shim', () => {
@@ -10,15 +11,24 @@ describe('spawn shim', () => {
   let shimPath: string
   let stubsDir: string
 
-  beforeAll(() => {
+  beforeAll(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'roost-shim-test-'))
     stubsDir = join(tmpDir, 'stubs')
     mkdirSync(stubsDir, { recursive: true })
 
-    // Write a shim with the same content _write_shim produces in bin/roost
     shimPath = join(tmpDir, HOOK_NAME)
-    writeFileSync(shimPath, `#!/bin/sh\nexec "$(roost root)/bin/${HOOK_NAME}" "$@"\n`)
-    chmodSync(shimPath, 0o755)
+
+    // Write the shim via _write_shim from bin/roost so the test stays in sync
+    // with the production format — if the template changes, this test fails.
+    const proc = Bun.spawn(
+      ['bash', '-c', `source "${join(BIN_DIR, 'roost')}" && _write_shim "${HOOK_NAME}" "${tmpDir}"`],
+      { stdout: 'pipe', stderr: 'pipe' },
+    )
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode, `_write_shim setup failed: ${stderr}`).toBe(0)
   })
 
   afterAll(() => {


### PR DESCRIPTION
Closes #275

`roost spawn` was writing `${ROOST_DIR}/bin/...` into `roost-settings.json` at spawn time. After `brew upgrade roost` rotates the Cellar dir, those paths 404 (exitCode 127) on every hook invocation.

**Fix**: `cmd_spawn` now writes a thin resolver shim for each hook into `$ROOST_DATA_DIR/`. Each shim calls `$(roost root)/bin/<name>` so the plugin root is resolved fresh on every invocation via the PATH-stable `roost` symlink in `/opt/homebrew/bin/`. The settings JSON references the shim paths instead of the baked Cellar path.

**Forward-only**: pre-bump workers retain their old baked paths and stay stranded until respawned. No self-rewire mechanism — per the issue's out-of-scope note, we accept that pre-bump sessions need a respawn after Cellar rotation.

**Cleanup**: shims live entirely inside `$ROOST_DATA_DIR/` and are removed by `roost shutdown` along with the rest of the session data.

**Test**: `test/spawn-shim.test.ts` writes a shim and swaps what `roost root` returns between two stub roots — verifies the same shim file routes to whichever root is current at exec time.