### PR TITLE
maint: switch lead-pm + docs to direct dispatcher CRUD (0.5.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,20 +170,22 @@ roost spawn scratch-h -c '#sandbox' -m haiku \
 ## Project dispatcher
 
 `roost init` bootstraps your project's dispatcher config and copies the
-role prompts into `.claude/commands/`. Then spawn the watcher — a haiku
-agent that supervises the poll loop and routes GitHub events (CI
-transitions, PR comments, issue updates) into the right
-`#<project>-issue-N` channels:
+role prompts into `.claude/commands/`. Then start the dispatcher — it polls
+GitHub on a tick, routes events (CI transitions, PR comments, issue updates)
+into the right `#<project>-issue-N` channels, and accepts watch/unwatch DMs
+to control which issues and PRs are tracked:
 
 ```bash
 cd ~/Dev/myproject
 roost init                              # first-time: writes .orchestrator/config.json + prompts
 CONFIG_DIR="$(pwd)/.orchestrator"
-roost spawn myproject-watcher -m haiku \
-  --channels '#myproject-leads' \
-  --prompt "/watcher myproject myproject-lead-pm <your-nick> $CONFIG_DIR" \
-  --perm-irc --perm-target myproject-lead-pm
+"$ROOST_DIR/bin/start-dispatcher" "$CONFIG_DIR"
 ```
+
+DM the dispatcher (`<project>-dispatcher`) to manage the watch list:
+`watch <N>`, `unwatch <N>`, `watch pr <N>`, `watch list`, `help`. The
+dispatcher's allowlist defaults to `[<project>-lead-pm]`; set
+`irc.command_senders` in config to override.
 
 `project` namespaces every per-project artifact (`<project>-worker-N` nicks,
 `#<project>-issue-N` channels, etc.) so multiple projects can share one ergo.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ CONFIG_DIR="$(pwd)/.orchestrator"
 ```
 
 DM the dispatcher (`<project>-dispatcher`) to manage the watch list:
-`watch <N>`, `unwatch <N>`, `watch pr <N>`, `watch list`, `help`. The
-dispatcher's allowlist defaults to `[<project>-lead-pm]`; set
-`irc.command_senders` in config to override.
+`watch <N>`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`,
+`watch list`, `help`. The dispatcher's allowlist defaults to
+`[<project>-lead-pm]`; set `irc.command_senders` in config to override.
 
 `project` namespaces every per-project artifact (`<project>-worker-N` nicks,
 `#<project>-issue-N` channels, etc.) so multiple projects can share one ergo.

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -74,7 +74,7 @@ State files in `.orchestrator/`:
 
 | File | Purpose |
 |---|---|
-| `config.json` | Tracked in git. Hand-edited or mutated by a watcher agent. |
+| `config.json` | Tracked in git. Hand-edited or mutated via DMs to the dispatcher (`watch <N>`, `unwatch <N>`, `watch pr <N>`, etc.). |
 | `config.example.json` | Tracked. Template for forks. |
 | `state.json` | Last seen GH state per watched entry. Re-seedable. |
 | `last-tick.txt` | Heartbeat timestamp. Use for healthchecks. |

--- a/docs/ROOST-IN-PRACTICE.md
+++ b/docs/ROOST-IN-PRACTICE.md
@@ -38,9 +38,9 @@ sits in `#leads-<project>` continuously and joins each issue
 channel while it's active.
 
 For the first issue, lead-pm opens a channel called `#issue-42`,
-DMs a small bookkeeping agent called **watcher** to subscribe to
-the issue (so GitHub events for it route to that channel), creates
-an isolated git worktree, and spawns a worker into it.
+DMs the dispatcher (`watch 42`) to subscribe to the issue (so
+GitHub events for it route to that channel), creates an isolated
+git worktree, and spawns a worker into it.
 
 **worker-42** reads the issue, posts an implementation plan in
 `#issue-42`, and waits. lead-pm reads the plan and pushes back —
@@ -57,8 +57,9 @@ diff cold, posts findings to GitHub, and exits. Its playbook is
 flips the PR ready and tags you as the human reviewer.
 
 You approve. lead-pm merges, terminates the worker, parts the
-channel, cleans up the worktree, DMs the watcher to unsubscribe,
-and posts a one-paragraph postmortem in `#leads-<project>` — what
+channel, cleans up the worktree, DMs the dispatcher to unsubscribe
+(`unwatch 42`, `unwatch pr 73`), and posts a one-paragraph
+postmortem in `#leads-<project>` — what
 went well, what was painful, what to fix next time. Then it picks
 the next pickable issue off the DAG and the cycle repeats.
 
@@ -102,7 +103,6 @@ already reading. There's no second pathway for "human-to-agent" —
 you're just another nick on the IRC server.
 
 The slash-command prompts (`prompts/lead-pm.md`,
-`prompts/worker.md`, `prompts/reviewer.md`, `prompts/watcher.md`)
-are the operational source of truth — they're what the agents
-actually run, and they're the right starting point for standing up
-your own project on Roost.
+`prompts/worker.md`, `prompts/reviewer.md`) are the operational
+source of truth — they're what the agents actually run, and they're
+the right starting point for standing up your own project on Roost.

