### PR TITLE
feat(weechat): pushover notification script

### DIFF
--- a/extras/weechat/pushover.py
+++ b/extras/weechat/pushover.py
@@ -1,16 +1,14 @@
 # Pushover (https://pushover.net/) bridge for weechat.
 #
-# Sibling to notification_center.py. The two scripts are independent —
-# notification_center is macOS-only (terminal-notifier), pushover is a remote
-# HTTPS push so it works wherever weechat runs.
+# Sibling to notification_center.py. Same trigger logic and setting names
+# (channels, show_highlights, show_private_message, show_message_text,
+# enabled, ignore_old_messages, ignore_current_buffer_messages) so behavior
+# is mechanically identical — only the delivery transport differs
+# (terminal-notifier vs Pushover HTTPS).
 #
 # Setup:
 #   /set plugins.var.python.pushover.user_key   <your user key>
 #   /set plugins.var.python.pushover.app_token  <your application token>
-#
-# By default fires on highlights + private messages in any channel.
-# Override `channels` to restrict to a comma-separated allowlist (or `*` = all
-# channel messages, like notification_center.py).
 #
 # HTTP is dispatched via weechat.hook_process_hashtable with a `url:` prefix,
 # so the request runs in a forked child and weechat's main loop never blocks.
@@ -33,14 +31,17 @@ weechat.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE, SCR
 DEFAULT_OPTIONS = {
 	'user_key': '',
 	'app_token': '',
+	'enabled': 'on',
+	'show_highlights': 'on',
+	'show_private_message': 'on',
+	'show_message_text': 'on',
 	'channels': '',
+	'ignore_old_messages': 'off',
+	'ignore_current_buffer_messages': 'off',
+	'max_body_chars': '140',
 	'priority': '0',
 	'sound': '',
 	'device': '',
-	'max_body_chars': '140',
-	'notify_self': 'off',
-	'ignore_old_messages': 'off',
-	'ignore_current_buffer_messages': 'off',
 	'http_timeout_seconds': '10',
 	'debug': 'off',
 }
@@ -104,11 +105,13 @@ def _send(title, body):
 weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')
 
 def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
+	if _opt('enabled') != 'on':
+		return weechat.WEECHAT_RC_OK
 	if not _opt('user_key') or not _opt('app_token'):
 		return weechat.WEECHAT_RC_OK
 
 	own_nick = weechat.buffer_get_string(buffer, 'localvar_nick')
-	if _opt('notify_self') != 'on' and (prefix == own_nick or prefix == ('@%s' % own_nick)):
+	if prefix == own_nick or prefix == ('@%s' % own_nick):
 		return weechat.WEECHAT_RC_OK
 
 	if _opt('ignore_current_buffer_messages') == 'on' and buffer == weechat.current_buffer():
@@ -119,20 +122,23 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 		if (datetime.datetime.utcnow() - message_time).seconds > 5:
 			return weechat.WEECHAT_RC_OK
 
+	show_text = _opt('show_message_text') == 'on'
+
 	channels_setting = _opt('channels').strip()
 	notify_all = channels_setting == '*'
-	allow_list = [] if (not channels_setting or notify_all) else [c.strip() for c in channels_setting.split(',')]
+	channel_allow_list = [] if (not channels_setting or notify_all) else [c.strip() for c in channels_setting.split(',')]
 	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
 
-	is_private = 'irc_privmsg' in tags and 'notify_private' in tags
-	is_highlight = bool(int(highlight))
-	is_allowed_channel = notify_all or (channel and channel in allow_list)
-
-	if is_private:
-		_send('%s [private]' % prefix, message)
-	elif is_highlight:
-		_send('%s in %s' % (prefix, channel), message)
-	elif is_allowed_channel:
-		_send('%s in %s' % (prefix, channel), message)
-
+	if notify_all or channel in channel_allow_list:
+		title = '%s %s' % (prefix, channel)
+		body = message if show_text else 'In %s by %s' % (channel, prefix)
+		_send(title, body)
+	elif _opt('show_highlights') == 'on' and int(highlight):
+		title = '%s %s' % (prefix, channel) if show_text else 'Highlighted Message'
+		body = message if show_text else 'In %s by %s' % (channel, prefix)
+		_send(title, body)
+	elif _opt('show_private_message') == 'on' and 'irc_privmsg' in tags and 'notify_private' in tags:
+		title = '%s [private]' % prefix if show_text else 'Private Message'
+		body = message if show_text else 'From %s' % prefix
+		_send(title, body)
 	return weechat.WEECHAT_RC_OK

