### PR TITLE
document when to invoke stop-dispatcher

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -47,7 +47,7 @@ When the lead mentions you with intent, you do four things in order:
 
 If you never get an affirmative, sit and wait. Do not nag.
 
-## Five dances you own
+## Six dances you own
 
 ### Setup dance
 
@@ -139,7 +139,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
    - Part `#<project>-issue-<I>`.
    - Pull main in the primary worktree (HTTPS one-shot is safe: `git fetch https://github.com/<owner>/<repo>.git main && git merge --ff-only FETCH_HEAD`).
    - Remove the worktree: `git worktree remove <path>`.
-   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running; `stop-dispatcher` is not part of cleanup.
+   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running across issues; full shutdown is the milestone teardown dance below.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 
 ### Follow-up dance
@@ -159,6 +159,19 @@ On confirmation, run `gh issue create` with `--title`, `--body` (the rendered te
 
 If the lead omits the source link (no PR/issue context in the intent), ask for it in the ack rather than filing context-free — a follow-up issue without a back-reference is dead history six months from now.
 
+### Milestone teardown dance
+
+Trigger: lead mentions you with intent like "milestone done, stand down" or "all done, tear it down".
+
+Ack template: `stop dispatcher + shut down apm; go?`
+
+On confirmation:
+
+1. DM `<project>-dispatcher`: `watch list`. If anything is still being watched, **halt** and re-ack in `#<project>-leads`: `still watching <list>; stop anyway?` — wait for an explicit affirmative before continuing. This prevents silently killing the dispatcher mid-issue.
+2. `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"`.
+3. Post in `#<project>-leads`: `dispatcher stopped, shutting down`.
+4. `roost shutdown <project>-apm`.
+
 ## When the lead authors a PR themselves
 
 Some changes are small enough that the lead skips spawning a worker. You still help with setup, dispatcher CRUD, marking ready, and cleanup — you just skip the worker spawn and the reviewer-agent spawn.
@@ -175,7 +188,6 @@ Some changes are small enough that the lead skips spawning a worker. You still h
 - No GitHub narrative comments on PRs or issues — workers, reviewers, and the lead handle that. You *do* file follow-up issues via `gh issue create` per the follow-up dance, and post the durable token-cost comment per the merge + cleanup dance. Nothing else.
 - No unsolicited source edits. Edit/Write/Grep/Glob are available so you can do project research and small file tweaks the lead asks for (and PR body hygiene), but don't refactor or open PRs of your own.
 - No spawning unrelated agents. Worker and reviewer only, per the dances above.
-- No `stop-dispatcher` calls. Milestone teardown is `unwatch` DMs only; the daemon stays up for the next issue. Stopping it is operator-driven (incidents, upgrades, decommission).
 
 ## Naming convention
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -139,7 +139,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
    - Part `#<project>-issue-<I>`.
    - Pull main in the primary worktree (HTTPS one-shot is safe: `git fetch https://github.com/<owner>/<repo>.git main && git merge --ff-only FETCH_HEAD`).
    - Remove the worktree: `git worktree remove <path>`.
-   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>`. The daemon keeps running — `stop-dispatcher` is not part of cleanup.
+   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running; `stop-dispatcher` is not part of cleanup.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 
 ### Follow-up dance

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -139,7 +139,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
    - Part `#<project>-issue-<I>`.
    - Pull main in the primary worktree (HTTPS one-shot is safe: `git fetch https://github.com/<owner>/<repo>.git main && git merge --ff-only FETCH_HEAD`).
    - Remove the worktree: `git worktree remove <path>`.
-   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>`.
+   - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>`. The daemon keeps running — `stop-dispatcher` is not part of cleanup.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 
 ### Follow-up dance
@@ -175,6 +175,7 @@ Some changes are small enough that the lead skips spawning a worker. You still h
 - No GitHub narrative comments on PRs or issues — workers, reviewers, and the lead handle that. You *do* file follow-up issues via `gh issue create` per the follow-up dance, and post the durable token-cost comment per the merge + cleanup dance. Nothing else.
 - No unsolicited source edits. Edit/Write/Grep/Glob are available so you can do project research and small file tweaks the lead asks for (and PR body hygiene), but don't refactor or open PRs of your own.
 - No spawning unrelated agents. Worker and reviewer only, per the dances above.
+- No `stop-dispatcher` calls. Milestone teardown is `unwatch` DMs only; the daemon stays up for the next issue. Stopping it is operator-driven (incidents, upgrades, decommission).
 
 ## Naming convention
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -111,6 +111,8 @@ For each issue:
 
 8. **Post a postmortem in `#<project>-leads`** about how the issue went. Come with suggestions about how to make the next issue easier. This is yours, not the APM's. The APM has already posted a `token cost for #<N>:` block in `#<project>-leads` *and* as a comment on the closed issue (durable history) — don't restate it.
 
+9. **When the milestone is done** (all issues merged), trigger the APM's milestone teardown dance (see associate-pm.md) by mentioning it: `<project>-apm milestone done, stand down`. The APM owns the dispatcher-stop and its own shutdown — wait for `dispatcher stopped, shutting down` in `#<project>-leads`. If no confirmation arrives within ~30s (APM crashed mid-teardown), call `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"` yourself. Then: `roost shutdown <project>-lead-pm`.
+
 Before confirming the APM's merge ack, double-check: the PR is approved by the human (not just CI green, not just a reviewer-agent comment), the branch is the one you intended, and there are no uncommitted changes in the worktree.
 
 ## Filing follow-up issues

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -105,7 +105,7 @@ or agent can check three things, in order from cheapest to most informative:
 
 ### Stopping
 
-At milestone end, the APM only sends `unwatch` DMs — the daemon keeps running so it's ready for the next issue without a cold start. Don't call `stop-dispatcher` as part of normal teardown.
+At milestone end, the APM only sends `unwatch` DMs — the daemon keeps running so it's ready for the next issue without a cold start. Don't call `stop-dispatcher` as part of normal teardown. Agents reach this via the milestone-teardown dance in associate-pm.md.
 
 Use `stop-dispatcher` when you need to actually stop the daemon — incidents, upgrades, decommission:
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -113,7 +113,7 @@ Use `stop-dispatcher` when you need to actually stop the daemon — incidents, u
 bin/stop-dispatcher <config-dir>
 ```
 
-Sends SIGTERM and waits up to 30s (override with `STOP_TIMEOUT=<seconds>`). Idempotent — exits 0 if no live dispatcher is found.
+Sends SIGTERM and waits up to 30s (override with `STOP_TIMEOUT=<seconds>`). No SIGKILL escalation — if the daemon hangs past 30s, kill it manually. Idempotent — exits 0 if no live dispatcher is found.
 
 ## Events dispatched
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -103,6 +103,18 @@ or agent can check three things, in order from cheapest to most informative:
    successful tick" — during a brief IRC blip it may lag reality by one
    interval.
 
+### Stopping
+
+At milestone end, the APM only sends `unwatch` DMs — the daemon keeps running so it's ready for the next issue without a cold start. Don't call `stop-dispatcher` as part of normal teardown.
+
+Use `stop-dispatcher` when you need to actually stop the daemon — incidents, upgrades, decommission:
+
+```sh
+bin/stop-dispatcher <config-dir>
+```
+
+Sends SIGTERM and waits up to 30s (override with `STOP_TIMEOUT=<seconds>`). Idempotent — exits 0 if no live dispatcher is found.
+
 ## Events dispatched
 
 | Event | Fires when |


### PR DESCRIPTION
Closes #314

`stop-dispatcher` shipped in #309 but neither the APM prompt nor DISPATCHER.md said when to use it. Alex flagged this in the #309 review.

- `agents/associate-pm.md`: note in the merge+cleanup `unwatch` step that the daemon keeps running, and add a "What you do not do" bullet explicitly ruling out `stop-dispatcher` calls from the APM.
- `docs/DISPATCHER.md`: new "Stopping" subsection — APM uses `unwatch` DMs at milestone end; `stop-dispatcher` is for operator use (incidents, upgrades, decommission).