### PR TITLE
add lead-pm spawn example to roost help

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -48,8 +48,9 @@ Commands:
 Quick start:
   roost init
   roost spawn <project>-lead-pm \\
+    --agent lead-pm \\
     --channels '#<project>-leads' \\
-    --prompt '/lead-pm <project> <milestone> <your-nick> <your-gh-login>'
+    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'
 
 Run 'roost <command> --help' for per-command usage.
 EOF
@@ -461,8 +462,9 @@ cmd_init() {
 
   printf '\nNext step:\n'
   printf '  roost spawn %s-lead-pm \\\n' "$project"
+  printf '    --agent lead-pm \\\n'
   printf "    --channels '#%s-leads' \\\n" "$project"
-  printf "    --prompt '/lead-pm %s <milestone> <your-irc-nick> <your-gh-login>'\n" "$project"
+  printf "    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'\n"
 }
 
 require_tmux() {

--- a/bin/roost
+++ b/bin/roost
@@ -45,6 +45,12 @@ Commands:
   root                     Print the roost plugin root directory.
   send <nick> <message...> Inject text into a nick's tmux pane.
 
+Quick start:
+  roost init
+  roost spawn <project>-lead-pm \\
+    --channels '#<project>-leads' \\
+    --prompt '/lead-pm <project> <milestone> <your-nick> <your-gh-login>'
+
 Run 'roost <command> --help' for per-command usage.
 EOF
 }


### PR DESCRIPTION
Closes #321

Adds a Quick start block to `usage()` showing the lead-pm spawn command with `<project>` placeholders. `roost init` already prints this at the end of its run; now it's also visible in basic help for users who forget or skip init.