### PR TITLE
fix(dispatcher): retry transient gh errors before notifying

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,11 +19,10 @@ import {
 } from './orchestrator/config.js'
 
 import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js'
-import { getPluginFactory, registeredPluginNames, type Plugin, type TaggedEvent } from './orchestrator/plugin.js'
+import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger, type TaggedEvent } from './orchestrator/plugin.js'
 import './orchestrator/registry.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dm-handler.js'
-import { setRetryLogger } from './orchestrator/plugins/github/github-api.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
 // ---- Path setup ------------------------------------------------------------
@@ -80,7 +79,7 @@ async function runOneTick(
 // Instantiate plugins from `config.plugins` via the registry. Order follows
 // `Object.keys` insertion order in the config JSON, so emission order is
 // predictable from the operator's POV.
-function buildPlugins(config: OrchestratorConfig, defaultChannel: string): Plugin[] {
+function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: PluginLogger): Plugin[] {
   const names = Object.keys(config.plugins ?? {})
   return names.map(name => {
     const factory = getPluginFactory(name)
@@ -88,9 +87,13 @@ function buildPlugins(config: OrchestratorConfig, defaultChannel: string): Plugi
       const available = registeredPluginNames().sort().join(', ') || '(none)'
       throw new Error(`unknown plugin in config: ${name}. available: ${available}`)
     }
-    return factory(defaultChannel)
+    return factory(defaultChannel, log)
   })
 }
