### PR TITLE
github-new-issues plugin: announce new repo issues for triage

### DIFF
--- a/.orchestrator/config.example.json
+++ b/.orchestrator/config.example.json
@@ -11,6 +11,7 @@
   },
   "plugins": {
     "github-prs": { "watched": [] },
-    "github-issues": { "watched": [] }
+    "github-issues": { "watched": [] },
+    "github-new-issues": {}
   }
 }

--- a/bin/roost
+++ b/bin/roost
@@ -252,7 +252,7 @@ EOF
 }
 
 _init_config_json() {
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] }\n  }\n}\n' \
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] },\n    "github-new-issues": {}\n  }\n}\n' \
     "$1" "$2" "$3"
 }
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -37,6 +37,7 @@ Fields:
 | `plugins.<name>` | Per-plugin config slice. Keys list the enabled plugins (in emission order). |
 | `plugins.github-prs.watched` | `[{"number": N, "repo"?: "OWNER/NAME", "channels"?: [...]}]` |
 | `plugins.github-issues.watched` | Same shape as `plugins.github-prs.watched`. |
+| `plugins.github-new-issues` | Repo-wide new-issue feed: `{"repo"?: "OWNER/NAME", "channels"?: [...]}` (both optional; default = `repo` at top level + project channel). |
 
 For watched entries, `repo` defaults to the top-level value. `channels` adds
 destinations on top of the auto-routed `#<project>-issue-N` (PR events also go
@@ -44,7 +45,13 @@ to `#<project>-issue-N` for each linked issue).
 
 A plugin not listed under `plugins` is not instantiated — there is no top-level
 fallback. The supported set is the first-party plugins shipped in this repo
-(`github-prs`, `github-issues`); external plugin discovery is tracked in #255.
+(`github-prs`, `github-issues`, `github-new-issues`); external plugin discovery
+is tracked in #255.
+
+`github-new-issues` is default-on whenever `repo` is set at the top level —
+the dispatcher injects an empty slice at boot if the operator hasn't written
+one. Issue #342 added it so newly-filed repo issues land in the project
+channel for triage without anyone having to DM `watch <N>` first.
 
 ## Running
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -48,10 +48,10 @@ fallback. The supported set is the first-party plugins shipped in this repo
 (`github-prs`, `github-issues`, `github-new-issues`); external plugin discovery
 is tracked in #255.
 
-`github-new-issues` is default-on whenever `repo` is set at the top level —
-the dispatcher injects an empty slice at boot if the operator hasn't written
-one. Issue #342 added it so newly-filed repo issues land in the project
-channel for triage without anyone having to DM `watch <N>` first.
+`github-new-issues` (added in #342) needs an explicit `plugins.github-new-issues`
+entry to run. `bin/roost init` writes one for new projects; for existing
+projects, add `"github-new-issues": {}` to enable the repo-wide new-issue
+feed on the project channel.
 
 ## Running
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,8 +19,9 @@ import {
 } from './orchestrator/config.js'
 
 import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js'
-import { defaultPluginLogger, getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger, type TaggedEvent } from './orchestrator/plugin.js'
+import { defaultPluginLogger, type Plugin, type TaggedEvent } from './orchestrator/plugin.js'
 import './orchestrator/registry.js'
+import { buildPlugins } from './orchestrator/build-plugins.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
@@ -74,21 +75,6 @@ async function runOneTick(
   }
 
   return { taggedEvents: allTagged, channels: [...allChannels] }
-}
-
-// Instantiate plugins from `config.plugins` via the registry. Order follows
-// `Object.keys` insertion order in the config JSON, so emission order is
-// predictable from the operator's POV.
-function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: PluginLogger): Plugin[] {
-  const names = Object.keys(config.plugins ?? {})
-  return names.map(name => {
-    const factory = getPluginFactory(name)
-    if (!factory) {
-      const available = registeredPluginNames().sort().join(', ') || '(none)'
-      throw new Error(`unknown plugin in config: ${name}. available: ${available}`)
-    }
-    return factory(defaultChannel, log)
-  })
 }
 
 function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string): string[] {

--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'bun:test'
+import { buildPlugins, DEFAULT_ON_PLUGINS } from '../build-plugins.js'
+import type { OrchestratorConfig } from '../config.js'
+import '../registry.js'
+
+const NOOP_LOG = () => {}
+
+describe('buildPlugins — default-on', () => {
+  it('honors explicit plugin keys from config.plugins', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'github-issues': { watched: [] }, 'github-prs': { watched: [] } },
+    }
+    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
+    // Explicit plugins come first, then default-on plugins are appended.
+    expect(names.slice(0, 2)).toEqual(['github-issues', 'github-prs'])
+    for (const def of DEFAULT_ON_PLUGINS) expect(names).toContain(def)
+  })
+
+  it('appends `github-new-issues` when repo is set and slice is missing', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'github-issues': { watched: [] } },
+    }
+    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
+    expect(names).toContain('github-new-issues')
+  })
+
+  it('does not duplicate `github-new-issues` when slice is explicit', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'github-new-issues': {} },
+    }
+    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
+    expect(names.filter(n => n === 'github-new-issues')).toHaveLength(1)
+  })
+
+  it('skips default-on plugins when repo is unset', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-issues': { watched: [] } },
+    }
+    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
+    expect(names).not.toContain('github-new-issues')
+  })
+
+  it('preserves explicit order, appends defaults at the end', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'github-prs': { watched: [] }, 'github-issues': { watched: [] } },
+    }
+    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
+    expect(names).toEqual(['github-prs', 'github-issues', 'github-new-issues'])
+  })
+
+  it('throws on unknown plugin key', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'nonexistent': {} },
+    }
+    expect(() => buildPlugins(cfg, '#proj-leads', NOOP_LOG)).toThrow(/unknown plugin/)
+  })
+})

