### PR TITLE
maint: bump package.json to 0.5.9 ahead of v0.5.9 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump version 0.5.8 → 0.5.9 ahead of the v0.5.9 release tag.