+
+// One-shot modes (--dispatch-irc, plain CLI) log plugin diagnostics straight
+// to stderr — they don't own a daemon.log to fan out to.
+const stderrLog: PluginLogger = (msg) => { process.stderr.write(msg) }
 
 function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string): string[] {
   const chans = new Set<string>([projectChannel])
@@ -111,9 +114,6 @@ async function runDaemon(stateDir: string): Promise<void> {
     logWriter.write(msg)
     logWriter.flush()
   }
-  // Route gh retry diagnostics through the daemon log so operators grepping
-  // daemon.log for noisy classifier patterns can see the trail.
-  setRetryLogger(log)
 
   // The in-daemon claim is the source of truth for "this dispatcher owns
   // this stateDir" — exclusive-create on the PID file. bin/start-dispatcher
@@ -130,7 +130,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   const port = ircCfg.port ?? 6667
   const interval = Math.max(5, ircCfg.interval_seconds ?? 60) * 1000
 
-  const plugins = buildPlugins(config, projectChannel)
+  const plugins = buildPlugins(config, projectChannel, log)
   const initialChannels = bootChannels(plugins, config, projectChannel)
   log(`orchestrator[daemon]: starting nick=${nick} server=${server}:${port} channels=${initialChannels.join(',')} interval=${interval / 1000}s\n`)
 
@@ -265,7 +265,7 @@ async function runDispatchIrc(stateDir: string, seed: boolean): Promise<void> {
   const server = ircCfg.server ?? '127.0.0.1'
   const port = ircCfg.port ?? 6667
 
-  const plugins = buildPlugins(config, projectChannel)
+  const plugins = buildPlugins(config, projectChannel, stderrLog)
   const channels = bootChannels(plugins, config, projectChannel)
 
   const client = new RoostIrcClientImpl({
@@ -322,7 +322,7 @@ async function main(): Promise<void> {
     // One-shot: fetch + diff, print events JSON
     const config = await loadConfig(stateDir)
     const projectChannel = resolveProjectChannel(config)
-    const plugins = buildPlugins(config, projectChannel)
+    const plugins = buildPlugins(config, projectChannel, stderrLog)
     const result = await runOneTick(stateDir, config, plugins, {
       seed: values['seed'] as boolean,
       dryRun: values['dry-run'] as boolean,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -23,6 +23,7 @@ import { getPluginFactory, registeredPluginNames, type Plugin, type TaggedEvent 
 import './orchestrator/registry.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dm-handler.js'
+import { setRetryLogger } from './orchestrator/plugins/github/github-api.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
 // ---- Path setup ------------------------------------------------------------
@@ -110,6 +111,9 @@ async function runDaemon(stateDir: string): Promise<void> {
     logWriter.write(msg)
     logWriter.flush()
   }
+  // Route gh retry diagnostics through the daemon log so operators grepping
+  // daemon.log for noisy classifier patterns can see the trail.
+  setRetryLogger(log)
 
   // The in-daemon claim is the source of truth for "this dispatcher owns
   // this stateDir" — exclusive-create on the PID file. bin/start-dispatcher

--- a/src/orchestrator/__tests__/plugin.test.ts
+++ b/src/orchestrator/__tests__/plugin.test.ts
@@ -100,7 +100,7 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
 
     const factory = getPluginFactory('stub')
     expect(factory).toBeTypeOf('function')
-    const plugin = factory!('#default-leads')
+    const plugin = factory!('#default-leads', () => {})
 
     const config: OrchestratorConfig = {
       project: 'demo',
@@ -133,7 +133,7 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
 
   it('passes prevState through under the plugin name slice across ticks', async () => {
     registerPlugin('stub', (defaultChannel) => new StubPlugin(defaultChannel))
-    const plugin = getPluginFactory('stub')!('#default-leads')
+    const plugin = getPluginFactory('stub')!('#default-leads', () => {})
     const config: OrchestratorConfig = { plugins: { stub: { rooms: ['#room'] } } }
 
     const t1 = await plugin.runTick(config, null)
@@ -154,12 +154,12 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
   // guard against that drift.
   it('couples class name to registry key for the stub plugin', () => {
     registerPlugin('stub', (defaultChannel) => new StubPlugin(defaultChannel))
-    expect(getPluginFactory('stub')!('#x').name).toBe('stub')
+    expect(getPluginFactory('stub')!('#x', () => {}).name).toBe('stub')
   })
 
   it('couples class name to registry key for both built-ins', async () => {
     await import('../registry.js')
-    expect(getPluginFactory('github-prs')!('#x').name).toBe('github-prs')
-    expect(getPluginFactory('github-issues')!('#x').name).toBe('github-issues')
+    expect(getPluginFactory('github-prs')!('#x', () => {}).name).toBe('github-prs')
+    expect(getPluginFactory('github-issues')!('#x', () => {}).name).toBe('github-issues')
   })
 })

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -83,7 +83,12 @@ export abstract class BasePlugin implements Plugin {
 // `config.plugins` and instantiates via `getPluginFactory`. Side-effect
 // imports in src/orchestrator/registry.ts populate the built-in set.
 
-export type PluginFactory = (defaultChannel: string) => Plugin
+// Diagnostic log sink passed to every plugin factory. Plugins use it for
+// boot-time wiring (e.g., the github plugin pipes its retry trace through
+// this), letting core stay plugin-agnostic.
+export type PluginLogger = (msg: string) => void
+
+export type PluginFactory = (defaultChannel: string, log: PluginLogger) => Plugin
 
 const REGISTRY = new Map<string, PluginFactory>()
 

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, retryGh, setRetryLogger } from '../github-api.js'
+import { GhError, spawnGh, setRetryLogger } from '../github-api.js'
 
 function mkErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
@@ -23,11 +23,11 @@ function harness(): Harness & {
   }
 }
 
-describe('retryGh', () => {
+describe('spawnGh (retry-aware)', () => {
   it('returns on first attempt without retrying', async () => {
     const h = harness()
     let calls = 0
-    const out = await retryGh(['api', '/x'], {
+    const out = await spawnGh(['api', '/x'], {
       sleep: h.sleep,
       log: h.log,
       random: () => 0,
@@ -42,7 +42,7 @@ describe('retryGh', () => {
   it('retries on transient 5xx then succeeds', async () => {
     const h = harness()
     let calls = 0
-    const out = await retryGh(['api', '/x'], {
+    const out = await spawnGh(['api', '/x'], {
       sleep: h.sleep,
       log: h.log,
       baseMs: 100,
@@ -67,7 +67,7 @@ describe('retryGh', () => {
     let calls = 0
     let caught: unknown = null
     try {
-      await retryGh(['api', '/x'], {
+      await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
         baseMs: 100,
@@ -92,7 +92,7 @@ describe('retryGh', () => {
     let calls = 0
     let caught: unknown = null
     try {
-      await retryGh(['api', '/x'], {
+      await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
         exec: async () => { calls++; throw mkErr('gh: HTTP 404: Not Found') },
@@ -111,7 +111,7 @@ describe('retryGh', () => {
     const stderr = 'gh: HTTP 422: Validation Failed\nfield X may not be null'
     let caught: unknown = null
     try {
-      await retryGh(['api', '/x'], {
+      await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
         exec: async () => { calls++; throw mkErr(stderr) },
@@ -143,7 +143,7 @@ describe('retryGh', () => {
       const h = harness()
       let calls = 0
       try {
-        await retryGh(['api', '/x'], {
+        await spawnGh(['api', '/x'], {
           sleep: h.sleep,
           log: h.log,
           baseMs: 1,
@@ -159,7 +159,7 @@ describe('retryGh', () => {
   it('applies jitter via injected random', async () => {
     const h = harness()
     try {
-      await retryGh(['api', '/x'], {
+      await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
         baseMs: 100,
@@ -178,7 +178,7 @@ describe('retryGh', () => {
     setRetryLogger((msg) => { captured.push(msg) })
     try {
       let calls = 0
-      const out = await retryGh(['api', '/x'], {
+      const out = await spawnGh(['api', '/x'], {
         // No `log` injected — falls through to currentDefaultLog.
         sleep: async () => { /* no real wait */ },
         baseMs: 1,
@@ -202,7 +202,7 @@ describe('retryGh', () => {
     let calls = 0
     let caught: unknown = null
     try {
-      await retryGh(['api', '/x'], {
+      await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
         exec: async () => { calls++; throw new Error('bun.spawn died') },

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'bun:test'
+import { GhError, retryGh } from '../github-api.js'
+
+function mkErr(stderr: string): GhError {
+  return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
+}
+
+interface Harness {
+  attempts: string[][]
+  sleeps: number[]
+  logs: string[]
+}
+
+function harness(): Harness & {
+  sleep: (ms: number) => Promise<void>
+  log: (msg: string) => void
+} {
+  const h: Harness = { attempts: [], sleeps: [], logs: [] }
+  return {
+    ...h,
+    sleep: async (ms: number) => { h.sleeps.push(ms) },
+    log: (msg: string) => { h.logs.push(msg) },
+  }
+}
+
+describe('retryGh', () => {
+  it('returns on first attempt without retrying', async () => {
+    const h = harness()
+    let calls = 0
+    const out = await retryGh(['api', '/x'], {
+      sleep: h.sleep,
+      log: h.log,
+      random: () => 0,
+      exec: async () => { calls++; return { ok: true } },
+    })
+    expect(out).toEqual({ ok: true })
+    expect(calls).toBe(1)
+    expect(h.sleeps).toEqual([])
+    expect(h.logs).toEqual([])
+  })
+
+  it('retries on transient 5xx then succeeds', async () => {
+    const h = harness()
+    let calls = 0
+    const out = await retryGh(['api', '/x'], {
+      sleep: h.sleep,
+      log: h.log,
+      baseMs: 100,
+      random: () => 0,
+      exec: async () => {
+        calls++
+        if (calls === 1) throw mkErr('gh: HTTP 503: Service Unavailable')
+        return { ok: true }
+      },
+    })
+    expect(out).toEqual({ ok: true })
+    expect(calls).toBe(2)
+    expect(h.sleeps).toEqual([100])
+    expect(h.logs.length).toBe(1)
+    expect(h.logs[0]).toContain('attempt 1/3')
+    expect(h.logs[0]).toContain('matched=http-5xx')
+    expect(h.logs[0]).toContain('backoff 100ms')
+  })
+
+  it('exhausts and rethrows after N transient attempts', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await retryGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        baseMs: 100,
+        random: () => 0,
+        exec: async () => { calls++; throw mkErr('gh: HTTP 502: Bad Gateway') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(3)
+    expect(h.sleeps).toEqual([100, 200])
+    expect(caught).toBeInstanceOf(GhError)
+    const ge = caught as GhError
+    expect(ge.attempts).toBe(3)
+    expect(ge.message).toContain('after 3 retries')
+    // Two backoff logs + one exhaustion log.
+    expect(h.logs.length).toBe(3)
+    expect(h.logs[2]).toContain('exhausted 3 attempts')
+    expect(h.logs[2]).toContain('HTTP 502: Bad Gateway')
+  })
+
+  it('does not retry on non-transient errors (404)', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await retryGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw mkErr('gh: HTTP 404: Not Found') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(h.sleeps).toEqual([])
+    expect(h.logs).toEqual([])
+    expect(caught).toBeInstanceOf(GhError)
+    expect((caught as GhError).attempts).toBe(1)
+  })
+
+  it('treats 422 as non-transient but logs stderr verbatim', async () => {
+    const h = harness()
+    let calls = 0
+    const stderr = 'gh: HTTP 422: Validation Failed\nfield X may not be null'
+    let caught: unknown = null
+    try {
+      await retryGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw mkErr(stderr) },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(h.sleeps).toEqual([])
+    expect(caught).toBeInstanceOf(GhError)
+    expect(h.logs.length).toBe(1)
+    expect(h.logs[0]).toContain('HTTP 422 (non-transient)')
+    expect(h.logs[0]).toContain('field X may not be null')
+  })
+
+  it('classifies common transient shapes', async () => {
+    const cases: Array<[string, string]> = [
+      ['gh: HTTP 500', 'http-5xx'],
+      ['gh: HTTP 504: Gateway Timeout', 'http-5xx'],
+      ['gh: HTTP 429: rate limit', 'http-429-rate-limit'],
+      ['dial tcp: i/o timeout', 'timeout'],
+      ['context deadline exceeded', 'timeout'],
+      ['request timed out', 'timeout'],
+      ['dial tcp: connection refused', 'connection-refused'],
+      ['read tcp: connection reset by peer', 'connection-reset'],
+      ['lookup api.github.com: no such host', 'dns'],
+      ['network is unreachable', 'network-unreachable'],
+      ['unexpected EOF', 'eof'],
+    ]
+    for (const [stderr, label] of cases) {
+      const h = harness()
+      let calls = 0
+      try {
+        await retryGh(['api', '/x'], {
+          sleep: h.sleep,
+          log: h.log,
+          baseMs: 1,
+          random: () => 0,
+          exec: async () => { calls++; throw mkErr(stderr) },
+        })
+      } catch { /* exhausted */ }
+      expect(calls).toBe(3)
+      expect(h.logs[0]).toContain(`matched=${label}`)
+    }
+  })
+
+  it('applies jitter via injected random', async () => {
+    const h = harness()
+    try {
+      await retryGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        baseMs: 100,
+        jitterFraction: 0.5,
+        random: () => 1, // max jitter → 1 + 0.5 = 1.5x
+        exec: async () => { throw mkErr('HTTP 500') },
+      })
+    } catch { /* exhausted */ }
+    // i=0: 100 * 1 * 1.5 = 150; i=1: 100 * 2 * 1.5 = 300
+    expect(h.sleeps).toEqual([150, 300])
+  })
+
+  it('rethrows non-GhError immediately without classifying', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await retryGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw new Error('bun.spawn died') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(h.sleeps).toEqual([])
+    expect((caught as Error).message).toBe('bun.spawn died')
+  })
+})

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, retryGh } from '../github-api.js'
+import { GhError, retryGh, setRetryLogger } from '../github-api.js'
 
 function mkErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
@@ -170,6 +170,31 @@ describe('retryGh', () => {
     } catch { /* exhausted */ }
     // i=0: 100 * 1 * 1.5 = 150; i=1: 100 * 2 * 1.5 = 300
     expect(h.sleeps).toEqual([150, 300])
+  })
+
+  it('setRetryLogger swaps the default log sink for callers that omit deps.log', async () => {
+    const captured: string[] = []
+    const original = (msg: string) => { process.stderr.write(msg) }
+    setRetryLogger((msg) => { captured.push(msg) })
+    try {
+      let calls = 0
+      const out = await retryGh(['api', '/x'], {
+        // No `log` injected — falls through to currentDefaultLog.
+        sleep: async () => { /* no real wait */ },
+        baseMs: 1,
+        random: () => 0,
+        exec: async () => {
+          calls++
+          if (calls === 1) throw mkErr('HTTP 502')
+          return { ok: true }
+        },
+      })
+      expect(out).toEqual({ ok: true })
+      expect(captured.length).toBe(1)
+      expect(captured[0]).toContain('matched=http-5xx')
+    } finally {
+      setRetryLogger(original)
+    }
   })
 
   it('rethrows non-GhError immediately without classifying', async () => {

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -69,14 +69,18 @@ export interface RetryDeps {
 }
 
 const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
-// Retry diagnostics go to stderr — the daemon launcher redirects stderr to
-// dispatcher-boot.log via nohup, so operators chasing a noisy classifier can
-// find the trail there.
-const defaultLog = (msg: string) => { process.stderr.write(msg) }
+// Retry diagnostics default to stderr. The daemon overrides this via
+// setRetryLogger() to fan out to daemon.log too; one-shot modes (--dispatch-irc,
+// plain CLI) keep the stderr-only default so output lands on the operator's tty.
+let currentDefaultLog: (msg: string) => void = (msg) => { process.stderr.write(msg) }
+
+export function setRetryLogger(fn: (msg: string) => void): void {
+  currentDefaultLog = fn
+}
 
 export async function retryGh(args: string[], deps: RetryDeps = {}): Promise<unknown> {
   const sleep = deps.sleep ?? defaultSleep
-  const log = deps.log ?? defaultLog
+  const log = deps.log ?? currentDefaultLog
   const totalAttempts = deps.attempts ?? 3
   const baseMs = deps.baseMs ?? 1000
   const jitterFraction = deps.jitterFraction ?? 0.5
@@ -113,6 +117,15 @@ async function ghApi(endpoint: string, paginate = false): Promise<unknown> {
   const args = ['api']
   if (paginate) args.push('--paginate')
   args.push(endpoint)
+  return retryGh(args)
+}
+
+// Centralized so a future gh call can't slip past the retry wrapper.
+async function ghGraphql(query: string, vars: Record<string, string | number>): Promise<unknown> {
+  const args: string[] = ['api', 'graphql', '-f', `query=${query}`]
+  for (const [k, v] of Object.entries(vars)) {
+    args.push('-F', `${k}=${v}`)
+  }
   return retryGh(args)
 }
 
@@ -260,13 +273,7 @@ export async function fetchPrLinkedIssues(repo: string, number: number): Promise
     'pullRequest(number:$number){' +
     'closingIssuesReferences(first:25){nodes{number}}}}}'
   )
-  const result = await retryGh([
-    'api', 'graphql',
-    '-f', `query=${query}`,
-    '-F', `owner=${owner}`,
-    '-F', `name=${name}`,
-    '-F', `number=${number}`,
-  ])
+  const result = await ghGraphql(query, { owner, name, number })
   if (!result) return []
   const r = result as Record<string, unknown>
   const nodes = (

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -1,7 +1,36 @@
+// Transient stderr classifier — patterns we'll retry on. Anything else
+// (404/401/422/etc.) throws on the first attempt. 422 is logged verbatim
+// in retryGh so a 422-as-race can be spotted in dispatcher logs.
+const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
+  { re: /HTTP 5\d\d/i, label: 'http-5xx' },
+  { re: /HTTP 429/i, label: 'http-429-rate-limit' },
+  { re: /\btimed out\b/i, label: 'timeout' },
+  { re: /\bcontext deadline exceeded\b/i, label: 'timeout' },
+  { re: /\bi\/o timeout\b/i, label: 'timeout' },
+  { re: /\bconnection refused\b/i, label: 'connection-refused' },
+  { re: /\bconnection reset\b/i, label: 'connection-reset' },
+  { re: /\bno such host\b/i, label: 'dns' },
+  { re: /\bnetwork is unreachable\b/i, label: 'network-unreachable' },
+  { re: /\bEOF\b/, label: 'eof' },
+]
+
+const HTTP_422 = /HTTP 422/i
+
+function classifyTransient(stderr: string): string | null {
+  for (const { re, label } of TRANSIENT_PATTERNS) {
+    if (re.test(stderr)) return label
+  }
+  return null
+}
+
 export class GhError extends Error {
-  constructor(msg: string) {
+  readonly stderr: string
+  readonly attempts: number
+  constructor(msg: string, stderr = '', attempts = 1) {
     super(msg)
     this.name = 'GhError'
+    this.stderr = stderr
+    this.attempts = attempts
   }
 }
 
@@ -14,7 +43,8 @@ async function spawnGh(args: string[]): Promise<unknown> {
   const exitCode = await proc.exited
   if (exitCode !== 0) {
     throw new GhError(
-      `gh failed (exit ${exitCode}): gh ${args.join(' ')}\n${errOut.trim()}`
+      `gh failed (exit ${exitCode}): gh ${args.join(' ')}\n${errOut.trim()}`,
+      errOut
     )
   }
   const trimmed = out.trim()
@@ -26,11 +56,64 @@ async function spawnGh(args: string[]): Promise<unknown> {
   }
 }
 
+export interface RetryDeps {
+  // Each option is injectable so tests can pin behavior (no real sleeps, no
+  // real gh, deterministic jitter).
+  sleep?: (ms: number) => Promise<void>
+  log?: (msg: string) => void
+  attempts?: number          // total tries including the first; default 3
+  baseMs?: number            // first backoff window; default 1000
+  jitterFraction?: number    // backoff *= 1 + random()*jitterFraction; default 0.5
+  random?: () => number      // 0..1; default Math.random
+  exec?: (args: string[]) => Promise<unknown>  // default spawnGh
+}
+
+const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+// Retry diagnostics go to stderr — the daemon launcher redirects stderr to
+// dispatcher-boot.log via nohup, so operators chasing a noisy classifier can
+// find the trail there.
+const defaultLog = (msg: string) => { process.stderr.write(msg) }
+
+export async function retryGh(args: string[], deps: RetryDeps = {}): Promise<unknown> {
+  const sleep = deps.sleep ?? defaultSleep
+  const log = deps.log ?? defaultLog
+  const totalAttempts = deps.attempts ?? 3
+  const baseMs = deps.baseMs ?? 1000
+  const jitterFraction = deps.jitterFraction ?? 0.5
+  const random = deps.random ?? Math.random
+  const exec = deps.exec ?? spawnGh
+
+  const cmd = `gh ${args.join(' ')}`
+  for (let i = 0; i < totalAttempts; i++) {
+    try {
+      return await exec(args)
+    } catch (e) {
+      if (!(e instanceof GhError)) throw e
+      if (HTTP_422.test(e.stderr)) {
+        log(`gh-retry: ${cmd} HTTP 422 (non-transient) — stderr verbatim:\n${e.stderr}\n`)
+        throw new GhError(e.message, e.stderr, i + 1)
+      }
+      const matched = classifyTransient(e.stderr)
+      if (!matched) throw new GhError(e.message, e.stderr, i + 1)
+      const attemptNum = i + 1
+      if (attemptNum >= totalAttempts) {
+        log(`gh-retry: ${cmd} exhausted ${totalAttempts} attempts (matched=${matched}) — stderr verbatim:\n${e.stderr}\n`)
+        throw new GhError(`${e.message}\n(after ${totalAttempts} retries)`, e.stderr, totalAttempts)
+      }
+      const backoff = Math.round(baseMs * Math.pow(2, i) * (1 + random() * jitterFraction))
+      log(`gh-retry: ${cmd} attempt ${attemptNum}/${totalAttempts} matched=${matched}, backoff ${backoff}ms before next try\n`)
+      await sleep(backoff)
+    }
+  }
+  // Unreachable.
+  throw new GhError(`retryGh: loop exited without result for ${cmd}`)
+}
+
 async function ghApi(endpoint: string, paginate = false): Promise<unknown> {
   const args = ['api']
   if (paginate) args.push('--paginate')
   args.push(endpoint)
-  return spawnGh(args)
+  return retryGh(args)
 }
 
 export interface GhLabel {
@@ -177,7 +260,7 @@ export async function fetchPrLinkedIssues(repo: string, number: number): Promise
     'pullRequest(number:$number){' +
     'closingIssuesReferences(first:25){nodes{number}}}}}'
   )
-  const result = await spawnGh([
+  const result = await retryGh([
     'api', 'graphql',
     '-f', `query=${query}`,
     '-F', `owner=${owner}`,

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -1,6 +1,6 @@
 // Transient stderr classifier — patterns we'll retry on. Anything else
 // (404/401/422/etc.) throws on the first attempt. 422 is logged verbatim
-// in retryGh so a 422-as-race can be spotted in dispatcher logs.
+// in spawnGh so a 422-as-race can be spotted in dispatcher logs.
 const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
   { re: /HTTP 5\d\d/i, label: 'http-5xx' },
   { re: /HTTP 429/i, label: 'http-429-rate-limit' },
@@ -34,7 +34,10 @@ export class GhError extends Error {
   }
 }
 
-async function spawnGh(args: string[]): Promise<unknown> {
+// Single gh attempt — runs the subprocess and parses output. Throws GhError
+// on non-zero exit. Default implementation of SpawnDeps.exec; tests inject
+// a fake to avoid spawning a real gh.
+async function runGhOnce(args: string[]): Promise<unknown> {
   const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' })
   const [out, errOut] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -56,7 +59,7 @@ async function spawnGh(args: string[]): Promise<unknown> {
   }
 }
 
-export interface RetryDeps {
+export interface SpawnDeps {
   // Each option is injectable so tests can pin behavior (no real sleeps, no
   // real gh, deterministic jitter).
   sleep?: (ms: number) => Promise<void>
@@ -65,7 +68,7 @@ export interface RetryDeps {
   baseMs?: number            // first backoff window; default 1000
   jitterFraction?: number    // backoff *= 1 + random()*jitterFraction; default 0.5
   random?: () => number      // 0..1; default Math.random
-  exec?: (args: string[]) => Promise<unknown>  // default spawnGh
+  exec?: (args: string[]) => Promise<unknown>  // default runGhOnce
 }
 
 const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
@@ -78,27 +81,33 @@ export function setRetryLogger(fn: (msg: string) => void): void {
   currentDefaultLog = fn
 }
 
-export async function retryGh(args: string[], deps: RetryDeps = {}): Promise<unknown> {
+// The single gh entrypoint — every gh call goes through here, so retry is
+// the contract for every caller. ghApi/ghGraphql below are thin shape
+// helpers; both delegate to spawnGh so retry can't be bypassed by a future
+// caller.
+export async function spawnGh(args: string[], deps: SpawnDeps = {}): Promise<unknown> {
   const sleep = deps.sleep ?? defaultSleep
   const log = deps.log ?? currentDefaultLog
   const totalAttempts = deps.attempts ?? 3
   const baseMs = deps.baseMs ?? 1000
   const jitterFraction = deps.jitterFraction ?? 0.5
   const random = deps.random ?? Math.random
-  const exec = deps.exec ?? spawnGh
+  const exec = deps.exec ?? runGhOnce
 
   const cmd = `gh ${args.join(' ')}`
   for (let i = 0; i < totalAttempts; i++) {
     try {
       return await exec(args)
     } catch (e) {
+      // Non-GhError surfaces an upstream contract problem (missing gh binary,
+      // bun spawn crash, etc.) — bypass retry.
       if (!(e instanceof GhError)) throw e
       if (HTTP_422.test(e.stderr)) {
         log(`gh-retry: ${cmd} HTTP 422 (non-transient) — stderr verbatim:\n${e.stderr}\n`)
-        throw new GhError(e.message, e.stderr, i + 1)
+        throw e
       }
       const matched = classifyTransient(e.stderr)
-      if (!matched) throw new GhError(e.message, e.stderr, i + 1)
+      if (!matched) throw e
       const attemptNum = i + 1
       if (attemptNum >= totalAttempts) {
         log(`gh-retry: ${cmd} exhausted ${totalAttempts} attempts (matched=${matched}) — stderr verbatim:\n${e.stderr}\n`)
@@ -109,15 +118,15 @@ export async function retryGh(args: string[], deps: RetryDeps = {}): Promise<unk
       await sleep(backoff)
     }
   }
-  // Unreachable.
-  throw new GhError(`retryGh: loop exited without result for ${cmd}`)
+  // Unreachable — the loop always returns or throws.
+  throw new GhError(`spawnGh: loop exited without result for ${cmd}`)
 }
 
 async function ghApi(endpoint: string, paginate = false): Promise<unknown> {
   const args = ['api']
   if (paginate) args.push('--paginate')
   args.push(endpoint)
-  return retryGh(args)
+  return spawnGh(args)
 }
 
 // Centralized so a future gh call can't slip past the retry wrapper.
@@ -126,7 +135,7 @@ async function ghGraphql(query: string, vars: Record<string, string | number>): 
   for (const [k, v] of Object.entries(vars)) {
     args.push('-F', `${k}=${v}`)
   }
-  return retryGh(args)
+  return spawnGh(args)
 }
 
 export interface GhLabel {

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -4,6 +4,16 @@
 import { registerPlugin } from './plugin.js'
 import { GitHubPrsPlugin } from './plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
+import { setRetryLogger } from './plugins/github/github-api.js'
 
-registerPlugin('github-prs', (defaultChannel) => new GitHubPrsPlugin(defaultChannel))
-registerPlugin('github-issues', (defaultChannel) => new GitHubIssuesPlugin(defaultChannel))
+// Both github factories share the same retry-log sink — last writer wins,
+// but since they receive the same `log` from buildPlugins it's a no-op
+// re-set.
+registerPlugin('github-prs', (defaultChannel, log) => {
+  setRetryLogger(log)
+  return new GitHubPrsPlugin(defaultChannel)
+})
+registerPlugin('github-issues', (defaultChannel, log) => {
+  setRetryLogger(log)
+  return new GitHubIssuesPlugin(defaultChannel)
+})


### PR DESCRIPTION
Closes #296

## Summary
- Wraps gh CLI calls in a retry-with-backoff helper (`retryGh`) — transient classes (5xx, 429, timeouts, network) retry up to 3x with exponential backoff + jitter; non-transient (404/401/403/422) throws immediately.
- 422 stays non-transient but logs stderr verbatim so a 422-as-race can be spotted in dispatcher logs.
- Sleep/log/attempts/baseMs/jitterFraction/random/exec are all injectable so tests pin behavior deterministically.
- Retry trail (`gh <cmd> attempt N/total matched=<label>, backoff Xms`) goes to stderr — captured to dispatcher-boot.log via the daemon launcher.

## Test plan
- [x] `bun test src/orchestrator/plugins/github/__tests__/github-api.test.ts` — 8 new tests, all pass
- [x] `bun test` — 434/434 pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] dogfood: watch a real dispatcher; confirm intermittent gh 5xx no longer fires [dispatcher_error] after first retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)