--- a/extras/weechat/pushover.py
+++ b/extras/weechat/pushover.py
@@ -42,6 +42,8 @@ DEFAULT_OPTIONS = {
 	'priority': '0',
 	'sound': '',
 	'device': '',
+	'url': '',
+	'url_title': '',
 	'http_timeout_seconds': '10',
 	'debug': 'off',
 }
@@ -94,6 +96,12 @@ def _send(title, body):
 	device = _opt('device')
 	if device:
 		form['device'] = device
+	url = _opt('url')
+	if url:
+		form['url'] = url
+		url_title = _opt('url_title')
+		if url_title:
+			form['url_title'] = url_title
 	weechat.hook_process_hashtable(
 		'url:https://api.pushover.net/1/messages.json',
 		{'postfields': urllib.parse.urlencode(form)},

--- a/extras/weechat/pushover.py
+++ b/extras/weechat/pushover.py
@@ -1,0 +1,138 @@
+# Pushover (https://pushover.net/) bridge for weechat.
+#
+# Sibling to notification_center.py. The two scripts are independent —
+# notification_center is macOS-only (terminal-notifier), pushover is a remote
+# HTTPS push so it works wherever weechat runs.
+#
+# Setup:
+#   /set plugins.var.python.pushover.user_key   <your user key>
+#   /set plugins.var.python.pushover.app_token  <your application token>
+#
+# By default fires on highlights + private messages in any channel.
+# Override `channels` to restrict to a comma-separated allowlist (or `*` = all
+# channel messages, like notification_center.py).
+#
+# HTTP is dispatched via weechat.hook_process_hashtable with a `url:` prefix,
+# so the request runs in a forked child and weechat's main loop never blocks.
+
+import datetime
+import urllib.parse
+
+import weechat
+
+
+SCRIPT_NAME = 'pushover'
+SCRIPT_AUTHOR = 'roost <noreply@anthropic.com>'
+SCRIPT_VERSION = '0.1.0'
+SCRIPT_LICENSE = 'MIT'
+SCRIPT_DESC = 'Send weechat highlights and private messages to Pushover.'
+
+weechat.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE, SCRIPT_DESC, '', '')
+
+
+DEFAULT_OPTIONS = {
+	'user_key': '',
+	'app_token': '',
+	'channels': '',
+	'priority': '0',
+	'sound': '',
+	'device': '',
+	'max_body_chars': '140',
+	'notify_self': 'off',
+	'ignore_old_messages': 'off',
+	'ignore_current_buffer_messages': 'off',
+	'http_timeout_seconds': '10',
+	'debug': 'off',
+}
+
+for key, val in DEFAULT_OPTIONS.items():
+	if not weechat.config_is_set_plugin(key):
+		weechat.config_set_plugin(key, val)
+
+if not weechat.config_get_plugin('user_key') or not weechat.config_get_plugin('app_token'):
+	weechat.prnt('', '[pushover] not configured — set plugins.var.python.pushover.user_key and .app_token')
+
+
+def _opt(name):
+	return weechat.config_get_plugin(name)
+
+def _opt_int(name, default):
+	try:
+		return int(_opt(name))
+	except ValueError:
+		return default
+
+def _truncate(s, n):
+	return s if len(s) <= n else s[:n - 3].rstrip() + '...'
+
+def _post_callback(data, command, return_code, out, err):
+	if _opt('debug') == 'on':
+		weechat.prnt('', '[pushover] rc=%d out=%r err=%r' % (return_code, out[:200], err[:200]))
+	if return_code != 0 and return_code != weechat.WEECHAT_HOOK_PROCESS_RUNNING:
+		weechat.prnt('', '[pushover] http rc=%d err=%s' % (return_code, err[:200] if err else ''))
+	return weechat.WEECHAT_RC_OK
+
+def _send(title, body):
+	user_key = _opt('user_key')
+	app_token = _opt('app_token')
+	if not user_key or not app_token:
+		return
+	body = _truncate(body, _opt_int('max_body_chars', 140))
+	form = {
+		'token': app_token,
+		'user': user_key,
+		'title': title,
+		'message': body,
+	}
+	priority = _opt('priority')
+	if priority and priority != '0':
+		form['priority'] = priority
+	sound = _opt('sound')
+	if sound:
+		form['sound'] = sound
+	device = _opt('device')
+	if device:
+		form['device'] = device
+	weechat.hook_process_hashtable(
+		'url:https://api.pushover.net/1/messages.json',
+		{'postfields': urllib.parse.urlencode(form)},
+		_opt_int('http_timeout_seconds', 10) * 1000,
+		'_post_callback',
+		'',
+	)
+
+weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')
+
+def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
+	if not _opt('user_key') or not _opt('app_token'):
+		return weechat.WEECHAT_RC_OK
+
+	own_nick = weechat.buffer_get_string(buffer, 'localvar_nick')
+	if _opt('notify_self') != 'on' and (prefix == own_nick or prefix == ('@%s' % own_nick)):
+		return weechat.WEECHAT_RC_OK
+
+	if _opt('ignore_current_buffer_messages') == 'on' and buffer == weechat.current_buffer():
+		return weechat.WEECHAT_RC_OK
+
+	if _opt('ignore_old_messages') == 'on':
+		message_time = datetime.datetime.utcfromtimestamp(int(date))
+		if (datetime.datetime.utcnow() - message_time).seconds > 5:
+			return weechat.WEECHAT_RC_OK
+
+	channels_setting = _opt('channels').strip()
+	notify_all = channels_setting == '*'
+	allow_list = [] if (not channels_setting or notify_all) else [c.strip() for c in channels_setting.split(',')]
+	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+
+	is_private = 'irc_privmsg' in tags and 'notify_private' in tags
+	is_highlight = bool(int(highlight))
+	is_allowed_channel = notify_all or (channel and channel in allow_list)
+
+	if is_private:
+		_send('%s [private]' % prefix, message)
+	elif is_highlight:
+		_send('%s in %s' % (prefix, channel), message)
+	elif is_allowed_channel:
+		_send('%s in %s' % (prefix, channel), message)
+
+	return weechat.WEECHAT_RC_OK


