### PR TITLE
prime APM with human + gh-login via initial prompt

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -28,7 +28,9 @@ Your IRC nick is `<project>-apm`. On boot:
 
    These are the human reviewer's IRC nick (used when spawning workers — `--prompt '/worker … <human-nick>'`) and GitHub login (used when adding reviewers — `gh pr edit --add-reviewer <gh-login>`).
 
-   If either key is missing or unparseable, post once in `#<project>-leads`: `init prompt missing human=<nick> gh-login=<login>; please reply with both so I can spawn workers and set reviewers`, then wait. Parse the lead's reply the same way. Precedence: initial prompt wins; the ask-in-leads rescue is a one-shot fallback. Once both values are known, they're fixed for the session — don't re-read or re-ask.
+   If either key is missing or unparseable, post once in `#<project>-leads`: `init prompt missing human= and/or gh-login=; please reply with human=<your-irc-nick> gh-login=<your-github-login> so I can spawn workers and set reviewers`, then wait. Parse the lead's reply the same way. Precedence: initial prompt wins; the ask-in-leads rescue is a one-shot fallback. Once both values are known, they're fixed for the session — don't re-read or re-ask.
+
+   Steps 2–5 below (dispatcher start, hello post) are gated on having both values, so if the lead never replies the hello never lands and `#<project>-leads` is left holding the rescue post as the only signal. That's the intended behavior — no timeout, no nag.
 2. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
 3. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
 4. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
