### PR TITLE
extract dispatcher PID liveness helpers into _dispatcher-pid-lib.sh

### DIFF
--- a/bin/_dispatcher-pid-lib.sh
+++ b/bin/_dispatcher-pid-lib.sh
@@ -1,6 +1,9 @@
 # shellcheck shell=bash
 # _dispatcher-pid-lib.sh — source this; do not execute directly.
-# Requires callers to set: PID_FILE, CONFIG_DIR
+# PID_FILE and CONFIG_DIR must be in scope at call time (set by the sourcing script).
+#
+# The two-stage liveness contract (PID alive + ps args references CONFIG_DIR) is
+# mirrored in TS at src/orchestrator/config.ts:readDispatcherPid — keep in sync.
 
 # Pull pid out of the JSON without depending on jq. Portable across BSD sed
 # (darwin) and GNU sed (linux).
@@ -18,6 +21,7 @@ pid_file_is_live() {
   pid="$(read_pid)"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
+  # `ps -p PID -o args=` works on darwin and linux. Grep for our config-dir.
   # shellcheck disable=SC2154
   ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
   return 0

--- a/bin/_dispatcher-pid-lib.sh
+++ b/bin/_dispatcher-pid-lib.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+# _dispatcher-pid-lib.sh — source this; do not execute directly.
+# Requires callers to set: PID_FILE, CONFIG_DIR
+
+# Pull pid out of the JSON without depending on jq. Portable across BSD sed
+# (darwin) and GNU sed (linux).
+read_pid() {
+  # shellcheck disable=SC2154
+  [ -f "$PID_FILE" ] || return 1
+  sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$PID_FILE" | head -1
+}
+
+# Returns 0 if the PID file points at a live dispatcher for *this* config-dir.
+# Two-stage check: PID alive (`kill -0`) AND `ps` shows the config-dir arg,
+# so a recycled PID owned by an unrelated process doesn't fool us.
+pid_file_is_live() {
+  local pid
+  pid="$(read_pid)"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  # shellcheck disable=SC2154
+  ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
+  return 0
+}

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -35,27 +35,10 @@ DISPATCHER_BIN="${ROOST_DISPATCHER_BIN:-$DIR/dispatcher}"
 PID_FILE="$CONFIG_DIR/dispatcher.pid"
 LOCK_DIR="$CONFIG_DIR/.dispatcher.start.lock"
 
+# shellcheck disable=SC1091
+source "$DIR/_dispatcher-pid-lib.sh"
+
 mkdir -p "$CONFIG_DIR"
-
-# Pull pid out of the JSON without depending on jq. Portable across BSD sed
-# (darwin) and GNU sed (linux).
-read_pid() {
-  [ -f "$PID_FILE" ] || return 1
-  sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$PID_FILE" | head -1
-}
-
-# Returns 0 if the PID file points at a live dispatcher for *this* config-dir.
-# Two-stage check: PID alive (`kill -0`) AND `ps` shows the config-dir arg,
-# so a recycled PID owned by an unrelated process doesn't fool us.
-pid_file_is_live() {
-  local pid
-  pid="$(read_pid)"
-  [ -n "$pid" ] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
-  # `ps -p PID -o args=` works on darwin and linux. Grep for our config-dir.
-  ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
-  return 0
-}
 
 report_running() {
   local pid

--- a/bin/stop-dispatcher
+++ b/bin/stop-dispatcher
@@ -25,27 +25,12 @@ if [ "$#" -lt 1 ]; then
 fi
 
 CONFIG_DIR="$1"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PID_FILE="$CONFIG_DIR/dispatcher.pid"
 STOP_TIMEOUT="${STOP_TIMEOUT:-30}"
 
-# Pull pid out of the JSON without depending on jq. Portable across BSD sed
-# (darwin) and GNU sed (linux).
-read_pid() {
-  [ -f "$PID_FILE" ] || return 1
-  sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$PID_FILE" | head -1
-}
-
-# Returns 0 if the PID file points at a live dispatcher for *this* config-dir.
-# Mirrors the same two-stage check as bin/start-dispatcher: PID alive AND
-# cmdline references our config-dir (PID-recycle defense).
-pid_file_is_live() {
-  local pid
-  pid="$(read_pid)"
-  [ -n "$pid" ] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
-  ps -p "$pid" -o args= 2>/dev/null | grep -Fq -- "$CONFIG_DIR" || return 1
-  return 0
-}
+# shellcheck disable=SC1091
+source "$DIR/_dispatcher-pid-lib.sh"
 
 if [ ! -f "$PID_FILE" ]; then
   echo "dispatcher not running (no PID file)"


### PR DESCRIPTION
Closes #312

`read_pid` and `pid_file_is_live` were byte-identical in `bin/start-dispatcher` and `bin/stop-dispatcher`. Pulled into a sourced `bin/_dispatcher-pid-lib.sh`; callers set `PID_FILE` and `CONFIG_DIR` before sourcing.

- All 6 start-dispatcher tests pass, all 5 stop-dispatcher tests pass
- `bun run lint` (eslint + shellcheck) and `bun run typecheck` clean