--- a/prompts/lead-pm.md
+++ b/prompts/lead-pm.md
@@ -20,24 +20,21 @@ Every per-project artifact carries a `$0-` prefix:
 - Issue channel: `#$0-issue-<N>`
 - Worker nick: `$0-worker-<N>`
 - Reviewer nick: `$0-reviewer-<N>`
-- Watcher nick: `$0-watcher`
 - Dispatcher nick: `$0-dispatcher` (set in `.orchestrator/config.json`)
 
 The prefix exists for **IRC nick uniqueness** across projects sharing one ergo, and for **GitHub comment attribution** (agents share one GH account, so `[$0-worker-N]` disambiguates which project the comment came from). It is *not* an in-chat speaker label — IRC nicks already show who said what.
 
-When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the watcher to add a watch — pass the explicit channel rather than relying on dispatcher defaults. Namespacing in spawn args + watch commands is the lead's job.
+When you spawn an agent, always pass the namespaced nick + the matching `--channels` value explicitly. Same when DMing the dispatcher to add a watch — pass the explicit channel rather than relying on auto-routing defaults. Namespacing in spawn args + watch commands is the lead's job.
 
 ## Getting started
 
-Spawn the watcher — pre-expand the config dir so the absolute path is baked in at spawn time:
+Start the dispatcher daemon — it owns watch-list CRUD via IRC DMs and posts GitHub events to per-issue channels:
 ```bash
 CONFIG_DIR="$(pwd)/.orchestrator"
-roost spawn $0-watcher --model haiku --channels '#$0-leads' --prompt "/watcher $0 $0-lead-pm $2 $CONFIG_DIR" --perm-irc --perm-target $0-lead-pm
+"$ROOST_DIR/bin/start-dispatcher" "$CONFIG_DIR"
 ```
 
-The watcher starts the dispatcher daemon automatically on boot — you don't need to start it manually.
-
-The watcher is an agent in roost. You can DM it to control what issues and PRs will automatically post in issue channels.
+Then DM `$0-dispatcher` to control what issues and PRs route to which channels. The dispatcher's allowlist defaults to `[$0-lead-pm]` so your DMs are accepted out of the box; other senders are ignored.
 
 - `watch <N>` — add N to `plugins.github-issues.watched` (idempotent)
 - `watch <N> #foo #bar` — add N and attach extra channels (append + dedupe on existing entry)
@@ -63,7 +60,7 @@ If you comment on GitHub, prefix your comment with your name [$0-lead-pm]
 
 To work on an issue:
 1. Join #$0-issue-<N> on Roost
-2. Message the watcher to watch the issue
+2. DM `$0-dispatcher`: `watch <N>` (the issue auto-routes to `#$0-issue-<N>`)
 3. Create a new branch and worktree for the issue. Install dependencies in the worktree (bun or yarn)
 
    Before continuing: read the issue. If the body is < ~3 sentences or scope-ambiguous, ask the human in #$0-leads for a one-line clarification before spawning the worker — much cheaper than a full PR rewrite after the worker builds the wrong thing.
@@ -79,7 +76,7 @@ To work on an issue:
   - Does it believably resolve the issue?
   - Does it set the project up for downstream success, or is it a pending footgun?
   - When worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan
