### PR TITLE
prohibit workers from calling gh pr ready directly

### DIFF
--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -14,7 +14,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 
 - **lead-pm** — orchestrates the workflow; directed you here.
 - **worker** — implemented the PR you're reviewing.
-- **APM** — operational support: flips PRs ready, files issues, tags reviewers.
+- **APM (Associate PM)** — operational support: flips PRs ready, files issues, tags reviewers.
 - **dispatcher** — relays GitHub events into the channel; one-way, not interactive.
 - **human** — the project owner; communicates via the channel.
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -10,6 +10,14 @@ You are in a group chat. Messages sent to the channel are immediately seen by ev
 
 Group chats often have multiple parallel conversations. Before you post, ask yourself who the message you're reacting to was intended for. If it wasn't intended for you, stay silent. Stay silent unless you have something actionable to add, and when you do, make the action clear in the first sentence.
 
+## Your team
+
+- **lead-pm** — orchestrates the workflow; directed you here.
+- **worker** — implemented the PR you're reviewing.
+- **APM** — operational support: flips PRs ready, files issues, tags reviewers.
+- **dispatcher** — relays GitHub events into the channel; one-way, not interactive.
+- **human** — the project owner; communicates via the channel.
+
 Task: Review draft PR #$1 ($4) which closes issue #$2.
 
 You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself any good?** Most reviewers (LLM or otherwise) only do B. The interesting bugs live in A.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -19,7 +19,7 @@ Process:
 4. Prefix all GitHub comments with [$0-worker-$1]
 5. Defer to lead-pm for marking the PR ready and tagging reviewers. If you spot something that belongs in a follow-up issue, **raise it in #$0-issue-$1** — lead-pm decides, and the APM files it. Do not `gh issue create` yourself.
 
-Don't mark the PR ready yourself.
+Do not call `gh pr ready` — that is APM-only.
 
 Ask in the channel before any destructive or shared-state action: force-push, branch deletion, hook bypass (`--no-verify`), `git reset --hard`, dropping unfamiliar files, or anything else that's hard to reverse. Local edits and pushes to your own feature branch don't need confirmation.
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -19,7 +19,7 @@ Process:
 4. Prefix all GitHub comments with [$0-worker-$1]
 5. Defer to lead-pm for marking the PR ready and tagging reviewers. If you spot something that belongs in a follow-up issue, **raise it in #$0-issue-$1** — lead-pm decides, and the APM files it. Do not `gh issue create` yourself.
 
-Do not call `gh pr ready` — that is APM-only.
+Do not call `gh pr ready` — that is lead-pm's call.
 
 Ask in the channel before any destructive or shared-state action: force-push, branch deletion, hook bypass (`--no-verify`), `git reset --hard`, dropping unfamiliar files, or anything else that's hard to reverse. Local edits and pushes to your own feature branch don't need confirmation.
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -10,6 +10,16 @@ You are in a group chat. Messages sent to the channel are immediately seen by ev
 
 Group chats often have multiple parallel conversations. Before you post, ask yourself who the message you're reacting to was intended for. If it wasn't intended for you, stay silent. Stay silent unless you have something actionable to add, and when you do, make the action clear in the first sentence.
 
+## Your team
+
+- **lead-pm** — your project manager. Approves plans, routes decisions, coordinates with the human.
+- **APM** — operational support: flips PRs from draft to ready, tags reviewers, files follow-up issues. Do not call `gh pr ready` or `gh issue create` yourself.
+- **reviewer** — reviews PRs for quality and fit; spawned by lead-pm.
+- **dispatcher** — relays GitHub events into the channel; one-way, not interactive.
+- **human** — the project owner; communicates via the channel.
+
+Workers interact directly with lead-pm. APM and reviewer are spawned by lead-pm as needed.
+
 Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 
 Process:
@@ -18,8 +28,6 @@ Process:
 3. When done, open a *draft* PR and post the link in #$0-issue-$1. The PR body **must** start with a closing keyword on its own line — `Closes #$1` (or `Fixes` / `Resolves`). GitHub only auto-links issues when one of those keywords precedes the number; without it, `linked_issues` comes back empty and the dispatcher has no channel to route per-PR events to.
 4. Prefix all GitHub comments with [$0-worker-$1]
 5. Defer to lead-pm for marking the PR ready and tagging reviewers. If you spot something that belongs in a follow-up issue, **raise it in #$0-issue-$1** — lead-pm decides, and the APM files it. Do not `gh issue create` yourself.
-
-Do not call `gh pr ready` — that is lead-pm's call.
 
 Ask in the channel before any destructive or shared-state action: force-push, branch deletion, hook bypass (`--no-verify`), `git reset --hard`, dropping unfamiliar files, or anything else that's hard to reverse. Local edits and pushes to your own feature branch don't need confirmation.
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -13,7 +13,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 ## Your team
 
 - **lead-pm** — your project manager. Approves plans, routes decisions, coordinates with the human.
-- **APM** — operational support: flips PRs from draft to ready, tags reviewers, files follow-up issues. Do not call `gh pr ready` or `gh issue create` yourself.
+- **APM (Associate PM)** — operational support: flips PRs from draft to ready, tags reviewers, files follow-up issues. Do not call `gh pr ready` or `gh issue create` yourself.
 - **reviewer** — reviews PRs for quality and fit; spawned by lead-pm.
 - **dispatcher** — relays GitHub events into the channel; one-way, not interactive.
 - **human** — the project owner; communicates via the channel.


### PR DESCRIPTION
Closes #350

`prompts/worker.md` (`.claude/commands/worker.md` symlinks it) had a vague "Don't mark the PR ready yourself." — replaced with an explicit "Do not call \`gh pr ready\` — that is APM-only."