### PR TITLE
fix(dispatcher): project-local PID file + idempotent start (#301)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: Test with coverage
         run: bun test --coverage
+
+      - name: Shell tests — start-dispatcher
+        run: bash test/start-dispatcher_test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage/
 .orchestrator/.state.*.tmp
 .orchestrator/daemon.log
 .orchestrator/joined-channels.txt
+.orchestrator/dispatcher-boot.log
 .orchestrator/.dispatcher.start.lock/
 
 # Python bytecode cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ coverage/
 .orchestrator/last-error.txt
 .orchestrator/.state.*.tmp
 .orchestrator/daemon.log
+.orchestrator/joined-channels.txt
+.orchestrator/.dispatcher.start.lock/
 
 # Python bytecode cache
 __pycache__/

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -20,7 +20,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 Your IRC nick is `<project>-apm`. On boot:
 
 1. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
-2. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it checks `.orchestrator/dispatcher.pid` (project-local; can't confuse another team's daemon for ours) and reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
+2. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
 3. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
 4. Post a one-line hello in `#<project>-leads` so the lead knows you're alive.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -20,7 +20,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 Your IRC nick is `<project>-apm`. On boot:
 
 1. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
-2. Make sure the dispatcher daemon is running for this project. Check `ps` for an `orchestrator` process pointing at this project's `.orchestrator/` directory; if none, start it with `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"` — the helper backgrounds the daemon and verifies it's alive. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
+2. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it checks `.orchestrator/dispatcher.pid` (project-local; can't confuse another team's daemon for ours) and reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
 3. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
 4. Post a one-line hello in `#<project>-leads` so the lead knows you're alive.
 

--- a/bin/roost
+++ b/bin/roost
@@ -242,7 +242,7 @@ _init_config_json() {
 }
 
 _init_gitignore() {
-  printf 'state.json\nlast-tick.txt\nlast-error.txt\n'
+  printf 'state.json\nlast-tick.txt\nlast-error.txt\ndispatcher.pid\njoined-channels.txt\ndispatcher-boot.log\ndaemon.log\n.dispatcher.start.lock\n'
 }
 
 cmd_init() {

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -47,7 +47,7 @@ read_pid() {
 # so a recycled PID owned by an unrelated process doesn't fool us.
 pid_file_is_live() {
   local pid
-  pid="$(read_pid)" || return 1
+  pid="$(read_pid)"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   # `ps -p PID -o args=` works on darwin and linux. Grep for our config-dir.

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # start-dispatcher <config-dir>
 #
-# Starts the roost dispatcher daemon for the given config directory and
-# verifies it is alive after a 2-second boot window.
+# Starts the roost dispatcher daemon for the given config directory, or
+# reports an existing running daemon as ok. Idempotent — safe to call from
+# multiple agents (APM, watcher) at the same time.
 #
-# Exits 0 on success. Exits 1 on failure with a diagnostic on stderr
-# prefixed "start-dispatcher: FAIL: <reason>".
+# Lifecycle:
+#   1. Take a mkdir lock at <config-dir>/.dispatcher.start.lock. Loser polls
+#      <config-dir>/dispatcher.pid (≤2s) for the winner's PID.
+#   2. With the lock held, read dispatcher.pid. If the PID is alive AND its
+#      cmdline mentions <config-dir>, exit 0 ("already running").
+#   3. Otherwise (no file, dead PID, or recycled-PID mismatch) spawn
+#      dispatcher --daemon, wait 2s for it to write dispatcher.pid, exit 0.
 #
-# Idempotency: no existing-PID guard. If a dispatcher is already running
-# for this config-dir a second copy will start. The watcher calls this
-# once on boot; avoiding double-starts is the caller's responsibility.
+# Exits 0 on success (started or already running). Exits 1 on failure with a
+# diagnostic on stderr prefixed "start-dispatcher: FAIL: <reason>".
+#
+# PID file format (frozen — bin/start-dispatcher and the #302 shutdown
+# helper both depend on it): JSON `{"pid": N, "started_at_ms": M, "cmdline": "..."}`.
 
 set -euo pipefail
 
@@ -20,17 +28,114 @@ fi
 
 CONFIG_DIR="$1"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Override hook for tests — defaults to the sibling `dispatcher` script.
+DISPATCHER_BIN="${ROOST_DISPATCHER_BIN:-$DIR/dispatcher}"
+PID_FILE="$CONFIG_DIR/dispatcher.pid"
+LOCK_DIR="$CONFIG_DIR/.dispatcher.start.lock"
 
-nohup "$DIR/dispatcher" --daemon --config-dir "$CONFIG_DIR" >> "$CONFIG_DIR/dispatcher-boot.log" 2>&1 &
-DISP_PID=$!
+mkdir -p "$CONFIG_DIR"
 
-# 2s catches immediate failures (missing config, env, syntax);
-# steady-state crashes are visible in daemon.log
-sleep 2
+# Pull pid out of the JSON without depending on jq. Portable across BSD sed
+# (darwin) and GNU sed (linux).
+read_pid() {
+  [ -f "$PID_FILE" ] || return 1
+  sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$PID_FILE" | head -1
+}
 
-if kill -0 "$DISP_PID" 2>/dev/null; then
-  echo "dispatcher ok (pid $DISP_PID)"
-else
-  echo "start-dispatcher: FAIL: dispatcher (pid $DISP_PID) exited within 2s — see $CONFIG_DIR/dispatcher-boot.log" >&2
-  exit 1
+# Returns 0 if the PID file points at a live dispatcher for *this* config-dir.
+# Two-stage check: PID alive (`kill -0`) AND `ps` shows the config-dir arg,
+# so a recycled PID owned by an unrelated process doesn't fool us.
+pid_file_is_live() {
+  local pid
+  pid="$(read_pid)" || return 1
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  # `ps -p PID -o args=` works on darwin and linux. Grep for our config-dir.
+  ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
+  return 0
+}
+
+report_running() {
+  local pid
+  pid="$(read_pid)"
+  echo "dispatcher already running (pid $pid)"
+}
+
+spawn_daemon() {
+  # Stale or absent PID file — clean up if present, then start fresh. The
+  # daemon will exclusively re-create the PID file inside writeDispatcherPid;
+  # if that fails it logs and exits within the 2s window.
+  rm -f "$PID_FILE"
+  nohup "$DISPATCHER_BIN" --daemon --config-dir "$CONFIG_DIR" >> "$CONFIG_DIR/dispatcher-boot.log" 2>&1 &
+  local disp_pid=$!
+
+  # 2s catches immediate failures (missing config, env, syntax, PID-file
+  # collision); steady-state crashes are visible in daemon.log.
+  sleep 2
+
+  if kill -0 "$disp_pid" 2>/dev/null; then
+    echo "dispatcher ok (pid $disp_pid)"
+    return 0
+  fi
+
+  # Spawned PID is dead. Two possibilities:
+  #  - the daemon crashed before writing PID file → genuine boot failure
+  #  - we lost a race with another start-dispatcher whose daemon won the
+  #    exclusive PID claim, and our daemon exited with "already running"
+  if pid_file_is_live; then
+    report_running
+    return 0
+  fi
+  echo "start-dispatcher: FAIL: dispatcher (pid $disp_pid) exited within 2s — see $CONFIG_DIR/dispatcher-boot.log" >&2
+  return 1
+}
+
+acquire_lock_and_run() {
+  # `mkdir` is POSIX-atomic — winner gets the lock, losers see EEXIST.
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    # shellcheck disable=SC2064
+    trap "rmdir '$LOCK_DIR' 2>/dev/null || true" EXIT
+    if pid_file_is_live; then
+      report_running
+      return 0
+    fi
+    spawn_daemon
+    return $?
+  fi
+  return 2  # lock held by someone else
+}
+
+# Wait for an in-flight start-dispatcher to finish writing the PID file.
+# Polls for up to ~5s in 0.5s slices.
+wait_for_winner() {
+  local n=10
+  while [ "$n" -gt 0 ]; do
+    sleep 0.5
+    if pid_file_is_live; then
+      report_running
+      return 0
+    fi
+    n=$((n-1))
+  done
+  return 1
+}
+
+if acquire_lock_and_run; then
+  exit 0
 fi
+
+# We didn't get the lock — wait for the winner's PID file to land.
+if wait_for_winner; then
+  exit 0
+fi
+
+# Stale lock recovery: no PID file appeared and no live dispatcher. The lock
+# holder crashed before writing. Forcibly clear the lock and retry once.
+echo "start-dispatcher: stale lock at $LOCK_DIR, recovering" >&2
+rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+if acquire_lock_and_run; then
+  exit 0
+fi
+
+echo "start-dispatcher: FAIL: could not acquire lock after stale-lock recovery" >&2
+exit 1

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -66,7 +66,9 @@ automatically.
 ## Lifecycle
 
 The daemon is dumb on purpose — it loops, ticks, sleeps. Bring it up under
-whatever process supervisor your project already uses (tmux, systemd, launchd).
+whatever process supervisor your project already uses (tmux, systemd, launchd),
+or via the bundled `bin/start-dispatcher <config-dir>` helper, which is
+idempotent — safe to call concurrently from multiple agents.
 
 Run from your project root — `.orchestrator/` is resolved relative to `process.cwd()`.
 
@@ -80,6 +82,26 @@ State files in `.orchestrator/`:
 | `last-tick.txt` | Heartbeat timestamp. Use for healthchecks. |
 | `last-error.txt` | Last fatal tick error. Cleared on success. |
 | `daemon.log` | Per-tick log line. Tail this when debugging. |
+| `dispatcher.pid` | PID file for the running daemon (JSON `{pid, started_at_ms, cmdline}`). Written on boot via exclusive create, removed on graceful exit. |
+| `joined-channels.txt` | Channels the dispatcher believes it's joined to, one per line. Refreshed each tick — freshness is "as of last successful poll", not "right now". |
+
+### Readiness check (three signals)
+
+To verify a dispatcher is running and healthy for *this* project, an operator
+or agent can check three things, in order from cheapest to most informative:
+
+1. **PID file** — `cat .orchestrator/dispatcher.pid` and `kill -0 <pid>`. The
+   file lives inside this project's `.orchestrator/`, so it can't be confused
+   with another team's daemon. The `cmdline` field also embeds the absolute
+   config-dir path, which `bin/start-dispatcher` uses to defend against PID
+   recycle.
+2. **Heartbeat** — `cat .orchestrator/last-tick.txt`. Should be within the
+   last `irc.interval_seconds * 2`.
+3. **Joined channels** — `cat .orchestrator/joined-channels.txt`. Should
+   contain the project channel (`#<project>-leads` by default) and every
+   `#<project>-issue-N` for currently-watched items. Snapshot is "last
+   successful tick" — during a brief IRC blip it may lag reality by one
+   interval.
 
 ## Events dispatched
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -111,8 +111,9 @@ async function runDaemon(stateDir: string): Promise<void> {
     logWriter.flush()
   }
 
-  // Claim the PID file exclusively — defense-in-depth against accidental
-  // double-starts that bypass bin/start-dispatcher's mkdir lock.
+  // The in-daemon claim is the source of truth for "this dispatcher owns
+  // this stateDir" — exclusive-create on the PID file. bin/start-dispatcher
+  // has its own mkdir lock that serves as the cheap front-door check.
   const pidInfo = await writeDispatcherPid(stateDir)
   log(`orchestrator[daemon]: pid ${pidInfo.pid} written to ${stateDir}/dispatcher.pid\n`)
 
@@ -202,6 +203,7 @@ async function runDaemon(stateDir: string): Promise<void> {
 
     // Sync IRC membership against the plugin's reported desired set + project channel.
     const desired = new Set<string>([projectChannel, ...result.channels])
+    let joinedSnapshot: string[] | null = null
     try {
       const currentlyJoined = (await client.whoisChannels()) ?? []
       for (const ch of currentlyJoined) {
@@ -210,15 +212,19 @@ async function runDaemon(stateDir: string): Promise<void> {
       for (const ch of desired) {
         if (!client.isJoined(ch)) await client.join(ch)
       }
+      // Reconcile succeeded — `desired` is what we should be in. Avoid a
+      // second whoisChannels round-trip just to snapshot.
+      joinedSnapshot = [...desired].sort()
     } catch (e) {
       log(`orchestrator[daemon]: channel sync failed: ${e}\n`)
     }
 
     // Snapshot of channels we believe we're joined to, for operator
     // readiness checks. Freshness is "last successful tick", not "now".
+    // On reconcile failure, re-query so the snapshot reflects reality.
     try {
-      const joined = (await client.whoisChannels()) ?? []
-      await writeJoinedChannels(stateDir, joined.sort())
+      const joined = joinedSnapshot ?? ((await client.whoisChannels()) ?? []).sort()
+      await writeJoinedChannels(stateDir, joined)
     } catch (e) {
       log(`orchestrator[daemon]: joined-channels snapshot failed: ${e}\n`)
     }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -7,6 +7,9 @@ import {
   loadState,
   writeState,
   writeHeartbeat,
+  writeJoinedChannels,
+  writeDispatcherPid,
+  removeDispatcherPid,
   writeLastError,
   clearLastError,
   getPluginState,
@@ -108,6 +111,11 @@ async function runDaemon(stateDir: string): Promise<void> {
     logWriter.flush()
   }
 
+  // Claim the PID file exclusively — defense-in-depth against accidental
+  // double-starts that bypass bin/start-dispatcher's mkdir lock.
+  const pidInfo = await writeDispatcherPid(stateDir)
+  log(`orchestrator[daemon]: pid ${pidInfo.pid} written to ${stateDir}/dispatcher.pid\n`)
+
   let config = await loadConfig(stateDir)
   const ircCfg = config.irc ?? {}
   const nick = ircCfg.nick
@@ -206,6 +214,15 @@ async function runDaemon(stateDir: string): Promise<void> {
       log(`orchestrator[daemon]: channel sync failed: ${e}\n`)
     }
 
+    // Snapshot of channels we believe we're joined to, for operator
+    // readiness checks. Freshness is "last successful tick", not "now".
+    try {
+      const joined = (await client.whoisChannels()) ?? []
+      await writeJoinedChannels(stateDir, joined.sort())
+    } catch (e) {
+      log(`orchestrator[daemon]: joined-channels snapshot failed: ${e}\n`)
+    }
+
     if (result.taggedEvents.length) {
       try {
         await dispatchTaggedEvents(result.taggedEvents, client)
@@ -222,6 +239,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   }
 
   client.quit()
+  await removeDispatcherPid(stateDir)
   logWriter.flush()
   log('orchestrator[daemon]: exited cleanly\n')
 }

--- a/src/orchestrator/__tests__/dispatcher-pid.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-pid.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, rm, writeFile, readFile, access } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DISPATCHER_PID_FILE,
+  readDispatcherPid,
+  writeDispatcherPid,
+  removeDispatcherPid,
+  writeJoinedChannels,
+} from '../config.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'roost-pid-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('writeDispatcherPid', () => {
+  it('writes a PID file with pid + started_at_ms + cmdline', async () => {
+    const info = await writeDispatcherPid(dir)
+    expect(info.pid).toBe(process.pid)
+    expect(info.started_at_ms).toBeGreaterThan(0)
+    expect(typeof info.cmdline).toBe('string')
+
+    const raw = await readFile(join(dir, DISPATCHER_PID_FILE), 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.pid).toBe(process.pid)
+    expect(parsed.started_at_ms).toBe(info.started_at_ms)
+  })
+
+  it('refuses to overwrite a PID file owned by a live process whose cmdline matches stateDir', async () => {
+    // Spawn a real child whose command line includes `dir`, mimicking a
+    // live dispatcher started with `--config-dir <dir>`. `ps -p <child>`
+    // will report the embedded path, so readDispatcherPid sees it as live.
+    const child = Bun.spawn(['bash', '-c', `: ${dir}; sleep 5`])
+    try {
+      await writeFile(
+        join(dir, DISPATCHER_PID_FILE),
+        JSON.stringify({ pid: child.pid, started_at_ms: 0, cmdline: `bash ${dir}` })
+      )
+      await expect(writeDispatcherPid(dir)).rejects.toThrow(/already running/)
+    } finally {
+      child.kill()
+      await child.exited
+    }
+  })
+
+  it('overwrites a stale PID file (dead PID, no cmdline match)', async () => {
+    // PID 1 (init) is alive but its cmdline won't include our stateDir.
+    // readDispatcherPid treats this as stale → writeDispatcherPid recovers.
+    await writeFile(
+      join(dir, DISPATCHER_PID_FILE),
+      JSON.stringify({ pid: 1, started_at_ms: 0, cmdline: 'unrelated' })
+    )
+    const info = await writeDispatcherPid(dir)
+    expect(info.pid).toBe(process.pid)
+  })
+
+  it('overwrites a PID file containing a dead PID', async () => {
+    // A PID we're confident is dead: very high number unlikely to exist.
+    await writeFile(
+      join(dir, DISPATCHER_PID_FILE),
+      JSON.stringify({ pid: 999999, started_at_ms: 0, cmdline: dir })
+    )
+    const info = await writeDispatcherPid(dir)
+    expect(info.pid).toBe(process.pid)
+  })
+})
+
+describe('readDispatcherPid', () => {
+  it('returns null when no PID file exists', async () => {
+    expect(await readDispatcherPid(dir)).toBeNull()
+  })
+
+  it('returns null when JSON is malformed', async () => {
+    await writeFile(join(dir, DISPATCHER_PID_FILE), 'not json')
+    expect(await readDispatcherPid(dir)).toBeNull()
+  })
+
+  it('returns null when the PID is dead', async () => {
+    await writeFile(
+      join(dir, DISPATCHER_PID_FILE),
+      JSON.stringify({ pid: 999999, started_at_ms: 0, cmdline: dir })
+    )
+    expect(await readDispatcherPid(dir)).toBeNull()
+  })
+
+  it('returns null when the PID is alive but cmdline does not reference stateDir (recycle defense)', async () => {
+    // PID 1 is alive but its cmdline is not our daemon.
+    await writeFile(
+      join(dir, DISPATCHER_PID_FILE),
+      JSON.stringify({ pid: 1, started_at_ms: 0, cmdline: 'unrelated' })
+    )
+    expect(await readDispatcherPid(dir)).toBeNull()
+  })
+
+  it('returns the info when the daemon is our own process (round-trip)', async () => {
+    // writeDispatcherPid records our own argv, which includes the test
+    // runner path. That cmdline won't include `dir`, so we forge one that
+    // does — covering the happy-path read.
+    await writeFile(
+      join(dir, DISPATCHER_PID_FILE),
+      JSON.stringify({ pid: process.pid, started_at_ms: 1, cmdline: `bun --foo ${dir}` })
+    )
+    // The forged cmdline isn't what ps will report for the test runner, so
+    // this should still return null — verifying the ps cross-check is real.
+    expect(await readDispatcherPid(dir)).toBeNull()
+  })
+})
+
+describe('removeDispatcherPid', () => {
+  it('removes the file when present', async () => {
+    await writeDispatcherPid(dir)
+    await removeDispatcherPid(dir)
+    await expect(access(join(dir, DISPATCHER_PID_FILE))).rejects.toThrow()
+  })
+
+  it('is a no-op when absent', async () => {
+    await expect(removeDispatcherPid(dir)).resolves.toBeUndefined()
+  })
+})
+
+describe('writeJoinedChannels', () => {
+  it('writes channels one per line with trailing newline', async () => {
+    await writeJoinedChannels(dir, ['#a', '#b', '#c'])
+    const text = await readFile(join(dir, 'joined-channels.txt'), 'utf8')
+    expect(text).toBe('#a\n#b\n#c\n')
+  })
+
+  it('writes an empty file when channels is empty', async () => {
+    await writeJoinedChannels(dir, [])
+    const text = await readFile(join(dir, 'joined-channels.txt'), 'utf8')
+    expect(text).toBe('')
+  })
+})

--- a/src/orchestrator/__tests__/dispatcher-pid.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-pid.test.ts
@@ -122,16 +122,14 @@ describe('readDispatcherPid', () => {
     expect(await readDispatcherPid(dir)).toBeNull()
   })
 
-  it('returns the info when the daemon is our own process (round-trip)', async () => {
-    // writeDispatcherPid records our own argv, which includes the test
-    // runner path. That cmdline won't include `dir`, so we forge one that
-    // does — covering the happy-path read.
+  it('ignores the recorded cmdline field and trusts only ps', async () => {
+    // Forging the JSON cmdline shouldn't fool readDispatcherPid — the ps
+    // cross-check uses the kernel's view, not anything in the file. The
+    // test runner's real `ps args=` does not contain `dir`, so this is null.
     await writeFile(
       join(dir, DISPATCHER_PID_FILE),
       JSON.stringify({ pid: process.pid, started_at_ms: 1, cmdline: `bun --foo ${dir}` })
     )
-    // The forged cmdline isn't what ps will report for the test runner, so
-    // this should still return null — verifying the ps cross-check is real.
     expect(await readDispatcherPid(dir)).toBeNull()
   })
 })

--- a/src/orchestrator/__tests__/dispatcher-pid.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-pid.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, rm, writeFile, readFile, access } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import {
   DISPATCHER_PID_FILE,
   readDispatcherPid,
@@ -9,6 +11,21 @@ import {
   removeDispatcherPid,
   writeJoinedChannels,
 } from '../config.js'
+
+const execFileP = promisify(execFile)
+
+// Bun.spawn returns before exec completes — on linux the kernel may report
+// the pre-exec command line for a beat. Poll ps until it shows the dir.
+async function waitForPsToShow(pid: number, needle: string): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    try {
+      const { stdout } = await execFileP('ps', ['-p', String(pid), '-o', 'args='])
+      if (stdout.includes(needle)) return
+    } catch { /* process not yet visible */ }
+    await new Promise(r => setTimeout(r, 20))
+  }
+  throw new Error(`ps never reported pid ${pid} with needle ${needle}`)
+}
 
 let dir: string
 
@@ -35,10 +52,16 @@ describe('writeDispatcherPid', () => {
 
   it('refuses to overwrite a PID file owned by a live process whose cmdline matches stateDir', async () => {
     // Spawn a real child whose command line includes `dir`, mimicking a
-    // live dispatcher started with `--config-dir <dir>`. `ps -p <child>`
-    // will report the embedded path, so readDispatcherPid sees it as live.
-    const child = Bun.spawn(['bash', '-c', `: ${dir}; sleep 5`])
+    // live dispatcher started with `--config-dir <dir>`. Using a script
+    // path under `dir` is the most portable way to get `ps` to surface the
+    // path — `bash -c "..."` argv handling varies between darwin/linux ps.
+    const script = join(dir, 'fake-daemon.sh')
+    await writeFile(script, '#!/usr/bin/env bash\nsleep 5\n')
+    const child = Bun.spawn(['bash', script])
     try {
+      // Bun.spawn returns before exec completes — poll ps until the dir
+      // shows up in args so the test fails fast if the contract breaks.
+      await waitForPsToShow(child.pid, dir)
       await writeFile(
         join(dir, DISPATCHER_PID_FILE),
         JSON.stringify({ pid: child.pid, started_at_ms: 0, cmdline: `bash ${dir}` })

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -1,5 +1,9 @@
-import { mkdir, rename, unlink } from 'node:fs/promises'
+import { mkdir, rename, unlink, writeFile, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
 
 // Bumped to 3 in #116 — split GitHub plugin into Prs/Issues, each owns its
 // own state slice. Schema bumps trigger a one-time re-seed via loadState().
@@ -131,6 +135,93 @@ export async function mutateConfig(
 export async function writeHeartbeat(stateDir: string): Promise<void> {
   await mkdir(stateDir, { recursive: true })
   await Bun.write(join(stateDir, 'last-tick.txt'), new Date().toISOString() + '\n')
+}
+
+// Dispatcher PID file. JSON `{pid, started_at_ms, cmdline}`. Frozen format —
+// `bin/start-dispatcher` and #302 (shutdown helper) both parse this.
+export const DISPATCHER_PID_FILE = 'dispatcher.pid'
+
+export interface DispatcherPidInfo {
+  pid: number
+  started_at_ms: number
+  cmdline: string
+}
+
+// Cross-platform: `ps -p <pid> -o args=` returns the full command line on
+// both darwin and linux. Empty string on dead PID. We grep for a substring
+// (the config-dir arg) to defend against PID recycle.
+async function readPsArgs(pid: number): Promise<string> {
+  try {
+    const { stdout } = await execFileP('ps', ['-p', String(pid), '-o', 'args='])
+    return stdout.trim()
+  } catch {
+    return ''
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true } catch { return false }
+}
+
+// Returns the live dispatcher's PID info if the PID file exists, the PID is
+// alive, AND its cmdline includes our stateDir (cheap PID-recycle defense).
+// Returns null if no file, file unreadable, PID dead, or cmdline mismatch —
+// in any of those cases the caller should clean up and proceed to start.
+export async function readDispatcherPid(stateDir: string): Promise<DispatcherPidInfo | null> {
+  const path = join(stateDir, DISPATCHER_PID_FILE)
+  let raw: string
+  try { raw = await readFile(path, 'utf8') } catch { return null }
+  let info: DispatcherPidInfo
+  try {
+    info = JSON.parse(raw) as DispatcherPidInfo
+    if (typeof info.pid !== 'number') return null
+  } catch { return null }
+  if (!isAlive(info.pid)) return null
+  const args = await readPsArgs(info.pid)
+  // cmdline must reference our stateDir to rule out PID recycle. We compare
+  // against the absolute path the daemon recorded — if the operator moved
+  // the dir, the recorded cmdline still pins identity.
+  if (!args.includes(stateDir)) return null
+  return info
+}
+
+// Write the PID file exclusively (O_EXCL via `wx`). Caller (the daemon) has
+// already verified no live dispatcher owns the stateDir. If the file exists
+// but is stale (held by no live owner), clean it up and retry once.
+export async function writeDispatcherPid(stateDir: string): Promise<DispatcherPidInfo> {
+  await mkdir(stateDir, { recursive: true })
+  const path = join(stateDir, DISPATCHER_PID_FILE)
+  const info: DispatcherPidInfo = {
+    pid: process.pid,
+    started_at_ms: Date.now(),
+    cmdline: [process.execPath, ...process.argv.slice(1)].join(' '),
+  }
+  const payload = JSON.stringify(info) + '\n'
+  try {
+    await writeFile(path, payload, { flag: 'wx' })
+    return info
+  } catch {
+    const existing = await readDispatcherPid(stateDir)
+    if (existing) throw new Error(`dispatcher already running (pid ${existing.pid})`)
+    // Stale file with no live owner — remove and try once more.
+    try { await unlink(path) } catch { /* race with another cleaner */ }
+    await writeFile(path, payload, { flag: 'wx' })
+    return info
+  }
+}
+
+export async function removeDispatcherPid(stateDir: string): Promise<void> {
+  try { await unlink(join(stateDir, DISPATCHER_PID_FILE)) } catch { /* ignore */ }
+}
+
+// Snapshot of channels the dispatcher believes it's joined to, written each
+// tick alongside the heartbeat. Operators read this to verify the dispatcher
+// is in the channels they expect. Freshness == last successful tick (the
+// dispatcher's view at boundary), not "right now" — see DISPATCHER.md.
+export async function writeJoinedChannels(stateDir: string, channels: string[]): Promise<void> {
+  await mkdir(stateDir, { recursive: true })
+  const body = channels.length ? channels.join('\n') + '\n' : ''
+  await Bun.write(join(stateDir, 'joined-channels.txt'), body)
 }
 
 export async function writeLastError(stateDir: string, tb: string): Promise<void> {

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -137,8 +137,11 @@ export async function writeHeartbeat(stateDir: string): Promise<void> {
   await Bun.write(join(stateDir, 'last-tick.txt'), new Date().toISOString() + '\n')
 }
 
-// Dispatcher PID file. JSON `{pid, started_at_ms, cmdline}`. Frozen format —
-// `bin/start-dispatcher` and #302 (shutdown helper) both parse this.
+// Dispatcher PID file. JSON `{pid, started_at_ms, cmdline}`. Only `pid` is
+// contractual today — `bin/start-dispatcher` reads it for the front-door
+// liveness check. `started_at_ms` and `cmdline` are written for operator
+// inspection and as the substrate for future readers (e.g. #302 shutdown
+// helper) — extend with care once a consumer lands.
 export const DISPATCHER_PID_FILE = 'dispatcher.pid'
 
 export interface DispatcherPidInfo {
@@ -159,8 +162,14 @@ async function readPsArgs(pid: number): Promise<string> {
   }
 }
 
+// signal-0 distinguishes "no such process" (ESRCH) from "process exists but
+// you can't signal it" (EPERM, e.g. daemon owned by a different uid). Both
+// kill -0 failures look identical in shell, but in TS we can keep the
+// safer answer: EPERM means alive, treat as not-ours-but-still-running.
 function isAlive(pid: number): boolean {
-  try { process.kill(pid, 0); return true } catch { return false }
+  try { process.kill(pid, 0); return true } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM'
+  }
 }
 
 // Returns the live dispatcher's PID info if the PID file exists, the PID is
@@ -188,6 +197,9 @@ export async function readDispatcherPid(stateDir: string): Promise<DispatcherPid
 // Write the PID file exclusively (O_EXCL via `wx`). Caller (the daemon) has
 // already verified no live dispatcher owns the stateDir. If the file exists
 // but is stale (held by no live owner), clean it up and retry once.
+//
+// Uses node:fs/promises rather than Bun.write because the latter has no
+// exclusive-create flag — `wx` is the load-bearing primitive here.
 export async function writeDispatcherPid(stateDir: string): Promise<DispatcherPidInfo> {
   await mkdir(stateDir, { recursive: true })
   const path = join(stateDir, DISPATCHER_PID_FILE)

--- a/test/start-dispatcher_test.sh
+++ b/test/start-dispatcher_test.sh
@@ -128,9 +128,11 @@ wait "$unrelated_pid" 2>/dev/null || true
 kill_descendants "$TDIR/dispatcher.pid"
 rm -rf "$TDIR"
 
-# -- Test 5: concurrent-start race ----------------------------------------
+# -- Test 5: concurrent-start serialization -------------------------------
 # Two parallel start-dispatcher calls — exactly one daemon survives, both
-# exit 0, PID file points at the survivor.
+# exit 0, PID file points at the survivor. Exercises the mkdir lock and
+# wait_for_winner path; the daemon-side exclusive PID claim is covered by
+# the unit tests in dispatcher-pid.test.ts.
 
 TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
 # Inject a small delay before the daemon writes its PID file, widening the
@@ -151,9 +153,9 @@ done
 if [ "$rc_a" -eq 0 ] && [ "$rc_b" -eq 0 ] \
     && [ -n "$pid_in_file" ] && kill -0 "$pid_in_file" 2>/dev/null \
     && [ "$live_count" -eq 1 ]; then
-  ok "concurrent-start race: both exit 0, exactly one daemon survives"
+  ok "concurrent-start serialization: both exit 0, exactly one daemon survives"
 else
-  fail "concurrent-start race" "rc_a=$rc_a rc_b=$rc_b pid_in_file=$pid_in_file live_count=$live_count"
+  fail "concurrent-start serialization" "rc_a=$rc_a rc_b=$rc_b pid_in_file=$pid_in_file live_count=$live_count"
   echo "--- out1 ---"; cat "$TDIR/out1.log"
   echo "--- out2 ---"; cat "$TDIR/out2.log"
 fi

--- a/test/start-dispatcher_test.sh
+++ b/test/start-dispatcher_test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Tests for bin/start-dispatcher. Plain bash, no bats.
+# Run: bash test/start-dispatcher_test.sh
+#
+# Uses ROOST_DISPATCHER_BIN to substitute a fake dispatcher that just writes
+# the PID file (the same way the real daemon does on boot) and sleeps. No
+# IRC required.
+
+set -uo pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+START="$ROOT/bin/start-dispatcher"
+PASS=0
+FAIL=0
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
+
+make_fake_dispatcher() {
+  # Args: <output-path> [extra-shell-prelude]
+  # The fake honors --config-dir, writes a PID file in the daemon's own
+  # format (JSON: pid, started_at_ms, cmdline), and sleeps. The prelude can
+  # inject a delay or an early exit for race-window tests.
+  local out="$1"
+  local prelude="${2:-}"
+  cat > "$out" <<EOF
+#!/usr/bin/env bash
+set -u
+config_dir=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --config-dir) config_dir="\$2"; shift 2;;
+    *) shift;;
+  esac
+done
+${prelude}
+# Mirror src/orchestrator/config.ts writeDispatcherPid: exclusive create.
+if ! ( set -C; printf '{"pid":%d,"started_at_ms":%d,"cmdline":"%s"}\n' "\$\$" "\$(date +%s)" "fake-dispatcher --config-dir \${config_dir}" > "\${config_dir}/dispatcher.pid" ) 2>/dev/null; then
+  echo "fake-dispatcher: PID file exists — bailing" >&2
+  exit 1
+fi
+trap 'rm -f "\${config_dir}/dispatcher.pid"' EXIT
+sleep 30
+EOF
+  chmod +x "$out"
+}
+
+# Clean up any descendants the test leaves behind. Belt-and-suspenders since
+# fake daemons trap-clean their own PID files.
+kill_descendants() {
+  local pid_file="$1"
+  if [ -f "$pid_file" ]; then
+    local pid
+    pid="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$pid_file" | head -1)"
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  fi
+}
+
+# -- Test 1: single boot writes a PID file, exits 0 -----------------------
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+make_fake_dispatcher "$TDIR/fake-dispatcher"
+if ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" >/dev/null 2>&1 \
+    && [ -f "$TDIR/dispatcher.pid" ]; then
+  ok "single boot: PID file written, exit 0"
+else
+  fail "single boot"
+fi
+kill_descendants "$TDIR/dispatcher.pid"
+rm -rf "$TDIR"
+
+# -- Test 2: idempotent — second call reports already-running -------------
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+make_fake_dispatcher "$TDIR/fake-dispatcher"
+ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" >/dev/null 2>&1
+first_pid="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$TDIR/dispatcher.pid" | head -1)"
+second_out="$(ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" 2>&1)"
+second_pid="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$TDIR/dispatcher.pid" | head -1)"
+if echo "$second_out" | grep -q "already running" && [ "$first_pid" = "$second_pid" ]; then
+  ok "idempotent: second call reports already-running, PID unchanged"
+else
+  fail "idempotent" "out=$second_out first=$first_pid second=$second_pid"
+fi
+kill_descendants "$TDIR/dispatcher.pid"
+rm -rf "$TDIR"
+
+# -- Test 3: stale PID cleanup --------------------------------------------
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+make_fake_dispatcher "$TDIR/fake-dispatcher"
+# Pre-populate a stale PID file with a definitely-dead PID.
+printf '{"pid":999999,"started_at_ms":0,"cmdline":"old --config-dir %s"}\n' "$TDIR" > "$TDIR/dispatcher.pid"
+if ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" >/dev/null 2>&1; then
+  new_pid="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$TDIR/dispatcher.pid" | head -1)"
+  if [ "$new_pid" != "999999" ] && kill -0 "$new_pid" 2>/dev/null; then
+    ok "stale PID cleanup: respawned, new PID alive"
+  else
+    fail "stale PID cleanup" "new_pid=$new_pid"
+  fi
+else
+  fail "stale PID cleanup" "start-dispatcher exited non-zero"
+fi
+kill_descendants "$TDIR/dispatcher.pid"
+rm -rf "$TDIR"
+
+# -- Test 4: PID-recycle defense ------------------------------------------
+# Live PID but its cmdline does not reference our config-dir → treat as stale.
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+make_fake_dispatcher "$TDIR/fake-dispatcher"
+# Spawn a child whose cmdline does NOT include $TDIR.
+sleep 30 &
+unrelated_pid=$!
+printf '{"pid":%d,"started_at_ms":0,"cmdline":"recycled"}\n' "$unrelated_pid" > "$TDIR/dispatcher.pid"
+if ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" >/dev/null 2>&1; then
+  new_pid="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$TDIR/dispatcher.pid" | head -1)"
+  if [ "$new_pid" != "$unrelated_pid" ] && kill -0 "$new_pid" 2>/dev/null; then
+    ok "PID-recycle defense: respawned despite live unrelated PID"
+  else
+    fail "PID-recycle defense" "new_pid=$new_pid unrelated=$unrelated_pid"
+  fi
+else
+  fail "PID-recycle defense" "start-dispatcher exited non-zero"
+fi
+kill "$unrelated_pid" 2>/dev/null || true
+wait "$unrelated_pid" 2>/dev/null || true
+kill_descendants "$TDIR/dispatcher.pid"
+rm -rf "$TDIR"
+
+# -- Test 5: concurrent-start race ----------------------------------------
+# Two parallel start-dispatcher calls — exactly one daemon survives, both
+# exit 0, PID file points at the survivor.
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+# Inject a small delay before the daemon writes its PID file, widening the
+# race window so both callers reliably take the spawn branch.
+make_fake_dispatcher "$TDIR/fake-dispatcher" "sleep 0.3"
+ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" > "$TDIR/out1.log" 2>&1 &
+a=$!
+ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" > "$TDIR/out2.log" 2>&1 &
+b=$!
+wait "$a"; rc_a=$?
+wait "$b"; rc_b=$?
+sleep 0.5
+pid_in_file="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$TDIR/dispatcher.pid" | head -1)"
+live_count=0
+for p in $(pgrep -f "$TDIR/fake-dispatcher" || true); do
+  live_count=$((live_count+1))
+done
+if [ "$rc_a" -eq 0 ] && [ "$rc_b" -eq 0 ] \
+    && [ -n "$pid_in_file" ] && kill -0 "$pid_in_file" 2>/dev/null \
+    && [ "$live_count" -eq 1 ]; then
+  ok "concurrent-start race: both exit 0, exactly one daemon survives"
+else
+  fail "concurrent-start race" "rc_a=$rc_a rc_b=$rc_b pid_in_file=$pid_in_file live_count=$live_count"
+  echo "--- out1 ---"; cat "$TDIR/out1.log"
+  echo "--- out2 ---"; cat "$TDIR/out2.log"
+fi
+# kill all fake dispatchers we may have spawned
+pkill -f "$TDIR/fake-dispatcher" 2>/dev/null || true
+rm -rf "$TDIR"
+
+# -- Test 6: stale lock recovery ------------------------------------------
+# A leftover lock dir from a crashed start-dispatcher (no daemon, no PID
+# file) should be cleaned up and we retry once.
+
+TDIR="$(mktemp -d /tmp/start-dispatcher-test-XXXXXXXX)"
+make_fake_dispatcher "$TDIR/fake-dispatcher"
+mkdir -p "$TDIR/.dispatcher.start.lock"
+if ROOST_DISPATCHER_BIN="$TDIR/fake-dispatcher" "$START" "$TDIR" > "$TDIR/out.log" 2>&1; then
+  if [ -f "$TDIR/dispatcher.pid" ] && [ ! -d "$TDIR/.dispatcher.start.lock" ]; then
+    ok "stale lock recovery: lock removed, daemon started"
+  else
+    fail "stale lock recovery" "pid_file=$( [ -f "$TDIR/dispatcher.pid" ] && echo y || echo n) lock=$( [ -d "$TDIR/.dispatcher.start.lock" ] && echo y || echo n)"
+  fi
+else
+  fail "stale lock recovery" "start-dispatcher exited non-zero"
+  cat "$TDIR/out.log"
+fi
+kill_descendants "$TDIR/dispatcher.pid"
+rm -rf "$TDIR"
+
+echo
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #301

## Summary

The current dispatcher life check (`ps | grep orchestrator`) cross-matches other teams' daemons — bit us when one team mistook another team's dispatcher for theirs. This PR adds a project-local PID file and makes `bin/start-dispatcher` idempotent, plus a second readiness signal via `joined-channels.txt`.

## What changed

- **Daemon** (`src/orchestrator.ts`, `src/orchestrator/config.ts`): writes `<config-dir>/dispatcher.pid` exclusively on boot (JSON: `pid`, `started_at_ms`, `cmdline`), removes it on graceful exit. Writes `<config-dir>/joined-channels.txt` after each tick's channel sync.
- **`bin/start-dispatcher`**: now idempotent and concurrency-safe.
  - Acquires a `mkdir` lock at `<config-dir>/.dispatcher.start.lock` (POSIX-atomic).
  - With lock held: if `dispatcher.pid` points at a live process whose `ps` cmdline includes `<config-dir>` → exit 0 ("already running"). Otherwise spawn.
  - Losers poll the PID file for up to ~5s; on timeout, force-clear the stale lock and retry once.
  - Two-stage liveness check (`kill -0` + cmdline match) defends against PID recycle.
- **APM prompt** (`agents/associate-pm.md`): replaces the `ps` check with a `start-dispatcher` call.
- **Docs** (`docs/DISPATCHER.md`): documents the PID file format (frozen — #302 shutdown helper will read it), `joined-channels.txt`, and a three-signal readiness recipe with the "last successful tick" freshness caveat.
- **`.gitignore` + `_init_gitignore`**: add `dispatcher.pid` (already covered by repo `*.pid`), `joined-channels.txt`, `.dispatcher.start.lock`.

## Tests

- `src/orchestrator/__tests__/dispatcher-pid.test.ts` — write/read/remove helpers, exclusive-create against a live owner, stale cleanup, recycle defense, joined-channels file shape. 13 cases.
- `test/start-dispatcher_test.sh` — 6 shell tests using a fake dispatcher (via `ROOST_DISPATCHER_BIN`): single boot, idempotent, stale PID cleanup, PID-recycle defense, **concurrent-start race (load-bearing)**, stale-lock recovery.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 426/426 pass
- [x] `bash test/start-dispatcher_test.sh` — 6/6 pass
- [x] `bash test/init_test.sh` — pre-existing unrelated failure (`--dry-run: bypasses existing-config guard`), all gitignore tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)