### PR TITLE
maint: bump package.json to 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.0",
+  "version": "0.5.5",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps package.json 0.5.0 → 0.5.5 ahead of the v0.5.5 tag.

0.5.5 contents:
- #286 atomic config writes (mutateConfig promise-queue mutex, sortedJson)
- #287 dispatcher inbound DM command handler + Plugin.handleCommand surface (replaces haiku watcher's JSON CRUD loop)
- #289 weechat pushover.py mirroring notification_center.py with pushover-specific knobs
- #290 lead-pm prompt + README + DISPATCHER + ROOST-IN-PRACTICE realigned to direct-dispatcher CRUD

## Test plan

- [ ] Merge, then tag v0.5.5 and push to fire .github/workflows/release.yml
- [ ] Watch AvesAlight/homebrew-tap commit log for the formula bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)