### PR TITLE
converge dispatcher logging on a single PluginLogger contract

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -91,9 +91,6 @@ function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: P
   })
 }
 
-// One-shot modes (--dispatch-irc, plain CLI) log plugin diagnostics straight
-// to stderr — they don't own a daemon.log to fan out to. The daemon supplies
-// its own combined stderr+file sink in runDaemon().
 function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string): string[] {
   const chans = new Set<string>([projectChannel])
   for (const plugin of plugins) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,7 +19,7 @@ import {
 } from './orchestrator/config.js'
 
 import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js'
-import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger, type TaggedEvent } from './orchestrator/plugin.js'
+import { defaultPluginLogger, getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger, type TaggedEvent } from './orchestrator/plugin.js'
 import './orchestrator/registry.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dm-handler.js'
@@ -92,9 +92,8 @@ function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: P
 }
 
 // One-shot modes (--dispatch-irc, plain CLI) log plugin diagnostics straight
-// to stderr — they don't own a daemon.log to fan out to.
-const stderrLog: PluginLogger = (msg) => { process.stderr.write(msg) }
-
+// to stderr — they don't own a daemon.log to fan out to. The daemon supplies
+// its own combined stderr+file sink in runDaemon().
 function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string): string[] {
   const chans = new Set<string>([projectChannel])
   for (const plugin of plugins) {
@@ -265,7 +264,7 @@ async function runDispatchIrc(stateDir: string, seed: boolean): Promise<void> {
   const server = ircCfg.server ?? '127.0.0.1'
   const port = ircCfg.port ?? 6667
 
-  const plugins = buildPlugins(config, projectChannel, stderrLog)
+  const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
   const channels = bootChannels(plugins, config, projectChannel)
 
   const client = new RoostIrcClientImpl({
@@ -322,7 +321,7 @@ async function main(): Promise<void> {
     // One-shot: fetch + diff, print events JSON
     const config = await loadConfig(stateDir)
     const projectChannel = resolveProjectChannel(config)
-    const plugins = buildPlugins(config, projectChannel, stderrLog)
+    const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
     const result = await runOneTick(stateDir, config, plugins, {
       seed: values['seed'] as boolean,
       dryRun: values['dry-run'] as boolean,

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -88,9 +88,8 @@ export abstract class BasePlugin implements Plugin {
 // this), letting core stay plugin-agnostic.
 export type PluginLogger = (msg: string) => void
 
-// Stderr-only fallback. Used by tests and as a last-resort default for
-// helpers that prefer a parameter to a thrown-on-missing-log error; the
-// real dispatcher modes always supply their own sink via the factory.
+// Stderr-only fallback for direct-construction test paths. The real
+// dispatcher modes always supply their own sink via the plugin factory.
 export const defaultPluginLogger: PluginLogger = (msg) => { process.stderr.write(msg) }
 
 export type PluginFactory = (defaultChannel: string, log: PluginLogger) => Plugin

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -88,6 +88,11 @@ export abstract class BasePlugin implements Plugin {
 // this), letting core stay plugin-agnostic.
 export type PluginLogger = (msg: string) => void
 
+// Stderr-only fallback. Used by tests and as a last-resort default for
+// helpers that prefer a parameter to a thrown-on-missing-log error; the
+// real dispatcher modes always supply their own sink via the factory.
+export const defaultPluginLogger: PluginLogger = (msg) => { process.stderr.write(msg) }
+
 export type PluginFactory = (defaultChannel: string, log: PluginLogger) => Plugin
 
 const REGISTRY = new Map<string, PluginFactory>()

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, setRetryLogger } from '../github-api.js'
+import { GhError, spawnGh } from '../github-api.js'
 
 function mkErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
@@ -172,29 +172,23 @@ describe('spawnGh (retry-aware)', () => {
     expect(h.sleeps).toEqual([150, 300])
   })
 
-  it('setRetryLogger swaps the default log sink for callers that omit deps.log', async () => {
+  it('uses deps.log when caller supplies one — the prod path through the plugin factory', async () => {
     const captured: string[] = []
-    const original = (msg: string) => { process.stderr.write(msg) }
-    setRetryLogger((msg) => { captured.push(msg) })
-    try {
-      let calls = 0
-      const out = await spawnGh(['api', '/x'], {
-        // No `log` injected — falls through to currentDefaultLog.
-        sleep: async () => { /* no real wait */ },
-        baseMs: 1,
-        random: () => 0,
-        exec: async () => {
-          calls++
-          if (calls === 1) throw mkErr('HTTP 502')
-          return { ok: true }
-        },
-      })
-      expect(out).toEqual({ ok: true })
-      expect(captured.length).toBe(1)
-      expect(captured[0]).toContain('matched=http-5xx')
-    } finally {
-      setRetryLogger(original)
-    }
+    let calls = 0
+    const out = await spawnGh(['api', '/x'], {
+      log: (msg) => { captured.push(msg) },
+      sleep: async () => { /* no real wait */ },
+      baseMs: 1,
+      random: () => 0,
+      exec: async () => {
+        calls++
+        if (calls === 1) throw mkErr('HTTP 502')
+        return { ok: true }
+      },
+    })
+    expect(out).toEqual({ ok: true })
+    expect(captured.length).toBe(1)
+    expect(captured[0]).toContain('matched=http-5xx')
   })
 
   it('rethrows non-GhError immediately without classifying', async () => {

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -172,25 +172,6 @@ describe('spawnGh (retry-aware)', () => {
     expect(h.sleeps).toEqual([150, 300])
   })
 
-  it('uses deps.log when caller supplies one — the prod path through the plugin factory', async () => {
-    const captured: string[] = []
-    let calls = 0
-    const out = await spawnGh(['api', '/x'], {
-      log: (msg) => { captured.push(msg) },
-      sleep: async () => { /* no real wait */ },
-      baseMs: 1,
-      random: () => 0,
-      exec: async () => {
-        calls++
-        if (calls === 1) throw mkErr('HTTP 502')
-        return { ok: true }
-      },
-    })
-    expect(out).toEqual({ ok: true })
-    expect(captured.length).toBe(1)
-    expect(captured[0]).toContain('matched=http-5xx')
-  })
-
   it('rethrows non-GhError immediately without classifying', async () => {
     const h = harness()
     let calls = 0

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -11,7 +11,7 @@ import type { Command } from '../../dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
-import { BasePlugin } from '../../plugin.js'
+import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
 
 interface GhPluginConfig {
   watched?: WatchedEntry[]
@@ -25,6 +25,13 @@ export abstract class GhBase extends BasePlugin {
   // Singular noun used in reply lines (e.g. "issue", "pr"). Plural is the
   // plugin name slice.
   protected abstract readonly label: string
+
+  // Diagnostic sink supplied by the plugin factory (see registry.ts). The
+  // default is stderr-only for tests that instantiate plugins directly; the
+  // real dispatcher always passes its own combined sink.
+  constructor(defaultChannel: string, protected readonly log: PluginLogger = defaultPluginLogger) {
+    super(defaultChannel)
+  }
 
   protected agentLogins(config: OrchestratorConfig): Set<string> {
     return new Set(config.agent_logins ?? [])

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -26,9 +26,6 @@ export abstract class GhBase extends BasePlugin {
   // plugin name slice.
   protected abstract readonly label: string
 
-  // Diagnostic sink supplied by the plugin factory (see registry.ts). The
-  // default is stderr-only for tests that instantiate plugins directly; the
-  // real dispatcher always passes its own combined sink.
   constructor(defaultChannel: string, protected readonly log: PluginLogger = defaultPluginLogger) {
     super(defaultChannel)
   }

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -1,4 +1,4 @@
-import { defaultPluginLogger, type PluginLogger } from '../../plugin.js'
+import type { PluginLogger } from '../../plugin.js'
 
 // Transient stderr classifier — patterns we'll retry on. Anything else
 // (404/401/422/etc.) throws on the first attempt. 422 is logged verbatim
@@ -62,10 +62,12 @@ async function runGhOnce(args: string[]): Promise<unknown> {
 }
 
 export interface SpawnDeps {
+  // log is required so every gh call has a real sink — no module-globalish
+  // default. Plugins thread their factory-supplied logger down through here.
+  log: PluginLogger
   // Each option is injectable so tests can pin behavior (no real sleeps, no
   // real gh, deterministic jitter).
   sleep?: (ms: number) => Promise<void>
-  log?: (msg: string) => void
   attempts?: number          // total tries including the first; default 3
   baseMs?: number            // first backoff window; default 1000
   jitterFraction?: number    // backoff *= 1 + random()*jitterFraction; default 0.5
@@ -78,12 +80,10 @@ const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
 // The single gh entrypoint — every gh call goes through here, so retry is
 // the contract for every caller. ghApi/ghGraphql below are thin shape
 // helpers; both delegate to spawnGh so retry can't be bypassed by a future
-// caller. The `deps.log` fallback to defaultPluginLogger is a test affordance
-// (stderr only) — every production caller threads its plugin's logger down
-// from the factory, so this default should never fire in the daemon.
-export async function spawnGh(args: string[], deps: SpawnDeps = {}): Promise<unknown> {
+// caller.
+export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown> {
   const sleep = deps.sleep ?? defaultSleep
-  const log = deps.log ?? defaultPluginLogger
+  const log = deps.log
   const totalAttempts = deps.attempts ?? 3
   const baseMs = deps.baseMs ?? 1000
   const jitterFraction = deps.jitterFraction ?? 0.5

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -1,3 +1,5 @@
+import { defaultPluginLogger, type PluginLogger } from '../../plugin.js'
+
 // Transient stderr classifier — patterns we'll retry on. Anything else
 // (404/401/422/etc.) throws on the first attempt. 422 is logged verbatim
 // in spawnGh so a 422-as-race can be spotted in dispatcher logs.
@@ -72,22 +74,16 @@ export interface SpawnDeps {
 }
 
 const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
-// Retry diagnostics default to stderr. The daemon overrides this via
-// setRetryLogger() to fan out to daemon.log too; one-shot modes (--dispatch-irc,
-// plain CLI) keep the stderr-only default so output lands on the operator's tty.
-let currentDefaultLog: (msg: string) => void = (msg) => { process.stderr.write(msg) }
-
-export function setRetryLogger(fn: (msg: string) => void): void {
-  currentDefaultLog = fn
-}
 
 // The single gh entrypoint — every gh call goes through here, so retry is
 // the contract for every caller. ghApi/ghGraphql below are thin shape
 // helpers; both delegate to spawnGh so retry can't be bypassed by a future
-// caller.
+// caller. The `deps.log` fallback to defaultPluginLogger is a test affordance
+// (stderr only) — every production caller threads its plugin's logger down
+// from the factory, so this default should never fire in the daemon.
 export async function spawnGh(args: string[], deps: SpawnDeps = {}): Promise<unknown> {
   const sleep = deps.sleep ?? defaultSleep
-  const log = deps.log ?? currentDefaultLog
+  const log = deps.log ?? defaultPluginLogger
   const totalAttempts = deps.attempts ?? 3
   const baseMs = deps.baseMs ?? 1000
   const jitterFraction = deps.jitterFraction ?? 0.5
@@ -122,20 +118,20 @@ export async function spawnGh(args: string[], deps: SpawnDeps = {}): Promise<unk
   throw new GhError(`spawnGh: loop exited without result for ${cmd}`)
 }
 
-async function ghApi(endpoint: string, paginate = false): Promise<unknown> {
+async function ghApi(log: PluginLogger, endpoint: string, paginate = false): Promise<unknown> {
   const args = ['api']
   if (paginate) args.push('--paginate')
   args.push(endpoint)
-  return spawnGh(args)
+  return spawnGh(args, { log })
 }
 
 // Centralized so a future gh call can't slip past the retry wrapper.
-async function ghGraphql(query: string, vars: Record<string, string | number>): Promise<unknown> {
+async function ghGraphql(log: PluginLogger, query: string, vars: Record<string, string | number>): Promise<unknown> {
   const args: string[] = ['api', 'graphql', '-f', `query=${query}`]
   for (const [k, v] of Object.entries(vars)) {
     args.push('-F', `${k}=${v}`)
   }
-  return spawnGh(args)
+  return spawnGh(args, { log })
 }
 
 export interface GhLabel {
@@ -231,21 +227,21 @@ export function labelNames(labels: GhLabel[] | null | undefined): string[] {
     .sort()
 }
 
-export async function fetchPr(repo: string, number: number): Promise<FetchedPr> {
-  const pr = (await ghApi(`repos/${repo}/pulls/${number}`) ?? {}) as GhPr
+export async function fetchPr(log: PluginLogger, repo: string, number: number): Promise<FetchedPr> {
+  const pr = (await ghApi(log, `repos/${repo}/pulls/${number}`) ?? {}) as GhPr
   const head = pr.head ?? {}
   const sha = head.sha
 
   let runs: GhCheckRun[] = []
   let statuses: GhStatus[] = []
   if (sha) {
-    const checkResp = await ghApi(`repos/${repo}/commits/${sha}/check-runs?per_page=100`, true)
+    const checkResp = await ghApi(log, `repos/${repo}/commits/${sha}/check-runs?per_page=100`, true)
     if (checkResp && typeof checkResp === 'object' && !Array.isArray(checkResp)) {
       runs = ((checkResp as Record<string, unknown>).check_runs ?? []) as GhCheckRun[]
     } else if (Array.isArray(checkResp)) {
       runs = checkResp as GhCheckRun[]
     }
-    const combined = (await ghApi(`repos/${repo}/commits/${sha}/status`) ?? {}) as Record<string, unknown>
+    const combined = (await ghApi(log, `repos/${repo}/commits/${sha}/status`) ?? {}) as Record<string, unknown>
     statuses = (combined.statuses ?? []) as GhStatus[]
   }
 
@@ -262,19 +258,19 @@ export async function fetchPr(repo: string, number: number): Promise<FetchedPr> 
   }
 }
 
-export async function fetchPrReviewComments(repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(`repos/${repo}/pulls/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+export async function fetchPrReviewComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
+  return (await ghApi(log, `repos/${repo}/pulls/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
 }
 
-export async function fetchPrConversationComments(repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+export async function fetchPrConversationComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
+  return (await ghApi(log, `repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
 }
 
-export async function fetchPrReviews(repo: string, number: number): Promise<GhReview[]> {
-  return (await ghApi(`repos/${repo}/pulls/${number}/reviews?per_page=100`, true) ?? []) as GhReview[]
+export async function fetchPrReviews(log: PluginLogger, repo: string, number: number): Promise<GhReview[]> {
+  return (await ghApi(log, `repos/${repo}/pulls/${number}/reviews?per_page=100`, true) ?? []) as GhReview[]
 }
 
-export async function fetchPrLinkedIssues(repo: string, number: number): Promise<number[]> {
+export async function fetchPrLinkedIssues(log: PluginLogger, repo: string, number: number): Promise<number[]> {
   const [owner, name] = repo.split('/', 2)
   const query = (
     'query($owner:String!,$name:String!,$number:Int!){' +
@@ -282,7 +278,7 @@ export async function fetchPrLinkedIssues(repo: string, number: number): Promise
     'pullRequest(number:$number){' +
     'closingIssuesReferences(first:25){nodes{number}}}}}'
   )
-  const result = await ghGraphql(query, { owner, name, number })
+  const result = await ghGraphql(log, query, { owner, name, number })
   if (!result) return []
   const r = result as Record<string, unknown>
   const nodes = (
@@ -295,10 +291,10 @@ export async function fetchPrLinkedIssues(repo: string, number: number): Promise
     .sort((a, b) => a - b)
 }
 
-export async function fetchIssue(repo: string, number: number): Promise<GhIssue> {
-  return (await ghApi(`repos/${repo}/issues/${number}`) ?? {}) as GhIssue
+export async function fetchIssue(log: PluginLogger, repo: string, number: number): Promise<GhIssue> {
+  return (await ghApi(log, `repos/${repo}/issues/${number}`) ?? {}) as GhIssue
 }
 
-export async function fetchIssueComments(repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+export async function fetchIssueComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
+  return (await ghApi(log, `repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
 }

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -41,7 +41,7 @@ export class GitHubIssuesPlugin extends GhBase {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevIssue: IssueSnap | null | undefined = prev === null ? undefined : (prev.issues[key] ?? null)
-      const { snap, events } = await scrapeIssue(repo, number, prevIssue, agentLogins)
+      const { snap, events } = await scrapeIssue(this.log, repo, number, prevIssue, agentLogins)
       return { key, snap, events, entryChannels }
     }))
 

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -48,7 +48,7 @@ export class GitHubPrsPlugin extends GhBase {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevPr: PrSnap | null | undefined = prev === null ? undefined : (prev.prs[key] ?? null)
-      const { snap, events } = await scrapePr(repo, number, prevPr, agentLogins)
+      const { snap, events } = await scrapePr(this.log, repo, number, prevPr, agentLogins)
       return { key, snap, events, entryChannels }
     }))
 

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -6,6 +6,7 @@
 //   null      → entity is new to the watch list; emit seed/backlog events
 //   PrSnap    → normal tick; diff against prev and emit change events
 import type { PrSnap, IssueSnap } from './types.js'
+import type { PluginLogger } from '../../plugin.js'
 import { snapshotPr, snapshotIssue, stripInternals } from './snapshot.js'
 import type { PrSnapInternal, IssueSnapInternal } from './snapshot.js'
 import { diffPr, diffIssue } from './diff.js'
@@ -63,12 +64,13 @@ export function computeIssueEvents(
 }
 
 export async function scrapePr(
+  log: PluginLogger,
   repo: string,
   number: number,
   prevSnap: PrSnap | null | undefined,
   agentLogins: Set<string>
 ): Promise<ScrapeResult<PrSnap>> {
-  const snap = await snapshotPr(repo, number, prevSnap ?? undefined)
+  const snap = await snapshotPr(log, repo, number, prevSnap ?? undefined)
   const { events, nextWarnedNoLinked } = computePrEvents(snap, prevSnap, agentLogins)
   const stripped = stripInternals(snap) as PrSnap
   stripped.warned_no_linked = nextWarnedNoLinked
@@ -76,11 +78,12 @@ export async function scrapePr(
 }
 
 export async function scrapeIssue(
+  log: PluginLogger,
   repo: string,
   number: number,
   prevIssue: IssueSnap | null | undefined,
   agentLogins: Set<string>
 ): Promise<ScrapeResult<IssueSnap>> {
-  const snap = await snapshotIssue(repo, number)
+  const snap = await snapshotIssue(log, repo, number)
   return { snap: stripInternals(snap) as IssueSnap, events: computeIssueEvents(snap, prevIssue, agentLogins) }
 }

--- a/src/orchestrator/plugins/github/snapshot.ts
+++ b/src/orchestrator/plugins/github/snapshot.ts
@@ -1,4 +1,5 @@
 import type { PrSnap, IssueSnap } from './types.js'
+import type { PluginLogger } from '../../plugin.js'
 import {
   fetchPr,
   fetchPrReviewComments,
@@ -45,22 +46,23 @@ function indexById<T extends { id?: number }>(items: T[]): Record<number, T> {
 }
 
 export async function snapshotPr(
+  log: PluginLogger,
   repo: string,
   number: number,
   prevSnap?: PrSnap | null
 ): Promise<PrSnapInternal> {
-  const view = await fetchPr(repo, number)
+  const view = await fetchPr(log, repo, number)
   const [reviewComments, convComments, reviews] = await Promise.all([
-    fetchPrReviewComments(repo, number),
-    fetchPrConversationComments(repo, number),
-    fetchPrReviews(repo, number),
+    fetchPrReviewComments(log, repo, number),
+    fetchPrConversationComments(log, repo, number),
+    fetchPrReviews(log, repo, number),
   ])
 
   const curHead = view.head_oid
   const linkedIssues =
     prevSnap && prevSnap.head_oid === curHead
       ? prevSnap.linked_issues ?? []
-      : await fetchPrLinkedIssues(repo, number)
+      : await fetchPrLinkedIssues(log, repo, number)
 
   return {
     repo,
@@ -84,10 +86,10 @@ export async function snapshotPr(
   }
 }
 
-export async function snapshotIssue(repo: string, number: number): Promise<IssueSnapInternal> {
+export async function snapshotIssue(log: PluginLogger, repo: string, number: number): Promise<IssueSnapInternal> {
   const [issue, comments] = await Promise.all([
-    fetchIssue(repo, number),
-    fetchIssueComments(repo, number),
+    fetchIssue(log, repo, number),
+    fetchIssueComments(log, repo, number),
   ])
   return {
     repo,

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -4,16 +4,6 @@
 import { registerPlugin } from './plugin.js'
 import { GitHubPrsPlugin } from './plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
-import { setRetryLogger } from './plugins/github/github-api.js'
 
-// Both github factories share the same retry-log sink — last writer wins,
-// but since they receive the same `log` from buildPlugins it's a no-op
-// re-set.
-registerPlugin('github-prs', (defaultChannel, log) => {
-  setRetryLogger(log)
-  return new GitHubPrsPlugin(defaultChannel)
-})
-registerPlugin('github-issues', (defaultChannel, log) => {
-  setRetryLogger(log)
-  return new GitHubIssuesPlugin(defaultChannel)
-})
+registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
+registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))


### PR DESCRIPTION
Closes #313

## Summary

- Drop the `setRetryLogger` module-global in `github-api.ts`. `GhBase` now stores the factory-supplied logger and threads it through `scrape*` → `snapshot*` → `fetch*` → `spawnGh({ log })`.
- Add `defaultPluginLogger` (stderr-only) on `plugin.ts` so callers don't reinvent the stderr-write closure. `spawnGh`'s `deps.log` default points at it — flagged inline as a test affordance, never the prod path (registry.ts always supplies a logger).
- Collapse `orchestrator.ts`'s `stderrLog` const onto the shared default. Daemon's stderr+file closure stays — it's the one legitimate dual sink.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (460 pass)
- [x] github-api test reframed: `setRetryLogger` test → `deps.log` threading test