### PR TITLE
maint: bump package.json to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump package.json from 0.4.0 → 0.5.0 ahead of `v0.5.0` tag push.

Ships:
- #276 / #277 — `PreToolUse` Bash hook closes the safety-analyzer bypass in `perm-irc`
- #275 / #280 — spawn hooks resolve roost dir at exec time via per-session shim (survives Cellar rotation)
- #278 / #279 — reconcile `permission-prompt` / `pretouluse-prompt` asymmetries (timeout env, default reasons, unrecognized-reply tests)
- #281 / #282 — extract `test/helpers/permbot-stub.ts`, align stderr prefix to `*-hook[${WORKER}]:`

## Test plan
- [x] All 1.0 milestone items merged before bump
- [ ] After merge: `git tag v0.5.0 && git push origin v0.5.0` → release workflow ships GitHub release + tap formula bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)