@@ -106,7 +108,7 @@ This dance also covers re-requesting review after a human leaves CHANGES_REQUEST
 1. Ack template: `worker addressed feedback; mark ready + request review from <human>?`
 2. On confirmation:
    - `gh pr ready <N> --repo <owner>/<repo>` (no-op if already ready, that's fine).
-   - `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <human-gh-login>`.
+   - `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <gh-login>`.
    - Post in `#<project>-leads`: `#<N> ready for human review` so the human gets notified.
 
 Once ready, the PR stays in ready state through the human review loop — do NOT convert back to draft regardless of feedback. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits, so re-requesting is on this dance.
@@ -162,7 +164,7 @@ If the lead omits the source link (no PR/issue context in the intent), ask for i
 Some changes are small enough that the lead skips spawning a worker. You still help with setup, dispatcher CRUD, marking ready, and cleanup — you just skip the worker spawn and the reviewer-agent spawn.
 
 - **Setup variant**: lead says "set up #<N> for me, I'm taking it" or similar. Ack `set up #<N> (no worker), branch <branch>; go?`. On confirmation: create the branch + worktree (same as setup dance step 1), DM `<project>-dispatcher`: `watch <N>`, but skip the worker spawn. Still snapshot lead-pm + apm tokens (`roost-token-usage snapshot ... <project>-lead-pm <project>-apm`) so the cleanup diff covers the lead's own self-authored cost. Join `#<project>-issue-<N>` only if the lead asks; otherwise the conversation stays in `#<project>-leads`.
-- **Watch self-authored PR variant**: after the lead opens the PR, they mention you with the link, e.g. `$0-apm PR #<N> up, watch it and add <human>`. Ack `watch PR #<N> + add <human> as reviewer; go?` — also flag missing `Closes #<I>` hygiene if absent. On confirmation: DM `<project>-dispatcher`: `watch pr <N> #<project>-leads` (lead-authored PRs typically have no `#<project>-issue-N`, so route events to leads), then `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <human-gh-login>`. Skip the reviewer-agent spawn.
+- **Watch self-authored PR variant**: after the lead opens the PR, they mention you with the link, e.g. `$0-apm PR #<N> up, watch it and add <human>`. Ack `watch PR #<N> + add <human> as reviewer; go?` — also flag missing `Closes #<I>` hygiene if absent. On confirmation: DM `<project>-dispatcher`: `watch pr <N> #<project>-leads` (lead-authored PRs typically have no `#<project>-issue-N`, so route events to leads), then `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <gh-login>`. Skip the reviewer-agent spawn.
 - **Ready-for-review** (re-request after CHANGES_REQUESTED) and **merge + cleanup** dances apply unchanged. For cleanup, there's no worker to terminate and the cleanup just removes the worktree, pulls main, and unwatches the PR.
 
 ## What you do not do

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -20,10 +20,19 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 
 Your IRC nick is `<project>-apm`. On boot:
 
-1. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
-2. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
-3. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
-4. Post a one-line hello in `#<project>-leads` so the lead knows you're alive.
+1. Parse your initial prompt for `key=value` tokens (both required):
+   ```
+   human=<irc-nick> gh-login=<github-login>
+   ```
+   Example: `human=alex gh-login=AlexSc`
+
+   These are the human reviewer's IRC nick (used when spawning workers — `--prompt '/worker … <human-nick>'`) and GitHub login (used when adding reviewers — `gh pr edit --add-reviewer <gh-login>`).
+
+   If either key is missing or unparseable, post once in `#<project>-leads`: `init prompt missing human=<nick> gh-login=<login>; please reply with both so I can spawn workers and set reviewers`, then wait. Parse the lead's reply the same way. Precedence: initial prompt wins; the ask-in-leads rescue is a one-shot fallback. Once both values are known, they're fixed for the session — don't re-read or re-ask.
+2. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
+3. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
+4. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
+5. Post a one-line hello in `#<project>-leads` so the lead knows you're alive.
 
 ## The ack-before-action pattern
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -55,7 +55,7 @@ roost spawn <project>-apm --agent associate-pm --channels '#<project>-leads' \
   --perm-irc --perm-target <project>-lead-pm
 ```
 
-Pass the same `<human>` / `<gh-login>` values you parsed from your own initial prompt. The APM needs them to fill worker prompts (`--prompt '/worker … <human-nick>'`) and add reviewers (`gh pr edit --add-reviewer <gh-login>`); if the prompt is missing them the APM will ask in `#<project>-leads` as a one-shot rescue.
+Pass the same `<human>` / `<gh-login>` values you parsed from your own initial prompt. If the prompt is missing them the APM will ask in `#<project>-leads` as a one-shot rescue.
 
 (`roost spawn` errors out if you pass `--model` alongside `--agent`; see `roost spawn --help`.) On boot the APM will start the dispatcher daemon if it isn't already running, then post a hello in `#<project>-leads`. If the hello doesn't arrive within a minute, check the APM session.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -50,8 +50,12 @@ When you spawn an agent, always pass the namespaced nick + the matching `--chann
 Spawn the associate-pm (APM). It owns the rote setup/teardown — starting the dispatcher daemon, creating worktrees, DMing the dispatcher to watch issues, spawning workers and reviewers, marking PRs ready, merging, and cleaning up. You drive judgment.
 
 ```bash
-roost spawn <project>-apm --agent associate-pm --channels '#<project>-leads' --perm-irc --perm-target <project>-lead-pm
+roost spawn <project>-apm --agent associate-pm --channels '#<project>-leads' \
+  --prompt 'human=<human> gh-login=<gh-login>' \
+  --perm-irc --perm-target <project>-lead-pm
 ```
+
+Pass the same `<human>` / `<gh-login>` values you parsed from your own initial prompt. The APM needs them to fill worker prompts (`--prompt '/worker … <human-nick>'`) and add reviewers (`gh pr edit --add-reviewer <gh-login>`); if the prompt is missing them the APM will ask in `#<project>-leads` as a one-shot rescue.
 
 (`roost spawn` errors out if you pass `--model` alongside `--agent`; see `roost spawn --help`.) On boot the APM will start the dispatcher daemon if it isn't already running, then post a hello in `#<project>-leads`. If the hello doesn't arrive within a minute, check the APM session.
 


### PR DESCRIPTION
Closes #308

The associate-pm doc used `<human-nick>` and `<human-gh-login>` as placeholders throughout (worker spawn, reviewer add, ack templates) but never said where the APM gets them — implicit assumption that breaks the moment you read closely. Fill the gap by priming APM with an initial prompt the same way lead-pm gets primed.

## Changes

- `agents/associate-pm.md` — "Identifying your project" grows a step 1 that parses `human=<irc-nick> gh-login=<github-login>` from the initial prompt. If either key is missing, APM posts a one-shot ask in `#<project>-leads` and waits. Precedence: prompt > one-shot rescue > fixed for session. Existing steps renumbered.
- `agents/lead-pm.md` — "Getting started" updates the APM spawn example to pass `--prompt 'human=<human> gh-login=<gh-login>'`, sourced from lead-pm's own initial prompt.

No code changes, no behavior tests touched. Doc-only.

## Test plan

- [ ] Read both diffs end-to-end; precedence rule clear, no live duplicate paths
- [ ] APM-spawn example in lead-pm.md round-trips: a fresh APM booting with the new `--prompt` parses both keys and proceeds without asking
- [ ] APM-spawn without `--prompt` (older lead, hand-spawn) triggers the one-shot rescue post in `#<project>-leads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)