### PR TITLE
feat: bin/stop-dispatcher — graceful dispatcher shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,6 @@ jobs:
 
       - name: Shell tests — start-dispatcher
         run: bash test/start-dispatcher_test.sh
+
+      - name: Shell tests — stop-dispatcher
+        run: bash test/stop-dispatcher_test.sh

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -16,8 +16,10 @@
 # Exits 0 on success (started or already running). Exits 1 on failure with a
 # diagnostic on stderr prefixed "start-dispatcher: FAIL: <reason>".
 #
-# PID file format (frozen — bin/start-dispatcher and the #302 shutdown
-# helper both depend on it): JSON `{"pid": N, "started_at_ms": M, "cmdline": "..."}`.
+# To stop the daemon: bin/stop-dispatcher <config-dir>  (idempotent; symmetric counterpart)
+#
+# PID file format (frozen — bin/start-dispatcher and bin/stop-dispatcher both
+# depend on it): JSON `{"pid": N, "started_at_ms": M, "cmdline": "..."}`.
 
 set -euo pipefail
 

--- a/bin/stop-dispatcher
+++ b/bin/stop-dispatcher
@@ -4,7 +4,7 @@
 # Gracefully stops the roost dispatcher daemon for the given config directory.
 # Idempotent — exits 0 if no live dispatcher is found.
 #
-# Sends SIGTERM and waits up to STOP_TIMEOUT seconds (default: 20) for the
+# Sends SIGTERM and waits up to STOP_TIMEOUT seconds (default: 30) for the
 # process to exit. The daemon finishes its current tick then exits cleanly.
 # Does NOT send SIGKILL — if the daemon hangs, inspect and kill manually.
 #
@@ -26,7 +26,7 @@ fi
 
 CONFIG_DIR="$1"
 PID_FILE="$CONFIG_DIR/dispatcher.pid"
-STOP_TIMEOUT="${STOP_TIMEOUT:-20}"
+STOP_TIMEOUT="${STOP_TIMEOUT:-30}"
 
 # Pull pid out of the JSON without depending on jq. Portable across BSD sed
 # (darwin) and GNU sed (linux).
@@ -84,6 +84,6 @@ cat >&2 <<EOF
 stop-dispatcher: FAIL: dispatcher (pid $PID) did not exit within ${STOP_TIMEOUT}s.
   Check:   ps -p $PID -o args=
   Kill:    kill -9 $PID
-  Retry with longer timeout: STOP_TIMEOUT=60 $(dirname "$(realpath "$0" 2>/dev/null || echo "$0")")/stop-dispatcher $CONFIG_DIR
+  Retry with longer timeout: STOP_TIMEOUT=60 $(command -v realpath >/dev/null && realpath "$0" || echo "$0") $CONFIG_DIR
 EOF
 exit 1

--- a/bin/stop-dispatcher
+++ b/bin/stop-dispatcher
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# stop-dispatcher <config-dir>
+#
+# Gracefully stops the roost dispatcher daemon for the given config directory.
+# Idempotent — exits 0 if no live dispatcher is found.
+#
+# Sends SIGTERM and waits up to STOP_TIMEOUT seconds (default: 20) for the
+# process to exit. The daemon finishes its current tick then exits cleanly.
+# Does NOT send SIGKILL — if the daemon hangs, inspect and kill manually.
+#
+# Operator-driven; the APM does not stop the dispatcher automatically at
+# milestone end (it sends `unwatch` DMs but leaves the daemon running).
+#
+# Exits 0 on success (stopped or already stopped). Exits 1 on timeout with
+# a diagnostic on stderr prefixed "stop-dispatcher: FAIL: <reason>".
+#
+# PID file format (frozen — same as bin/start-dispatcher):
+# JSON `{"pid": N, "started_at_ms": M, "cmdline": "..."}`.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "stop-dispatcher: usage: stop-dispatcher <config-dir>" >&2
+  exit 1
+fi
+
+CONFIG_DIR="$1"
+PID_FILE="$CONFIG_DIR/dispatcher.pid"
+STOP_TIMEOUT="${STOP_TIMEOUT:-20}"
+
+# Pull pid out of the JSON without depending on jq. Portable across BSD sed
+# (darwin) and GNU sed (linux).
+read_pid() {
+  [ -f "$PID_FILE" ] || return 1
+  sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$PID_FILE" | head -1
+}
+
+# Returns 0 if the PID file points at a live dispatcher for *this* config-dir.
+# Mirrors the same two-stage check as bin/start-dispatcher: PID alive AND
+# cmdline references our config-dir (PID-recycle defense).
+pid_file_is_live() {
+  local pid
+  pid="$(read_pid)"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
+  return 0
+}
+
+if [ ! -f "$PID_FILE" ]; then
+  echo "dispatcher not running (no PID file)"
+  exit 0
+fi
+
+PID="$(read_pid)"
+
+if [ -z "$PID" ]; then
+  echo "dispatcher not running (PID file unreadable or empty)"
+  rm -f "$PID_FILE"
+  exit 0
+fi
+
+if ! pid_file_is_live; then
+  echo "dispatcher not running (stale PID file, pid=$PID)"
+  rm -f "$PID_FILE"
+  exit 0
+fi
+
+echo "stopping dispatcher (pid $PID)..."
+kill -TERM "$PID"
+
+elapsed=0
+while [ "$elapsed" -lt "$STOP_TIMEOUT" ]; do
+  sleep 1
+  elapsed=$((elapsed + 1))
+  if ! kill -0 "$PID" 2>/dev/null; then
+    rm -f "$PID_FILE"
+    echo "dispatcher stopped (pid $PID, ${elapsed}s)"
+    exit 0
+  fi
+done
+
+cat >&2 <<EOF
+stop-dispatcher: FAIL: dispatcher (pid $PID) did not exit within ${STOP_TIMEOUT}s.
+  Check:   ps -p $PID -o args=
+  Kill:    kill -9 $PID
+  Retry with longer timeout: STOP_TIMEOUT=60 $(dirname "$(realpath "$0" 2>/dev/null || echo "$0")")/stop-dispatcher $CONFIG_DIR
+EOF
+exit 1

