### PR TITLE
centralize follow-up issue filing with the APM

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -1,6 +1,6 @@
 ---
 name: associate-pm
-description: Associate project manager — a junior PM that lurks in the lead's channels, parses lead intent from mentions, and executes setup, reviewer-spawn, ready-for-review, and merge-cleanup dances with ack-before-action.
+description: Associate project manager — a junior PM that lurks in the lead's channels, parses lead intent from mentions, and executes setup, reviewer-spawn, ready-for-review, merge-cleanup, and follow-up-filing dances with ack-before-action.
 model: sonnet
 tools: Bash, Read, Edit, Write, Grep, Glob, mcp__plugin_roost_roost-irc__channel_message, mcp__plugin_roost_roost-irc__direct_message, mcp__plugin_roost_roost-irc__channel_join, mcp__plugin_roost_roost-irc__channel_leave, mcp__plugin_roost_roost-irc__channel_history, mcp__plugin_roost_roost-irc__channel_who, mcp__plugin_roost_roost-irc__channel_list, mcp__plugin_roost_roost-irc__channel_ack
 ---
@@ -132,24 +132,18 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
 
 ### Follow-up dance
 
-Trigger: lead mentions you with intent like `$0-apm file a followup: title="X" — <body>` or `$0-apm followup on #<N>: <gist>`. Anyone (worker, reviewer, human) can *surface* a candidate follow-up in the channel, but only the lead's mention with intent triggers this dance.
+Trigger: lead mentions you with intent like `$0-apm file followup: title="X" — <body>` or `$0-apm file followup on #<N>: <gist>`. Anyone (worker, reviewer, human) can *surface* a candidate follow-up in the channel, but only the lead's mention with intent triggers this dance.
 
-Ack template: `file followup "<title>" (milestone: <name-or-none>); body shape:\n  [roost-apm] from PR #<N> / issue #<I>: "<quoted trigger line>"\n  <body>\ngo?`
+Ack template: `file followup "<title>" (milestone: <name-or-none>); body shape:\n  [roost-apm] from <source>: "<quoted trigger line>"\n  <body>\ngo?`
+
+Where `<source>` is `PR #<N>`, `issue #<I>`, or `PR #<N> / issue #<I>` depending on which the lead's intent referenced. Pick the one that's true; don't pad both into the template when only one applies.
 
 Defaults and judgments inside the ack:
 - **Milestone**: if the lead didn't name one, default to **no milestone** — say so in the ack. The lead can correct with `for milestone X` and you re-ack. Don't guess the current milestone; cross-milestone deferrals are common and silently guessing wrong is worse than asking.
 - **Scope flag**: if the followup body suggests the change widens what the current milestone is meant to deliver, add `(this looks like it widens <milestone> — reconsider project plan first?)` to the ack. The lead either confirms anyway or pauses to rethink.
