### PR TITLE
maint: bump package.json to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Ships #294 (associate-pm agent + `--agent` spawn flag) so scratcher can dogfood the new APM pattern.

After merge: `git tag v0.5.6 && git push origin v0.5.6` triggers the release workflow → GitHub release + homebrew-tap formula bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)