--- a/test/stop-dispatcher_test.sh
+++ b/test/stop-dispatcher_test.sh
@@ -44,13 +44,16 @@ else
 fi
 rm -rf "$TDIR"
 
-# -- Test 3: PID-recycle (live but cmdline doesn't match) → exit 0, file removed --
+# -- Test 3: PID-recycle (live but ps args don't reference $TDIR) → exit 0, file removed --
+# pid_file_is_live checks the real ps args for the process, not the JSON cmdline field.
+# The JSON cmdline value in the PID file is decorative from stop-dispatcher's perspective;
+# what matters is that `ps -p $PID -o args=` doesn't mention $TDIR.
 
 TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
 sleep 30 &
 unrelated_pid=$!
-# Write a PID file pointing at the live-but-unrelated process with our dir
-# NOT in the cmdline (the sleep binary's cmdline is just "sleep 30").
+# Write a PID file pointing at the live sleep process. Its real `ps args` are "sleep 30",
+# which don't include $TDIR — so pid_file_is_live returns false (PID-recycle defense).
 printf '{"pid":%d,"started_at_ms":0,"cmdline":"unrelated"}\n' "$unrelated_pid" > "$TDIR/dispatcher.pid"
 out="$("$STOP" "$TDIR" 2>&1)"
 rc=$?

