### PR TITLE
pin Homebrew formula action to AvesAlight fork with 303-redirect fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
           generate_release_notes: true
 
       - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@v4.1
+        # AvesAlight fork of mislav/bump-homebrew-formula-action with redirect-status fix; see #343
+        uses: AvesAlight/bump-homebrew-formula-action@efacc598ed9b4b1bc526125f82d2dfba17509842
         with:
           formula-name: roost
           formula-path: Formula/roost.rb


### PR DESCRIPTION
Closes #343

## What

`mislav/bump-homebrew-formula-action@v4.1` broke ~2026-05-16: GitHub now returns HTTP 303 for codeload tarball redirects on Actions runners, but the action's `resolveRedirect()` only accepted 302, failing with "unexpected HTTP 303 response" before writing the formula.

## Fix

Forked the action to `AvesAlight/bump-homebrew-formula-action`. Changed `resolveRedirect()` to accept any 3xx redirect with a Location header (matches what the existing `stream()` helper already does). Rebuilt `lib/index.js` with ncc and tagged `v4.1.1`.

`release.yml` now pins to the fork SHA (`efacc598`) with an explanatory comment.

## Follow-up

Upstream issue: mislav/bump-homebrew-formula-action#340 — once a patched upstream release lands we can revert to the upstream action. The fork is the durable fix until then.