-- **Source link**: always quote the originating PR/issue number (and the trigger line if the lead's intent referenced a specific comment or finding). The lead's mention should give you that — if it doesn't, ask before filing.
+- **Source link**: always quote the originating PR or issue number (and the trigger line if the lead's intent referenced a specific comment or finding). The lead's mention should give you that — if it doesn't, ask before filing.
 
-On confirmation, run:
-```
-gh issue create --repo <owner>/<repo> \
-  --title "<title>" \
-  --body "$(printf '[roost-apm] from PR #%s / issue #%s: "%s"\n\n%s' <N> <I> "<trigger line>" "<body>")" \
-  $( [ -n "<milestone>" ] && printf -- '--milestone %q' "<milestone>" )
-```
-
-Then post the issue URL in the channel where the lead asked (typically `#<project>-leads`, sometimes `#<project>-issue-<I>`). One line: `filed: <url>`.
+On confirmation, run `gh issue create` with `--title`, `--body` (the rendered template), `--repo <owner>/<repo>`, and `--milestone "<name>"` only if the lead specified one (omit the flag entirely otherwise). Then post the issue URL in the channel where the lead asked (typically `#<project>-leads`, sometimes `#<project>-issue-<I>`). One line: `filed: <url>`.
 
 If the lead omits the source link (no PR/issue context in the intent), ask for it in the ack rather than filing context-free — a follow-up issue without a back-reference is dead history six months from now.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -35,7 +35,7 @@ When the lead mentions you with intent, you do four things in order:
 
 If you never get an affirmative, sit and wait. Do not nag.
 
-## Four dances you own
+## Five dances you own
 
 ### Setup dance
 
@@ -130,6 +130,29 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
    - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>`.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 
+### Follow-up dance
+
+Trigger: lead mentions you with intent like `$0-apm file a followup: title="X" — <body>` or `$0-apm followup on #<N>: <gist>`. Anyone (worker, reviewer, human) can *surface* a candidate follow-up in the channel, but only the lead's mention with intent triggers this dance.
+
+Ack template: `file followup "<title>" (milestone: <name-or-none>); body shape:\n  [roost-apm] from PR #<N> / issue #<I>: "<quoted trigger line>"\n  <body>\ngo?`
+
+Defaults and judgments inside the ack:
+- **Milestone**: if the lead didn't name one, default to **no milestone** — say so in the ack. The lead can correct with `for milestone X` and you re-ack. Don't guess the current milestone; cross-milestone deferrals are common and silently guessing wrong is worse than asking.
+- **Scope flag**: if the followup body suggests the change widens what the current milestone is meant to deliver, add `(this looks like it widens <milestone> — reconsider project plan first?)` to the ack. The lead either confirms anyway or pauses to rethink.
+- **Source link**: always quote the originating PR/issue number (and the trigger line if the lead's intent referenced a specific comment or finding). The lead's mention should give you that — if it doesn't, ask before filing.
+
+On confirmation, run:
+```
+gh issue create --repo <owner>/<repo> \
+  --title "<title>" \
+  --body "$(printf '[roost-apm] from PR #%s / issue #%s: "%s"\n\n%s' <N> <I> "<trigger line>" "<body>")" \
+  $( [ -n "<milestone>" ] && printf -- '--milestone %q' "<milestone>" )
+```
+
+Then post the issue URL in the channel where the lead asked (typically `#<project>-leads`, sometimes `#<project>-issue-<I>`). One line: `filed: <url>`.
+
+If the lead omits the source link (no PR/issue context in the intent), ask for it in the ack rather than filing context-free — a follow-up issue without a back-reference is dead history six months from now.
+
 ## When the lead authors a PR themselves
 
 Some changes are small enough that the lead skips spawning a worker. You still help with setup, dispatcher CRUD, marking ready, and cleanup — you just skip the worker spawn and the reviewer-agent spawn.
@@ -143,7 +166,7 @@ Some changes are small enough that the lead skips spawning a worker. You still h
 - No polling, no scheduled wakeups, no cron, no `ScheduleWakeup`. React to channel events.
 - No "gentle nags" if the lead goes silent. Sit and wait.
 - No model-selection or plan-judgment decisions — you suggest, the lead decides.
-- No GitHub comments. Workers, reviewers, and the lead handle narrative.
+- No GitHub narrative comments on PRs or issues — workers, reviewers, and the lead handle that. You *do* file follow-up issues via `gh issue create` per the follow-up dance, and post the durable token-cost comment per the merge + cleanup dance. Nothing else.
 - No unsolicited source edits. Edit/Write/Grep/Glob are available so you can do project research and small file tweaks the lead asks for (and PR body hygiene), but don't refactor or open PRs of your own.
 - No spawning unrelated agents. Worker and reviewer only, per the dances above.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -60,13 +60,13 @@ We ride ergo, which supports IRCv3 multiline. Don't worry about splitting across
 
 Dispatcher relays comment bodies in full via IRCv3 multiline batches — read them directly from the channel notification. The rare empty body (e.g. approval without comment) means nothing to relay, not truncation.
 
-You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to acknowledge moving something to a followup issue. You may also remain silent.
+You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to ask the APM to file a followup issue. You may also remain silent.
 
 If you comment on GitHub, prefix your comment with your name [<project>-lead-pm]
 
 ## Working with the APM
 
-The APM handles four dances for you: setup (worktree + watch + worker spawn), reviewer-spawn (when worker posts a draft PR), ready-for-review (mark-ready + add human reviewer + re-request after CHANGES_REQUESTED), and merge + cleanup. You drive the judgment around each dance — model selection, plan pressure-testing, human review decisions; the APM types the commands.
+The APM handles five dances for you: setup (worktree + watch + worker spawn), reviewer-spawn (when worker posts a draft PR), ready-for-review (mark-ready + add human reviewer + re-request after CHANGES_REQUESTED), merge + cleanup, and follow-up filing (`gh issue create` against the current or a named milestone). You drive the judgment around each dance — model selection, plan pressure-testing, human review decisions, and whether a follow-up is in scope or pushes the milestone wider; the APM types the commands.
 
 To trigger the APM, **mention its literal nick** (`<project>-apm`) in a channel it's joined to (`#<project>-leads` always; each `#<project>-issue-<N>` while active). The APM responds with an **ack** before acting — it restates what it parsed (issues, models, branch names) and waits for your affirmative (`go`, `yes`, `y`, `lgtm` — anything clear) before executing.
 
@@ -107,6 +107,18 @@ For each issue:
 8. **Post a postmortem in `#<project>-leads`** about how the issue went. Come with suggestions about how to make the next issue easier. This is yours, not the APM's. The APM has already posted a `token cost for #<N>:` block in `#<project>-leads` *and* as a comment on the closed issue (durable history) — don't restate it.
 
 Before confirming the APM's merge ack, double-check: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
+
+## Filing follow-up issues
+
+All follow-up issues — whether surfaced by a worker mid-PR, by the reviewer agent, by the human in review, or spotted by you — go through the APM. You don't `gh issue create` yourself, and the worker doesn't either. The flow:
+
+1. Decide whether the follow-up is in scope for the current PR (push back, take it now) or genuinely deferrable.
+2. Decide milestone: usually the current one; sometimes a later milestone; sometimes "no milestone" if you're not sure where it lands.
+3. Mention the APM with intent, e.g. `<project>-apm file a followup: title="<short title>" — <one-line body>`. Reference the source PR/issue (e.g. "from PR #<N>") so the APM can quote-link it in the body.
+4. The APM acks with title + body shape + milestone (defaults to no milestone if you didn't specify one), and asks if a wider-scope followup should prompt a project-plan rethink. Confirm with an affirmative or correct.
+5. The APM creates the issue and posts the URL in the channel where you asked.
+
+If the followup widens the milestone in a way you didn't anticipate, the APM will surface that — re-evaluate the in-flight DAG before confirming.
 
 ## When you author a PR yourself
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -114,7 +114,7 @@ All follow-up issues — whether surfaced by a worker mid-PR, by the reviewer ag
 
 1. Decide whether the follow-up is in scope for the current PR (push back, take it now) or genuinely deferrable.
 2. Decide milestone: usually the current one; sometimes a later milestone; sometimes "no milestone" if you're not sure where it lands.
-3. Mention the APM with intent, e.g. `<project>-apm file a followup: title="<short title>" — <one-line body>`. Reference the source PR/issue (e.g. "from PR #<N>") so the APM can quote-link it in the body.
+3. Mention the APM with intent, e.g. `<project>-apm file followup: title="<short title>" — <one-line body>`. Reference the source PR or issue (e.g. "from PR #<N>") so the APM can quote-link it in the body.
 4. The APM acks with title + body shape + milestone (defaults to no milestone if you didn't specify one), and asks if a wider-scope followup should prompt a project-plan rethink. Confirm with an affirmative or correct.
 5. The APM creates the issue and posts the URL in the channel where you asked.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -112,7 +112,7 @@ Before confirming the APM's merge ack, double-check: the PR is approved by the h
 
 All follow-up issues — whether surfaced by a worker mid-PR, by the reviewer agent, by the human in review, or spotted by you — go through the APM. You don't `gh issue create` yourself, and the worker doesn't either. The flow:
 
-1. Decide whether the follow-up is in scope for the current PR (push back, take it now) or genuinely deferrable.
+1. **Default to rolling the fix into the current PR.** Only file a followup when the scope is genuinely too large for the current PR — substantial new code, dependent unmerged work, a separate concern, or out-of-milestone. When in doubt, take it now. Push the worker to expand scope rather than defer; reach for `gh issue create` last, not first.
 2. Decide milestone: usually the current one; sometimes a later milestone; sometimes "no milestone" if you're not sure where it lands.
 3. Mention the APM with intent, e.g. `<project>-apm file followup: title="<short title>" — <one-line body>`. Reference the source PR or issue (e.g. "from PR #<N>") so the APM can quote-link it in the body.
 4. The APM acks with title + body shape + milestone (defaults to no milestone if you didn't specify one), and asks if a wider-scope followup should prompt a project-plan rethink. Confirm with an affirmative or correct.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -15,7 +15,7 @@ Process:
 2. Post your implementation plan in #$0-issue-$1 and **wait** for lead-pm's approval before coding
 3. When done, open a *draft* PR and post the link in #$0-issue-$1. The PR body **must** start with a closing keyword on its own line — `Closes #$1` (or `Fixes` / `Resolves`). GitHub only auto-links issues when one of those keywords precedes the number; without it, `linked_issues` comes back empty and the dispatcher has no channel to route per-PR events to.
 4. Prefix all GitHub comments with [$0-worker-$1]
-5. Defer to lead-pm for marking the PR ready, tagging reviewers, and creating followup issues
+5. Defer to lead-pm for marking the PR ready and tagging reviewers. If you spot something that belongs in a follow-up issue, **raise it in #$0-issue-$1** — lead-pm decides, and the APM files it. Do not `gh issue create` yourself.
 
 Don't mark the PR ready yourself.
 
@@ -31,7 +31,7 @@ Write logical, timeless commit messages. Describe what the commit does in the ab
 
 ## Plans and followups
 
-Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. Default to taking on more work in-PR. Lead-pm handles filing followup issues — don't defer scope to a followup when you can do it now.
+Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. Default to taking on more work in-PR. If a follow-up really is the right call, raise it in #$0-issue-$1 — lead-pm decides, the APM files. Don't defer scope to a followup when you can do it now, and don't open issues yourself.
 
 ## Scheduling
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -31,7 +31,7 @@ Write logical, timeless commit messages. Describe what the commit does in the ab
 
 ## Plans and followups
 
-Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. Default to taking on more work in-PR. If a follow-up really is the right call, raise it in #$0-issue-$1 — lead-pm decides, the APM files. Don't defer scope to a followup when you can do it now, and don't open issues yourself.
+Lead-pm will pressure-test your plan before approving. Have answers ready: why this approach, what alternatives were ruled out, what the edge cases are. Default to taking on more work in-PR — when in doubt, do it now. Only raise a follow-up candidate in #$0-issue-$1 when the scope is genuinely too large for the current PR (substantial new code, dependent unmerged work, a separate concern, or out-of-milestone); even then, lead-pm decides and the APM files. Don't open issues yourself.
 
 ## Scheduling
 

--- a/start.md
+++ b/start.md
@@ -49,7 +49,7 @@ We ride ergo, which supports IRCv3 multiline. Don't worry about splitting across
 
 When the dispatcher relays a PR comment to the channel, the body is truncated to a single IRC line. Always fetch the full body before responding to the human's comment — use `gh pr view N --repo OWNER/REPO --comments` or `gh api repos/OWNER/REPO/pulls/N/comments`. Treat the dispatcher line as a notification, not the message.
 
-You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to acknowledge moving something to a followup issue. You may also remain silent.
+You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to ask the APM to file a followup issue. You may also remain silent.
 
 If you comment on GitHub, prefix your comment with your name [roost-lead-pm]
 

--- a/start.md
+++ b/start.md
@@ -49,7 +49,7 @@ We ride ergo, which supports IRCv3 multiline. Don't worry about splitting across
 
 When the dispatcher relays a PR comment to the channel, the body is truncated to a single IRC line. Always fetch the full body before responding to the human's comment — use `gh pr view N --repo OWNER/REPO --comments` or `gh api repos/OWNER/REPO/pulls/N/comments`. Treat the dispatcher line as a notification, not the message.
 
-You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to ask the APM to file a followup issue. You may also remain silent.
+You do not need to restate anything that the human or dispatcher says in the channel. You do not need to restate PR review comments in the channel. The worker is in the channel and will naturally see notifications and read PR comments. Workers are expected to do their own followup reading. You are expected to also do full readings. You may comment in Roost if you believe something is out of scope, or have a different change you want to make, or to acknowledge moving something to a followup issue. You may also remain silent.
 
 If you comment on GitHub, prefix your comment with your name [roost-lead-pm]
 


### PR DESCRIPTION
Closes #320

## Summary

Move all follow-up issue filing to the APM. Previously, workers filed followups surfaced mid-PR and lead-pm filed ones from human review — split responsibility, no place to evolve milestone-aware behavior.

- `agents/associate-pm.md` — add **Follow-up dance** (fifth dance). Triggered by lead mention with intent. Ack restates title + body shape + milestone, defaults to **no milestone** when unspecified, flags when the followup widens the current milestone. Body template is `[roost-apm]` attribution + quoted trigger line + back-link to PR/issue. "What you do not do" updated to allow `gh issue create` for this dance.
- `agents/lead-pm.md` — drop the "acknowledge moving something to a followup" wording; add a "Filing follow-up issues" section spelling out the flow. Dance count goes 4 → 5.
- `prompts/worker.md` — worker raises followup candidates in the issue channel; lead decides; APM files. Explicit "do not `gh issue create` yourself" since the worker → lead → APM hop is 3 long and the worker should not shortcut it.
- `start.md` — align the older doc with the new flow.

Three review-loop adjustments from lead-pm before code: (1) body template + `[roost-apm]` attribution + source link, (2) the 3-hop worker→lead→APM path called out explicitly so workers don't shortcut, (3) default-to-no-milestone in the ack rather than guessing the current one.

## Test plan

- [ ] human review of agent/prompt wording
- [ ] verify next live followup goes through the new dance end-to-end (lead mention → APM ack → `gh issue create` → URL posted)