### PR TITLE
maint: bump package.json to 0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Ships #299 (orchestrator default-trusts APM DMs).

After merge: `git tag v0.5.8 && git push origin v0.5.8` triggers release workflow → GitHub release + homebrew-tap formula bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)