### PR TITLE
extract test/helpers/permbot-stub.ts + align stderr prefix

### DIFF
--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -26,7 +26,7 @@ function emit(decision: 'ask', reason?: string): never
 function emit(decision: 'allow' | 'deny', reason?: string): never
 function emit(decision: string, reason = ''): never {
   if (decision === 'ask') {
-    process.stderr.write(`perm-hook: deferring to terminal (${reason})\n`)
+    process.stderr.write(`perm-hook[${WORKER}]: deferring to terminal (${reason})\n`)
     process.exit(0)
   }
   const dec: { behavior: string; message?: string } = { behavior: decision }
@@ -160,7 +160,7 @@ export function resolveTranscriptPath(transcriptPath: string, agentId: string): 
 export async function askDaemon(summary: string): Promise<string | null> {
   const req: Record<string, unknown> = { summary, timeout: SOCKET_SAFETY_TIMEOUT, kind: 'permission' }
   if (PERM_TARGET) req['replyTarget'] = PERM_TARGET
-  return socketRoundtrip(SOCK_PATH, req, (msg) => { process.stderr.write(`perm-hook: ${msg}\n`) })
+  return socketRoundtrip(SOCK_PATH, req, (msg) => { process.stderr.write(`perm-hook[${WORKER}]: ${msg}\n`) })
 }
 
 // ---- Fallback DM via RoostIrcClient (transient connection) ------------------
@@ -204,7 +204,7 @@ if (import.meta.main) {
   try {
     payload = JSON.parse(await Bun.stdin.text()) as Record<string, unknown>
   } catch (e) {
-    process.stderr.write(`perm-hook: bad stdin JSON: ${e}\n`)
+    process.stderr.write(`perm-hook[${WORKER}]: bad stdin JSON: ${e}\n`)
     emit('ask', 'hook input parse error')
   }
 

--- a/test/ask-question-hook.test.ts
+++ b/test/ask-question-hook.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'bun:test'
 import * as fs from 'node:fs'
 import * as net from 'node:net'
-import * as os from 'node:os'
 import * as path from 'node:path'
 import { formatQuestionsForIRC, mapOneReply, mapReplyToAnswers } from '../src/ask-question-hook.js'
 import { suppressLateRejection } from './helpers/tool.js'
+import { startPermbotStub, makeSock } from './helpers/permbot-stub.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/ask-question-hook.ts')
 
@@ -149,32 +149,6 @@ describe('mapReplyToAnswers', () => {
 })
 
 // ---- Hook subprocess --------------------------------------------------------
-
-/** Minimal permbot socket stub: reads one JSON line, responds immediately.
- *  Returns a ready promise (server is listening) and a done promise (response sent). */
-function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
-  let onReady!: () => void
-  const ready = new Promise<void>(r => { onReady = r })
-  let onDone!: () => void
-  const done = new Promise<void>(r => { onDone = r })
-  const server = net.createServer((sock) => {
-    let buf = ''
-    sock.on('data', (d) => {
-      buf += d.toString('utf8')
-      if (!buf.includes('\n')) return
-      sock.write(JSON.stringify(reply) + '\n')
-      sock.end()
-      server.close()
-      onDone()
-    })
-  })
-  server.listen(sockPath, () => { onReady() })
-  return { ready, done }
-}
-
-function makeSock(): string {
-  return path.join(os.tmpdir(), `ask-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
-}
 
 const QUESTION_PAYLOAD = JSON.stringify({
   tool_name: 'AskUserQuestion',

--- a/test/ask-question-hook.test.ts
+++ b/test/ask-question-hook.test.ts
@@ -176,7 +176,7 @@ async function runHook(env: Record<string, string>, stdin = QUESTION_PAYLOAD): P
 
 describe('ask-question-hook subprocess', () => {
   it('resolves via permbot socket and returns allow + answers', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('ask-hook')
     const stub = startPermbotStub(sockPath, { reply: '1' })
     await stub.ready  // ensure server is listening before hook tries to connect
 
@@ -196,7 +196,7 @@ describe('ask-question-hook subprocess', () => {
   }, 10_000)
 
   it('returns deny when permbot times out', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('ask-hook')
     // Stub that accepts connections but never responds → triggers socket timeout
     const server = net.createServer(() => {})
     await suppressLateRejection(new Promise<void>(r => server.listen(sockPath, r)))
@@ -259,7 +259,7 @@ describe('ask-question-hook subprocess', () => {
   }, 5_000)
 
   it('returns deny when operator replies with chat keyword', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('ask-hook')
     const stub = startPermbotStub(sockPath, { reply: 'chat' })
     await stub.ready
 
@@ -278,7 +278,7 @@ describe('ask-question-hook subprocess', () => {
   }, 10_000)
 
   it('passes the questions array through to updatedInput', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('ask-hook')
     const stub = startPermbotStub(sockPath, { reply: 'Vue' })
     await stub.ready
 

--- a/test/helpers/permbot-stub.ts
+++ b/test/helpers/permbot-stub.ts
@@ -23,7 +23,7 @@ export function startPermbotStub(sockPath: string, reply: object): { ready: Prom
   return { ready, done }
 }
 
-export function makeSock(prefix = 'permbot-stub'): string {
+export function makeSock(prefix: string): string {
   return path.join(os.tmpdir(), `${prefix}-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
 }
 
@@ -42,7 +42,7 @@ export function captureIRC(): Promise<{ port: number; lines: () => Promise<strin
         buf += d.toString()
         const lines = buf.split('\r\n'); buf = lines.pop() ?? ''
         for (const line of lines) {
-          if (!line) continue
+          if (!line) continue  // skip blank framing lines from split('\r\n')
           if (line.startsWith('CAP LS')) {
             sock.write(':s CAP * LS :\r\n')
           } else if (line.startsWith('CAP END') && !sentWelcome) {

--- a/test/helpers/permbot-stub.ts
+++ b/test/helpers/permbot-stub.ts
@@ -1,0 +1,66 @@
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/** Minimal permbot socket stub: reads one JSON line, responds immediately. */
+export function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
+  let onReady!: () => void
+  const ready = new Promise<void>(r => { onReady = r })
+  let onDone!: () => void
+  const done = new Promise<void>(r => { onDone = r })
+  const server = net.createServer((sock) => {
+    let buf = ''
+    sock.on('data', (d) => {
+      buf += d.toString('utf8')
+      if (!buf.includes('\n')) return
+      sock.write(JSON.stringify(reply) + '\n')
+      sock.end()
+      server.close()
+      onDone()
+    })
+  })
+  server.listen(sockPath, () => { onReady() })
+  return { ready, done }
+}
+
+export function makeSock(prefix = 'permbot-stub'): string {
+  return path.join(os.tmpdir(), `${prefix}-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
+}
+
+/**
+ * Minimal IRC stub handling CAP negotiation (RoostIrcClientImpl sends CAP LS
+ * before NICK/USER). Sends 001 after CAP END, closes on QUIT.
+ */
+export function captureIRC(): Promise<{ port: number; lines: () => Promise<string[]> }> {
+  return new Promise((resolve) => {
+    const collected: string[] = []
+    let closed!: () => void
+    const done = new Promise<string[]>(res => { closed = () => res(collected) })
+    const server = net.createServer((sock) => {
+      let buf = '', nick = 'unknown', sentWelcome = false
+      sock.on('data', (d) => {
+        buf += d.toString()
+        const lines = buf.split('\r\n'); buf = lines.pop() ?? ''
+        for (const line of lines) {
+          if (!line) continue
+          if (line.startsWith('CAP LS')) {
+            sock.write(':s CAP * LS :\r\n')
+          } else if (line.startsWith('CAP END') && !sentWelcome) {
+            sentWelcome = true
+            sock.write(`:s 001 ${nick} :Welcome\r\n`)
+          } else if (line.startsWith('NICK ')) {
+            nick = line.slice(5).trim()
+          } else if (line.startsWith('QUIT')) {
+            sock.end()
+          }
+          collected.push(line)
+        }
+      })
+      sock.on('close', () => { server.close(); closed() })
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as net.AddressInfo).port
+      resolve({ port, lines: () => done })
+    })
+  })
+}

--- a/test/irc-permission-prompt.test.ts
+++ b/test/irc-permission-prompt.test.ts
@@ -41,7 +41,7 @@ describe('irc-permission-prompt fallback DM', () => {
   }, 15_000)
 
   it('sends fallback DM when operator reply is unrecognized', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('irc-perm-hook')
     const stub = startPermbotStub(sockPath, { reply: 'maybe' })
     await stub.ready
 

--- a/test/irc-permission-prompt.test.ts
+++ b/test/irc-permission-prompt.test.ts
@@ -1,51 +1,10 @@
 import { describe, it, expect } from 'bun:test'
 import * as net from 'node:net'
-import * as os from 'node:os'
-import * as path from 'node:path'
 import { join } from 'node:path'
+import { startPermbotStub, makeSock, captureIRC } from './helpers/permbot-stub.js'
 
 const HOOK = join(import.meta.dirname, '../src/permission-prompt.ts')
 const PAYLOAD = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm /tmp/x', description: 'test' }, transcript_path: '' })
-
-/**
- * Spin up a minimal IRC stub that handles CAP negotiation (RoostIrcClientImpl
- * sends CAP LS before NICK/USER), sends 001 after CAP END, and closes on QUIT.
- */
-function captureIRC(): Promise<{ port: number; lines: () => Promise<string[]> }> {
-  return new Promise((resolve) => {
-    const collected: string[] = []
-    let closed!: () => void
-    const done = new Promise<string[]>((res) => { closed = () => res(collected) })
-
-    const server = net.createServer((sock) => {
-      let buf = '', nick = 'unknown', sentWelcome = false
-      sock.on('data', (d) => {
-        buf += d.toString()
-        const lines = buf.split('\r\n'); buf = lines.pop() ?? ''
-        for (const line of lines) {
-          if (!line) continue
-          if (line.startsWith('CAP LS')) {
-            sock.write(':s CAP * LS :\r\n')
-          } else if (line.startsWith('CAP END') && !sentWelcome) {
-            sentWelcome = true
-            sock.write(`:s 001 ${nick} :Welcome\r\n`)
-          } else if (line.startsWith('NICK ')) {
-            nick = line.slice(5).trim()
-          } else if (line.startsWith('QUIT')) {
-            sock.end()
-          }
-          collected.push(line)
-        }
-      })
-      sock.on('close', () => { server.close(); closed() })
-    })
-
-    server.listen(0, '127.0.0.1', () => {
-      const port = (server.address() as net.AddressInfo).port
-      resolve({ port, lines: () => done })
-    })
-  })
-}
 
 async function runHook(env: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
   const proc = Bun.spawn(['bun', HOOK], {
@@ -60,30 +19,6 @@ async function runHook(env: Record<string, string>): Promise<{ stdout: string; s
   ])
   await proc.exited
   return { stdout, stderr }
-}
-
-function makeSock(): string {
-  return path.join(os.tmpdir(), `irc-perm-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
-}
-
-function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
-  let onReady!: () => void
-  const ready = new Promise<void>(r => { onReady = r })
-  let onDone!: () => void
-  const done = new Promise<void>(r => { onDone = r })
-  const server = net.createServer((sock) => {
-    let buf = ''
-    sock.on('data', (d) => {
-      buf += d.toString('utf8')
-      if (!buf.includes('\n')) return
-      sock.write(JSON.stringify(reply) + '\n')
-      sock.end()
-      server.close()
-      onDone()
-    })
-  })
-  server.listen(sockPath, () => { onReady() })
-  return { ready, done }
 }
 
 describe('irc-permission-prompt fallback DM', () => {

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -228,7 +228,7 @@ describe('permission-prompt hook', () => {
   })
 
   it('allow carries default reason when operator replies with bare y', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('perm-hook')
     const stub = startPermbotStub(sockPath, { reply: 'y' })
     await stub.ready
 
@@ -247,7 +247,7 @@ describe('permission-prompt hook', () => {
   }, 10_000)
 
   it('deny carries default reason when operator replies with bare n', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('perm-hook')
     const stub = startPermbotStub(sockPath, { reply: 'n' })
     await stub.ready
 
@@ -266,7 +266,7 @@ describe('permission-prompt hook', () => {
   }, 10_000)
 
   it('emits ask when operator reply is unrecognized', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('perm-hook')
     const stub = startPermbotStub(sockPath, { reply: 'maybe later' })
     await stub.ready
 
@@ -286,7 +286,7 @@ describe('permission-prompt hook', () => {
   }, 10_000)
 
   it('emits ask when permbot times out', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('perm-hook')
     // Stub accepts connection but never responds — exercises the timeout path.
     const server = net.createServer(() => {})
     await suppressLateRejection(new Promise<void>(r => server.listen(sockPath, r)))

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { summarize, extractIntent, resolveTranscriptPath } from '../src/permission-prompt.js'
 import { suppressLateRejection } from './helpers/tool.js'
+import { startPermbotStub, makeSock, captureIRC } from './helpers/permbot-stub.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/permission-prompt.ts')
 
@@ -165,46 +166,6 @@ describe('resolveTranscriptPath', () => {
 
 // ---- hook integration (subprocess) -----------------------------------------
 
-/**
- * Spin up a minimal IRC stub that handles CAP negotiation (needed by
- * RoostIrcClientImpl which sends CAP LS before NICK/USER). Sends 001 after
- * CAP END is received, collects all lines until the connection closes.
- */
-function captureIRC(): Promise<{ port: number; lines: () => Promise<string[]> }> {
-  return new Promise((resolve) => {
-    const collected: string[] = []
-    let closed!: () => void
-    const done = new Promise<string[]>(res => { closed = () => res(collected) })
-    const server = net.createServer((sock) => {
-      let buf = ''
-      let nick = 'unknown'
-      let sentWelcome = false
-      sock.on('data', (d) => {
-        buf += d.toString()
-        for (const line of buf.split('\r\n').slice(0, -1)) {
-          if (line.startsWith('CAP LS')) {
-            sock.write(':s CAP * LS :\r\n')  // advertise no caps
-          } else if (line.startsWith('CAP END') && !sentWelcome) {
-            sentWelcome = true
-            sock.write(`:s 001 ${nick} :Welcome\r\n`)
-          } else if (line.startsWith('NICK ')) {
-            nick = line.slice(5).trim()
-          } else if (line.startsWith('QUIT')) {
-            sock.end()
-          }
-          collected.push(line)
-        }
-        buf = buf.slice(buf.lastIndexOf('\r\n') + 2)
-      })
-      sock.on('close', () => { server.close(); closed() })
-    })
-    server.listen(0, '127.0.0.1', () => {
-      const port = (server.address() as net.AddressInfo).port
-      resolve({ port, lines: () => done })
-    })
-  })
-}
-
 const PAYLOAD = JSON.stringify({
   tool_name: 'Bash',
   tool_input: { command: 'rm /tmp/x', description: 'delete temp file' },
@@ -224,31 +185,6 @@ async function runHook(env: Record<string, string>): Promise<{ stdout: string; s
   ])
   await proc.exited
   return { stdout, stderr, exit: proc.exitCode ?? 0 }
-}
-
-/** Minimal permbot socket stub: reads one JSON line, responds immediately. */
-function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
-  let onReady!: () => void
-  const ready = new Promise<void>(r => { onReady = r })
-  let onDone!: () => void
-  const done = new Promise<void>(r => { onDone = r })
-  const server = net.createServer((sock) => {
-    let buf = ''
-    sock.on('data', (d) => {
-      buf += d.toString('utf8')
-      if (!buf.includes('\n')) return
-      sock.write(JSON.stringify(reply) + '\n')
-      sock.end()
-      server.close()
-      onDone()
-    })
-  })
-  server.listen(sockPath, () => { onReady() })
-  return { ready, done }
-}
-
-function makeSock(): string {
-  return path.join(os.tmpdir(), `perm-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
 }
 
 describe('permission-prompt hook', () => {

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { classifyBash } from '../src/pretooluse-prompt.js'
 import { suppressLateRejection } from './helpers/tool.js'
+import { startPermbotStub, makeSock } from './helpers/permbot-stub.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/pretooluse-prompt.ts')
 
@@ -144,32 +145,6 @@ describe('classifyBash', () => {
 })
 
 // ---- Hook subprocess --------------------------------------------------------
-
-/** Minimal permbot socket stub: reads one JSON line, responds immediately.
- *  Returns a ready promise (server is listening) and a done promise (response sent). */
-function startPermbotStub(sockPath: string, reply: object): { ready: Promise<void>; done: Promise<void> } {
-  let onReady!: () => void
-  const ready = new Promise<void>(r => { onReady = r })
-  let onDone!: () => void
-  const done = new Promise<void>(r => { onDone = r })
-  const server = net.createServer((sock) => {
-    let buf = ''
-    sock.on('data', (d) => {
-      buf += d.toString('utf8')
-      if (!buf.includes('\n')) return
-      sock.write(JSON.stringify(reply) + '\n')
-      sock.end()
-      server.close()
-      onDone()
-    })
-  })
-  server.listen(sockPath, () => { onReady() })
-  return { ready, done }
-}
-
-function makeSock(): string {
-  return path.join(os.tmpdir(), `pretooluse-hook-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
-}
 
 const SAFETY_CHECK_PAYLOAD = JSON.stringify({
   tool_name: 'Bash',

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -175,7 +175,7 @@ async function runHook(env: Record<string, string>, stdin = SAFETY_CHECK_PAYLOAD
 
 describe('pretooluse-prompt hook subprocess', () => {
   it('allows on operator y reply', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('pretooluse-hook')
     const stub = startPermbotStub(sockPath, { reply: 'y' })
     await stub.ready
 
@@ -194,7 +194,7 @@ describe('pretooluse-prompt hook subprocess', () => {
   }, 10_000)
 
   it('denies on operator n reply', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('pretooluse-hook')
     const stub = startPermbotStub(sockPath, { reply: 'n' })
     await stub.ready
 
@@ -212,7 +212,7 @@ describe('pretooluse-prompt hook subprocess', () => {
   }, 10_000)
 
   it('emits ask + falls back when operator reply is unrecognized', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('pretooluse-hook')
     const stub = startPermbotStub(sockPath, { reply: 'maybe later' })
     await stub.ready
 
@@ -233,7 +233,7 @@ describe('pretooluse-prompt hook subprocess', () => {
   }, 10_000)
 
   it('allow carries default reason when operator replies with bare y', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('pretooluse-hook')
     const stub = startPermbotStub(sockPath, { reply: 'y' })
     await stub.ready
 
@@ -252,7 +252,7 @@ describe('pretooluse-prompt hook subprocess', () => {
   }, 10_000)
 
   it('emits ask when permbot times out', async () => {
-    const sockPath = makeSock()
+    const sockPath = makeSock('pretooluse-hook')
     // Stub accepts connection but never responds — socket-level timeout path.
     const server = net.createServer(() => {})
     await suppressLateRejection(new Promise<void>(r => server.listen(sockPath, r)))


### PR DESCRIPTION
Closes #281

- `startPermbotStub`, `makeSock`, `captureIRC` extracted from 4 test files into `test/helpers/permbot-stub.ts`
- `captureIRC` consolidated using the cleaner `lines.pop()` buffer management from `irc-permission-prompt.test.ts`
- `permission-prompt.ts` stderr prefix changed from `perm-hook:` to `perm-hook[${WORKER}]:` to match `pretooluse-hook[${WORKER}]:` — both hooks now include the worker nick for per-worker log grepping while keeping their distinct `perm-hook`/`pretooluse-hook` discriminators