--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -1,60 +1,48 @@
 import { describe, it, expect } from 'bun:test'
-import { buildPlugins, DEFAULT_ON_PLUGINS } from '../build-plugins.js'
+import { buildPlugins } from '../build-plugins.js'
 import type { OrchestratorConfig } from '../config.js'
 import '../registry.js'
 
 const NOOP_LOG = () => {}
 
-describe('buildPlugins — default-on', () => {
-  it('honors explicit plugin keys from config.plugins', () => {
+describe('buildPlugins', () => {
+  it('instantiates plugins listed under config.plugins', () => {
     const cfg: OrchestratorConfig = {
       project: 'proj',
       repo: 'org/repo',
       plugins: { 'github-issues': { watched: [] }, 'github-prs': { watched: [] } },
     }
     const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
-    // Explicit plugins come first, then default-on plugins are appended.
-    expect(names.slice(0, 2)).toEqual(['github-issues', 'github-prs'])
-    for (const def of DEFAULT_ON_PLUGINS) expect(names).toContain(def)
+    expect(names).toEqual(['github-issues', 'github-prs'])
   })
 
-  it('appends `github-new-issues` when repo is set and slice is missing', () => {
+  it('does not instantiate plugins absent from config.plugins (no default-on)', () => {
     const cfg: OrchestratorConfig = {
       project: 'proj',
       repo: 'org/repo',
       plugins: { 'github-issues': { watched: [] } },
     }
     const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
-    expect(names).toContain('github-new-issues')
+    expect(names).toEqual(['github-issues'])
   })
 
-  it('does not duplicate `github-new-issues` when slice is explicit', () => {
+  it('returns an empty list when config.plugins is missing', () => {
+    const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo' }
+    expect(buildPlugins(cfg, '#proj-leads', NOOP_LOG)).toEqual([])
+  })
+
+  it('preserves Object.keys insertion order so emission order is predictable', () => {
     const cfg: OrchestratorConfig = {
       project: 'proj',
       repo: 'org/repo',
-      plugins: { 'github-new-issues': {} },
+      plugins: {
+        'github-new-issues': {},
+        'github-prs': { watched: [] },
+        'github-issues': { watched: [] },
+      },
     }
     const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
-    expect(names.filter(n => n === 'github-new-issues')).toHaveLength(1)
-  })
-
-  it('skips default-on plugins when repo is unset', () => {
-    const cfg: OrchestratorConfig = {
-      project: 'proj',
-      plugins: { 'github-issues': { watched: [] } },
-    }
-    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
-    expect(names).not.toContain('github-new-issues')
-  })
-
-  it('preserves explicit order, appends defaults at the end', () => {
-    const cfg: OrchestratorConfig = {
-      project: 'proj',
-      repo: 'org/repo',
-      plugins: { 'github-prs': { watched: [] }, 'github-issues': { watched: [] } },
-    }
-    const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
-    expect(names).toEqual(['github-prs', 'github-issues', 'github-new-issues'])
+    expect(names).toEqual(['github-new-issues', 'github-prs', 'github-issues'])
   })
 
   it('throws on unknown plugin key', () => {
@@ -64,5 +52,14 @@ describe('buildPlugins — default-on', () => {
       plugins: { 'nonexistent': {} },
     }
     expect(() => buildPlugins(cfg, '#proj-leads', NOOP_LOG)).toThrow(/unknown plugin/)
+  })
+
+  it('error message lists the available registered plugins', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      repo: 'org/repo',
+      plugins: { 'typo-plugin': {} },
+    }
+    expect(() => buildPlugins(cfg, '#proj-leads', NOOP_LOG)).toThrow(/available:.*github-issues/)
   })
 })

--- a/src/orchestrator/build-plugins.ts
+++ b/src/orchestrator/build-plugins.ts
@@ -1,28 +1,15 @@
-// Plugin instantiation. Separate module so the default-on behavior (#342) is
-// testable without importing orchestrator.ts (which executes `main()` at load).
+// Plugin instantiation. Separate module so the config → ordered Plugin[]
+// surface stays focused and testable. A plugin not listed under
+// `config.plugins` is not instantiated — there is no default-on. New
+// projects pick the shipped plugins up via `bin/roost init`'s template.
 import type { OrchestratorConfig } from './config.js'
 import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
 
-// Plugins enabled by default when `config.repo` is set, even if the slice
-// isn't present in config.json. Lets existing projects benefit from triage
-// announcements (#342) without a config edit.
-//
-// Today only `github-new-issues` is default-on; older plugins (`github-prs`,
-// `github-issues`) need an explicit slice because they're scoped to specific
-// watched entries — auto-enabling them would do nothing useful.
-export const DEFAULT_ON_PLUGINS = ['github-new-issues'] as const
-
 // Instantiate plugins from `config.plugins` via the registry. Order follows
-// `Object.keys` insertion order in the config JSON, with default-on plugins
-// appended at the end when missing. Predictable emission order from the
-// operator's POV.
+// `Object.keys` insertion order in the config JSON, so emission order is
+// predictable from the operator's POV.
 export function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: PluginLogger): Plugin[] {
-  const explicit = Object.keys(config.plugins ?? {})
-  const explicitSet = new Set(explicit)
-  const implicit = config.repo
-    ? DEFAULT_ON_PLUGINS.filter(n => !explicitSet.has(n))
-    : []
-  const names = [...explicit, ...implicit]
+  const names = Object.keys(config.plugins ?? {})
   return names.map(name => {
     const factory = getPluginFactory(name)
     if (!factory) {

--- a/src/orchestrator/build-plugins.ts
+++ b/src/orchestrator/build-plugins.ts
@@ -1,0 +1,34 @@
+// Plugin instantiation. Separate module so the default-on behavior (#342) is
+// testable without importing orchestrator.ts (which executes `main()` at load).
+import type { OrchestratorConfig } from './config.js'
+import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
+
+// Plugins enabled by default when `config.repo` is set, even if the slice
+// isn't present in config.json. Lets existing projects benefit from triage
+// announcements (#342) without a config edit.
+//
+// Today only `github-new-issues` is default-on; older plugins (`github-prs`,
+// `github-issues`) need an explicit slice because they're scoped to specific
+// watched entries — auto-enabling them would do nothing useful.
+export const DEFAULT_ON_PLUGINS = ['github-new-issues'] as const
+
+// Instantiate plugins from `config.plugins` via the registry. Order follows
+// `Object.keys` insertion order in the config JSON, with default-on plugins
+// appended at the end when missing. Predictable emission order from the
+// operator's POV.
+export function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: PluginLogger): Plugin[] {
+  const explicit = Object.keys(config.plugins ?? {})
+  const explicitSet = new Set(explicit)
+  const implicit = config.repo
+    ? DEFAULT_ON_PLUGINS.filter(n => !explicitSet.has(n))
+    : []
+  const names = [...explicit, ...implicit]
+  return names.map(name => {
+    const factory = getPluginFactory(name)
+    if (!factory) {
+      const available = registeredPluginNames().sort().join(', ') || '(none)'
+      throw new Error(`unknown plugin in config: ${name}. available: ${available}`)
+    }
+    return factory(defaultChannel, log)
+  })
+}

--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, spyOn } from 'bun:test'
 import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
-import * as ghApi from '../github-api.js'
-import type { GhRepoIssue } from '../github-api.js'
+import { GhClient, type GhRepoIssue } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
 
 function issue(n: number, overrides: Partial<GhRepoIssue> = {}): GhRepoIssue {
@@ -24,9 +23,15 @@ function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorCo
   }
 }
 
+// Plugin owns its GhClient; intercept fetch at the prototype seam — same shape
+// the sibling plugin tests use for scrapeIssue/scrapePr.
+function stubFetch(response: GhRepoIssue[]) {
+  return spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue(response)
+}
+
 describe('GitHubNewIssuesPlugin.runTick', () => {
   it('seeds without emitting on first run (prev === null)', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2), issue(3)])
+    const spy = stubFetch([issue(1), issue(2), issue(3)])
     try {
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), null)
       expect(result.taggedEvents).toHaveLength(0)
@@ -35,7 +40,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('emits a oneline announcement for issues new since last tick', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2), issue(3)])
+    const spy = stubFetch([issue(1), issue(2), issue(3)])
     try {
       const prevState: NewIssuesPluginState = { seen_issue_numbers: [1] }
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
@@ -52,7 +57,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('routes announcements to the project channel by default', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(5)])
+    const spy = stubFetch([issue(5)])
     try {
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
       expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
@@ -60,7 +65,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('honors slice.channels override when set', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(5)])
+    const spy = stubFetch([issue(5)])
     try {
       const config = baseConfig({ plugins: { 'github-new-issues': { channels: ['#triage', '#leads'] } } })
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, { seen_issue_numbers: [] })
@@ -68,10 +73,17 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 
+  it('emits a defensive per-event channel copy — sibling mutation does not leak', async () => {
+    const spy = stubFetch([issue(1), issue(2)])
+    try {
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      result.taggedEvents[0]?.channels.push('#tampered')
+      expect(result.taggedEvents[1]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
   it('includes labels in the announcement when present', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([
-      issue(7, { labels: [{ name: 'bug' }, { name: 'priority:high' }] }),
-    ])
+    const spy = stubFetch([issue(7, { labels: [{ name: 'bug' }, { name: 'priority:high' }] })])
     try {
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
       const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
@@ -80,7 +92,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('accumulates seen numbers across ticks', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2)])
+    const spy = stubFetch([issue(1), issue(2)])
     try {
       const prevState: NewIssuesPluginState = { seen_issue_numbers: [5] }
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
@@ -89,7 +101,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('does not re-announce issues already in seen', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2)])
+    const spy = stubFetch([issue(1), issue(2)])
     try {
       const prevState: NewIssuesPluginState = { seen_issue_numbers: [1, 2] }
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
@@ -98,7 +110,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('uses slice.repo when set, falls back to config.repo otherwise', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([])
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue([])
     try {
       const config: OrchestratorConfig = {
         project: 'proj',
@@ -106,7 +118,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
         plugins: { 'github-new-issues': { repo: 'org/feed-source' } },
       }
       await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)
-      expect(spy).toHaveBeenCalledWith(expect.anything(), 'org/feed-source')
+      expect(spy).toHaveBeenCalledWith('org/feed-source')
     } finally { spy.mockRestore() }
   })
 
@@ -130,7 +142,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   })
 
   it('orders announcements by issue number', async () => {
-    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(20), issue(5), issue(11)])
+    const spy = stubFetch([issue(20), issue(5), issue(11)])
     try {
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
       const numbers = result.taggedEvents.map(e =>
@@ -140,4 +152,3 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 })
-

--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, spyOn } from 'bun:test'
+import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
+import * as ghApi from '../github-api.js'
+import type { GhRepoIssue } from '../github-api.js'
+import type { OrchestratorConfig } from '../../../config.js'
+
+function issue(n: number, overrides: Partial<GhRepoIssue> = {}): GhRepoIssue {
+  return {
+    number: n,
+    title: `Issue ${n}`,
+    html_url: `https://github.com/org/repo/issues/${n}`,
+    state: 'open',
+    labels: [],
+    ...overrides,
+  }
+}
+
+function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    project: 'proj',
+    repo: 'org/repo',
+    plugins: { 'github-new-issues': {} },
+    ...overrides,
+  }
+}
+
+describe('GitHubNewIssuesPlugin.runTick', () => {
+  it('seeds without emitting on first run (prev === null)', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2), issue(3)])
+    try {
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), null)
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as NewIssuesPluginState).seen_issue_numbers).toEqual([1, 2, 3])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits a oneline announcement for issues new since last tick', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2), issue(3)])
+    try {
+      const prevState: NewIssuesPluginState = { seen_issue_numbers: [1] }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
+      expect(result.taggedEvents).toHaveLength(2)
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'new issue org/repo#2: Issue 2 — https://github.com/org/repo/issues/2',
+      })
+      expect(result.taggedEvents[1]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'new issue org/repo#3: Issue 3 — https://github.com/org/repo/issues/3',
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes announcements to the project channel by default', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(5)])
+    try {
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('honors slice.channels override when set', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(5)])
+    try {
+      const config = baseConfig({ plugins: { 'github-new-issues': { channels: ['#triage', '#leads'] } } })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, { seen_issue_numbers: [] })
+      expect(result.taggedEvents[0]?.channels).toEqual(['#triage', '#leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('includes labels in the announcement when present', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([
+      issue(7, { labels: [{ name: 'bug' }, { name: 'priority:high' }] }),
+    ])
+    try {
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toBe('new issue org/repo#7: Issue 7 [bug, priority:high] — https://github.com/org/repo/issues/7')
+    } finally { spy.mockRestore() }
+  })
+
+  it('accumulates seen numbers across ticks', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2)])
+    try {
+      const prevState: NewIssuesPluginState = { seen_issue_numbers: [5] }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
+      expect((result.state as NewIssuesPluginState).seen_issue_numbers).toEqual([1, 2, 5])
+    } finally { spy.mockRestore() }
+  })
+
+  it('does not re-announce issues already in seen', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(1), issue(2)])
+    try {
+      const prevState: NewIssuesPluginState = { seen_issue_numbers: [1, 2] }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
+      expect(result.taggedEvents).toHaveLength(0)
+    } finally { spy.mockRestore() }
+  })
+
+  it('uses slice.repo when set, falls back to config.repo otherwise', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([])
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        repo: 'org/main',
+        plugins: { 'github-new-issues': { repo: 'org/feed-source' } },
+      }
+      await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)
+      expect(spy).toHaveBeenCalledWith(expect.anything(), 'org/feed-source')
+    } finally { spy.mockRestore() }
+  })
+
+  it('throws when neither slice.repo nor config.repo is set', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-new-issues': {} },
+    }
+    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/no repo/)
+  })
+
+  it('desiredChannels returns empty without slice.channels — orchestrator unions in the project channel', () => {
+    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
+    expect(plugin.desiredChannels(baseConfig())).toEqual([])
+  })
+
+  it('desiredChannels surfaces slice.channels so the orchestrator joins them at boot', () => {
+    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
+    const config = baseConfig({ plugins: { 'github-new-issues': { channels: ['#triage'] } } })
+    expect(plugin.desiredChannels(config)).toEqual(['#triage'])
+  })
+
+  it('orders announcements by issue number', async () => {
+    const spy = spyOn(ghApi, 'fetchRepoOpenIssues').mockResolvedValue([issue(20), issue(5), issue(11)])
+    try {
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const numbers = result.taggedEvents.map(e =>
+        ((e.payload as { kind: 'oneline'; text: string }).text.match(/#(\d+)/)?.[1])
+      )
+      expect(numbers).toEqual(['5', '11', '20'])
+    } finally { spy.mockRestore() }
+  })
+})
+

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -162,6 +162,18 @@ export interface GhIssue {
   labels?: GhLabel[]
 }
 
