### PR TITLE
drop filesystem guard from dry-run prompt/agent listing

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -381,9 +381,7 @@ cmd_init() {
         local _name _dst
         _name="$(basename "$_pf" .md)"
         _dst="${commands_dir}/${_name}.md"
-        if [ ! -f "$_dst" ] || [ "$force_prompts" -eq 1 ] || [ "$force" -eq 1 ]; then
-          echo "--- ${_dst} (copied verbatim from plugin prompts/${_name}.md) ---"
-        fi
+        echo "--- ${_dst} (copied verbatim from plugin prompts/${_name}.md) ---"
       done
     fi
     if [ "$no_agents" -eq 0 ] && [ "${#agent_files[@]}" -gt 0 ]; then
@@ -391,9 +389,7 @@ cmd_init() {
         local _aname _adst
         _aname="$(basename "$_af" .md)"
         _adst="${agents_dst_dir}/${_aname}.md"
-        if [ ! -f "$_adst" ] || [ "$force_agents" -eq 1 ] || [ "$force" -eq 1 ]; then
-          echo "--- ${_adst} (copied verbatim from plugin agents/${_aname}.md) ---"
-        fi
+        echo "--- ${_adst} (copied verbatim from plugin agents/${_aname}.md) ---"
       done
     fi
     exit 0

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -160,8 +160,10 @@ teardown
 
 setup "https://github.com/TestOwner/myproject.git"
 cd "$TDIR"
-roost_init >/dev/null 2>&1
-dry_out="$(roost_init --dry-run 2>/dev/null)"
+dry_out=""
+if roost_init >/dev/null 2>&1; then
+  dry_out="$(roost_init --dry-run 2>/dev/null)"
+fi
 if echo "$dry_out" | grep -q 'worker.md' \
     && echo "$dry_out" | grep -q 'lead-pm.md'; then
   ok "--dry-run: shows prompts/agents unconditionally when files exist"

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -156,6 +156,21 @@ fi
 cd - >/dev/null
 teardown
 
+# --- --dry-run: lists prompts/agents even when they already exist ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+roost_init >/dev/null 2>&1
+dry_out="$(roost_init --dry-run 2>/dev/null)"
+if echo "$dry_out" | grep -q 'worker.md' \
+    && echo "$dry_out" | grep -q 'lead-pm.md'; then
+  ok "--dry-run: shows prompts/agents unconditionally when files exist"
+else
+  fail "--dry-run: shows prompts/agents unconditionally when files exist"
+fi
+cd - >/dev/null
+teardown
+
 # --- --force: overwrites existing config ---
 
 setup "https://github.com/TestOwner/myproject.git"


### PR DESCRIPTION
Closes #349

`--dry-run` now shows prompts and agents unconditionally, matching config/gitignore. The `[ ! -f "$_dst" ]` checks in the dry-run block were the mismatch — preview should show the full intended install regardless of what's on disk.

added a regression test: init once, then `--dry-run` again, verify both `worker.md` and `lead-pm.md` appear in output.