-6. Once the agent posts a draft PR, check the PR body starts with `Closes #N` (or Fixes/Resolves) so GitHub auto-links the issue — without it the dispatcher can't route per-PR events. Edit the body yourself if needed (`gh pr edit N --body "..."`). Then ask the watcher to watch it with `watch pr`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--cwd <worker's worktree>` (so the reviewer's reads are in-cwd, otherwise it floods you with permission prompts) and `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url> $2'`. Default to Opus for review regardless of worker model — opus consistently surfaces a class of findings (dead paths, duplicated invariants, misleading comments) that sonnet misses, and review cost is small relative to the cost of a stale comment shipping. Drop to Sonnet only for trivially-sized PRs (e.g. doc/prompt tweaks well under 100 lines).
+6. Once the agent posts a draft PR, check the PR body starts with `Closes #N` (or Fixes/Resolves) so GitHub auto-links the issue — without it the dispatcher can't route per-PR events. Edit the body yourself if needed (`gh pr edit N --body "..."`). Then DM the dispatcher: `watch pr <N>`. Then spawn a reviewer agent named `$0-reviewer-<PR>` with `--cwd <worker's worktree>` (so the reviewer's reads are in-cwd, otherwise it floods you with permission prompts) and `--prompt '/reviewer $0 <PR> <ISSUE> <branch> <pr-url> $2'`. Default to Opus for review regardless of worker model — opus consistently surfaces a class of findings (dead paths, duplicated invariants, misleading comments) that sonnet misses, and review cost is small relative to the cost of a stale comment shipping. Drop to Sonnet only for trivially-sized PRs (e.g. doc/prompt tweaks well under 100 lines).
 7. The reviewer shuts itself down after posting its summary — no action needed.
 8. Once the worker addresses reviewer findings, **you** (the lead-pm) mark the PR ready and add `$3` as reviewer:
    - `gh pr ready N --repo OWNER/REPO`
@@ -99,7 +96,7 @@ To work on an issue:
   - Merge the PR using --merge
   - Pull main in the primary repo
   - Clean up the worktree
-  - Unwatch the issue and the PR by dm'ing watcher
+  - DM the dispatcher to unwatch the issue and the PR (`unwatch <N>`, `unwatch pr <N>`)
 10. Post a postmortem in '#$0-leads' about how the issue went. Come with suggestions about how to make the next issue easier.
 
 Before merging a PR or removing a worktree, confirm: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
@@ -110,9 +107,9 @@ Some changes are small enough that spawning a worker is overhead — a doc tweak
 
 - Same setup as a worker PR (step 3): new branch + worktree, even for a one-liner. Keeps the primary worktree free for other in-flight work. Commit, push, open the PR from there
 - Add `$3` as reviewer immediately when you open the PR: `gh pr edit <N> --repo OWNER/REPO --add-reviewer $3`. Self-authored PRs aren't draft + ready toggled, so the request-review step doesn't happen automatically — you have to do it explicitly
-- DM the watcher to watch it: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
+- DM the dispatcher: `watch pr <N> #$0-leads` (the `#$0-leads` attachment routes events to the leads channel since there's typically no `#$0-issue-N` for self-authored PRs)
 - Stay engaged through the review loop the same way you would for a worker's PR — don't fire-and-forget. If the human leaves CHANGES_REQUESTED and you push a fix, re-request review the same way (`--add-reviewer $3`)
-- After human approval, merge follows the same flow as step 9: terminate-N/A, merge `--merge`, pull main, clean up branch, unwatch
+- After human approval, merge follows the same flow as step 9: terminate-N/A, merge `--merge`, pull main, clean up branch, DM dispatcher `unwatch pr <N>`
 
 ## Ready?
 


### PR DESCRIPTION
Aligns the operational prompts and docs with the 0.5.5 dispatcher behavior shipped in #284 + #287. Lead-pm starts the dispatcher daemon directly and DMs it for watch/unwatch/list/help — same grammar, no LLM-on-JSON loop.

## Summary
- `prompts/lead-pm.md`: drop spawn-the-watcher step; replace "DM the watcher" with "DM the dispatcher" throughout; drop watcher nick from naming convention
- `README.md`: rewrite Project dispatcher section to start the dispatcher directly + describe the DM surface and default allowlist
- `docs/DISPATCHER.md`: config.json mutation note points at dispatcher DMs
- `docs/ROOST-IN-PRACTICE.md`: narrative updated end-to-end; drop `prompts/watcher.md` from operational source-of-truth list

The watcher prompt + skill files stay in tree — 0.6.0 will recycle the slot for the autonomous observer agent (separate scope).

## Test plan
- [ ] Read `prompts/lead-pm.md` end-to-end — every reference to the watcher's CRUD role should now point at the dispatcher; the spawn-watcher step from Getting Started is gone.
- [ ] Read README's Project dispatcher section — the example should start the dispatcher directly via `bin/start-dispatcher`, not via `roost spawn ... -m haiku`.
- [ ] Confirm the four files are the only diff (prompts/lead-pm.md, README.md, docs/DISPATCHER.md, docs/ROOST-IN-PRACTICE.md).

[roost-lead-pm]

🤖 Generated with [Claude Code](https://claude.com/claude-code)