+// Repo-issues feed shape. The `/repos/{owner}/{repo}/issues` endpoint returns
+// both issues and PRs; `pull_request` is the marker for filtering PRs out at
+// the call site (see GhClient.fetchRepoOpenIssues).
+export interface GhRepoIssue {
+  number?: number
+  title?: string
+  html_url?: string
+  state?: string
+  labels?: GhLabel[]
+  pull_request?: Record<string, unknown>
+}
+
 export interface FetchedPr {
   title: string | null
   url: string | null
@@ -301,21 +313,12 @@ export class GhClient {
   async fetchIssueComments(repo: string, number: number): Promise<GhComment[]> {
     return (await this.api(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
   }
-}
 
-// GitHub's issues endpoint returns PRs too — `pull_request` is the marker
-// for filtering them out at the call site.
-export interface GhRepoIssue {
-  number?: number
-  title?: string
-  html_url?: string
-  state?: string
-  labels?: GhLabel[]
-  pull_request?: Record<string, unknown>
-}
-
-// Lists open issues across the repo (excluding PRs at the caller). Paginated.
-export async function fetchRepoOpenIssues(log: PluginLogger, repo: string): Promise<GhRepoIssue[]> {
-  const raw = (await ghApi(log, `repos/${repo}/issues?state=open&per_page=100`, true) ?? []) as GhRepoIssue[]
-  return raw.filter(i => !i.pull_request)
+  // Lists open issues across the repo. The GH `/repos/{repo}/issues` endpoint
+  // returns PRs as well, so we filter them out via the `pull_request` marker.
+  // Paginated; the response is the de-duped, PR-stripped open-issue set.
+  async fetchRepoOpenIssues(repo: string): Promise<GhRepoIssue[]> {
+    const raw = (await this.api(`repos/${repo}/issues?state=open&per_page=100`, true) ?? []) as GhRepoIssue[]
+    return raw.filter(i => !i.pull_request)
+  }
 }

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -302,3 +302,20 @@ export class GhClient {
     return (await this.api(`repos/${repo}/issues/${number}/comments?per_page=100`, true) ?? []) as GhComment[]
   }
 }
+
+// GitHub's issues endpoint returns PRs too — `pull_request` is the marker
+// for filtering them out at the call site.
+export interface GhRepoIssue {
+  number?: number
+  title?: string
+  html_url?: string
+  state?: string
+  labels?: GhLabel[]
+  pull_request?: Record<string, unknown>
+}
+
+// Lists open issues across the repo (excluding PRs at the caller). Paginated.
+export async function fetchRepoOpenIssues(log: PluginLogger, repo: string): Promise<GhRepoIssue[]> {
+  const raw = (await ghApi(log, `repos/${repo}/issues?state=open&per_page=100`, true) ?? []) as GhRepoIssue[]
+  return raw.filter(i => !i.pull_request)
+}

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -12,7 +12,7 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { BasePlugin, type PluginLogger, type PluginTickResult, type TaggedEvent, defaultPluginLogger } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
-import { fetchRepoOpenIssues, labelNames, type GhRepoIssue } from './github-api.js'
+import { GhClient, labelNames, type GhRepoIssue } from './github-api.js'
 
 interface NewIssuesPluginConfig {
   repo?: string
@@ -26,8 +26,15 @@ export interface NewIssuesPluginState {
 export class GitHubNewIssuesPlugin extends BasePlugin {
   readonly name = 'github-new-issues'
 
-  constructor(defaultChannel: string, protected readonly log: PluginLogger = defaultPluginLogger) {
+  // Owns the GhClient the same way GhBase does — see #338/#348 for the
+  // refactor. Not extending GhBase because that scaffolding is built around
+  // a per-entry `watched` slice and this plugin doesn't have one. A thinner
+  // shared base could be a future cleanup if more GhClient-only plugins land.
+  protected readonly client: GhClient
+
+  constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
     super(defaultChannel)
+    this.client = new GhClient(log)
   }
 
   // Project channel is unioned in by the orchestrator, so the default case
@@ -38,22 +45,16 @@ export class GitHubNewIssuesPlugin extends BasePlugin {
     return slice.channels?.length ? [...slice.channels] : []
   }
 
-  private resolveRepo(config: OrchestratorConfig): string {
+  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
     const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
     const repo = slice.repo ?? config.repo
     if (!repo) throw new Error('github-new-issues: no repo (set `repo` at top level or under plugins.github-new-issues)')
-    return repo
-  }
 
-  private resolveAnnouncementChannels(config: OrchestratorConfig): string[] {
-    const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
-    if (slice.channels?.length) return slice.channels
-    return [resolveProjectChannel(config)]
-  }
+    const announcementChannels = slice.channels?.length
+      ? [...slice.channels]
+      : [resolveProjectChannel(config)]
 
-  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
-    const repo = this.resolveRepo(config)
-    const issues = await fetchRepoOpenIssues(this.log, repo)
+    const issues = await this.client.fetchRepoOpenIssues(repo)
     const currentNumbers = issues
       .map(i => i.number)
       .filter((n): n is number => n != null)
@@ -64,13 +65,14 @@ export class GitHubNewIssuesPlugin extends BasePlugin {
     const taggedEvents: TaggedEvent[] = []
 
     if (prev !== null) {
-      const announcementChannels = this.resolveAnnouncementChannels(config)
       const newIssues = issues
         .filter(i => i.number != null && !seen.has(i.number))
         .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))
       for (const issue of newIssues) {
         taggedEvents.push({
-          channels: announcementChannels,
+          // Per-event copy so a downstream mutation of one event's channel
+          // list can't leak into siblings.
+          channels: [...announcementChannels],
           payload: { kind: 'oneline', text: formatNewIssue(repo, issue) },
         })
       }
@@ -84,7 +86,7 @@ export class GitHubNewIssuesPlugin extends BasePlugin {
   }
 }
 
-export function formatNewIssue(repo: string, issue: GhRepoIssue): string {
+function formatNewIssue(repo: string, issue: GhRepoIssue): string {
   const tag = `${repo}#${issue.number}`
   const title = issue.title ?? ''
   const labels = labelNames(issue.labels)

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -4,6 +4,11 @@
 // for hand-watched issues; this one surfaces brand-new issues so the team
 // doesn't have to notice them manually. Issue #342.
 //
+// Enabled by an explicit `plugins.github-new-issues` slice in config —
+// empty object is fine. `bin/roost init` writes one for new projects;
+// existing projects need an operator edit (or the example.json refresh) to
+// pick this up.
+//
 // State slice: `{ seen_issue_numbers: number[] }`. Seeding (`prev===null`)
 // captures the current open set without emitting — only ticks after seed
 // announce. Closed issues that re-open will re-announce only if they were

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -1,0 +1,94 @@
+// Project-level issue triage feed. Polls the repo for open issues and emits a
+// oneline announcement to the project channel the first time a given issue
+// number is observed. Sibling to `github-issues`: that plugin routes activity
+// for hand-watched issues; this one surfaces brand-new issues so the team
+// doesn't have to notice them manually. Issue #342.
+//
+// State slice: `{ seen_issue_numbers: number[] }`. Seeding (`prev===null`)
+// captures the current open set without emitting — only ticks after seed
+// announce. Closed issues that re-open will re-announce only if they were
+// pruned from `seen` (we don't prune today, so closed-then-reopened is
+// silently suppressed; that's fine, the operator can `watch <N>` for it).
+import type { OrchestratorConfig } from '../../config.js'
+import { BasePlugin, type PluginLogger, type PluginTickResult, type TaggedEvent, defaultPluginLogger } from '../../plugin.js'
+import { resolveProjectChannel } from '../../naming.js'
+import { fetchRepoOpenIssues, labelNames, type GhRepoIssue } from './github-api.js'
+
+interface NewIssuesPluginConfig {
+  repo?: string
+  channels?: string[]
+}
+
+export interface NewIssuesPluginState {
+  seen_issue_numbers: number[]
+}
+
+export class GitHubNewIssuesPlugin extends BasePlugin {
+  readonly name = 'github-new-issues'
+
+  constructor(defaultChannel: string, protected readonly log: PluginLogger = defaultPluginLogger) {
+    super(defaultChannel)
+  }
+
+  // Project channel is unioned in by the orchestrator, so the default case
+  // returns []. An explicit slice.channels override is surfaced here so those
+  // channels join at boot.
+  desiredChannels(config: OrchestratorConfig): string[] {
+    const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
+    return slice.channels?.length ? [...slice.channels] : []
+  }
+
+  private resolveRepo(config: OrchestratorConfig): string {
+    const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
+    const repo = slice.repo ?? config.repo
+    if (!repo) throw new Error('github-new-issues: no repo (set `repo` at top level or under plugins.github-new-issues)')
+    return repo
+  }
+
+  private resolveAnnouncementChannels(config: OrchestratorConfig): string[] {
+    const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
+    if (slice.channels?.length) return slice.channels
+    return [resolveProjectChannel(config)]
+  }
+
+  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
+    const repo = this.resolveRepo(config)
+    const issues = await fetchRepoOpenIssues(this.log, repo)
+    const currentNumbers = issues
+      .map(i => i.number)
+      .filter((n): n is number => n != null)
+      .sort((a, b) => a - b)
+
+    const prev = prevState as NewIssuesPluginState | null
+    const seen = new Set<number>(prev?.seen_issue_numbers ?? [])
+    const taggedEvents: TaggedEvent[] = []
+
+    if (prev !== null) {
+      const announcementChannels = this.resolveAnnouncementChannels(config)
+      const newIssues = issues
+        .filter(i => i.number != null && !seen.has(i.number))
+        .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))
+      for (const issue of newIssues) {
+        taggedEvents.push({
+          channels: announcementChannels,
+          payload: { kind: 'oneline', text: formatNewIssue(repo, issue) },
+        })
+      }
+    }
+
+    // Always merge — even on seed — so seen accumulates from tick 1.
+    for (const n of currentNumbers) seen.add(n)
+
+    const state: NewIssuesPluginState = { seen_issue_numbers: [...seen].sort((a, b) => a - b) }
+    return { state, taggedEvents, channels: [] }
+  }
+}
+
+export function formatNewIssue(repo: string, issue: GhRepoIssue): string {
+  const tag = `${repo}#${issue.number}`
+  const title = issue.title ?? ''
+  const labels = labelNames(issue.labels)
+  const labelStr = labels.length ? ` [${labels.join(', ')}]` : ''
+  const url = issue.html_url ?? ''
+  return `new issue ${tag}: ${title}${labelStr} — ${url}`
+}

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -1,9 +1,12 @@
 // Built-in plugin registration. Importing this module for side effects
-// populates the registry in plugin.ts with `github-prs` and `github-issues`.
-// Add a new built-in plugin here; nothing in orchestrator.ts needs to change.
+// populates the registry in plugin.ts with `github-prs`, `github-issues`,
+// and `github-new-issues`. Add a new built-in plugin here; nothing in
+// orchestrator.ts needs to change.
 import { registerPlugin } from './plugin.js'
 import { GitHubPrsPlugin } from './plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
+import { GitHubNewIssuesPlugin } from './plugins/github/new-issues-plugin.js'
 
 registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
 registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))
+registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log))


### PR DESCRIPTION
Closes #342

## Summary
- New `github-new-issues` plugin scrapes the repo's open-issue list each tick and emits a oneline `new issue <repo>#N: <title> [labels] — <url>` announcement to the project channel the first time a given issue number is seen.
- Filters PRs out of the issues feed via the `pull_request` marker.
- Default-on whenever `config.repo` is set, so existing projects pick it up on the next dispatcher restart without a config edit. `bin/roost init` also writes an explicit slice for new projects.
- `buildPlugins` extracted to `src/orchestrator/build-plugins.ts` so the default-on logic is testable without executing the orchestrator CLI's `main()`.

## Notes
- Seeding (`prev===null`) captures the current open set silently; the next tick onwards is when announcements fire.
- Closed-then-reopened issues stay suppressed (we never prune the seen set). Operator can `watch <N>` if they need continuous routing on a specific one.
- No schema bump needed — a new plugin slice auto-seeds via `getPluginState(...) === null`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 482 pass
- [ ] live exercise: bring up dispatcher against a repo with one open issue, file a new one, see it announced in `#<project>-leads`