### PR TITLE
feat(dispatcher): handle inbound DM commands for watch/unwatch CRUD

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,6 +19,7 @@ import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js
 import { getPluginFactory, registeredPluginNames, type Plugin, type TaggedEvent } from './orchestrator/plugin.js'
 import './orchestrator/registry.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
+import { handleDm } from './orchestrator/dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
 // ---- Path setup ------------------------------------------------------------
@@ -130,6 +131,24 @@ async function runDaemon(stateDir: string): Promise<void> {
 
   await connectAndWait(client, { host: server, port, nick, autoReconnect: true, autoReconnectMaxRetries: 30 }, initialChannels)
   log('orchestrator[daemon]: connected\n')
+
+  // DM command handler — replaces the haiku watcher's LLM-on-JSON loop.
+  // Channel messages are ignored; DMs run the allowlist + parser + mutateConfig
+  // pipeline in dm-handler.ts. handleDm itself never throws.
+  client.on('message', (msg) => {
+    if (!msg.isDirect) return
+    handleDm(
+      {
+        stateDir,
+        dm: (nick, text) => { try { client.say(nick, text) } catch (e) { log(`orchestrator[daemon]: dm reply failed: ${e}\n`) } },
+        postProjectError: (text) => { try { client.say(projectChannel, text) } catch { /* best-effort */ } },
+        log: (line) => log(`${line}\n`),
+      },
+      { sender: msg.sender, text: msg.text },
+    ).catch((e: unknown) => {
+      log(`orchestrator[daemon]: dm-handler crashed: ${e}\n`)
+    })
+  })
 
   let stop = false
   const stopController = new AbortController()

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -132,20 +132,24 @@ async function runDaemon(stateDir: string): Promise<void> {
   await connectAndWait(client, { host: server, port, nick, autoReconnect: true, autoReconnectMaxRetries: 30 }, initialChannels)
   log('orchestrator[daemon]: connected\n')
 
-  // DM command handler — replaces the haiku watcher's LLM-on-JSON loop.
-  // Channel messages are ignored; DMs run the allowlist + parser + mutateConfig
-  // pipeline in dm-handler.ts. handleDm itself never throws.
+  // DM command handler. Channel messages are ignored; DMs flow through
+  // the allowlist + parser + mutateConfig pipeline in dm-handler.ts.
+  // Built once at boot — no per-message closure over the inbound `msg`.
+  const dmHandlerDeps = {
+    stateDir,
+    plugins,
+    dm: (nick: string, text: string) => {
+      try { client.say(nick, text) } catch (e) { log(`orchestrator[daemon]: dm reply failed: ${e}\n`) }
+    },
+    postProjectError: (text: string) => {
+      try { client.say(projectChannel, text) } catch { /* best-effort */ }
+    },
+    log: (line: string) => log(`${line}\n`),
+  }
+
   client.on('message', (msg) => {
     if (!msg.isDirect) return
-    handleDm(
-      {
-        stateDir,
-        dm: (nick, text) => { try { client.say(nick, text) } catch (e) { log(`orchestrator[daemon]: dm reply failed: ${e}\n`) } },
-        postProjectError: (text) => { try { client.say(projectChannel, text) } catch { /* best-effort */ } },
-        log: (line) => log(`${line}\n`),
-      },
-      { sender: msg.sender, text: msg.text },
-    ).catch((e: unknown) => {
+    handleDm(dmHandlerDeps, { sender: msg.sender, text: msg.text }).catch((e: unknown) => {
       log(`orchestrator[daemon]: dm-handler crashed: ${e}\n`)
     })
   })

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -134,7 +134,6 @@ async function runDaemon(stateDir: string): Promise<void> {
 
   // DM command handler. Channel messages are ignored; DMs flow through
   // the allowlist + parser + mutateConfig pipeline in dm-handler.ts.
-  // Built once at boot — no per-message closure over the inbound `msg`.
   const dmHandlerDeps = {
     stateDir,
     plugins,

--- a/src/orchestrator/__tests__/dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dm-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -77,7 +77,23 @@ describe('parseCommand', () => {
   it('rejects bareword channel arguments', () => {
     const cmd = parseCommand('watch 5 foo') as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
-    expect(cmd.error).toMatch(/channels must start with #/)
+    expect(cmd.error).toMatch(/channels must match/)
+  })
+
+  it('rejects malformed channel arguments', () => {
+    // Bare `#`, double-`#`, embedded space, embedded `,` all fail at parse
+    // rather than later at the IRC server.
+    for (const bad of ['#', '##foo']) {
+      const cmd = parseCommand(`watch 5 ${bad}`) as Extract<Command, { kind: 'unknown' }>
+      expect(cmd.kind).toBe('unknown')
+      expect(cmd.error).toMatch(/channels must match/)
+    }
+  })
+
+  it('rejects trailing tokens after `watch list`', () => {
+    const cmd = parseCommand('watch list foo') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/watch list takes no arguments/)
   })
 
   it('rejects non-integer numbers', () => {
@@ -159,8 +175,26 @@ describe('applyCommand', () => {
 
   it('emits help text and list text for those commands', () => {
     const config: OrchestratorConfig = {}
-    expect(applyCommand(config, { kind: 'help' })).toMatch(/commands \(DM only\)/)
+    const help = applyCommand(config, { kind: 'help' })
+    expect(help).toMatch(/commands \(DM only\)/)
+    // HELP_TEXT mentions the multi-cmd separator grammar.
+    expect(help).toMatch(/newline, semicolon, or comma/)
+    // And that any parse error aborts the batch.
+    expect(help).toMatch(/aborts the batch/)
     expect(applyCommand(config, { kind: 'list' })).toMatch(/issues \(0\)/)
+  })
+
+  it('no-op channel add does not dirty entry.channels', () => {
+    // Adding only existing channels reports "unchanged" and leaves the
+    // entry's array reference alone (saves a redundant allocation).
+    const before = ['#a', '#b']
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5, channels: before }] } },
+    }
+    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#a', '#b'] })
+    expect(out).toMatch(/channels unchanged/)
+    const after = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
+    expect(after).toBe(before)
   })
 })
 
@@ -186,7 +220,7 @@ describe('formatList', () => {
 })
 
 describe('resolveAllowlist', () => {
-  it('defaults to [<project>-lead-pm] when unset', () => {
+  it('defaults to [leadPmNick(project)] when unset', () => {
     expect(resolveAllowlist({ project: 'roost' })).toEqual(['roost-lead-pm'])
   })
 
@@ -197,6 +231,13 @@ describe('resolveAllowlist', () => {
 
   it('returns [] when no project/repo to derive a default from', () => {
     expect(resolveAllowlist({})).toEqual([])
+  })
+
+  it('logs the cause when project is unresolvable', () => {
+    const logs: string[] = []
+    const out = resolveAllowlist({}, line => logs.push(line))
+    expect(out).toEqual([])
+    expect(logs.some(l => l.includes('cannot resolve default allowlist'))).toBe(true)
   })
 })
 
@@ -267,9 +308,31 @@ describe('handleDm', () => {
     const { deps, irc } = makeDeps(dir)
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5 foo' })
     expect(irc.dms).toHaveLength(1)
-    expect(irc.dms[0].text).toMatch(/error: channels must start with #/)
+    expect(irc.dms[0].text).toMatch(/error: channels must match/)
     // Config untouched
     expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('any unknown in a batch aborts the whole batch — no partial application', async () => {
+    // `watch 5 foo` fails to parse (bareword channel); `watch 6` would
+    // succeed in isolation. The whole batch is rejected and no entry is
+    // written.
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5 foo; watch 6' })
+    expect(irc.dms).toHaveLength(1)
+    expect(irc.dms[0].text).toMatch(/error: channels must match/)
+    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('reports all parse errors when multiple commands fail', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list foo; watch 5 bar' })
+    expect(irc.dms).toHaveLength(1)
+    const reply = irc.dms[0].text
+    expect(reply).toMatch(/watch list takes no arguments/)
+    expect(reply).toMatch(/channels must match/)
   })
 
   it('watch list replies with the formatted lists', async () => {
@@ -298,12 +361,29 @@ describe('handleDm', () => {
     expect(irc.errors).toEqual([])
   })
 
-  it('config write error surfaces to project channel + DM, no throw', async () => {
-    // Point at a non-existent dir to force loadConfig to fail
+  it('config load error surfaces to project channel, no throw', async () => {
+    // Point at a non-existent dir to force loadConfig to fail.
     const bogusDir = join(dir, 'does', 'not', 'exist')
     const { deps, irc } = makeDeps(bogusDir)
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
     expect(irc.errors.some(e => e.startsWith('[dispatcher_error] config load'))).toBe(true)
+  })
+
+  it('config write error surfaces to project channel + DM, no throw', async () => {
+    // Seed a valid config, then revoke write permission on the dir so
+    // loadConfig succeeds (the file is readable) but writeConfig fails
+    // when it tries to create the .tmp sibling. Restored in afterEach
+    // via the chmod 0o700 below so rm -rf can clean up.
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    await chmod(dir, 0o555)
+    try {
+      const { deps, irc } = makeDeps(dir)
+      await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+      expect(irc.errors.some(e => e.startsWith('[dispatcher_error] config write'))).toBe(true)
+      expect(irc.dms.some(d => d.text.startsWith('error: failed to update config'))).toBe(true)
+    } finally {
+      await chmod(dir, 0o700)
+    }
   })
 
   it('explicit empty allowlist blocks everyone (including lead-pm)', async () => {

--- a/src/orchestrator/__tests__/dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dm-handler.test.ts
@@ -3,16 +3,16 @@ import { chmod, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  applyCommand,
-  formatList,
   handleDm,
   parseCommand,
   parseCommands,
   resolveAllowlist,
   splitCommands,
   type Command,
+  type HandlerDeps,
 } from '../dm-handler.js'
 import { loadConfig, writeConfig, type OrchestratorConfig } from '../config.js'
+import type { Plugin, PluginTickResult } from '../plugin.js'
 
 let dir: string
 
@@ -24,6 +24,8 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
+// ---- Parser ----------------------------------------------------------------
+
 describe('splitCommands', () => {
   it('splits on newlines, semicolons, commas; trims; drops empties', () => {
     expect(splitCommands('watch 5\n watch 6 ; watch 7, ,\nhelp')).toEqual([
@@ -33,32 +35,28 @@ describe('splitCommands', () => {
 })
 
 describe('parseCommand', () => {
-  it('parses bare watch', () => {
-    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
+  it('parses bare watch as target=null', () => {
+    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', target: null, number: 5, channels: [] })
   })
 
   it('parses watch with channels', () => {
     expect(parseCommand('watch 5 #foo #bar')).toEqual({
-      kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#foo', '#bar'],
+      kind: 'watch', target: null, number: 5, channels: ['#foo', '#bar'],
     })
   })
 
-  it('parses unwatch', () => {
-    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', plugin: 'github-issues', number: 5 })
+  it('parses unwatch with target=null', () => {
+    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', target: null, number: 5 })
   })
 
-  it('parses watch pr', () => {
-    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', plugin: 'github-prs', number: 10, channels: [] })
+  it('parses target keyword from any non-numeric first token', () => {
+    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, channels: [] })
+    expect(parseCommand('watch linear 99')).toEqual({ kind: 'watch', target: 'linear', number: 99, channels: [] })
+    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', target: 'pr', number: 10 })
   })
 
-  it('parses watch pr with channels', () => {
-    expect(parseCommand('watch pr 10 #x #y')).toEqual({
-      kind: 'watch', plugin: 'github-prs', number: 10, channels: ['#x', '#y'],
-    })
-  })
-
-  it('parses unwatch pr', () => {
-    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', plugin: 'github-prs', number: 10 })
+  it('lowercases the target keyword', () => {
+    expect(parseCommand('watch PR 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, channels: [] })
   })
 
   it('parses watch list', () => {
@@ -70,7 +68,7 @@ describe('parseCommand', () => {
   })
 
   it('is case-insensitive on verbs', () => {
-    expect(parseCommand('WATCH PR 10')).toEqual({ kind: 'watch', plugin: 'github-prs', number: 10, channels: [] })
+    expect(parseCommand('WATCH 5')).toEqual({ kind: 'watch', target: null, number: 5, channels: [] })
     expect(parseCommand('Help')).toEqual({ kind: 'help' })
   })
 
@@ -81,8 +79,6 @@ describe('parseCommand', () => {
   })
 
   it('rejects malformed channel arguments', () => {
-    // Bare `#`, double-`#`, embedded space, embedded `,` all fail at parse
-    // rather than later at the IRC server.
     for (const bad of ['#', '##foo']) {
       const cmd = parseCommand(`watch 5 ${bad}`) as Extract<Command, { kind: 'unknown' }>
       expect(cmd.kind).toBe('unknown')
@@ -96,8 +92,22 @@ describe('parseCommand', () => {
     expect(cmd.error).toMatch(/watch list takes no arguments/)
   })
 
-  it('rejects non-integer numbers', () => {
-    expect(parseCommand('watch foo').kind).toBe('unknown')
+  it('rejects trailing tokens after `help`', () => {
+    const cmd = parseCommand('help me') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/help takes no arguments/)
+  })
+
+  it('rejects a reserved verb in the target slot', () => {
+    // `watch unwatch 5` is almost certainly a typo, not "target=unwatch";
+    // surface the reserved-verb collision rather than silently routing.
+    const cmd = parseCommand('watch unwatch 5') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/reserved verb/)
+  })
+
+  it('rejects non-positive integers', () => {
+    expect(parseCommand('watch foo bar').kind).toBe('unknown')
     expect(parseCommand('watch 5.5').kind).toBe('unknown')
     expect(parseCommand('watch -1').kind).toBe('unknown')
   })
@@ -123,101 +133,13 @@ describe('parseCommand', () => {
 describe('parseCommands', () => {
   it('parses multi-line input', () => {
     expect(parseCommands('watch 5; unwatch pr 10')).toEqual([
-      { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] },
-      { kind: 'unwatch', plugin: 'github-prs', number: 10 },
+      { kind: 'watch', target: null, number: 5, channels: [] },
+      { kind: 'unwatch', target: 'pr', number: 10 },
     ])
   })
 })
 
-describe('applyCommand', () => {
-  it('adds a new issue entry', () => {
-    const config: OrchestratorConfig = {}
-    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
-    expect(out).toMatch(/watching issue #5/)
-    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
-  })
-
-  it('is idempotent for re-adding without channels', () => {
-    const config: OrchestratorConfig = { plugins: { 'github-issues': { watched: [{ number: 5 }] } } }
-    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
-    expect(out).toMatch(/already watching/)
-  })
-
-  it('appends + dedupes channels onto existing entry', () => {
-    const config: OrchestratorConfig = {
-      plugins: { 'github-issues': { watched: [{ number: 5, channels: ['#a'] }] } },
-    }
-    applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#a', '#b'] })
-    const entry = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
-    expect(entry.channels).toEqual(['#a', '#b'])
-  })
-
-  it('removes an entry on unwatch', () => {
-    const config: OrchestratorConfig = {
-      plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
-    }
-    applyCommand(config, { kind: 'unwatch', plugin: 'github-issues', number: 5 })
-    expect((config.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
-  })
-
-  it('reports not-watching on unwatch of unknown entry', () => {
-    const config: OrchestratorConfig = {}
-    const out = applyCommand(config, { kind: 'unwatch', plugin: 'github-issues', number: 5 })
-    expect(out).toMatch(/not watching/)
-  })
-
-  it('watch pr targets the github-prs slice', () => {
-    const config: OrchestratorConfig = {}
-    applyCommand(config, { kind: 'watch', plugin: 'github-prs', number: 10, channels: ['#x'] })
-    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
-    expect(config.plugins?.['github-issues']).toBeUndefined()
-  })
-
-  it('emits help text and list text for those commands', () => {
-    const config: OrchestratorConfig = {}
-    const help = applyCommand(config, { kind: 'help' })
-    expect(help).toMatch(/commands \(DM only\)/)
-    // HELP_TEXT mentions the multi-cmd separator grammar.
-    expect(help).toMatch(/newline, semicolon, or comma/)
-    // And that any parse error aborts the batch.
-    expect(help).toMatch(/aborts the batch/)
-    expect(applyCommand(config, { kind: 'list' })).toMatch(/issues \(0\)/)
-  })
-
-  it('no-op channel add does not dirty entry.channels', () => {
-    // Adding only existing channels reports "unchanged" and leaves the
-    // entry's array reference alone (saves a redundant allocation).
-    const before = ['#a', '#b']
-    const config: OrchestratorConfig = {
-      plugins: { 'github-issues': { watched: [{ number: 5, channels: before }] } },
-    }
-    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#a', '#b'] })
-    expect(out).toMatch(/channels unchanged/)
-    const after = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
-    expect(after).toBe(before)
-  })
-})
-
-describe('formatList', () => {
-  it('formats both slices with channel attachments', () => {
-    const config: OrchestratorConfig = {
-      plugins: {
-        'github-issues': { watched: [{ number: 5 }, { number: 6, channels: ['#a', '#b'] }] },
-        'github-prs': { watched: [{ number: 10, channels: ['#x'] }] },
-      },
-    }
-    const out = formatList(config)
-    expect(out).toContain('issues (2):')
-    expect(out).toContain('  #5')
-    expect(out).toContain('  #6 + #a #b')
-    expect(out).toContain('prs (1):')
-    expect(out).toContain('  #10 + #x')
-  })
-
-  it('reports (none) for empty slices', () => {
-    expect(formatList({})).toContain('(none)')
-  })
-})
+// ---- Allowlist -------------------------------------------------------------
 
 describe('resolveAllowlist', () => {
   it('defaults to [leadPmNick(project)] when unset', () => {
@@ -241,7 +163,7 @@ describe('resolveAllowlist', () => {
   })
 })
 
-// ---- handleDm — end-to-end via real config files --------------------------
+// ---- handleDm routing — stub plugins ---------------------------------------
 
 interface FakeIrc {
   dms: Array<{ nick: string; text: string }>
@@ -249,85 +171,129 @@ interface FakeIrc {
   logs: string[]
 }
 
-function makeDeps(stateDir: string): { deps: Parameters<typeof handleDm>[0]; irc: FakeIrc } {
+// A minimal Plugin that claims a target keyword. Records every call so
+// tests can assert routing precisely without depending on slice schemas.
+class StubPlugin implements Plugin {
+  readonly name: string
+  readonly handled: Array<{ cmd: Command; configSnapshot: OrchestratorConfig }> = []
+  constructor(name: string, private readonly target: string | null, private readonly behavior?: (cmd: Command, config: OrchestratorConfig) => string | null) {
+    this.name = name
+  }
+  desiredChannels(): string[] { return [] }
+  async runTick(): Promise<PluginTickResult> {
+    return { state: null, taggedEvents: [], channels: [] }
+  }
+  handleCommand(config: OrchestratorConfig, cmd: Command): string | null {
+    this.handled.push({ cmd, configSnapshot: JSON.parse(JSON.stringify(config)) as OrchestratorConfig })
+    if (this.behavior) return this.behavior(cmd, config)
+    if (cmd.kind === 'list') return `${this.name}: list-section`
+    if (cmd.kind === 'help') return `${this.name}: help-section`
+    if (cmd.kind === 'watch' && cmd.target === this.target) {
+      config.plugins ??= {}
+      config.plugins[this.name] = { watched: cmd.number }
+      return `${this.name}: watched ${cmd.number}`
+    }
+    if (cmd.kind === 'unwatch' && cmd.target === this.target) {
+      return `${this.name}: unwatched ${cmd.number}`
+    }
+    return null
+  }
+}
+
+function makeDeps(stateDir: string, plugins: Plugin[] = []): { deps: HandlerDeps; irc: FakeIrc } {
   const irc: FakeIrc = { dms: [], errors: [], logs: [] }
-  const deps = {
+  const deps: HandlerDeps = {
     stateDir,
-    dm: (nick: string, text: string) => { irc.dms.push({ nick, text }) },
-    postProjectError: (text: string) => { irc.errors.push(text) },
-    log: (line: string) => { irc.logs.push(line) },
+    plugins,
+    dm: (nick, text) => { irc.dms.push({ nick, text }) },
+    postProjectError: (text) => { irc.errors.push(text) },
+    log: (line) => { irc.logs.push(line) },
   }
   return { deps, irc }
 }
 
-describe('handleDm', () => {
+describe('handleDm — routing', () => {
   it('rejects senders outside the allowlist with a tight one-liner', async () => {
     await writeConfig(dir, { project: 'roost', irc: { command_senders: ['alex'] }, plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'mallory', text: 'watch 5' })
     expect(irc.dms).toEqual([{ nick: 'mallory', text: 'not authorized; configure irc.command_senders' }])
-    // No mutation
-    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+    expect((await loadConfig(dir)).plugins?.['issues']).toBeUndefined()
   })
 
   it('allows the default lead-pm nick when command_senders is unset', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
     expect(irc.dms).toHaveLength(1)
-    expect(irc.dms[0].text).toMatch(/watching issue #5/)
-    const config = await loadConfig(dir)
-    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+    expect(irc.dms[0].text).toBe('issues: watched 5')
+    expect(issues.handled).toHaveLength(1)
   })
 
-  it('case-insensitive sender match', async () => {
-    await writeConfig(dir, { project: 'roost', irc: { command_senders: ['Alex'] }, plugins: {} })
-    const { deps, irc } = makeDeps(dir)
-    await handleDm(deps, { sender: 'ALEX', text: 'watch 7' })
-    expect(irc.dms[0].text).toMatch(/watching issue #7/)
-  })
-
-  it('mutates config and replies with a single confirmation for multi-command DMs', async () => {
+  it('routes target=null commands only to the matching plugin', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
-    await handleDm(deps, {
-      sender: 'roost-lead-pm',
-      text: 'watch 5 #foo\nwatch pr 10 #bar',
-    })
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const { deps, irc } = makeDeps(dir, [issues, prs])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+    // Both plugins are invoked, only issues claims it.
+    expect(issues.handled).toHaveLength(1)
+    expect(prs.handled).toHaveLength(1)
+    expect(irc.dms[0].text).toBe('issues: watched 5')
+  })
+
+  it('routes target=pr commands only to the matching plugin', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const { deps, irc } = makeDeps(dir, [issues, prs])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch pr 10' })
+    expect(irc.dms[0].text).toBe('prs: watched 10')
+  })
+
+  it('broadcasts `watch list` to every plugin and joins replies with \\n\\n', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const { deps, irc } = makeDeps(dir, [issues, prs])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list' })
     expect(irc.dms).toHaveLength(1)
-    const reply = irc.dms[0].text
-    expect(reply).toMatch(/watching issue #5/)
-    expect(reply).toMatch(/watching pr #10/)
-    const config = await loadConfig(dir)
-    expect(config.plugins?.['github-issues']).toEqual({ watched: [{ number: 5, channels: ['#foo'] }] })
-    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#bar'] }] })
+    expect(irc.dms[0].text).toBe('issues: list-section\n\nprs: list-section')
   })
 
-  it('parse failures reply with a one-liner and do not throw', async () => {
+  it('broadcasts `help` to every plugin and joins with \\n\\n', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
-    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5 foo' })
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const { deps, irc } = makeDeps(dir, [issues, prs])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'help' })
+    expect(irc.dms[0].text).toBe('issues: help-section\n\nprs: help-section')
+  })
+
+  it('surfaces "no plugin handles" when no plugin claims a target', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch linear 99' })
     expect(irc.dms).toHaveLength(1)
-    expect(irc.dms[0].text).toMatch(/error: channels must match/)
-    // Config untouched
-    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+    expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear <N>/)
+    expect(irc.dms[0].text).toMatch(/enabled plugins: issues/)
   })
 
-  it('any unknown in a batch aborts the whole batch — no partial application', async () => {
-    // `watch 5 foo` fails to parse (bareword channel); `watch 6` would
-    // succeed in isolation. The whole batch is rejected and no entry is
-    // written.
+  it('any parse error aborts the batch — no plugin called', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5 foo; watch 6' })
     expect(irc.dms).toHaveLength(1)
     expect(irc.dms[0].text).toMatch(/error: channels must match/)
-    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+    expect(issues.handled).toHaveLength(0)
   })
 
-  it('reports all parse errors when multiple commands fail', async () => {
+  it('reports multiple parse errors in one reply', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list foo; watch 5 bar' })
     expect(irc.dms).toHaveLength(1)
     const reply = irc.dms[0].text
@@ -335,49 +301,53 @@ describe('handleDm', () => {
     expect(reply).toMatch(/channels must match/)
   })
 
-  it('watch list replies with the formatted lists', async () => {
-    await writeConfig(dir, {
-      project: 'roost',
-      plugins: {
-        'github-issues': { watched: [{ number: 5 }] },
-        'github-prs': { watched: [{ number: 10, channels: ['#x'] }] },
-      },
-    })
-    const { deps, irc } = makeDeps(dir)
-    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list' })
+  it('multi-cmd write batch lands in one mutateConfig call (single atomic write)', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const { deps, irc } = makeDeps(dir, [issues, prs])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5\nwatch pr 10' })
     expect(irc.dms).toHaveLength(1)
-    const reply = irc.dms[0].text
-    expect(reply).toContain('issues (1):')
-    expect(reply).toContain('  #5')
-    expect(reply).toContain('prs (1):')
-    expect(reply).toContain('  #10 + #x')
+    expect(irc.dms[0].text).toBe('issues: watched 5\n\nprs: watched 10')
+    const config = await loadConfig(dir)
+    expect(config.plugins?.['issues']).toEqual({ watched: 5 })
+    expect(config.plugins?.['prs']).toEqual({ watched: 10 })
   })
 
   it('empty-body DMs are ignored silently', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'roost-lead-pm', text: '   ' })
     expect(irc.dms).toEqual([])
     expect(irc.errors).toEqual([])
   })
 
+  it('case-insensitive sender match', async () => {
+    await writeConfig(dir, { project: 'roost', irc: { command_senders: ['Alex'] }, plugins: {} })
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
+    await handleDm(deps, { sender: 'ALEX', text: 'watch 7' })
+    expect(irc.dms[0].text).toBe('issues: watched 7')
+  })
+
+  it('explicit empty allowlist blocks everyone (including lead-pm)', async () => {
+    await writeConfig(dir, { project: 'roost', irc: { command_senders: [] }, plugins: {} })
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+    expect(irc.dms).toEqual([{ nick: 'roost-lead-pm', text: 'not authorized; configure irc.command_senders' }])
+  })
+
   it('config load error surfaces to project channel, no throw', async () => {
-    // Point at a non-existent dir to force loadConfig to fail.
     const bogusDir = join(dir, 'does', 'not', 'exist')
-    const { deps, irc } = makeDeps(bogusDir)
+    const { deps, irc } = makeDeps(bogusDir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
     expect(irc.errors.some(e => e.startsWith('[dispatcher_error] config load'))).toBe(true)
   })
 
   it('config write error surfaces to project channel + DM, no throw', async () => {
-    // Seed a valid config, then revoke write permission on the dir so
-    // loadConfig succeeds (the file is readable) but writeConfig fails
-    // when it tries to create the .tmp sibling. Restored in afterEach
-    // via the chmod 0o700 below so rm -rf can clean up.
     await writeConfig(dir, { project: 'roost', plugins: {} })
     await chmod(dir, 0o555)
     try {
-      const { deps, irc } = makeDeps(dir)
+      const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
       await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
       expect(irc.errors.some(e => e.startsWith('[dispatcher_error] config write'))).toBe(true)
       expect(irc.dms.some(d => d.text.startsWith('error: failed to update config'))).toBe(true)
@@ -386,10 +356,26 @@ describe('handleDm', () => {
     }
   })
 
-  it('explicit empty allowlist blocks everyone (including lead-pm)', async () => {
-    await writeConfig(dir, { project: 'roost', irc: { command_senders: [] }, plugins: {} })
-    const { deps, irc } = makeDeps(dir)
+  it('plugin.handleCommand that throws is caught + surfaced as [dispatcher_error]', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const buggy = new StubPlugin('buggy', null, () => { throw new Error('plugin bug') })
+    const { deps, irc } = makeDeps(dir, [buggy])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
-    expect(irc.dms).toEqual([{ nick: 'roost-lead-pm', text: 'not authorized; configure irc.command_senders' }])
+    expect(irc.errors.some(e => e.includes('handleCommand'))).toBe(true)
+    expect(irc.dms.some(d => /handler crashed/.test(d.text))).toBe(true)
+  })
+
+  it('pure-read batches do not call mutateConfig (snapshot path)', async () => {
+    // Seed a watched entry. After `watch list`, config on disk is unchanged
+    // — proves we didn't re-serialize via mutateConfig.
+    await writeConfig(dir, { project: 'roost', plugins: { issues: { watched: [{ number: 99 }] } } })
+    const { mtimeMs: before } = await Bun.file(join(dir, 'config.json')).stat()
+    // Small delay so a write would show a different mtime.
+    await new Promise(r => setTimeout(r, 20))
+    const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list' })
+    expect(irc.dms).toHaveLength(1)
+    const { mtimeMs: after } = await Bun.file(join(dir, 'config.json')).stat()
+    expect(after).toBe(before)
   })
 })

--- a/src/orchestrator/__tests__/dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dm-handler.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  applyCommand,
+  formatList,
+  handleDm,
+  parseCommand,
+  parseCommands,
+  resolveAllowlist,
+  splitCommands,
+  type Command,
+} from '../dm-handler.js'
+import { loadConfig, writeConfig, type OrchestratorConfig } from '../config.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'roost-dm-handler-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('splitCommands', () => {
+  it('splits on newlines, semicolons, commas; trims; drops empties', () => {
+    expect(splitCommands('watch 5\n watch 6 ; watch 7, ,\nhelp')).toEqual([
+      'watch 5', 'watch 6', 'watch 7', 'help',
+    ])
+  })
+})
+
+describe('parseCommand', () => {
+  it('parses bare watch', () => {
+    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
+  })
+
+  it('parses watch with channels', () => {
+    expect(parseCommand('watch 5 #foo #bar')).toEqual({
+      kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#foo', '#bar'],
+    })
+  })
+
+  it('parses unwatch', () => {
+    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', plugin: 'github-issues', number: 5 })
+  })
+
+  it('parses watch pr', () => {
+    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', plugin: 'github-prs', number: 10, channels: [] })
+  })
+
+  it('parses watch pr with channels', () => {
+    expect(parseCommand('watch pr 10 #x #y')).toEqual({
+      kind: 'watch', plugin: 'github-prs', number: 10, channels: ['#x', '#y'],
+    })
+  })
+
+  it('parses unwatch pr', () => {
+    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', plugin: 'github-prs', number: 10 })
+  })
+
+  it('parses watch list', () => {
+    expect(parseCommand('watch list')).toEqual({ kind: 'list' })
+  })
+
+  it('parses help', () => {
+    expect(parseCommand('help')).toEqual({ kind: 'help' })
+  })
+
+  it('is case-insensitive on verbs', () => {
+    expect(parseCommand('WATCH PR 10')).toEqual({ kind: 'watch', plugin: 'github-prs', number: 10, channels: [] })
+    expect(parseCommand('Help')).toEqual({ kind: 'help' })
+  })
+
+  it('rejects bareword channel arguments', () => {
+    const cmd = parseCommand('watch 5 foo') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/channels must start with #/)
+  })
+
+  it('rejects non-integer numbers', () => {
+    expect(parseCommand('watch foo').kind).toBe('unknown')
+    expect(parseCommand('watch 5.5').kind).toBe('unknown')
+    expect(parseCommand('watch -1').kind).toBe('unknown')
+  })
+
+  it('rejects unwatch with channel args', () => {
+    const cmd = parseCommand('unwatch 5 #x') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/no channel arguments/)
+  })
+
+  it('rejects unknown verb', () => {
+    const cmd = parseCommand('foo bar') as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/unknown command/)
+  })
+
+  it('requires a number for watch/unwatch', () => {
+    expect(parseCommand('watch').kind).toBe('unknown')
+    expect(parseCommand('watch pr').kind).toBe('unknown')
+  })
+})
+
+describe('parseCommands', () => {
+  it('parses multi-line input', () => {
+    expect(parseCommands('watch 5; unwatch pr 10')).toEqual([
+      { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] },
+      { kind: 'unwatch', plugin: 'github-prs', number: 10 },
+    ])
+  })
+})
+
+describe('applyCommand', () => {
+  it('adds a new issue entry', () => {
+    const config: OrchestratorConfig = {}
+    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
+    expect(out).toMatch(/watching issue #5/)
+    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+  })
+
+  it('is idempotent for re-adding without channels', () => {
+    const config: OrchestratorConfig = { plugins: { 'github-issues': { watched: [{ number: 5 }] } } }
+    const out = applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: [] })
+    expect(out).toMatch(/already watching/)
+  })
+
+  it('appends + dedupes channels onto existing entry', () => {
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5, channels: ['#a'] }] } },
+    }
+    applyCommand(config, { kind: 'watch', plugin: 'github-issues', number: 5, channels: ['#a', '#b'] })
+    const entry = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
+    expect(entry.channels).toEqual(['#a', '#b'])
+  })
+
+  it('removes an entry on unwatch', () => {
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
+    }
+    applyCommand(config, { kind: 'unwatch', plugin: 'github-issues', number: 5 })
+    expect((config.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
+  })
+
+  it('reports not-watching on unwatch of unknown entry', () => {
+    const config: OrchestratorConfig = {}
+    const out = applyCommand(config, { kind: 'unwatch', plugin: 'github-issues', number: 5 })
+    expect(out).toMatch(/not watching/)
+  })
+
+  it('watch pr targets the github-prs slice', () => {
+    const config: OrchestratorConfig = {}
+    applyCommand(config, { kind: 'watch', plugin: 'github-prs', number: 10, channels: ['#x'] })
+    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
+    expect(config.plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('emits help text and list text for those commands', () => {
+    const config: OrchestratorConfig = {}
+    expect(applyCommand(config, { kind: 'help' })).toMatch(/commands \(DM only\)/)
+    expect(applyCommand(config, { kind: 'list' })).toMatch(/issues \(0\)/)
+  })
+})
+
+describe('formatList', () => {
+  it('formats both slices with channel attachments', () => {
+    const config: OrchestratorConfig = {
+      plugins: {
+        'github-issues': { watched: [{ number: 5 }, { number: 6, channels: ['#a', '#b'] }] },
+        'github-prs': { watched: [{ number: 10, channels: ['#x'] }] },
+      },
+    }
+    const out = formatList(config)
+    expect(out).toContain('issues (2):')
+    expect(out).toContain('  #5')
+    expect(out).toContain('  #6 + #a #b')
+    expect(out).toContain('prs (1):')
+    expect(out).toContain('  #10 + #x')
+  })
+
+  it('reports (none) for empty slices', () => {
+    expect(formatList({})).toContain('(none)')
+  })
+})
+
+describe('resolveAllowlist', () => {
+  it('defaults to [<project>-lead-pm] when unset', () => {
+    expect(resolveAllowlist({ project: 'roost' })).toEqual(['roost-lead-pm'])
+  })
+
+  it('returns the explicit list when set (including empty)', () => {
+    expect(resolveAllowlist({ irc: { command_senders: ['alex', 'bot'] } })).toEqual(['alex', 'bot'])
+    expect(resolveAllowlist({ irc: { command_senders: [] } })).toEqual([])
+  })
+
+  it('returns [] when no project/repo to derive a default from', () => {
+    expect(resolveAllowlist({})).toEqual([])
+  })
+})
+
+// ---- handleDm — end-to-end via real config files --------------------------
+
+interface FakeIrc {
+  dms: Array<{ nick: string; text: string }>
+  errors: string[]
+  logs: string[]
+}
+
+function makeDeps(stateDir: string): { deps: Parameters<typeof handleDm>[0]; irc: FakeIrc } {
+  const irc: FakeIrc = { dms: [], errors: [], logs: [] }
+  const deps = {
+    stateDir,
+    dm: (nick: string, text: string) => { irc.dms.push({ nick, text }) },
+    postProjectError: (text: string) => { irc.errors.push(text) },
+    log: (line: string) => { irc.logs.push(line) },
+  }
+  return { deps, irc }
+}
+
+describe('handleDm', () => {
+  it('rejects senders outside the allowlist with a tight one-liner', async () => {
+    await writeConfig(dir, { project: 'roost', irc: { command_senders: ['alex'] }, plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'mallory', text: 'watch 5' })
+    expect(irc.dms).toEqual([{ nick: 'mallory', text: 'not authorized; configure irc.command_senders' }])
+    // No mutation
+    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('allows the default lead-pm nick when command_senders is unset', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+    expect(irc.dms).toHaveLength(1)
+    expect(irc.dms[0].text).toMatch(/watching issue #5/)
+    const config = await loadConfig(dir)
+    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+  })
+
+  it('case-insensitive sender match', async () => {
+    await writeConfig(dir, { project: 'roost', irc: { command_senders: ['Alex'] }, plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'ALEX', text: 'watch 7' })
+    expect(irc.dms[0].text).toMatch(/watching issue #7/)
+  })
+
+  it('mutates config and replies with a single confirmation for multi-command DMs', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, {
+      sender: 'roost-lead-pm',
+      text: 'watch 5 #foo\nwatch pr 10 #bar',
+    })
+    expect(irc.dms).toHaveLength(1)
+    const reply = irc.dms[0].text
+    expect(reply).toMatch(/watching issue #5/)
+    expect(reply).toMatch(/watching pr #10/)
+    const config = await loadConfig(dir)
+    expect(config.plugins?.['github-issues']).toEqual({ watched: [{ number: 5, channels: ['#foo'] }] })
+    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#bar'] }] })
+  })
+
+  it('parse failures reply with a one-liner and do not throw', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5 foo' })
+    expect(irc.dms).toHaveLength(1)
+    expect(irc.dms[0].text).toMatch(/error: channels must start with #/)
+    // Config untouched
+    expect((await loadConfig(dir)).plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('watch list replies with the formatted lists', async () => {
+    await writeConfig(dir, {
+      project: 'roost',
+      plugins: {
+        'github-issues': { watched: [{ number: 5 }] },
+        'github-prs': { watched: [{ number: 10, channels: ['#x'] }] },
+      },
+    })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list' })
+    expect(irc.dms).toHaveLength(1)
+    const reply = irc.dms[0].text
+    expect(reply).toContain('issues (1):')
+    expect(reply).toContain('  #5')
+    expect(reply).toContain('prs (1):')
+    expect(reply).toContain('  #10 + #x')
+  })
+
+  it('empty-body DMs are ignored silently', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: '   ' })
+    expect(irc.dms).toEqual([])
+    expect(irc.errors).toEqual([])
+  })
+
+  it('config write error surfaces to project channel + DM, no throw', async () => {
+    // Point at a non-existent dir to force loadConfig to fail
+    const bogusDir = join(dir, 'does', 'not', 'exist')
+    const { deps, irc } = makeDeps(bogusDir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+    expect(irc.errors.some(e => e.startsWith('[dispatcher_error] config load'))).toBe(true)
+  })
+
+  it('explicit empty allowlist blocks everyone (including lead-pm)', async () => {
+    await writeConfig(dir, { project: 'roost', irc: { command_senders: [] }, plugins: {} })
+    const { deps, irc } = makeDeps(dir)
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
+    expect(irc.dms).toEqual([{ nick: 'roost-lead-pm', text: 'not authorized; configure irc.command_senders' }])
+  })
+})

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -22,6 +22,11 @@ export interface OrchestratorConfig {
     server?: string
     port?: number
     interval_seconds?: number
+    // Allowlist of nicks permitted to DM the dispatcher with watch/unwatch
+    // commands. When unset, defaults to `[leadPmNick(project)]` — the
+    // lead-pm that spawned this dispatcher (see naming.ts). Explicit `[]`
+    // disables remote control entirely.
+    command_senders?: string[]
   }
   // Per-plugin config slice, symmetric with `state.plugins.{name}`. The set
   // of enabled plugins is `Object.keys(plugins)`. Each slice is shaped by

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -1,56 +1,52 @@
-// Dispatcher DM handler: parses a small command grammar and mutates
-// .orchestrator/config.json. Replaces the haiku watcher's LLM-on-JSON loop
-// (see prompts/watcher.md) with a deterministic in-process path.
+// Dispatcher DM handler: parses a small command grammar and routes parsed
+// commands to plugins that opt in via `Plugin.handleCommand`. The parser
+// only knows verbs (`watch`/`unwatch`/`list`/`help`) and a free-form target
+// keyword; slice schemas, default targets, and reply phrasing all belong to
+// plugins.
 //
 // All commands arrive via DM (msg.isDirect === true). The handler:
 //   1. enforces an allowlist (config.irc.command_senders)
 //   2. parses the message body into Command[] (multi-cmd per line is fine)
-//   3. mutates config via mutateConfig (single serialized writer)
-//   4. DMs back ONE confirmation summarizing what changed
+//   3. inside one mutateConfig pass, asks each plugin to handle each cmd
+//   4. coalesces non-null plugin replies into ONE confirmation DM
 //
-// The handler never throws — parse/apply errors become a one-line DM to
-// the sender, and write errors are surfaced to the project channel by the
-// caller in orchestrator.ts.
+// The handler never throws — parse failures abort the batch with a one-line
+// DM, plugin.handleCommand throws bubble up as [dispatcher_error] on the
+// project channel.
 
-import { loadConfig, mutateConfig, type OrchestratorConfig, type WatchedEntry } from './config.js'
+import { loadConfig, mutateConfig, type OrchestratorConfig } from './config.js'
 import { defaultProject, leadPmNick } from './naming.js'
-
-type WatchPlugin = 'github-issues' | 'github-prs'
+import type { Plugin } from './plugin.js'
 
 export type Command =
-  | { kind: 'watch'; plugin: WatchPlugin; number: number; channels: string[] }
-  | { kind: 'unwatch'; plugin: WatchPlugin; number: number }
+  | { kind: 'watch'; target: string | null; number: number; channels: string[] }
+  | { kind: 'unwatch'; target: string | null; number: number }
   | { kind: 'list' }
   | { kind: 'help' }
   | { kind: 'unknown'; raw: string; error: string }
 
 export interface HandlerDeps {
   stateDir: string
+  // The enabled plugin set. Iterated for handleCommand routing. Built
+  // once at daemon boot — plugins are stateless w.r.t. command handling.
+  plugins: Plugin[]
   // Pure I/O — only the bits we need from RoostIrcClient.
   dm: (nick: string, text: string) => void
   postProjectError: (text: string) => void
   log: (line: string) => void
 }
 
-const HELP_TEXT = [
-  'commands (DM only):',
-  '  watch <N> [#chan ...]       — watch issue N (and route extra channels)',
-  '  unwatch <N>                 — stop watching issue N',
-  '  watch pr <N> [#chan ...]    — watch PR N (and route extra channels)',
-  '  unwatch pr <N>              — stop watching PR N',
-  '  watch list                  — show current watch lists',
-  '  help                        — this message',
-  'separate multiple commands per DM with newline, semicolon, or comma.',
-  'any parse error aborts the batch — nothing is applied.',
-].join('\n')
-
 const CHANNEL_RE = /^#[^\s,#]+$/
+
+// Verbs reserved for the dispatcher grammar — plugins can't override the
+// surface, but they decide what each verb does for their slice.
+const VERBS = new Set(['watch', 'unwatch', 'help'])
 
 // ---- Parser ----------------------------------------------------------------
 
 // Split a raw inbound body into individual command lines. Newlines /
 // semicolons / commas are all separators — matches the watcher prompt
-// grammar (which has been the operator-facing UX since the haiku watcher).
+// grammar (operator-facing UX since the haiku watcher).
 export function splitCommands(text: string): string[] {
   return text
     .split(/[\n;,]+/)
@@ -65,30 +61,37 @@ export function parseCommand(line: string): Command {
   if (tokens.length === 0) return { kind: 'unknown', raw: line, error: 'empty command' }
   const verb = tokens[0].toLowerCase()
 
-  if (verb === 'help') return { kind: 'help' }
-
-  if (verb === 'watch') {
-    if (tokens[1]?.toLowerCase() === 'list') {
-      if (tokens.length > 2) {
-        return { kind: 'unknown', raw: line, error: `watch list takes no arguments; got "${tokens.slice(2).join(' ')}"` }
-      }
-      return { kind: 'list' }
-    }
-    return parseWatchOrUnwatch(line, 'watch', tokens.slice(1))
+  if (verb === 'help') {
+    if (tokens.length > 1) return { kind: 'unknown', raw: line, error: `help takes no arguments; got "${tokens.slice(1).join(' ')}"` }
+    return { kind: 'help' }
   }
 
-  if (verb === 'unwatch') {
-    return parseWatchOrUnwatch(line, 'unwatch', tokens.slice(1))
+  if (verb === 'watch' && tokens[1]?.toLowerCase() === 'list') {
+    if (tokens.length > 2) return { kind: 'unknown', raw: line, error: `watch list takes no arguments; got "${tokens.slice(2).join(' ')}"` }
+    return { kind: 'list' }
   }
+
+  if (verb === 'watch') return parseWatchOrUnwatch(line, 'watch', tokens.slice(1))
+  if (verb === 'unwatch') return parseWatchOrUnwatch(line, 'unwatch', tokens.slice(1))
 
   return { kind: 'unknown', raw: line, error: `unknown command: ${tokens[0]}` }
 }
 
+// Parses `[target] <num> [#chan ...]` for watch, `[target] <num>` for unwatch.
+// `target` is whatever non-numeric keyword precedes the number (e.g. `pr`);
+// plugins choose which target keyword they claim, including `null` for the
+// bare form (no target keyword at all).
 function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: string[]): Command {
-  let plugin: WatchPlugin = 'github-issues'
+  let target: string | null = null
   let i = 0
-  if (rest[0]?.toLowerCase() === 'pr') {
-    plugin = 'github-prs'
+  // First token: either the number (no target keyword) or a target keyword
+  // followed by the number. `pr` today; future plugins (linear, etc.) can
+  // claim other words without touching the parser.
+  if (rest[0] !== undefined && !/^\d+$/.test(rest[0])) {
+    if (VERBS.has(rest[0].toLowerCase())) {
+      return { kind: 'unknown', raw, error: `${verb}: "${rest[0]}" is a reserved verb, not a target` }
+    }
+    target = rest[0].toLowerCase()
     i = 1
   }
 
@@ -97,7 +100,7 @@ function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: strin
     return { kind: 'unknown', raw, error: `${verb} requires an issue/PR number` }
   }
   const number = parseInt(numTok, 10)
-  if (!Number.isInteger(number) || number <= 0 || String(number) !== numTok) {
+  if (number <= 0 || String(number) !== numTok) {
     return { kind: 'unknown', raw, error: `${verb}: "${numTok}" is not a positive integer` }
   }
 
@@ -106,7 +109,7 @@ function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: strin
     if (channels.length) {
       return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
     }
-    return { kind: 'unwatch', plugin, number }
+    return { kind: 'unwatch', target, number }
   }
 
   for (const c of channels) {
@@ -114,94 +117,19 @@ function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: strin
       return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
     }
   }
-  return { kind: 'watch', plugin, number, channels }
+  return { kind: 'watch', target, number, channels }
 }
 
 export function parseCommands(text: string): Command[] {
   return splitCommands(text).map(parseCommand)
 }
 
-// ---- Apply -----------------------------------------------------------------
-
-interface WatchSlice {
-  watched?: WatchedEntry[]
-}
-
-function getSlice(config: OrchestratorConfig, plugin: WatchPlugin): WatchSlice {
-  config.plugins ??= {}
-  const existing = config.plugins[plugin]
-  if (existing && typeof existing === 'object') return existing as WatchSlice
-  const fresh: WatchSlice = {}
-  config.plugins[plugin] = fresh
-  return fresh
-}
-
-// One-line summary suitable for inclusion in the per-message confirmation
-// DM. The handler concatenates these with `\n`.
-export function applyCommand(config: OrchestratorConfig, cmd: Command): string {
-  if (cmd.kind === 'help') return HELP_TEXT
-  if (cmd.kind === 'list') return formatList(config)
-  if (cmd.kind === 'unknown') return `error: ${cmd.error} (line: ${cmd.raw})`
-
-  const slice = getSlice(config, cmd.plugin)
-  slice.watched ??= []
-  const watched = slice.watched
-  const label = cmd.plugin === 'github-prs' ? 'pr' : 'issue'
-
-  if (cmd.kind === 'watch') {
-    let entry = watched.find(e => e.number === cmd.number)
-    if (!entry) {
-      entry = { number: cmd.number }
-      if (cmd.channels.length) entry.channels = [...cmd.channels]
-      watched.push(entry)
-      return cmd.channels.length
-        ? `watching ${label} #${cmd.number} + ${cmd.channels.join(' ')}`
-        : `watching ${label} #${cmd.number}`
-    }
-    if (!cmd.channels.length) return `already watching ${label} #${cmd.number}`
-    const existing = new Set(entry.channels ?? [])
-    const added: string[] = []
-    for (const c of cmd.channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
-    if (!added.length) return `${label} #${cmd.number} channels unchanged`
-    entry.channels = [...existing]
-    return `${label} #${cmd.number} + ${added.join(' ')}`
-  }
-
-  // unwatch
-  const idx = watched.findIndex(e => e.number === cmd.number)
-  if (idx < 0) return `not watching ${label} #${cmd.number}`
-  watched.splice(idx, 1)
-  return `unwatched ${label} #${cmd.number}`
-}
-
-// ---- watch list formatter --------------------------------------------------
-
-export function formatList(config: OrchestratorConfig): string {
-  const issues = (config.plugins?.['github-issues'] as WatchSlice | undefined)?.watched ?? []
-  const prs = (config.plugins?.['github-prs'] as WatchSlice | undefined)?.watched ?? []
-
-  const fmtEntry = (e: WatchedEntry): string => {
-    const chans = e.channels?.length ? ` + ${e.channels.join(' ')}` : ''
-    return `  #${e.number}${chans}`
-  }
-
-  const lines: string[] = []
-  lines.push(`issues (${issues.length}):`)
-  if (issues.length) for (const e of issues) lines.push(fmtEntry(e))
-  else lines.push('  (none)')
-  lines.push(`prs (${prs.length}):`)
-  if (prs.length) for (const e of prs) lines.push(fmtEntry(e))
-  else lines.push('  (none)')
-  return lines.join('\n')
-}
-
 // ---- Allowlist -------------------------------------------------------------
 
 // Resolves command_senders. Unset → `[leadPmNick(project)]` (see
 // naming.ts:leadPmNick — the single source of truth for the convention).
-// Explicit `[]` means nobody is allowed; everyone gets rejected silently
-// past the initial DM reply. If project is unresolvable, falls back to
-// `[]` and logs the cause so an operator chasing a "not authorized"
+// Explicit `[]` means nobody is allowed. If project is unresolvable, falls
+// back to `[]` and logs the cause so an operator chasing a "not authorized"
 // reply can find the root cause in daemon.log.
 export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string) => void): string[] {
   const explicit = config.irc?.command_senders
@@ -214,6 +142,44 @@ export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string
   }
 }
 
+// ---- Routing ---------------------------------------------------------------
+
+// One DM-able description of a watch/unwatch the parser produced, used
+// only in the "no plugin handles..." reply. Matches the user's input shape.
+function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' }>): string {
+  const target = cmd.target ? `${cmd.target} ` : ''
+  return cmd.kind === 'watch'
+    ? `watch ${target}<N> [#chan ...]`
+    : `unwatch ${target}<N>`
+}
+
+// Ask every plugin to handle `cmd` against the (in-progress) config.
+// Returns the coalesced reply (or null if every plugin abstained — caller
+// surfaces "no plugin handles ..."). watch/unwatch should match exactly
+// one plugin; list/help broadcast to all and join with `\n\n`.
+async function routeOne(
+  config: OrchestratorConfig,
+  cmd: Command,
+  plugins: Plugin[],
+): Promise<string | null> {
+  if (cmd.kind === 'unknown') return `error: ${cmd.error}`
+  const replies: string[] = []
+  for (const p of plugins) {
+    const reply = await p.handleCommand?.(config, cmd)
+    if (reply !== null && reply !== undefined) replies.push(reply)
+  }
+  if (replies.length === 0) return null
+  // list/help broadcast to all enabled plugins — separate sections with a
+  // blank line so the output is readable when multiple plugins contribute.
+  const sep = cmd.kind === 'list' || cmd.kind === 'help' ? '\n\n' : '\n'
+  return replies.join(sep)
+}
+
+function unmatchedReply(cmd: Extract<Command, { kind: 'watch' | 'unwatch' }>, plugins: Plugin[]): string {
+  const names = plugins.map(p => p.name).sort().join(', ') || '(none)'
+  return `error: no plugin handles \`${describeCommand(cmd)}\` — enabled plugins: ${names}`
+}
+
 // ---- Handler entry point ---------------------------------------------------
 
 export interface InboundDm {
@@ -221,21 +187,17 @@ export interface InboundDm {
   text: string
 }
 
-// Top-level DM entry. Never throws — write/load failures are caught and
-// posted to the project channel via deps.postProjectError so the operator
-// notices a broken config.
+// Top-level DM entry. Never throws — load/write/handler failures are caught
+// and surfaced via deps.postProjectError + a DM to the sender so the
+// operator notices a broken handler.
 //
-// Read commands (help, list) and any-unknown batches short-circuit before
-// mutateConfig so we don't acquire the writer queue for a pure read or a
-// parse-failed message. Writes flow through mutateConfig as one atomic
-// commit per DM — a multi-cmd message is one fsync, one reply.
+// Read-only batches (only list/help/unknown) short-circuit before
+// mutateConfig so we don't acquire the writer queue or pay an fsync.
 export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> {
   const senderLower = dm.sender.toLowerCase()
   const body = dm.text.trim()
   if (!body) return
 
-  // Single loadConfig per DM. Used for allowlist + (if pure-read) for the
-  // formatList payload. Writes re-load inside mutateConfig for freshness.
   let snapshot: OrchestratorConfig
   try {
     snapshot = await loadConfig(deps.stateDir)
@@ -255,9 +217,8 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   const cmds = parseCommands(body)
   if (cmds.length === 0) return
 
-  // If any command failed to parse, report all parse errors and apply
-  // nothing — a typo in one half of a multi-cmd DM shouldn't silently
-  // commit the other half.
+  // Any parse failure aborts the batch — a typo shouldn't silently commit
+  // the half that parsed. Report all parse errors in one reply.
   const unknowns = cmds.filter((c): c is Extract<Command, { kind: 'unknown' }> => c.kind === 'unknown')
   if (unknowns.length) {
     for (const u of unknowns) deps.log(`dm-handler: ${dm.sender} parse: ${u.error}`)
@@ -265,31 +226,57 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
     return
   }
 
-  // Pure-read commands (help, list, or any mix of the two) don't need
-  // the writer queue. Format directly from the snapshot — no fsync.
-  if (cmds.every(c => c.kind === 'help' || c.kind === 'list')) {
-    const replies = cmds.map(c => applyCommand(snapshot, c))
-    for (const c of cmds) deps.log(`dm-handler: ${dm.sender} cmd=${c.kind}`)
-    deps.dm(dm.sender, replies.join('\n'))
+  const isPureRead = cmds.every(c => c.kind === 'list' || c.kind === 'help')
+
+  // Pure-read path: route against the snapshot, no fsync.
+  if (isPureRead) {
+    const replies: string[] = []
+    for (const cmd of cmds) {
+      try {
+        const reply = await routeOne(snapshot, cmd, deps.plugins)
+        if (reply !== null) replies.push(reply)
+        deps.log(`dm-handler: ${dm.sender} cmd=${cmd.kind}`)
+      } catch (e) {
+        deps.log(`dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
+        deps.postProjectError(`[dispatcher_error] handleCommand(${cmd.kind}): ${e}`)
+        replies.push(`error: handler crashed on ${cmd.kind}`)
+      }
+    }
+    if (replies.length) deps.dm(dm.sender, replies.join('\n\n'))
     return
   }
 
-  // Write path. mutateConfig re-loads inside the mutex for freshness.
+  // Write path: one mutateConfig call wraps the whole batch.
   const replies: string[] = []
+  let writeFailed = false
   try {
-    await mutateConfig(deps.stateDir, (config) => {
-      for (const cmd of cmds) replies.push(applyCommand(config, cmd))
+    await mutateConfig(deps.stateDir, async (config) => {
+      for (const cmd of cmds) {
+        try {
+          const reply = await routeOne(config, cmd, deps.plugins)
+          if (reply !== null) {
+            replies.push(reply)
+          } else if (cmd.kind === 'watch' || cmd.kind === 'unwatch') {
+            replies.push(unmatchedReply(cmd, deps.plugins))
+          }
+        } catch (e) {
+          deps.log(`dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
+          deps.postProjectError(`[dispatcher_error] handleCommand(${cmd.kind}): ${e}`)
+          replies.push(`error: handler crashed on ${cmd.kind}`)
+        }
+      }
     })
   } catch (e) {
+    writeFailed = true
     deps.log(`dm-handler: mutateConfig failed for ${dm.sender}: ${e}`)
     deps.postProjectError(`[dispatcher_error] config write: ${e}`)
     deps.dm(dm.sender, `error: failed to update config — ${e}`)
-    return
   }
 
+  if (writeFailed) return
   for (const cmd of cmds) {
-    const summary = `cmd=${cmd.kind}${'plugin' in cmd ? ` plugin=${cmd.plugin}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
+    const summary = `cmd=${cmd.kind}${'target' in cmd ? ` target=${cmd.target ?? '(default)'}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
     deps.log(`dm-handler: ${dm.sender} ${summary}`)
   }
-  deps.dm(dm.sender, replies.join('\n'))
+  deps.dm(dm.sender, replies.join('\n\n'))
 }

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -40,7 +40,11 @@ const HELP_TEXT = [
   '  unwatch pr <N>              — stop watching PR N',
   '  watch list                  — show current watch lists',
   '  help                        — this message',
+  'separate multiple commands per DM with newline, semicolon, or comma.',
+  'any parse error aborts the batch — nothing is applied.',
 ].join('\n')
+
+const CHANNEL_RE = /^#[^\s,#]+$/
 
 // ---- Parser ----------------------------------------------------------------
 
@@ -64,7 +68,12 @@ export function parseCommand(line: string): Command {
   if (verb === 'help') return { kind: 'help' }
 
   if (verb === 'watch') {
-    if (tokens[1]?.toLowerCase() === 'list') return { kind: 'list' }
+    if (tokens[1]?.toLowerCase() === 'list') {
+      if (tokens.length > 2) {
+        return { kind: 'unknown', raw: line, error: `watch list takes no arguments; got "${tokens.slice(2).join(' ')}"` }
+      }
+      return { kind: 'list' }
+    }
     return parseWatchOrUnwatch(line, 'watch', tokens.slice(1))
   }
 
@@ -101,8 +110,8 @@ function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: strin
   }
 
   for (const c of channels) {
-    if (!c.startsWith('#')) {
-      return { kind: 'unknown', raw, error: `channels must start with #: got "${c}"` }
+    if (!CHANNEL_RE.test(c)) {
+      return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
     }
   }
   return { kind: 'watch', plugin, number, channels }
@@ -153,10 +162,9 @@ export function applyCommand(config: OrchestratorConfig, cmd: Command): string {
     const existing = new Set(entry.channels ?? [])
     const added: string[] = []
     for (const c of cmd.channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
+    if (!added.length) return `${label} #${cmd.number} channels unchanged`
     entry.channels = [...existing]
-    return added.length
-      ? `${label} #${cmd.number} + ${added.join(' ')}`
-      : `${label} #${cmd.number} channels unchanged`
+    return `${label} #${cmd.number} + ${added.join(' ')}`
   }
 
   // unwatch
@@ -189,16 +197,19 @@ export function formatList(config: OrchestratorConfig): string {
 
 // ---- Allowlist -------------------------------------------------------------
 
-// Resolves command_senders. Unset → `[<project>-lead-pm]` by convention
-// (the lead-pm that spawned this dispatcher). Explicit `[]` means nobody
-// is allowed — the dispatcher silently drops everything except its own
-// process-internal mutations (none today).
-export function resolveAllowlist(config: OrchestratorConfig): string[] {
+// Resolves command_senders. Unset → `[leadPmNick(project)]` (see
+// naming.ts:leadPmNick — the single source of truth for the convention).
+// Explicit `[]` means nobody is allowed; everyone gets rejected silently
+// past the initial DM reply. If project is unresolvable, falls back to
+// `[]` and logs the cause so an operator chasing a "not authorized"
+// reply can find the root cause in daemon.log.
+export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string) => void): string[] {
   const explicit = config.irc?.command_senders
   if (explicit !== undefined) return explicit
   try {
     return [leadPmNick(defaultProject(config))]
-  } catch {
+  } catch (e) {
+    log?.(`dm-handler: cannot resolve default allowlist (no project/repo in config): ${e}`)
     return []
   }
 }
@@ -213,23 +224,28 @@ export interface InboundDm {
 // Top-level DM entry. Never throws — write/load failures are caught and
 // posted to the project channel via deps.postProjectError so the operator
 // notices a broken config.
+//
+// Read commands (help, list) and any-unknown batches short-circuit before
+// mutateConfig so we don't acquire the writer queue for a pure read or a
+// parse-failed message. Writes flow through mutateConfig as one atomic
+// commit per DM — a multi-cmd message is one fsync, one reply.
 export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> {
   const senderLower = dm.sender.toLowerCase()
   const body = dm.text.trim()
   if (!body) return
 
-  // Load the latest config to resolve the allowlist — config is hot-reloaded
-  // every tick, so operators editing command_senders take effect immediately.
-  let allowlist: string[]
+  // Single loadConfig per DM. Used for allowlist + (if pure-read) for the
+  // formatList payload. Writes re-load inside mutateConfig for freshness.
+  let snapshot: OrchestratorConfig
   try {
-    allowlist = resolveAllowlist(await loadConfig(deps.stateDir))
+    snapshot = await loadConfig(deps.stateDir)
   } catch (e) {
     deps.log(`dm-handler: config load failed for ${dm.sender}: ${e}`)
     deps.postProjectError(`[dispatcher_error] config load: ${e}`)
     return
   }
 
-  const allowed = new Set(allowlist.map(n => n.toLowerCase()))
+  const allowed = new Set(resolveAllowlist(snapshot, deps.log).map(n => n.toLowerCase()))
   if (!allowed.has(senderLower)) {
     deps.log(`dm-handler: rejecting ${dm.sender} (not in allowlist)`)
     deps.dm(dm.sender, 'not authorized; configure irc.command_senders')
@@ -239,9 +255,28 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   const cmds = parseCommands(body)
   if (cmds.length === 0) return
 
+  // If any command failed to parse, report all parse errors and apply
+  // nothing — a typo in one half of a multi-cmd DM shouldn't silently
+  // commit the other half.
+  const unknowns = cmds.filter((c): c is Extract<Command, { kind: 'unknown' }> => c.kind === 'unknown')
+  if (unknowns.length) {
+    for (const u of unknowns) deps.log(`dm-handler: ${dm.sender} parse: ${u.error}`)
+    deps.dm(dm.sender, unknowns.map(u => `error: ${u.error}`).join('\n'))
+    return
+  }
+
+  // Pure-read commands (help, list, or any mix of the two) don't need
+  // the writer queue. Format directly from the snapshot — no fsync.
+  if (cmds.every(c => c.kind === 'help' || c.kind === 'list')) {
+    const replies = cmds.map(c => applyCommand(snapshot, c))
+    for (const c of cmds) deps.log(`dm-handler: ${dm.sender} cmd=${c.kind}`)
+    deps.dm(dm.sender, replies.join('\n'))
+    return
+  }
+
+  // Write path. mutateConfig re-loads inside the mutex for freshness.
   const replies: string[] = []
   try {
-    // Single mutateConfig call so a multi-command DM is one atomic write.
     await mutateConfig(deps.stateDir, (config) => {
       for (const cmd of cmds) replies.push(applyCommand(config, cmd))
     })
@@ -253,11 +288,8 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   }
 
   for (const cmd of cmds) {
-    const summary = cmd.kind === 'unknown'
-      ? `parse: ${cmd.error}`
-      : `cmd=${cmd.kind}${'plugin' in cmd ? ` plugin=${cmd.plugin}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
+    const summary = `cmd=${cmd.kind}${'plugin' in cmd ? ` plugin=${cmd.plugin}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
     deps.log(`dm-handler: ${dm.sender} ${summary}`)
   }
-
   deps.dm(dm.sender, replies.join('\n'))
 }

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -1,0 +1,263 @@
+// Dispatcher DM handler: parses a small command grammar and mutates
+// .orchestrator/config.json. Replaces the haiku watcher's LLM-on-JSON loop
+// (see prompts/watcher.md) with a deterministic in-process path.
+//
+// All commands arrive via DM (msg.isDirect === true). The handler:
+//   1. enforces an allowlist (config.irc.command_senders)
+//   2. parses the message body into Command[] (multi-cmd per line is fine)
+//   3. mutates config via mutateConfig (single serialized writer)
+//   4. DMs back ONE confirmation summarizing what changed
+//
+// The handler never throws — parse/apply errors become a one-line DM to
+// the sender, and write errors are surfaced to the project channel by the
+// caller in orchestrator.ts.
+
+import { loadConfig, mutateConfig, type OrchestratorConfig, type WatchedEntry } from './config.js'
+import { defaultProject, leadPmNick } from './naming.js'
+
+type WatchPlugin = 'github-issues' | 'github-prs'
+
+export type Command =
+  | { kind: 'watch'; plugin: WatchPlugin; number: number; channels: string[] }
+  | { kind: 'unwatch'; plugin: WatchPlugin; number: number }
+  | { kind: 'list' }
+  | { kind: 'help' }
+  | { kind: 'unknown'; raw: string; error: string }
+
+export interface HandlerDeps {
+  stateDir: string
+  // Pure I/O — only the bits we need from RoostIrcClient.
+  dm: (nick: string, text: string) => void
+  postProjectError: (text: string) => void
+  log: (line: string) => void
+}
+
+const HELP_TEXT = [
+  'commands (DM only):',
+  '  watch <N> [#chan ...]       — watch issue N (and route extra channels)',
+  '  unwatch <N>                 — stop watching issue N',
+  '  watch pr <N> [#chan ...]    — watch PR N (and route extra channels)',
+  '  unwatch pr <N>              — stop watching PR N',
+  '  watch list                  — show current watch lists',
+  '  help                        — this message',
+].join('\n')
+
+// ---- Parser ----------------------------------------------------------------
+
+// Split a raw inbound body into individual command lines. Newlines /
+// semicolons / commas are all separators — matches the watcher prompt
+// grammar (which has been the operator-facing UX since the haiku watcher).
+export function splitCommands(text: string): string[] {
+  return text
+    .split(/[\n;,]+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+// Parse a single command line. Returns `unknown` rather than throwing so
+// the handler can DM a usage hint and keep processing.
+export function parseCommand(line: string): Command {
+  const tokens = line.split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return { kind: 'unknown', raw: line, error: 'empty command' }
+  const verb = tokens[0].toLowerCase()
+
+  if (verb === 'help') return { kind: 'help' }
+
+  if (verb === 'watch') {
+    if (tokens[1]?.toLowerCase() === 'list') return { kind: 'list' }
+    return parseWatchOrUnwatch(line, 'watch', tokens.slice(1))
+  }
+
+  if (verb === 'unwatch') {
+    return parseWatchOrUnwatch(line, 'unwatch', tokens.slice(1))
+  }
+
+  return { kind: 'unknown', raw: line, error: `unknown command: ${tokens[0]}` }
+}
+
+function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: string[]): Command {
+  let plugin: WatchPlugin = 'github-issues'
+  let i = 0
+  if (rest[0]?.toLowerCase() === 'pr') {
+    plugin = 'github-prs'
+    i = 1
+  }
+
+  const numTok = rest[i]
+  if (numTok === undefined) {
+    return { kind: 'unknown', raw, error: `${verb} requires an issue/PR number` }
+  }
+  const number = parseInt(numTok, 10)
+  if (!Number.isInteger(number) || number <= 0 || String(number) !== numTok) {
+    return { kind: 'unknown', raw, error: `${verb}: "${numTok}" is not a positive integer` }
+  }
+
+  const channels = rest.slice(i + 1)
+  if (verb === 'unwatch') {
+    if (channels.length) {
+      return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
+    }
+    return { kind: 'unwatch', plugin, number }
+  }
+
+  for (const c of channels) {
+    if (!c.startsWith('#')) {
+      return { kind: 'unknown', raw, error: `channels must start with #: got "${c}"` }
+    }
+  }
+  return { kind: 'watch', plugin, number, channels }
+}
+
+export function parseCommands(text: string): Command[] {
+  return splitCommands(text).map(parseCommand)
+}
+
+// ---- Apply -----------------------------------------------------------------
+
+interface WatchSlice {
+  watched?: WatchedEntry[]
+}
+
+function getSlice(config: OrchestratorConfig, plugin: WatchPlugin): WatchSlice {
+  config.plugins ??= {}
+  const existing = config.plugins[plugin]
+  if (existing && typeof existing === 'object') return existing as WatchSlice
+  const fresh: WatchSlice = {}
+  config.plugins[plugin] = fresh
+  return fresh
+}
+
+// One-line summary suitable for inclusion in the per-message confirmation
+// DM. The handler concatenates these with `\n`.
+export function applyCommand(config: OrchestratorConfig, cmd: Command): string {
+  if (cmd.kind === 'help') return HELP_TEXT
+  if (cmd.kind === 'list') return formatList(config)
+  if (cmd.kind === 'unknown') return `error: ${cmd.error} (line: ${cmd.raw})`
+
+  const slice = getSlice(config, cmd.plugin)
+  slice.watched ??= []
+  const watched = slice.watched
+  const label = cmd.plugin === 'github-prs' ? 'pr' : 'issue'
+
+  if (cmd.kind === 'watch') {
+    let entry = watched.find(e => e.number === cmd.number)
+    if (!entry) {
+      entry = { number: cmd.number }
+      if (cmd.channels.length) entry.channels = [...cmd.channels]
+      watched.push(entry)
+      return cmd.channels.length
+        ? `watching ${label} #${cmd.number} + ${cmd.channels.join(' ')}`
+        : `watching ${label} #${cmd.number}`
+    }
+    if (!cmd.channels.length) return `already watching ${label} #${cmd.number}`
+    const existing = new Set(entry.channels ?? [])
+    const added: string[] = []
+    for (const c of cmd.channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
+    entry.channels = [...existing]
+    return added.length
+      ? `${label} #${cmd.number} + ${added.join(' ')}`
+      : `${label} #${cmd.number} channels unchanged`
+  }
+
+  // unwatch
+  const idx = watched.findIndex(e => e.number === cmd.number)
+  if (idx < 0) return `not watching ${label} #${cmd.number}`
+  watched.splice(idx, 1)
+  return `unwatched ${label} #${cmd.number}`
+}
+
+// ---- watch list formatter --------------------------------------------------
+
+export function formatList(config: OrchestratorConfig): string {
+  const issues = (config.plugins?.['github-issues'] as WatchSlice | undefined)?.watched ?? []
+  const prs = (config.plugins?.['github-prs'] as WatchSlice | undefined)?.watched ?? []
+
+  const fmtEntry = (e: WatchedEntry): string => {
+    const chans = e.channels?.length ? ` + ${e.channels.join(' ')}` : ''
+    return `  #${e.number}${chans}`
+  }
+
+  const lines: string[] = []
+  lines.push(`issues (${issues.length}):`)
+  if (issues.length) for (const e of issues) lines.push(fmtEntry(e))
+  else lines.push('  (none)')
+  lines.push(`prs (${prs.length}):`)
+  if (prs.length) for (const e of prs) lines.push(fmtEntry(e))
+  else lines.push('  (none)')
+  return lines.join('\n')
+}
+
+// ---- Allowlist -------------------------------------------------------------
+
+// Resolves command_senders. Unset → `[<project>-lead-pm]` by convention
+// (the lead-pm that spawned this dispatcher). Explicit `[]` means nobody
+// is allowed — the dispatcher silently drops everything except its own
+// process-internal mutations (none today).
+export function resolveAllowlist(config: OrchestratorConfig): string[] {
+  const explicit = config.irc?.command_senders
+  if (explicit !== undefined) return explicit
+  try {
+    return [leadPmNick(defaultProject(config))]
+  } catch {
+    return []
+  }
+}
+
+// ---- Handler entry point ---------------------------------------------------
+
+export interface InboundDm {
+  sender: string
+  text: string
+}
+
+// Top-level DM entry. Never throws — write/load failures are caught and
+// posted to the project channel via deps.postProjectError so the operator
+// notices a broken config.
+export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> {
+  const senderLower = dm.sender.toLowerCase()
+  const body = dm.text.trim()
+  if (!body) return
+
+  // Load the latest config to resolve the allowlist — config is hot-reloaded
+  // every tick, so operators editing command_senders take effect immediately.
+  let allowlist: string[]
+  try {
+    allowlist = resolveAllowlist(await loadConfig(deps.stateDir))
+  } catch (e) {
+    deps.log(`dm-handler: config load failed for ${dm.sender}: ${e}`)
+    deps.postProjectError(`[dispatcher_error] config load: ${e}`)
+    return
+  }
+
+  const allowed = new Set(allowlist.map(n => n.toLowerCase()))
+  if (!allowed.has(senderLower)) {
+    deps.log(`dm-handler: rejecting ${dm.sender} (not in allowlist)`)
+    deps.dm(dm.sender, 'not authorized; configure irc.command_senders')
+    return
+  }
+
+  const cmds = parseCommands(body)
+  if (cmds.length === 0) return
+
+  const replies: string[] = []
+  try {
+    // Single mutateConfig call so a multi-command DM is one atomic write.
+    await mutateConfig(deps.stateDir, (config) => {
+      for (const cmd of cmds) replies.push(applyCommand(config, cmd))
+    })
+  } catch (e) {
+    deps.log(`dm-handler: mutateConfig failed for ${dm.sender}: ${e}`)
+    deps.postProjectError(`[dispatcher_error] config write: ${e}`)
+    deps.dm(dm.sender, `error: failed to update config — ${e}`)
+    return
+  }
+
+  for (const cmd of cmds) {
+    const summary = cmd.kind === 'unknown'
+      ? `parse: ${cmd.error}`
+      : `cmd=${cmd.kind}${'plugin' in cmd ? ` plugin=${cmd.plugin}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
+    deps.log(`dm-handler: ${dm.sender} ${summary}`)
+  }
+
+  deps.dm(dm.sender, replies.join('\n'))
+}

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -3,6 +3,12 @@
 // each tick returns pre-routed, pre-formatted events. Event kinds are
 // plugin-internal — the dispatcher iterates `TaggedEvent[]` and writes to IRC,
 // agnostic to the source plugin's event vocabulary.
+//
+// Plugins may also opt in to inbound DM commands via `handleCommand`: see
+// dm-handler.ts for the routing layer. Plugins mutate their own slice
+// (config.plugins[name]) in place inside the dispatcher's mutateConfig
+// callback; dm-handler never touches slice shapes.
+import type { Command } from './dm-handler.js'
 import type { OrchestratorConfig } from './config.js'
 
 // Pre-formatted payload variants. Plugins decide one-line vs. multi-line;
@@ -37,6 +43,16 @@ export interface Plugin {
   // including dynamic discoveries like PR linked-issues). Seeding is signaled
   // by `prevState === null`.
   runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
+  // Optional: handle a parsed DM command (see dm-handler.ts). Plugins mutate
+  // their own slice (config.plugins[name]) in place — the call site is wrapped
+  // in mutateConfig so writes are atomic across plugins. Return a reply line
+  // when this plugin handles the command, null when it doesn't apply.
+  // Implementations MUST NOT throw: deterministic failures (e.g. malformed
+  // slice) must come back as an `"error: ..."` string. The router will treat
+  // a thrown exception as a bug and surface a [dispatcher_error]. Both watch
+  // list and help are broadcast to every enabled plugin; replies are joined
+  // with `\n\n`.
+  handleCommand?(config: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
 }
 
 export abstract class BasePlugin implements Plugin {
@@ -44,6 +60,7 @@ export abstract class BasePlugin implements Plugin {
   constructor(protected readonly defaultChannel: string) {}
   abstract desiredChannels(config: OrchestratorConfig): string[]
   abstract runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
+  handleCommand?(config: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
 
   // Union auto-detected channels with the entry's declared channels;
   // fall back to the default channel if both are empty (defensive for any

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -267,3 +267,107 @@ describe('desiredChannels', () => {
     expect(new GitHubIssuesPlugin('#proj').desiredChannels({})).toEqual([])
   })
 })
+
+describe('GhBase.handleCommand — issues plugin (target=null)', () => {
+  const issues = () => new GitHubIssuesPlugin('#proj')
+
+  it('claims bare watch (target=null)', () => {
+    const config: OrchestratorConfig = {}
+    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: [] })
+    expect(out).toMatch(/watching issue #5/)
+    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+  })
+
+  it('ignores `watch pr` (returns null)', () => {
+    const config: OrchestratorConfig = {}
+    const out = issues().handleCommand!(config, { kind: 'watch', target: 'pr', number: 5, channels: [] })
+    expect(out).toBeNull()
+    expect(config.plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('is idempotent on duplicate watch', () => {
+    const config: OrchestratorConfig = { plugins: { 'github-issues': { watched: [{ number: 5 }] } } }
+    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: [] })
+    expect(out).toMatch(/already watching/)
+  })
+
+  it('appends + dedupes channels onto existing entry', () => {
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5, channels: ['#a'] }] } },
+    }
+    issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    const entry = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
+    expect(entry.channels).toEqual(['#a', '#b'])
+  })
+
+  it('no-op channel add does not dirty entry.channels', () => {
+    const before = ['#a', '#b']
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5, channels: before }] } },
+    }
+    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    expect(out).toMatch(/channels unchanged/)
+    const after = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
+    expect(after).toBe(before)
+  })
+
+  it('removes an entry on unwatch', () => {
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
+    }
+    issues().handleCommand!(config, { kind: 'unwatch', target: null, number: 5 })
+    expect((config.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
+  })
+
+  it('reports not-watching on unwatch of unknown entry', () => {
+    const out = issues().handleCommand!({}, { kind: 'unwatch', target: null, number: 5 })
+    expect(out).toMatch(/not watching/)
+  })
+
+  it('list returns the github-issues section', () => {
+    const config: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6, channels: ['#a'] }] } },
+    }
+    const out = issues().handleCommand!(config, { kind: 'list' })
+    expect(out).toContain('github-issues (2):')
+    expect(out).toContain('  #5')
+    expect(out).toContain('  #6 + #a')
+  })
+
+  it('list reports (none) for empty slice', () => {
+    expect(issues().handleCommand!({}, { kind: 'list' })).toContain('(none)')
+  })
+
+  it('help returns this plugin\'s usage block', () => {
+    const out = issues().handleCommand!({}, { kind: 'help' })!
+    expect(out).toContain('github-issues commands')
+    expect(out).toMatch(/watch <N>/)
+    expect(out).toMatch(/unwatch <N>/)
+    // No `pr` keyword in issues help.
+    expect(out).not.toContain('pr <N>')
+  })
+})
+
+describe('GhBase.handleCommand — prs plugin (target=pr)', () => {
+  const prs = () => new GitHubPrsPlugin('#proj')
+
+  it('claims `watch pr` (target=pr)', () => {
+    const config: OrchestratorConfig = {}
+    const out = prs().handleCommand!(config, { kind: 'watch', target: 'pr', number: 10, channels: ['#x'] })
+    expect(out).toMatch(/watching pr #10 \+ #x/)
+    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
+    expect(config.plugins?.['github-issues']).toBeUndefined()
+  })
+
+  it('ignores bare watch (returns null)', () => {
+    const out = prs().handleCommand!({}, { kind: 'watch', target: null, number: 10, channels: [] })
+    expect(out).toBeNull()
+  })
+
+  it('help mentions `pr <N>` form', () => {
+    const out = prs().handleCommand!({}, { kind: 'help' })!
+    expect(out).toContain('github-prs commands')
+    expect(out).toMatch(/watch pr <N>/)
+    expect(out).toMatch(/unwatch pr <N>/)
+  })
+})

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -3,6 +3,11 @@
 // and the convention that every GhBase plugin reads its watch list from a
 // `{ watched?: WatchedEntry[] }` slice under `config.plugins[name]`. Channel
 // resolution + default-channel fallback come from BasePlugin.
+//
+// Also implements `handleCommand` for the two verbs both plugins support:
+// each subclass declares the target keyword it claims (`null` = bare
+// `watch <N>`, `'pr'` = `watch pr <N>`) and a label used in reply text.
+import type { Command } from '../../dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
@@ -13,6 +18,14 @@ interface GhPluginConfig {
 }
 
 export abstract class GhBase extends BasePlugin {
+  // Target keyword this plugin claims for watch/unwatch. `null` = no keyword
+  // (bare `watch <N>`). The dispatcher's parser is target-agnostic; plugins
+  // declare which keyword (if any) they own here.
+  protected abstract readonly target: string | null
+  // Singular noun used in reply lines (e.g. "issue", "pr"). Plural is the
+  // plugin name slice.
+  protected abstract readonly label: string
+
   protected agentLogins(config: OrchestratorConfig): Set<string> {
     return new Set(config.agent_logins ?? [])
   }
@@ -35,5 +48,88 @@ export abstract class GhBase extends BasePlugin {
       for (const c of channels) chans.add(c)
     }
     return [...chans]
+  }
+
+  // ---- DM command handling --------------------------------------------
+
+  // Inbound DM command surface. The dispatcher (dm-handler.ts) calls this
+  // once per parsed command inside its mutateConfig pass — we mutate our
+  // own slice in place. Returns the reply line(s) when we handle the
+  // command, null when the command isn't ours. Never throws.
+  handleCommand(config: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(config)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'watch') {
+      if (cmd.target !== this.target) return null
+      return this.applyWatch(config, cmd.number, cmd.channels)
+    }
+    if (cmd.kind === 'unwatch') {
+      if (cmd.target !== this.target) return null
+      return this.applyUnwatch(config, cmd.number)
+    }
+    return null
+  }
+
+  // Read-or-create the typed slice under `config.plugins[name]`. Plugins
+  // own their slice shape; this is the one mutation seam.
+  private slice(config: OrchestratorConfig): GhPluginConfig {
+    config.plugins ??= {}
+    const existing = config.plugins[this.name]
+    if (existing && typeof existing === 'object') return existing as GhPluginConfig
+    const fresh: GhPluginConfig = {}
+    config.plugins[this.name] = fresh
+    return fresh
+  }
+
+  private applyWatch(config: OrchestratorConfig, number: number, channels: string[]): string {
+    const slice = this.slice(config)
+    slice.watched ??= []
+    const watched = slice.watched
+    let entry = watched.find(e => e.number === number)
+    if (!entry) {
+      entry = { number }
+      if (channels.length) entry.channels = [...channels]
+      watched.push(entry)
+      return channels.length
+        ? `watching ${this.label} #${number} + ${channels.join(' ')}`
+        : `watching ${this.label} #${number}`
+    }
+    if (!channels.length) return `already watching ${this.label} #${number}`
+    const existing = new Set(entry.channels ?? [])
+    const added: string[] = []
+    for (const c of channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
+    if (!added.length) return `${this.label} #${number} channels unchanged`
+    entry.channels = [...existing]
+    return `${this.label} #${number} + ${added.join(' ')}`
+  }
+
+  private applyUnwatch(config: OrchestratorConfig, number: number): string {
+    const slice = this.slice(config)
+    const watched = slice.watched ?? []
+    const idx = watched.findIndex(e => e.number === number)
+    if (idx < 0) return `not watching ${this.label} #${number}`
+    watched.splice(idx, 1)
+    return `unwatched ${this.label} #${number}`
+  }
+
+  private formatListSection(config: OrchestratorConfig): string {
+    const entries = this.watched(config)
+    const header = `${this.name} (${entries.length}):`
+    if (!entries.length) return `${header}\n  (none)`
+    const lines = entries.map(e => {
+      const chans = e.channels?.length ? ` + ${e.channels.join(' ')}` : ''
+      return `  #${e.number}${chans}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    const t = this.target ? `${this.target} ` : ''
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch ${t}<N> [#chan ...]    — watch ${this.label} N, route extra channels`,
+      `  unwatch ${t}<N>              — stop watching ${this.label} N`,
+      `  watch list                  — include this plugin's watched ${this.name} in the reply`,
+    ].join('\n')
   }
 }

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -10,6 +10,8 @@ import type { IssueSnap, IssuePluginState } from './types.js'
 
 export class GitHubIssuesPlugin extends GhBase {
   readonly name = 'github-issues'
+  protected readonly target = null
+  protected readonly label = 'issue'
 
   desiredChannels(config: OrchestratorConfig): string[] {
     return this.entryChannels(config, this.watched(config))

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -10,6 +10,8 @@ import type { PrSnap, PrPluginState } from './types.js'
 
 export class GitHubPrsPlugin extends GhBase {
   readonly name = 'github-prs'
+  protected readonly target = 'pr'
+  protected readonly label = 'pr'
 
   desiredChannels(config: OrchestratorConfig): string[] {
     return this.entryChannels(config, this.watched(config))


### PR DESCRIPTION
Closes #285

## Summary
- New `src/orchestrator/dm-handler.ts` parses DM bodies into a `Command[]` and mutates `.orchestrator/config.json` via `mutateConfig` (from #284). Multi-cmd messages land as one atomic write + one reply.
- Wired in `runDaemon` via `client.on('message', ...)`, filtered to `isDirect`. Channel messages are ignored; agents/humans drive watches by DMing the dispatcher.
- Auth via new `irc.command_senders?: string[]`. Unset defaults to `[<project>-lead-pm]` (the spawning lead-pm by convention); explicit `[]` disables remote control. Rejected senders get a tight `not authorized; configure irc.command_senders` — no command echo.
- Channel args must start with `#` — fails loudly rather than silently DWIM, so a namespace typo surfaces.

## Grammar (mirrors `prompts/watcher.md`)
`watch <N>` / `watch <N> #foo #bar` / `unwatch <N>` / `watch pr <N>` / `watch pr <N> #foo` / `unwatch pr <N>` / `watch list` / `help`. Split on `\n` / `;` / `,` for multi-command DMs. Case-insensitive on verbs.

## Error surfaces
- parse failure → one-liner DM, no mutation, no throw
- config load/write failure → `[dispatcher_error]` on project channel + DM to sender
- handler never throws out of the message callback

## Test plan
- [x] Parser shapes (every command + multi-cmd + unknown verb/bad number/missing `#`)
- [x] `applyCommand` mutations (idempotent add, channel append+dedupe, removal)
- [x] Allowlist enforcement (default + explicit + empty + case-insensitive)
- [x] Parse-failure DM is one-liner; handler doesn't throw
- [x] `watch list` output format with + without channel attachments
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 396 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)