### PR TITLE
roost spawn: fail loudly when --agent doesn't resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,6 @@ jobs:
 
       - name: Shell tests — start-dispatcher
         run: bash test/start-dispatcher_test.sh
+
+      - name: Shell tests — spawn
+        run: bash test/spawn_test.sh

--- a/bin/roost
+++ b/bin/roost
@@ -600,6 +600,9 @@ cmd_spawn() {
   if [ -n "${agent}" ]; then
     local _agent_cwd="${cwd}/.claude/agents/${agent}.md"
     local _agent_home="${HOME}/.claude/agents/${agent}.md"
+    # claude resolves --agent from <cwd>/.claude/agents/ and ~/.claude/agents/ only.
+    # plugin-tree agents (${ROOST_DIR}/agents/) are NOT searched by claude; operators
+    # must run `roost init` to copy/symlink them into <cwd>/.claude/agents/.
     if [ ! -f "${_agent_cwd}" ] && [ ! -f "${_agent_home}" ]; then
       echo "error: agent '${agent}' not found; searched:" >&2
       printf '  %s\n' "${_agent_cwd}" >&2

--- a/bin/roost
+++ b/bin/roost
@@ -597,6 +597,16 @@ cmd_spawn() {
       *)      permission_mode="acceptEdits" ;;
     esac
   fi
+  if [ -n "${agent}" ]; then
+    local _agent_cwd="${cwd}/.claude/agents/${agent}.md"
+    local _agent_home="${HOME}/.claude/agents/${agent}.md"
+    if [ ! -f "${_agent_cwd}" ] && [ ! -f "${_agent_home}" ]; then
+      echo "error: agent '${agent}' not found; searched:" >&2
+      printf '  %s\n' "${_agent_cwd}" >&2
+      printf '  %s\n' "${_agent_home}" >&2
+      exit 1
+    fi
+  fi
   # Properly shell-quote each extra arg so spaces and metachars survive
   # the bash → tmux → inner-shell boundary. printf '%q' produces output
   # that re-parses to the original token. Guarded against empty array

--- a/bin/roost
+++ b/bin/roost
@@ -598,15 +598,25 @@ cmd_spawn() {
     esac
   fi
   if [ -n "${agent}" ]; then
-    local _agent_cwd="${cwd}/.claude/agents/${agent}.md"
-    local _agent_home="${HOME}/.claude/agents/${agent}.md"
-    # claude resolves --agent from <cwd>/.claude/agents/ and ~/.claude/agents/ only.
+    # claude searches .claude/agents/ recursively by filename.
     # plugin-tree agents (${ROOST_DIR}/agents/) are NOT searched by claude; operators
     # must run `roost init` to copy/symlink them into <cwd>/.claude/agents/.
-    if [ ! -f "${_agent_cwd}" ] && [ ! -f "${_agent_home}" ]; then
+    local _agent_found=0
+    local _search_root
+    local _found_path=""
+    for _search_root in "${cwd}/.claude/agents" "${HOME}/.claude/agents"; do
+      if [ -d "${_search_root}" ]; then
+        _found_path="$(find "${_search_root}" -name "${agent}.md" -type f 2>/dev/null | head -1)"
+        if [ -n "${_found_path}" ]; then
+          _agent_found=1
+          break
+        fi
+      fi
+    done
+    if [ "${_agent_found}" -eq 0 ]; then
       echo "error: agent '${agent}' not found; searched:" >&2
-      printf '  %s\n' "${_agent_cwd}" >&2
-      printf '  %s\n' "${_agent_home}" >&2
+      printf '  %s/.claude/agents/**/%s.md\n' "${cwd}" "${agent}" >&2
+      printf '  %s/.claude/agents/**/%s.md\n' "${HOME}" "${agent}" >&2
       exit 1
     fi
   fi

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -28,7 +28,7 @@ setup
 err="$("${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" 2>&1)"; exit_code=$?
 if [ "$exit_code" -ne 0 ] \
     && echo "$err" | grep -q "agent 'definitelynotanagent' not found" \
-    && echo "$err" | grep -q ".claude/agents/definitelynotanagent.md"; then
+    && echo "$err" | grep -q ".claude/agents/.*definitelynotanagent.md"; then
   ok "missing agent: exits non-zero with agent name and searched paths"
 else
   fail "missing agent: exits non-zero with agent name and searched paths" "exit=$exit_code err=$err"
@@ -54,9 +54,7 @@ teardown
 
 setup
 err="$("${ROOST_BIN}" spawn testnick --agent missing --cwd "$TDIR" 2>&1)"; exit_code=$?
-cwd_path="$TDIR/.claude/agents/missing.md"
-home_path="$HOME/.claude/agents/missing.md"
-if echo "$err" | grep -qF "$cwd_path" && echo "$err" | grep -qF "$home_path"; then
+if echo "$err" | grep -qF "$TDIR/.claude/agents" && echo "$err" | grep -qF "$HOME/.claude/agents"; then
   ok "missing agent: both searched paths printed"
 else
   fail "missing agent: both searched paths printed" "err=$err"
@@ -87,6 +85,19 @@ if ! echo "$err" | grep -q "agent 'homeagent' not found"; then
   ok "home agent found: agent validation passes"
 else
   fail "home agent found: agent validation passes" "err=$err"
+fi
+teardown
+
+# -- Test 6: agent in subdirectory passes validation --------------------------
+
+setup
+mkdir -p "$TDIR/.claude/agents/sub"
+printf -- '---\ndescription: nested agent\n---\nYou are a nested agent.\n' > "$TDIR/.claude/agents/sub/nestedagent.md"
+err="$("${ROOST_BIN}" spawn testnick --agent nestedagent --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$err" | grep -q "agent 'nestedagent' not found"; then
+  ok "nested cwd agent found: agent validation passes"
+else
+  fail "nested cwd agent found: agent validation passes" "err=$err"
 fi
 teardown
 

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -25,9 +25,7 @@ teardown() {
 # -- Test 1: missing agent exits non-zero with clear message ------------------
 
 setup
-err="$("${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" 2>&1 || true)"
-exit_code=0
-"${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" >/dev/null 2>&1 || exit_code=$?
+err="$("${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" 2>&1)"; exit_code=$?
 if [ "$exit_code" -ne 0 ] \
     && echo "$err" | grep -q "agent 'definitelynotanagent' not found" \
     && echo "$err" | grep -q ".claude/agents/definitelynotanagent.md"; then
@@ -38,22 +36,24 @@ fi
 teardown
 
 # -- Test 2: agent in cwd path passes validation ------------------------------
+# Assertion: the "not found" error does NOT appear. The script may still fail
+# on missing tmux/ircd — this test only verifies agent validation doesn't trigger.
 
 setup
 mkdir -p "$TDIR/.claude/agents"
 printf -- '---\ndescription: test agent\n---\nYou are a test agent.\n' > "$TDIR/.claude/agents/myagent.md"
 err="$("${ROOST_BIN}" spawn testnick --agent myagent --cwd "$TDIR" 2>&1 || true)"
 if ! echo "$err" | grep -q "agent 'myagent' not found"; then
-  ok "cwd agent found: passes agent validation"
+  ok "cwd agent found: agent validation passes"
 else
-  fail "cwd agent found: passes agent validation" "err=$err"
+  fail "cwd agent found: agent validation passes" "err=$err"
 fi
 teardown
 
 # -- Test 3: both searched paths appear in error output -----------------------
 
 setup
-err="$("${ROOST_BIN}" spawn testnick --agent missing --cwd "$TDIR" 2>&1 || true)"
+err="$("${ROOST_BIN}" spawn testnick --agent missing --cwd "$TDIR" 2>&1)"; exit_code=$?
 cwd_path="$TDIR/.claude/agents/missing.md"
 home_path="$HOME/.claude/agents/missing.md"
 if echo "$err" | grep -qF "$cwd_path" && echo "$err" | grep -qF "$home_path"; then
@@ -71,6 +71,22 @@ if ! echo "$err" | grep -q "agent.*not found"; then
   ok "no --agent: validation not triggered"
 else
   fail "no --agent: validation not triggered" "err=$err"
+fi
+teardown
+
+# -- Test 5: agent in home path passes validation -----------------------------
+# Override HOME to a temp dir so we can plant an agent file there without
+# touching the real ~/.claude/agents/.
+
+setup
+fake_home="$TDIR/fakehome"
+mkdir -p "$fake_home/.claude/agents"
+printf -- '---\ndescription: home agent\n---\nYou are a home agent.\n' > "$fake_home/.claude/agents/homeagent.md"
+err="$(HOME="$fake_home" "${ROOST_BIN}" spawn testnick --agent homeagent --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$err" | grep -q "agent 'homeagent' not found"; then
+  ok "home agent found: agent validation passes"
+else
+  fail "home agent found: agent validation passes" "err=$err"
 fi
 teardown
 

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for `roost spawn --agent` validation. Plain bash, no bats.
+# Run: bash test/spawn_test.sh
+set -uo pipefail
+
+ROOST_BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/bin/roost"
+PASS=0
+FAIL=0
+TDIR=""
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
+
+setup() {
+  TDIR="$(mktemp -d /tmp/roost-spawn-test-XXXXXXXX)"
+  trap 'rm -rf "$TDIR"' EXIT
+}
+
+teardown() {
+  rm -rf "$TDIR"
+  trap - EXIT
+  TDIR=""
+}
+
+# -- Test 1: missing agent exits non-zero with clear message ------------------
+
+setup
+err="$("${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" 2>&1 || true)"
+exit_code=0
+"${ROOST_BIN}" spawn testnick --agent definitelynotanagent --cwd "$TDIR" >/dev/null 2>&1 || exit_code=$?
+if [ "$exit_code" -ne 0 ] \
+    && echo "$err" | grep -q "agent 'definitelynotanagent' not found" \
+    && echo "$err" | grep -q ".claude/agents/definitelynotanagent.md"; then
+  ok "missing agent: exits non-zero with agent name and searched paths"
+else
+  fail "missing agent: exits non-zero with agent name and searched paths" "exit=$exit_code err=$err"
+fi
+teardown
+
+# -- Test 2: agent in cwd path passes validation ------------------------------
+
+setup
+mkdir -p "$TDIR/.claude/agents"
+printf -- '---\ndescription: test agent\n---\nYou are a test agent.\n' > "$TDIR/.claude/agents/myagent.md"
+err="$("${ROOST_BIN}" spawn testnick --agent myagent --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$err" | grep -q "agent 'myagent' not found"; then
+  ok "cwd agent found: passes agent validation"
+else
+  fail "cwd agent found: passes agent validation" "err=$err"
+fi
+teardown
+
+# -- Test 3: both searched paths appear in error output -----------------------
+
+setup
+err="$("${ROOST_BIN}" spawn testnick --agent missing --cwd "$TDIR" 2>&1 || true)"
+cwd_path="$TDIR/.claude/agents/missing.md"
+home_path="$HOME/.claude/agents/missing.md"
+if echo "$err" | grep -qF "$cwd_path" && echo "$err" | grep -qF "$home_path"; then
+  ok "missing agent: both searched paths printed"
+else
+  fail "missing agent: both searched paths printed" "err=$err"
+fi
+teardown
+
+# -- Test 4: no --agent flag is unaffected ------------------------------------
+
+setup
+err="$("${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$err" | grep -q "agent.*not found"; then
+  ok "no --agent: validation not triggered"
+else
+  fail "no --agent: validation not triggered" "err=$err"
+fi
+teardown
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #304

\`roost spawn --agent <name>\` validates the agent file exists before invoking claude. If neither \`<cwd>/.claude/agents/<name>.md\` nor \`~/.claude/agents/<name>.md\` resolves, spawn exits non-zero and names both searched paths in the error.

Without this, claude silently falls back to a vanilla session when the agent file is missing — the bug that caused the APM to run prompt-less during 0.6.0 wave 1 dogfooding.

Adds \`test/spawn_test.sh\` (4 cases) and wires it into CI.

[roost-worker-304]