### PR TITLE
maint: bump package.json to 0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Ships 25d4493 (`roost init` now copies `agents/` to `.claude/agents/`) so projects can `roost spawn --agent associate-pm` after init.

After merge: `git tag v0.5.7 && git push origin v0.5.7` triggers release workflow → GitHub release + homebrew-tap formula bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)