### PR TITLE
maint: bump package.json to 0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump version 0.5.9 → 0.5.10 ahead of the v0.5.10 tag
- ships #319 (token-cost reporting + APM cleanup dance) to operators

## Test plan
- [x] CI green on main
- [ ] tag v0.5.10 after merge, watch release workflow + tap bump
- [ ] `brew upgrade roost`, restart lead-pm + apm to pick up new prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)