### PR TITLE
dedup transcript turns by requestId in token-usage

### DIFF
--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -155,8 +155,8 @@ function scanFile(text: string, report: NickReport, seenRequestIds: Set<string>,
     // Assistant turn: model + usage block.
     if (row.type === 'assistant' && row.message?.usage && row.message.model) {
       // Dedup multi-part API responses: same requestId → same usage block.
-      // Rows lacking a requestId (older transcripts, synthetic rows) fall
-      // through and count as today.
+      // Rows lacking a requestId (older transcripts, synthetic rows) are
+      // not deduped — each row counts independently.
       if (row.requestId) {
         if (seenRequestIds.has(row.requestId)) continue
         seenRequestIds.add(row.requestId)

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -106,6 +106,9 @@ interface AnyRow {
   subtype?: string
   timestamp?: string
   durationMs?: number
+  requestId?: string
+  uuid?: string
+  isSidechain?: boolean
   message?: {
     model?: string
     usage?: {
@@ -124,9 +127,18 @@ interface AnyRow {
 }
 
 // Walk one JSONL file, accumulate into `report`. Only rows with
-// `timestamp > sinceTs` (when sinceTs is set) contribute. Returns whether
-// the file contributed at all (used as the session-counter signal).
-function scanFile(text: string, report: NickReport, sinceTs?: string): boolean {
+// `timestamp > sinceTs` (when sinceTs is set) contribute. `seenRequestIds`
+// is shared across files so the same API call (one requestId) is only
+// counted once — Claude Code writes one assistant row per content block
+// of a multi-part response (text + tool_use + tool_use…) and each row
+// repeats the parent API call's `usage` block verbatim. Forked or resumed
+// transcripts also share requestIds across files. Sidechain (subagent)
+// rows are skipped: in current Claude Code their transcripts live in
+// `PROJECT/SESSION/subagents/agent-*.jsonl` and never carry the MCP
+// banner, so today this is defensive — older or future shapes that inline
+// sidechain rows are filtered here. Returns whether the file contributed
+// at all (used as the session-counter signal).
+function scanFile(text: string, report: NickReport, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string): boolean {
   let contributed = false
   for (const line of text.split('\n')) {
     if (!line) continue
@@ -138,9 +150,17 @@ function scanFile(text: string, report: NickReport, sinceTs?: string): boolean {
     }
     const ts = row.timestamp
     if (sinceTs && (!ts || ts <= sinceTs)) continue
+    if (row.isSidechain) continue
 
     // Assistant turn: model + usage block.
     if (row.type === 'assistant' && row.message?.usage && row.message.model) {
+      // Dedup multi-part API responses: same requestId → same usage block.
+      // Rows lacking a requestId (older transcripts, synthetic rows) fall
+      // through and count as today.
+      if (row.requestId) {
+        if (seenRequestIds.has(row.requestId)) continue
+        seenRequestIds.add(row.requestId)
+      }
       const u = row.message.usage
       // Cache-write breakdown: prefer the nested per-TTL fields when
       // present (every modern transcript has them). Fall back to lumping
@@ -178,7 +198,13 @@ function scanFile(text: string, report: NickReport, sinceTs?: string): boolean {
 
     // System turn_duration row: one per assistant API call, carries the
     // model's wall time for that call. Use these for API-time total.
+    // Dedup by uuid so forked/resumed transcripts don't re-add the same
+    // turn; within a single file these uuids are already unique.
     if (row.type === 'system' && row.subtype === 'turn_duration' && typeof row.durationMs === 'number') {
+      if (row.uuid) {
+        if (seenTurnUuids.has(row.uuid)) continue
+        seenTurnUuids.add(row.uuid)
+      }
       report.apiDurationMs += row.durationMs
       if (ts) trackTs(report, ts)
       contributed = true
@@ -196,6 +222,10 @@ export async function collectForNick(
   const marker = markerFor(nick)
   const files = await listSessionFiles(projectsRoot)
   const report = emptyReport()
+  // Scan-wide so a requestId / turn uuid shared across forked or resumed
+  // transcripts is only counted once.
+  const seenRequestIds = new Set<string>()
+  const seenTurnUuids = new Set<string>()
   for (const f of files) {
     let text: string
     try {
@@ -207,7 +237,7 @@ export async function collectForNick(
     // skip the parse entirely.
     if (!text.includes(marker)) continue
     report.files.push(f)
-    const contributed = scanFile(text, report, sinceTs)
+    const contributed = scanFile(text, report, seenRequestIds, seenTurnUuids, sinceTs)
     if (contributed) report.sessions += 1
   }
   return report

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -20,6 +20,16 @@ interface Turn {
   cache_r?: number
   // Optional API duration row that follows this turn.
   apiDurationMs?: number
+  // Optional requestId on the assistant row — repeating it across turns
+  // simulates Claude Code's "one assistant row per content block, all
+  // sharing the parent API call's usage" pattern.
+  requestId?: string
+  // Optional uuid on the system/turn_duration row — repeating across files
+  // simulates a forked/resumed transcript.
+  turnUuid?: string
+  // If true, mark the assistant row (and any paired turn_duration row)
+  // with isSidechain:true.
+  sidechain?: boolean
 }
 
 // Build a session JSONL containing the MCP banner for `nick` followed by the
@@ -56,18 +66,24 @@ async function writeSessionFile(
       // Aggregate-only path: legacy / fallback shape.
       usage.cache_creation_input_tokens = t.cache_w ?? 0
     }
-    lines.push(JSON.stringify({
+    const assist: Record<string, unknown> = {
       type: 'assistant',
       timestamp: t.ts,
       message: { role: 'assistant', model: t.model, usage },
-    }))
+    }
+    if (t.requestId) assist.requestId = t.requestId
+    if (t.sidechain) assist.isSidechain = true
+    lines.push(JSON.stringify(assist))
     if (typeof t.apiDurationMs === 'number') {
-      lines.push(JSON.stringify({
+      const dur: Record<string, unknown> = {
         type: 'system',
         subtype: 'turn_duration',
         durationMs: t.apiDurationMs,
         timestamp: t.ts,
-      }))
+      }
+      if (t.turnUuid) dur.uuid = t.turnUuid
+      if (t.sidechain) dur.isSidechain = true
+      lines.push(JSON.stringify(dur))
     }
   }
   const path = join(dir, filename)
@@ -229,6 +245,83 @@ describe('token-usage', () => {
       ])
       const r = await collectForNick('roost-x', projects)
       expect(r.unknownModels.has('<synthetic>')).toBe(false)
+    })
+
+    it('dedups assistant rows with the same requestId (multi-part response)', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Three assistant rows under the same requestId — Claude Code writes
+      // one row per content block (text, tool_use, tool_use) and each
+      // repeats the parent API call's usage block verbatim.
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, cache_w_5m: 1000, cache_r: 50000, requestId: 'req_A' },
+        { ts: '2026-05-16T10:00:01Z', model: 'claude-opus-4-7', input: 10, output: 100, cache_w_5m: 1000, cache_r: 50000, requestId: 'req_A' },
+        { ts: '2026-05-16T10:00:02Z', model: 'claude-opus-4-7', input: 10, output: 100, cache_w_5m: 1000, cache_r: 50000, requestId: 'req_A' },
+        // A genuinely new call must still count.
+        { ts: '2026-05-16T10:01:00Z', model: 'claude-opus-4-7', input: 5, output: 50, cache_w_5m: 500, cache_r: 25000, requestId: 'req_B' },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const opus = r.byModel.get('claude-opus-4-7')!
+      expect(opus.input).toBe(15)
+      expect(opus.output).toBe(150)
+      expect(opus.cache_creation_5m).toBe(1500)
+      expect(opus.cache_read).toBe(75000)
+    })
+
+    it('rows without requestId are not collapsed (older shapes count as today)', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // No requestId at all → each row counts independently.
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 7, output: 3 },
+        { ts: '2026-05-16T10:00:01Z', model: 'claude-opus-4-7', input: 7, output: 3 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const opus = r.byModel.get('claude-opus-4-7')!
+      expect(opus.input).toBe(14)
+      expect(opus.output).toBe(6)
+    })
+
+    it('dedups requestId across files (forked/resumed transcripts)', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      const turn = { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, cache_r: 5000, requestId: 'req_shared' }
+      await writeSessionFile(d, 'fork-a.jsonl', 'roost-x', [turn])
+      await writeSessionFile(d, 'fork-b.jsonl', 'roost-x', [turn])
+      const r = await collectForNick('roost-x', projects)
+      const opus = r.byModel.get('claude-opus-4-7')!
+      // Same requestId in two files → counted once.
+      expect(opus.input).toBe(10)
+      expect(opus.output).toBe(100)
+      expect(opus.cache_read).toBe(5000)
+    })
+
+    it('skips sidechain (subagent) assistant rows entirely', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, apiDurationMs: 1000, requestId: 'req_main' },
+        { ts: '2026-05-16T10:00:30Z', model: 'claude-opus-4-7', input: 999, output: 999, cache_w_5m: 99999, apiDurationMs: 5000, requestId: 'req_sub', sidechain: true },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const opus = r.byModel.get('claude-opus-4-7')!
+      // Only the main-thread row contributes.
+      expect(opus.input).toBe(10)
+      expect(opus.output).toBe(5)
+      expect(opus.cache_creation_5m).toBe(0)
+      // Sidechain turn_duration is also skipped.
+      expect(r.apiDurationMs).toBe(1000)
+    })
+
+    it('dedups turn_duration rows by uuid across files', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      const turn = { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_x', apiDurationMs: 4000, turnUuid: 'turn_shared' }
+      await writeSessionFile(d, 'fork-a.jsonl', 'roost-x', [turn])
+      await writeSessionFile(d, 'fork-b.jsonl', 'roost-x', [turn])
+      const r = await collectForNick('roost-x', projects)
+      // Counted once, not twice.
+      expect(r.apiDurationMs).toBe(4000)
     })
   })
 


### PR DESCRIPTION
Closes #331

## Summary
- Claude Code writes one assistant row per content block of a multi-part API response, and each row repeats the parent call's `usage` block verbatim. roost-token-usage was summing every row, inflating output / cache_write 1.5–2× in cache-heavy sessions. Dedup by `requestId` collapses the repeats.
- Lifted the seen-set to scan-wide (`collectForNick` level) since forked or resumed transcripts share requestIds across files. Verified on real data: one fork pair in my project shared 33 requestIds across two `.jsonl` files.
- Also dedup `turn_duration` rows by `uuid` (same fork-across-files concern) and skip `isSidechain:true` rows defensively — current Claude Code keeps subagent transcripts in a separate `PROJECT/SESSION/subagents/agent-*.jsonl` subtree (with no MCP banner, so our 1-deep glob already misses them), but older/future shapes might inline them.

Live re-probe on my `roost-lead-pm` corpus (10 matching files): output went from 3.44M → 1.61M (2.1×), cache_read 1.07B → 608M (1.77×) — matches alex's observed inflation shape.

Note: subagent attribution is the opposite-direction gap (we currently miss subagent spend entirely because subagent transcripts lack the MCP banner). Raised as a follow-up candidate in #roost-issue-331.

## Test plan
- [x] `bun test test/token-usage.test.ts` — 23 pass (5 new: requestId dedup, no-requestId fallthrough, cross-file dedup, sidechain skip, turn_duration uuid dedup)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Live probe against `~/.claude/projects` for `roost-lead-pm` to confirm the deflation matches the observed inflation

🤖 Generated with [Claude Code](https://claude.com/claude-code)