### PR TITLE
fix(orchestrator): default-trust apm DMs alongside lead-pm

### DIFF
--- a/src/orchestrator/__tests__/dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dm-handler.test.ts
@@ -142,8 +142,8 @@ describe('parseCommands', () => {
 // ---- Allowlist -------------------------------------------------------------
 
 describe('resolveAllowlist', () => {
-  it('defaults to [leadPmNick(project)] when unset', () => {
-    expect(resolveAllowlist({ project: 'roost' })).toEqual(['roost-lead-pm'])
+  it('defaults to [leadPmNick(project), apmNick(project)] when unset', () => {
+    expect(resolveAllowlist({ project: 'roost' })).toEqual(['roost-lead-pm', 'roost-apm'])
   })
 
   it('returns the explicit list when set (including empty)', () => {
@@ -228,6 +228,16 @@ describe('handleDm — routing', () => {
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
     expect(irc.dms).toHaveLength(1)
     expect(irc.dms[0].text).toBe('issues: watched 5')
+    expect(issues.handled).toHaveLength(1)
+  })
+
+  it('allows the default apm nick when command_senders is unset', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
+    await handleDm(deps, { sender: 'roost-apm', text: 'unwatch 5' })
+    expect(irc.dms).toHaveLength(1)
+    expect(irc.dms[0].text).toBe('issues: unwatched 5')
     expect(issues.handled).toHaveLength(1)
   })
 
@@ -329,11 +339,15 @@ describe('handleDm — routing', () => {
     expect(irc.dms[0].text).toBe('issues: watched 7')
   })
 
-  it('explicit empty allowlist blocks everyone (including lead-pm)', async () => {
+  it('explicit empty allowlist blocks everyone (including lead-pm and apm)', async () => {
     await writeConfig(dir, { project: 'roost', irc: { command_senders: [] }, plugins: {} })
     const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
-    expect(irc.dms).toEqual([{ nick: 'roost-lead-pm', text: 'not authorized; configure irc.command_senders' }])
+    await handleDm(deps, { sender: 'roost-apm', text: 'watch 5' })
+    expect(irc.dms).toEqual([
+      { nick: 'roost-lead-pm', text: 'not authorized; configure irc.command_senders' },
+      { nick: 'roost-apm', text: 'not authorized; configure irc.command_senders' },
+    ])
   })
 
   it('config load error surfaces to project channel, no throw', async () => {

--- a/src/orchestrator/__tests__/naming.test.ts
+++ b/src/orchestrator/__tests__/naming.test.ts
@@ -7,6 +7,7 @@ import {
   workerNick,
   reviewerNick,
   leadPmNick,
+  apmNick,
   watcherNick,
   dispatcherNick,
 } from '../naming.js'
@@ -46,6 +47,7 @@ describe('name helpers', () => {
     expect(workerNick('roost', 196)).toBe('roost-worker-196')
     expect(reviewerNick('roost', 200)).toBe('roost-reviewer-200')
     expect(leadPmNick('roost')).toBe('roost-lead-pm')
+    expect(apmNick('roost')).toBe('roost-apm')
     expect(watcherNick('roost')).toBe('roost-watcher')
     expect(dispatcherNick('roost')).toBe('roost-dispatcher')
   })

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -23,9 +23,9 @@ export interface OrchestratorConfig {
     port?: number
     interval_seconds?: number
     // Allowlist of nicks permitted to DM the dispatcher with watch/unwatch
-    // commands. When unset, defaults to `[leadPmNick(project)]` — the
-    // lead-pm that spawned this dispatcher (see naming.ts). Explicit `[]`
-    // disables remote control entirely.
+    // commands. When unset, defaults to `[leadPmNick(project), apmNick(project)]`
+    // — the lead-pm and APM that drive this project (see naming.ts).
+    // Explicit `[]` disables remote control entirely.
     command_senders?: string[]
   }
   // Per-plugin config slice, symmetric with `state.plugins.{name}`. The set

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -15,7 +15,7 @@
 // project channel.
 
 import { loadConfig, mutateConfig, type OrchestratorConfig } from './config.js'
-import { defaultProject, leadPmNick } from './naming.js'
+import { apmNick, defaultProject, leadPmNick } from './naming.js'
 import type { Plugin } from './plugin.js'
 
 export type Command =
@@ -126,8 +126,10 @@ export function parseCommands(text: string): Command[] {
 
 // ---- Allowlist -------------------------------------------------------------
 
-// Resolves command_senders. Unset → `[leadPmNick(project)]` (see
-// naming.ts:leadPmNick — the single source of truth for the convention).
+// Resolves command_senders. Unset → `[leadPmNick(project), apmNick(project)]`
+// (see naming.ts — single source of truth for the convention). Both lead and
+// APM are documented team members that need DM access; trusting both by
+// default avoids respawning a lead just to flip an unwatch.
 // Explicit `[]` means nobody is allowed. If project is unresolvable, falls
 // back to `[]` and logs the cause so an operator chasing a "not authorized"
 // reply can find the root cause in daemon.log.
@@ -135,7 +137,8 @@ export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string
   const explicit = config.irc?.command_senders
   if (explicit !== undefined) return explicit
   try {
-    return [leadPmNick(defaultProject(config))]
+    const project = defaultProject(config)
+    return [leadPmNick(project), apmNick(project)]
   } catch (e) {
     log?.(`dm-handler: cannot resolve default allowlist (no project/repo in config): ${e}`)
     return []

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -57,6 +57,10 @@ export function leadPmNick(project: string): string {
   return `${project}-lead-pm`
 }
 
+export function apmNick(project: string): string {
+  return `${project}-apm`
+}
+
 export function watcherNick(project: string): string {
   return `${project}-watcher`
 }


### PR DESCRIPTION
## Summary
- Dispatcher's default `command_senders` was lead-pm only, so APM hit "not authorized" on `unwatch pr <N>` during merge cleanup.
- Adds `apmNick(project)` and includes it in the default allowlist.
- Aligns config.ts comment + tests; explicit `command_senders: []` still blocks everyone.

The associate-pm agent prompt (#294, line 23) already claimed both were trusted — this just makes the implementation match.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/orchestrator/__tests__/dm-handler.test.ts src/orchestrator/__tests__/naming.test.ts` (56 pass)
- [x] full `bun test` (413 pass) on the equivalent diff in primary worktree before relocating to fix branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)