--- a/test/stop-dispatcher_test.sh
+++ b/test/stop-dispatcher_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Tests for bin/stop-dispatcher. Plain bash, no bats.
+# Run: bash test/stop-dispatcher_test.sh
+
+set -uo pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+STOP="$ROOT/bin/stop-dispatcher"
+PASS=0
+FAIL=0
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
+
+# Write a fake PID file in the same JSON format the daemon uses.
+write_pid_file() {
+  local dir="$1" pid="$2"
+  printf '{"pid":%d,"started_at_ms":%d,"cmdline":"fake-daemon --config-dir %s"}\n' \
+    "$pid" "$(date +%s)000" "$dir" > "$dir/dispatcher.pid"
+}
+
+# -- Test 1: no PID file → exit 0 (already stopped) -----------------------
+
+TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
+out="$("$STOP" "$TDIR" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -qi "not running"; then
+  ok "no PID file: exit 0, reports not running"
+else
+  fail "no PID file" "rc=$rc out=$out"
+fi
+rm -rf "$TDIR"
+
+# -- Test 2: stale PID file (dead PID) → exit 0, file removed -------------
+
+TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
+write_pid_file "$TDIR" 999999
+out="$("$STOP" "$TDIR" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && ! [ -f "$TDIR/dispatcher.pid" ]; then
+  ok "stale PID (dead process): exit 0, PID file cleaned up"
+else
+  fail "stale PID" "rc=$rc pid_file_exists=$( [ -f "$TDIR/dispatcher.pid" ] && echo y || echo n) out=$out"
+fi
+rm -rf "$TDIR"
+
+# -- Test 3: PID-recycle (live but cmdline doesn't match) → exit 0, file removed --
+
+TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
+sleep 30 &
+unrelated_pid=$!
+# Write a PID file pointing at the live-but-unrelated process with our dir
+# NOT in the cmdline (the sleep binary's cmdline is just "sleep 30").
+printf '{"pid":%d,"started_at_ms":0,"cmdline":"unrelated"}\n' "$unrelated_pid" > "$TDIR/dispatcher.pid"
+out="$("$STOP" "$TDIR" 2>&1)"
+rc=$?
+kill "$unrelated_pid" 2>/dev/null || true
+wait "$unrelated_pid" 2>/dev/null || true
+if [ "$rc" -eq 0 ] && ! [ -f "$TDIR/dispatcher.pid" ]; then
+  ok "PID-recycle (live unrelated PID): exit 0, stale PID file cleaned up"
+else
+  fail "PID-recycle" "rc=$rc pid_file_exists=$( [ -f "$TDIR/dispatcher.pid" ] && echo y || echo n) out=$out"
+fi
+rm -rf "$TDIR"
+
+# -- Test 4: live dispatcher → SIGTERM sent, exits 0, PID file removed ----
+
+TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
+# Spawn a sleeper whose cmdline includes $TDIR so pid_file_is_live returns true.
+# Using a wrapper script so the dir appears in ps args.
+fake_script="$TDIR/fake-daemon.sh"
+cat > "$fake_script" <<SCRIPT
+#!/usr/bin/env bash
+trap 'exit 0' TERM
+sleep 30 &
+wait
+SCRIPT
+chmod +x "$fake_script"
+bash "$fake_script" "$TDIR" &
+live_pid=$!
+# Brief poll until ps shows the dir in the process args. The dir is passed
+# as an arg so it appears in ps output.
+for _i in $(seq 1 20); do
+  ps_out="$(ps -p "$live_pid" -o args= 2>/dev/null || true)"
+  echo "$ps_out" | grep -Fq -- "$TDIR" && break
+  sleep 0.1
+done
+write_pid_file "$TDIR" "$live_pid"
+out="$("$STOP" "$TDIR" 2>&1)"
+rc=$?
+wait "$live_pid" 2>/dev/null || true
+if [ "$rc" -eq 0 ] && ! [ -f "$TDIR/dispatcher.pid" ] && ! kill -0 "$live_pid" 2>/dev/null; then
+  ok "live dispatcher: SIGTERM sent, exit 0, PID file removed"
+else
+  fail "live dispatcher" "rc=$rc pid_file_exists=$( [ -f "$TDIR/dispatcher.pid" ] && echo y || echo n) pid_alive=$( kill -0 "$live_pid" 2>/dev/null && echo y || echo n) out=$out"
+  kill "$live_pid" 2>/dev/null || true
+fi
+rm -rf "$TDIR"
+
+# -- Test 5: STOP_TIMEOUT respected — stubborn process → exit 1 -----------
+
+TDIR="$(mktemp -d /tmp/stop-dispatcher-test-XXXXXXXX)"
+# Spawn a process that ignores SIGTERM.
+fake_script="$TDIR/fake-daemon.sh"
+cat > "$fake_script" <<SCRIPT
+#!/usr/bin/env bash
+trap '' TERM
+sleep 30 &
+wait
+SCRIPT
+chmod +x "$fake_script"
+bash "$fake_script" "$TDIR" &
+stubborn_pid=$!
+for _i in $(seq 1 20); do
+  ps_out="$(ps -p "$stubborn_pid" -o args= 2>/dev/null || true)"
+  echo "$ps_out" | grep -Fq -- "$TDIR" && break
+  sleep 0.1
+done
+write_pid_file "$TDIR" "$stubborn_pid"
+out="$(STOP_TIMEOUT=2 "$STOP" "$TDIR" 2>&1)"
+rc=$?
+kill "$stubborn_pid" 2>/dev/null || true
+wait "$stubborn_pid" 2>/dev/null || true
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q "FAIL"; then
+  ok "STOP_TIMEOUT respected: stubborn process, exit 1 with FAIL diagnostic"
+else
+  fail "STOP_TIMEOUT" "rc=$rc out=$out"
+fi
+rm -rf "$TDIR"
+
+echo
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #302

Adds `bin/stop-dispatcher <config-dir>` — the symmetric counterpart to `bin/start-dispatcher`.

Sends SIGTERM to the live dispatcher (validated via PID file + ps cmdline check), polls up to `STOP_TIMEOUT` seconds (default: 20) for clean exit. Idempotent when nothing is running; cleans up stale/recycled PID files. On timeout, exits 1 with a copy-paste `kill -9` + retry invocation rather than escalating automatically.

Operator-driven; APM/watcher continue to use `start-dispatcher` — there is no agent-driven stop today.

## Changes
- `bin/stop-dispatcher` new script
- `test/stop-dispatcher_test.sh` 5 shell tests (no PID file, stale PID, PID-recycle, live daemon, timeout)
- `bin/start-dispatcher` header updated to cross-reference stop-dispatcher
- `.github/workflows/ci.yml` stop-dispatcher shell tests wired into CI