### PR TITLE
bundle gh+log into GhClient so plugins stop threading log everywhere

### DIFF
--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -12,6 +12,7 @@ import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
+import { GhClient } from './github-api.js'
 
 interface GhPluginConfig {
   watched?: WatchedEntry[]
@@ -26,8 +27,13 @@ export abstract class GhBase extends BasePlugin {
   // plugin name slice.
   protected abstract readonly label: string
 
-  constructor(defaultChannel: string, protected readonly log: PluginLogger = defaultPluginLogger) {
+  // Shared gh handle — owns the PluginLogger so individual fetch/snapshot/
+  // scrape callsites stay log-free.
+  protected readonly client: GhClient
+
+  constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
     super(defaultChannel)
+    this.client = new GhClient(log)
   }
 
   protected agentLogins(config: OrchestratorConfig): Set<string> {

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -77,10 +77,6 @@ export interface SpawnDeps {
 
 const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
 
-// The single gh entrypoint — every gh call goes through here, so retry is
-// the contract for every caller. ghApi/ghGraphql below are thin shape
-// helpers; both delegate to spawnGh so retry can't be bypassed by a future
-// caller.
 export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown> {
   const sleep = deps.sleep ?? defaultSleep
   const log = deps.log

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -118,22 +118,6 @@ export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown>
   throw new GhError(`spawnGh: loop exited without result for ${cmd}`)
 }
 
-async function ghApi(log: PluginLogger, endpoint: string, paginate = false): Promise<unknown> {
-  const args = ['api']
-  if (paginate) args.push('--paginate')
-  args.push(endpoint)
-  return spawnGh(args, { log })
-}
-
-// Centralized so a future gh call can't slip past the retry wrapper.
-async function ghGraphql(log: PluginLogger, query: string, vars: Record<string, string | number>): Promise<unknown> {
-  const args: string[] = ['api', 'graphql', '-f', `query=${query}`]
-  for (const [k, v] of Object.entries(vars)) {
-    args.push('-F', `${k}=${v}`)
-  }
-  return spawnGh(args, { log })
-}
-
 export interface GhLabel {
   name?: string
 }
@@ -227,74 +211,98 @@ export function labelNames(labels: GhLabel[] | null | undefined): string[] {
     .sort()
 }
 
-export async function fetchPr(log: PluginLogger, repo: string, number: number): Promise<FetchedPr> {
-  const pr = (await ghApi(log, `repos/${repo}/pulls/${number}`) ?? {}) as GhPr
-  const head = pr.head ?? {}
-  const sha = head.sha
+// GhClient — per-plugin handle that owns the PluginLogger and exposes the
+// fetch surface as instance methods. Every gh call lands in spawnGh via the
+// private api()/graphql() shape helpers, so retry stays the universal contract.
+// Plugins construct one at boot (see GhBase) and pass it down through
+// snapshot/scraper instead of threading `log` through each callsite.
+export class GhClient {
+  constructor(private readonly log: PluginLogger) {}
 
-  let runs: GhCheckRun[] = []
-  let statuses: GhStatus[] = []
-  if (sha) {
-    const checkResp = await ghApi(log, `repos/${repo}/commits/${sha}/check-runs?per_page=100`, true)
-    if (checkResp && typeof checkResp === 'object' && !Array.isArray(checkResp)) {
-      runs = ((checkResp as Record<string, unknown>).check_runs ?? []) as GhCheckRun[]
-    } else if (Array.isArray(checkResp)) {
-      runs = checkResp as GhCheckRun[]
+  private async api(endpoint: string, paginate = false): Promise<unknown> {
+    const args = ['api']
+    if (paginate) args.push('--paginate')
+    args.push(endpoint)
+    return spawnGh(args, { log: this.log })
+  }
+
+  private async graphql(query: string, vars: Record<string, string | number>): Promise<unknown> {
+    const args: string[] = ['api', 'graphql', '-f', `query=${query}`]
+    for (const [k, v] of Object.entries(vars)) {
+      args.push('-F', `${k}=${v}`)
     }
-    const combined = (await ghApi(log, `repos/${repo}/commits/${sha}/status`) ?? {}) as Record<string, unknown>
-    statuses = (combined.statuses ?? []) as GhStatus[]
+    return spawnGh(args, { log: this.log })
   }
 
-  return {
-    title: pr.title ?? null,
-    url: pr.html_url ?? null,
-    head_ref: head.ref ?? null,
-    head_oid: sha ?? null,
-    is_draft: Boolean(pr.draft),
-    merged_at: pr.merged_at ?? null,
-    state: pr.state ? pr.state.toUpperCase() : null,
-    labels: pr.labels ?? [],
-    ci_state: aggregateCi(runs, statuses),
+  async fetchPr(repo: string, number: number): Promise<FetchedPr> {
+    const pr = (await this.api(`repos/${repo}/pulls/${number}`) ?? {}) as GhPr
+    const head = pr.head ?? {}
+    const sha = head.sha
+
+    let runs: GhCheckRun[] = []
+    let statuses: GhStatus[] = []
+    if (sha) {
+      const checkResp = await this.api(`repos/${repo}/commits/${sha}/check-runs?per_page=100`, true)
+      if (checkResp && typeof checkResp === 'object' && !Array.isArray(checkResp)) {
+        runs = ((checkResp as Record<string, unknown>).check_runs ?? []) as GhCheckRun[]
+      } else if (Array.isArray(checkResp)) {
+        runs = checkResp as GhCheckRun[]
+      }
+      const combined = (await this.api(`repos/${repo}/commits/${sha}/status`) ?? {}) as Record<string, unknown>
+      statuses = (combined.statuses ?? []) as GhStatus[]
+    }
+
+    return {
+      title: pr.title ?? null,
+      url: pr.html_url ?? null,
+      head_ref: head.ref ?? null,
+      head_oid: sha ?? null,
+      is_draft: Boolean(pr.draft),
+      merged_at: pr.merged_at ?? null,
+      state: pr.state ? pr.state.toUpperCase() : null,
+      labels: pr.labels ?? [],
+      ci_state: aggregateCi(runs, statuses),
+    }
   }
-}
 
-export async function fetchPrReviewComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(log, `repos/${repo}/pulls/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
-}
+  async fetchPrReviewComments(repo: string, number: number): Promise<GhComment[]> {
+    return (await this.api(`repos/${repo}/pulls/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+  }
 
-export async function fetchPrConversationComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(log, `repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
-}
+  async fetchPrConversationComments(repo: string, number: number): Promise<GhComment[]> {
+    return (await this.api(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+  }
 
-export async function fetchPrReviews(log: PluginLogger, repo: string, number: number): Promise<GhReview[]> {
-  return (await ghApi(log, `repos/${repo}/pulls/${number}/reviews?per_page=100`, true) ?? []) as GhReview[]
-}
+  async fetchPrReviews(repo: string, number: number): Promise<GhReview[]> {
+    return (await this.api(`repos/${repo}/pulls/${number}/reviews?per_page=100`, true) ?? []) as GhReview[]
+  }
 
-export async function fetchPrLinkedIssues(log: PluginLogger, repo: string, number: number): Promise<number[]> {
-  const [owner, name] = repo.split('/', 2)
-  const query = (
-    'query($owner:String!,$name:String!,$number:Int!){' +
-    'repository(owner:$owner,name:$name){' +
-    'pullRequest(number:$number){' +
-    'closingIssuesReferences(first:25){nodes{number}}}}}'
-  )
-  const result = await ghGraphql(log, query, { owner, name, number })
-  if (!result) return []
-  const r = result as Record<string, unknown>
-  const nodes = (
-    ((r.data as Record<string, unknown> | undefined)?.repository as Record<string, unknown> | undefined)
-      ?.pullRequest as Record<string, unknown> | undefined
-  )?.closingIssuesReferences as { nodes?: Array<{ number?: number }> } | undefined
-  return (nodes?.nodes ?? [])
-    .filter(n => n.number != null)
-    .map(n => n.number as number)
-    .sort((a, b) => a - b)
-}
+  async fetchPrLinkedIssues(repo: string, number: number): Promise<number[]> {
+    const [owner, name] = repo.split('/', 2)
+    const query = (
+      'query($owner:String!,$name:String!,$number:Int!){' +
+      'repository(owner:$owner,name:$name){' +
+      'pullRequest(number:$number){' +
+      'closingIssuesReferences(first:25){nodes{number}}}}}'
+    )
+    const result = await this.graphql(query, { owner, name, number })
+    if (!result) return []
+    const r = result as Record<string, unknown>
+    const nodes = (
+      ((r.data as Record<string, unknown> | undefined)?.repository as Record<string, unknown> | undefined)
+        ?.pullRequest as Record<string, unknown> | undefined
+    )?.closingIssuesReferences as { nodes?: Array<{ number?: number }> } | undefined
+    return (nodes?.nodes ?? [])
+      .filter(n => n.number != null)
+      .map(n => n.number as number)
+      .sort((a, b) => a - b)
+  }
 
-export async function fetchIssue(log: PluginLogger, repo: string, number: number): Promise<GhIssue> {
-  return (await ghApi(log, `repos/${repo}/issues/${number}`) ?? {}) as GhIssue
-}
+  async fetchIssue(repo: string, number: number): Promise<GhIssue> {
+    return (await this.api(`repos/${repo}/issues/${number}`) ?? {}) as GhIssue
+  }
 
-export async function fetchIssueComments(log: PluginLogger, repo: string, number: number): Promise<GhComment[]> {
-  return (await ghApi(log, `repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+  async fetchIssueComments(repo: string, number: number): Promise<GhComment[]> {
+    return (await this.api(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
+  }
 }

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -41,7 +41,7 @@ export class GitHubIssuesPlugin extends GhBase {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevIssue: IssueSnap | null | undefined = prev === null ? undefined : (prev.issues[key] ?? null)
-      const { snap, events } = await scrapeIssue(this.log, repo, number, prevIssue, agentLogins)
+      const { snap, events } = await scrapeIssue(this.client, repo, number, prevIssue, agentLogins)
       return { key, snap, events, entryChannels }
     }))
 

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -48,7 +48,7 @@ export class GitHubPrsPlugin extends GhBase {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevPr: PrSnap | null | undefined = prev === null ? undefined : (prev.prs[key] ?? null)
-      const { snap, events } = await scrapePr(this.log, repo, number, prevPr, agentLogins)
+      const { snap, events } = await scrapePr(this.client, repo, number, prevPr, agentLogins)
       return { key, snap, events, entryChannels }
     }))
 

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -6,7 +6,7 @@
 //   null      → entity is new to the watch list; emit seed/backlog events
 //   PrSnap    → normal tick; diff against prev and emit change events
 import type { PrSnap, IssueSnap } from './types.js'
-import type { PluginLogger } from '../../plugin.js'
+import type { GhClient } from './github-api.js'
 import { snapshotPr, snapshotIssue, stripInternals } from './snapshot.js'
 import type { PrSnapInternal, IssueSnapInternal } from './snapshot.js'
 import { diffPr, diffIssue } from './diff.js'
@@ -64,13 +64,13 @@ export function computeIssueEvents(
 }
 
 export async function scrapePr(
-  log: PluginLogger,
+  client: GhClient,
   repo: string,
   number: number,
   prevSnap: PrSnap | null | undefined,
   agentLogins: Set<string>
 ): Promise<ScrapeResult<PrSnap>> {
-  const snap = await snapshotPr(log, repo, number, prevSnap ?? undefined)
+  const snap = await snapshotPr(client, repo, number, prevSnap ?? undefined)
   const { events, nextWarnedNoLinked } = computePrEvents(snap, prevSnap, agentLogins)
   const stripped = stripInternals(snap) as PrSnap
   stripped.warned_no_linked = nextWarnedNoLinked
@@ -78,12 +78,12 @@ export async function scrapePr(
 }
 
 export async function scrapeIssue(
-  log: PluginLogger,
+  client: GhClient,
   repo: string,
   number: number,
   prevIssue: IssueSnap | null | undefined,
   agentLogins: Set<string>
 ): Promise<ScrapeResult<IssueSnap>> {
-  const snap = await snapshotIssue(log, repo, number)
+  const snap = await snapshotIssue(client, repo, number)
   return { snap: stripInternals(snap) as IssueSnap, events: computeIssueEvents(snap, prevIssue, agentLogins) }
 }

--- a/src/orchestrator/plugins/github/snapshot.ts
+++ b/src/orchestrator/plugins/github/snapshot.ts
@@ -1,17 +1,6 @@
 import type { PrSnap, IssueSnap } from './types.js'
-import type { PluginLogger } from '../../plugin.js'
-import {
-  fetchPr,
-  fetchPrReviewComments,
-  fetchPrConversationComments,
-  fetchPrReviews,
-  fetchPrLinkedIssues,
-  fetchIssue,
-  fetchIssueComments,
-  labelNames,
-  type GhComment,
-  type GhReview,
-} from './github-api.js'
+import type { GhClient, GhComment, GhReview } from './github-api.js'
+import { labelNames } from './github-api.js'
 
 export interface PrSnapInternal extends PrSnap {
   _review_comments_by_id: Record<number, GhComment>
@@ -46,23 +35,23 @@ function indexById<T extends { id?: number }>(items: T[]): Record<number, T> {
 }
 
 export async function snapshotPr(
-  log: PluginLogger,
+  client: GhClient,
   repo: string,
   number: number,
   prevSnap?: PrSnap | null
 ): Promise<PrSnapInternal> {
-  const view = await fetchPr(log, repo, number)
+  const view = await client.fetchPr(repo, number)
   const [reviewComments, convComments, reviews] = await Promise.all([
-    fetchPrReviewComments(log, repo, number),
-    fetchPrConversationComments(log, repo, number),
-    fetchPrReviews(log, repo, number),
+    client.fetchPrReviewComments(repo, number),
+    client.fetchPrConversationComments(repo, number),
+    client.fetchPrReviews(repo, number),
   ])
 
   const curHead = view.head_oid
   const linkedIssues =
     prevSnap && prevSnap.head_oid === curHead
       ? prevSnap.linked_issues ?? []
-      : await fetchPrLinkedIssues(log, repo, number)
+      : await client.fetchPrLinkedIssues(repo, number)
 
   return {
     repo,
@@ -86,10 +75,10 @@ export async function snapshotPr(
   }
 }
 
-export async function snapshotIssue(log: PluginLogger, repo: string, number: number): Promise<IssueSnapInternal> {
+export async function snapshotIssue(client: GhClient, repo: string, number: number): Promise<IssueSnapInternal> {
   const [issue, comments] = await Promise.all([
-    fetchIssue(log, repo, number),
-    fetchIssueComments(log, repo, number),
+    client.fetchIssue(repo, number),
+    client.fetchIssueComments(repo, number),
   ])
   return {
     repo,


### PR DESCRIPTION
Closes #338

## Summary

- New `GhClient` class in `github-api.ts` — holds the `PluginLogger`, exposes the 7 fetch helpers as instance methods (`fetchPr`, `fetchPrReviewComments`, `fetchPrConversationComments`, `fetchPrReviews`, `fetchPrLinkedIssues`, `fetchIssue`, `fetchIssueComments`). Private `api()`/`graphql()` shape helpers delegate to top-level `spawnGh` so retry stays the universal contract.
- `snapshot.ts` / `scraper.ts`: `snapshotPr`/`snapshotIssue`/`scrapePr`/`scrapeIssue` take a `GhClient` instead of a bare `log`.
- `GhBase` constructs `this.client = new GhClient(log)` in the ctor (signature unchanged). `prs-plugin.ts`/`issues-plugin.ts` pass `this.client` to scrape*.
- Removed the top-level `fetchPr*` / `fetchIssue*` exports — `snapshot.ts` was the only caller. `spawnGh`, `GhError`, wire-shape types, `aggregateCi`, `labelNames` stay top-level so `github-api.test.ts` is unchanged.

Net: 7 fetch fns + 2 snapshot fns + 2 scrape fns lose their leading `log` parameter; one `client` field on `GhBase` replaces the threading.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (459 pass)