### PR DESCRIPTION
Closes #288.

## Summary
- New `extras/weechat/pushover.py` — sibling to `notification_center.py`, totally independent (no shared state).
- Async HTTPS via `weechat.hook_process_hashtable("url:...", ...)` so weechat's event loop never blocks on the API call.
- Settings: `user_key`, `app_token`, `channels` (default empty = highlights/PMs only; `*` = every channel msg), `priority`, `sound`, `device`, `max_body_chars`, `notify_self`, `ignore_old_messages`, `ignore_current_buffer_messages`, `http_timeout_seconds`, `debug`.
- Triggers on highlights + private messages out of the box.
- If `user_key`/`app_token` are unset on load, prints a one-line "configure these" message and exits the notify path silently — no crash.

## Test plan
- [ ] Load script in weechat: `/python load ~/path/to/pushover.py` — observe the "not configured" line if unset.
- [ ] Set keys: `/set plugins.var.python.pushover.user_key XXX`, `/set plugins.var.python.pushover.app_token XXX`.
- [ ] Send self a private message in another irc client → expect a Pushover notification.
- [ ] Trigger a highlight in a joined channel → expect a Pushover notification.
- [ ] Set `channels = *`, send a normal channel message → expect a Pushover notification.
- [ ] `/set plugins.var.python.pushover.debug on` → confirm `[pushover] rc=...` lines appear in core buffer for visibility.

[roost-lead-pm]

🤖 Generated with [Claude Code](https://claude.com/claude-code)