### PR TITLE
maint: bump package.json to 0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump `package.json` 0.5.10 → 0.5.11 ahead of `v0.5.11` tag.
- Ships #332 (token-usage requestId multi-part dedup — fixes cost over-reporting), wave 1 (#326/#327/#328/#329), and wave 2 (#335/#336) since v0.5.10.

## Test plan

- [ ] CI green
- [ ] Tag `v0.5.11` after merge → tap formula bumps → `brew upgrade roost` on the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)