### PR TITLE
surface excess cache-creation cost in roost-token-usage report

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -67,3 +67,14 @@ export function costFor(model: string, u: UsageCounts): number | null {
     + p.cache_read * u.cache_read
   ) / 1_000_000
 }
+
+// Returns the USD cost for cache creation tokens that were never read back.
+// `excess5m` and `excess1h` are the wasted tokens split by TTL tier
+// (proportionally allocated from the session's creation mix by the caller).
+// Returns `null` for unknown models, same contract as `costFor`.
+export function excessCreationCost(model: string, excess5m: number, excess1h: number): number | null {
+  if (SKIPPED_MODELS.has(model)) return 0
+  const p = PRICING[model]
+  if (!p) return null
+  return (p.cache_creation_5m * excess5m + p.cache_creation_1h * excess1h) / 1_000_000
+}

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -69,11 +69,15 @@ export function costFor(model: string, u: UsageCounts): number | null {
 }
 
 // Returns the USD cost premium for cache miss tokens — the extra spend vs what
-// a cache read would have cost. Defaults to the 5m creation tier (the common
-// case; cache_miss_reason doesn't expose TTL). Returns `null` for unknown models.
-export function missCostFor(model: string, tokens: number): number | null {
+// a cache read would have cost. `tokens5m` and `tokens1h` are the miss token
+// counts split by the creation tier of the row that reported the miss (so the
+// premium is computed at the correct rate per tier). Returns `null` for unknown models.
+export function missCostFor(model: string, tokens5m: number, tokens1h: number): number | null {
   if (SKIPPED_MODELS.has(model)) return 0
   const p = PRICING[model]
   if (!p) return null
-  return (p.cache_creation_5m - p.cache_read) * tokens / 1_000_000
+  return (
+    (p.cache_creation_5m - p.cache_read) * tokens5m
+    + (p.cache_creation_1h - p.cache_read) * tokens1h
+  ) / 1_000_000
 }

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -73,8 +73,5 @@ export function costFor(model: string, u: UsageCounts): number | null {
 // (proportionally allocated from the session's creation mix by the caller).
 // Returns `null` for unknown models, same contract as `costFor`.
 export function excessCreationCost(model: string, excess5m: number, excess1h: number): number | null {
-  if (SKIPPED_MODELS.has(model)) return 0
-  const p = PRICING[model]
-  if (!p) return null
-  return (p.cache_creation_5m * excess5m + p.cache_creation_1h * excess1h) / 1_000_000
+  return costFor(model, { input: 0, output: 0, cache_creation_5m: excess5m, cache_creation_1h: excess1h, cache_read: 0 })
 }

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -68,10 +68,12 @@ export function costFor(model: string, u: UsageCounts): number | null {
   ) / 1_000_000
 }
 
-// Returns the USD cost for cache creation tokens that were never read back.
-// `excess5m` and `excess1h` are the wasted tokens split by TTL tier
-// (proportionally allocated from the session's creation mix by the caller).
-// Returns `null` for unknown models, same contract as `costFor`.
-export function excessCreationCost(model: string, excess5m: number, excess1h: number): number | null {
-  return costFor(model, { input: 0, output: 0, cache_creation_5m: excess5m, cache_creation_1h: excess1h, cache_read: 0 })
+// Returns the USD cost premium for cache miss tokens — the extra spend vs what
+// a cache read would have cost. Defaults to the 5m creation tier (the common
+// case; cache_miss_reason doesn't expose TTL). Returns `null` for unknown models.
+export function missCostFor(model: string, tokens: number): number | null {
+  if (SKIPPED_MODELS.has(model)) return 0
+  const p = PRICING[model]
+  if (!p) return null
+  return (p.cache_creation_5m - p.cache_read) * tokens / 1_000_000
 }

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -41,14 +41,17 @@ import { mcpConnectionLine } from './mcp-banner.js'
 import { costFor, missCostFor, type UsageCounts } from './pricing.js'
 
 type ModelUsage = UsageCounts
+// Per-reason miss token counts split by cache-creation TTL tier. The tier
+// is read from the creation block on the same JSONL row that reported the miss.
+type MissCounts = { tokens5m: number; tokens1h: number }
 
 interface NickReport {
   byModel: Map<string, ModelUsage>
   // Direct cache miss data from message.diagnostics.cache_miss_reason.
   // Outer key: model ID. Inner key: reason type (tools_changed, system_changed,
   // messages_changed, previous_message_not_found, unavailable).
-  // Value: total cache_missed_input_tokens across all calls with that reason.
-  missByModel: Map<string, Map<string, number>>
+  // Value: miss token counts split by creation tier (from the same row's cache_creation block).
+  missByModel: Map<string, Map<string, MissCounts>>
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
@@ -89,15 +92,18 @@ function addToUsageMap(into: Map<string, UsageCounts>, model: string, u: UsageCo
   into.set(model, cur)
 }
 
-function addToMissMap(into: Map<string, Map<string, number>>, from: Map<string, Map<string, number>>): void {
+function addToMissMap(into: Map<string, Map<string, MissCounts>>, from: Map<string, Map<string, MissCounts>>): void {
   for (const [model, reasons] of from) {
     let intoReasons = into.get(model)
     if (!intoReasons) {
-      intoReasons = new Map<string, number>()
+      intoReasons = new Map<string, MissCounts>()
       into.set(model, intoReasons)
     }
-    for (const [reason, tokens] of reasons) {
-      intoReasons.set(reason, (intoReasons.get(reason) ?? 0) + tokens)
+    for (const [reason, counts] of reasons) {
+      const cur = intoReasons.get(reason) ?? { tokens5m: 0, tokens1h: 0 }
+      cur.tokens5m += counts.tokens5m
+      cur.tokens1h += counts.tokens1h
+      intoReasons.set(reason, cur)
     }
   }
 }
@@ -180,7 +186,7 @@ interface AnyRow {
 // nick-level accumulators.
 interface ScanResult {
   byModel: Map<string, UsageCounts>
-  missByModel: Map<string, Map<string, number>>
+  missByModel: Map<string, Map<string, MissCounts>>
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
@@ -202,7 +208,7 @@ interface ScanResult {
 // filtered here to avoid double-counting.
 function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
-  const missByModel = new Map<string, Map<string, number>>()
+  const missByModel = new Map<string, Map<string, MissCounts>>()
   let apiDurationMs = 0
   let wallFirst: string | undefined
   let wallLast: string | undefined
@@ -269,16 +275,30 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
       }
 
       // Cache miss reason: direct signal from Claude Code for why the cache
-      // was not hit. Parsed outside the "has tokens" guard — capture even on
-      // otherwise-empty usage rows.
+      // was not hit. Split the miss tokens by the creation tier mix on this
+      // same row so the premium is computed at the correct rate (1h vs 5m).
       const missReason = row.message.diagnostics?.cache_miss_reason
       if (missReason?.type && typeof missReason.cache_missed_input_tokens === 'number' && missReason.cache_missed_input_tokens > 0) {
+        const missTokens = missReason.cache_missed_input_tokens
+        const creationTotal = cache5m + cache1h
+        let miss5m: number, miss1h: number
+        if (creationTotal > 0) {
+          miss5m = missTokens * cache5m / creationTotal
+          miss1h = missTokens * cache1h / creationTotal
+        } else {
+          // No creation block on this row — fall back to 5m (conservative lower bound).
+          miss5m = missTokens
+          miss1h = 0
+        }
         let modelMiss = missByModel.get(row.message.model)
         if (!modelMiss) {
-          modelMiss = new Map<string, number>()
+          modelMiss = new Map<string, MissCounts>()
           missByModel.set(row.message.model, modelMiss)
         }
-        modelMiss.set(missReason.type, (modelMiss.get(missReason.type) ?? 0) + missReason.cache_missed_input_tokens)
+        const cur = modelMiss.get(missReason.type) ?? { tokens5m: 0, tokens1h: 0 }
+        cur.tokens5m += miss5m
+        cur.tokens1h += miss1h
+        modelMiss.set(missReason.type, cur)
       }
       continue
     }
@@ -427,16 +447,24 @@ function formatNick(nick: string, r: NickReport): string {
     let missStr = ''
     const modelMiss = r.missByModel.get(model)
     if (modelMiss && modelMiss.size > 0) {
-      const missTotal = [...modelMiss.values()].reduce((a, b) => a + b, 0)
-      const mc = missCostFor(model, missTotal)
+      let missTotal5m = 0, missTotal1h = 0
+      for (const { tokens5m, tokens1h } of modelMiss.values()) {
+        missTotal5m += tokens5m
+        missTotal1h += tokens1h
+      }
+      const mc = missCostFor(model, missTotal5m, missTotal1h)
       if (totalMissCost !== null) {
         if (mc === null) totalMissCost = null
         else totalMissCost += mc
       }
-      // Sort by token count descending so the costliest reason appears first.
-      const reasons = [...modelMiss.entries()].sort((a, b) => b[1] - a[1])
-      const reasonParts = reasons.map(([reason, tokens]) => `${reason} ${fmtTokens(tokens)} (${fmtDollars(missCostFor(model, tokens))})`)
-      missStr = `, miss: ${fmtTokens(missTotal)} (${fmtDollars(mc)}) [${reasonParts.join(' · ')}]`
+      // Sort by total token count descending so the costliest reason appears first.
+      const reasons = [...modelMiss.entries()].sort(
+        (a, b) => (b[1].tokens5m + b[1].tokens1h) - (a[1].tokens5m + a[1].tokens1h)
+      )
+      const reasonParts = reasons.map(([reason, { tokens5m, tokens1h }]) =>
+        `${reason} ${fmtTokens(tokens5m + tokens1h)} (${fmtDollars(missCostFor(model, tokens5m, tokens1h))})`
+      )
+      missStr = `, miss: ${fmtTokens(missTotal5m + missTotal1h)} (${fmtDollars(mc)}) [${reasonParts.join(' · ')}]`
     }
 
     perModel.push({

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -2,8 +2,8 @@
 // token-usage — read Claude Code session transcripts and summarize per-nick
 // API spend in a format inspired by Claude Code's own `/usage` panel:
 //
-//   <nick>: $14.38 · 18m57s api / 44m42s wall
-//     opus-4-7:    7.4k in / 63.4k out / 17.5M cache_r / 644.6k cache_w  ($14.38)
+//   <nick>: $14.38 ($1.42 miss) · 18m57s api / 44m42s wall
+//     opus-4-7:    7.4k in / 63.4k out / 17.5M cache_r / 644.6k cache_w  ($14.38, miss: 128.3k ($1.42) [tools_changed 16.2k ($0.18) · system_changed 112.1k ($1.24)])
 //     sonnet-4-6:  1.2k in /  2.4k out /  300k cache_r /   8.5k cache_w  ($0.42)
 //
 // Sessions are matched by the MCP banner produced by src/mcp-banner.ts —
@@ -38,23 +38,22 @@ import { readFile, mkdir, rename, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { mcpConnectionLine } from './mcp-banner.js'
-import { costFor, excessCreationCost, type UsageCounts } from './pricing.js'
+import { costFor, missCostFor, type UsageCounts } from './pricing.js'
 
 type ModelUsage = UsageCounts
 
 interface NickReport {
   byModel: Map<string, ModelUsage>
-  // Excess cache creation per model, summed across sessions. "Excess" = the
-  // portion of cache_creation that exceeded cache_read within a single session
-  // — tokens written but never read back. Computed per-session (not in aggregate)
-  // so a wasted write in one session isn't masked by reads in another.
-  excessByModel: Map<string, { excess5m: number; excess1h: number }>
+  // Direct cache miss data from message.diagnostics.cache_miss_reason.
+  // Outer key: model ID. Inner key: reason type (tools_changed, system_changed,
+  // messages_changed, previous_message_not_found, unavailable).
+  // Value: total cache_missed_input_tokens across all calls with that reason.
+  missByModel: Map<string, Map<string, number>>
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
   // Number of contributing JSONL transcript files (parent + each subagent file
-  // counted separately). Distinct from the "session" scope used for excess
-  // computation, which groups a parent and all its subagents together.
+  // counted separately).
   transcripts: number
   unknownModels: Set<string>
   files: string[]
@@ -70,7 +69,7 @@ interface SnapshotFile {
 function emptyReport(): NickReport {
   return {
     byModel: new Map(),
-    excessByModel: new Map(),
+    missByModel: new Map(),
     apiDurationMs: 0,
     transcripts: 0,
     unknownModels: new Set(),
@@ -90,19 +89,16 @@ function addToUsageMap(into: Map<string, UsageCounts>, model: string, u: UsageCo
   into.set(model, cur)
 }
 
-// For each model in the session map, compute the excess creation tokens
-// (max(0, creation_total - cache_read)) and accumulate into report.excessByModel.
-// The excess is split between tiers proportionally to their share of creation.
-function accumulateExcess(report: NickReport, sessionByModel: Map<string, UsageCounts>): void {
-  for (const [model, u] of sessionByModel) {
-    const creationTotal = u.cache_creation_5m + u.cache_creation_1h
-    const excess = Math.max(0, creationTotal - u.cache_read)
-    if (excess === 0 || creationTotal === 0) continue
-    const ratio5m = u.cache_creation_5m / creationTotal
-    const cur = report.excessByModel.get(model) ?? { excess5m: 0, excess1h: 0 }
-    cur.excess5m += excess * ratio5m
-    cur.excess1h += excess * (1 - ratio5m)
-    report.excessByModel.set(model, cur)
+function addToMissMap(into: Map<string, Map<string, number>>, from: Map<string, Map<string, number>>): void {
+  for (const [model, reasons] of from) {
+    let intoReasons = into.get(model)
+    if (!intoReasons) {
+      intoReasons = new Map<string, number>()
+      into.set(model, intoReasons)
+    }
+    for (const [reason, tokens] of reasons) {
+      intoReasons.set(reason, (intoReasons.get(reason) ?? 0) + tokens)
+    }
   }
 }
 
@@ -171,13 +167,20 @@ interface AnyRow {
         ephemeral_1h_input_tokens?: number
       }
     }
+    diagnostics?: {
+      cache_miss_reason?: {
+        type?: string
+        cache_missed_input_tokens?: number
+      }
+    }
   }
 }
 
 // Per-file scan result returned by scanFile. The caller merges these into the
-// session-level and nick-level accumulators.
+// nick-level accumulators.
 interface ScanResult {
   byModel: Map<string, UsageCounts>
+  missByModel: Map<string, Map<string, number>>
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
@@ -199,6 +202,7 @@ interface ScanResult {
 // filtered here to avoid double-counting.
 function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
+  const missByModel = new Map<string, Map<string, number>>()
   let apiDurationMs = 0
   let wallFirst: string | undefined
   let wallLast: string | undefined
@@ -263,6 +267,19 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
         if (ts) trackLocal(ts)
         contributed = true
       }
+
+      // Cache miss reason: direct signal from Claude Code for why the cache
+      // was not hit. Parsed outside the "has tokens" guard — capture even on
+      // otherwise-empty usage rows.
+      const missReason = row.message.diagnostics?.cache_miss_reason
+      if (missReason?.type && typeof missReason.cache_missed_input_tokens === 'number' && missReason.cache_missed_input_tokens > 0) {
+        let modelMiss = missByModel.get(row.message.model)
+        if (!modelMiss) {
+          modelMiss = new Map<string, number>()
+          missByModel.set(row.message.model, modelMiss)
+        }
+        modelMiss.set(missReason.type, (modelMiss.get(missReason.type) ?? 0) + missReason.cache_missed_input_tokens)
+      }
       continue
     }
 
@@ -281,7 +298,7 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
       continue
     }
   }
-  return { byModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed }
+  return { byModel, missByModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed }
 }
 
 export async function collectForNick(
@@ -308,15 +325,10 @@ export async function collectForNick(
     if (!text.includes(marker)) continue
     report.files.push(f)
 
-    // Accumulate parent + all subagents into a session-level map before
-    // merging into the nick-level report. This lets us compute per-session
-    // excess creation (writes that weren't read back within the session)
-    // without cross-session reads masking the waste.
-    const sessionByModel = new Map<string, UsageCounts>()
-
     const result = scanFile(text, seenRequestIds, seenTurnUuids, sinceTs)
     if (result.contributed) report.transcripts += 1
-    for (const [m, u] of result.byModel) addToUsageMap(sessionByModel, m, u)
+    for (const [m, u] of result.byModel) addToUsageMap(report.byModel, m, u)
+    addToMissMap(report.missByModel, result.missByModel)
     report.apiDurationMs += result.apiDurationMs
     if (result.wallFirst) trackTs(report, result.wallFirst)
     if (result.wallLast) trackTs(report, result.wallLast)
@@ -336,16 +348,13 @@ export async function collectForNick(
       // Each contributing subagent file increments transcripts independently —
       // a worker that fires 3 Task subagents shows `transcripts: 4` (parent + 3).
       if (subResult.contributed) report.transcripts += 1
-      for (const [m, u] of subResult.byModel) addToUsageMap(sessionByModel, m, u)
+      for (const [m, u] of subResult.byModel) addToUsageMap(report.byModel, m, u)
+      addToMissMap(report.missByModel, subResult.missByModel)
       report.apiDurationMs += subResult.apiDurationMs
       if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
       if (subResult.wallLast) trackTs(report, subResult.wallLast)
       for (const m of subResult.unknownModels) report.unknownModels.add(m)
     }
-
-    // Merge session totals into the nick-level report and compute excess.
-    for (const [model, u] of sessionByModel) addToUsageMap(report.byModel, model, u)
-    accumulateExcess(report, sessionByModel)
   }
   return report
 }
@@ -403,7 +412,7 @@ function shortModel(model: string): string {
 
 function formatNick(nick: string, r: NickReport): string {
   let totalCost: number | null = 0
-  let totalExcess: number | null = 0
+  let totalMissCost: number | null = 0
   const perModel: Array<{ model: string; line: string }> = []
   // Stable order so output is reproducible across runs.
   const models = [...r.byModel.keys()].sort()
@@ -415,17 +424,24 @@ function formatNick(nick: string, r: NickReport): string {
       else totalCost += c
     }
 
-    const exc = r.excessByModel.get(model)
-    const ec = exc ? excessCreationCost(model, exc.excess5m, exc.excess1h) : 0
-    if (totalExcess !== null) {
-      if (ec === null) totalExcess = null
-      else totalExcess += ec
+    let missStr = ''
+    const modelMiss = r.missByModel.get(model)
+    if (modelMiss && modelMiss.size > 0) {
+      const missTotal = [...modelMiss.values()].reduce((a, b) => a + b, 0)
+      const mc = missCostFor(model, missTotal)
+      if (totalMissCost !== null) {
+        if (mc === null) totalMissCost = null
+        else totalMissCost += mc
+      }
+      // Sort by token count descending so the costliest reason appears first.
+      const reasons = [...modelMiss.entries()].sort((a, b) => b[1] - a[1])
+      const reasonParts = reasons.map(([reason, tokens]) => `${reason} ${fmtTokens(tokens)} (${fmtDollars(missCostFor(model, tokens))})`)
+      missStr = `, miss: ${fmtTokens(missTotal)} (${fmtDollars(mc)}) [${reasonParts.join(' · ')}]`
     }
-    const excStr = ec !== 0 ? `, ${fmtDollars(ec)} excess` : ''
 
     perModel.push({
       model,
-      line: `  ${shortModel(model)}: ${fmtTokens(u.input)} in / ${fmtTokens(u.output)} out / ${fmtTokens(u.cache_read)} cache_r / ${fmtTokens(u.cache_creation_5m)} cache_w_5m / ${fmtTokens(u.cache_creation_1h)} cache_w_1h  (${fmtDollars(c)}${excStr})`,
+      line: `  ${shortModel(model)}: ${fmtTokens(u.input)} in / ${fmtTokens(u.output)} out / ${fmtTokens(u.cache_read)} cache_r / ${fmtTokens(u.cache_creation_5m)} cache_w_5m / ${fmtTokens(u.cache_creation_1h)} cache_w_1h  (${fmtDollars(c)}${missStr})`,
     })
   }
   let wallMs = 0
@@ -433,10 +449,10 @@ function formatNick(nick: string, r: NickReport): string {
     wallMs = Date.parse(r.wallLast) - Date.parse(r.wallFirst)
     if (wallMs < 0) wallMs = 0
   }
-  const excessPart = totalExcess === null || totalExcess > 0
-    ? ` (${fmtDollars(totalExcess)} excess)`
+  const missPart = totalMissCost === null || totalMissCost > 0
+    ? ` (${fmtDollars(totalMissCost)} miss)`
     : ''
-  const head = `${nick}: ${fmtDollars(totalCost)}${excessPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
+  const head = `${nick}: ${fmtDollars(totalCost)}${missPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
   if (perModel.length === 0) {
     return `${head}\n  (no in-window activity)`
   }
@@ -451,13 +467,12 @@ Subcommands:
              <stateDir>/token-snapshots.json. Subsequent reports for the
              same <issue> only count turns after this time.
   report     For each nick, print a multi-line cost report:
-                <nick>: $X.XX ($Y.YY excess) · 18m57s api / 44m42s wall
-                  <model>: in/out/cache_r/cache_w  ($X.XX, $Y.YY excess)
+                <nick>: $X.XX ($Y.YY miss) · 18m57s api / 44m42s wall
+                  <model>: in/out/cache_r/cache_w  ($X.XX, miss: N ($Y.YY) [reason ...])
              If a snapshot exists for <issue>+<nick>, only in-window turns
              count; otherwise the full transcript cumulative is reported.
-             "excess" = cost of cache writes that exceeded cache reads within
-             each session (a lower bound — only intra-session waste is
-             detected; reads in one session don't offset writes in another).
+             "miss" cost = (creation_rate - read_rate) x missed tokens; source:
+             message.diagnostics.cache_miss_reason in session transcripts.
 
 Cost is an estimate. Unknown model IDs render '$?' and emit a stderr
 warning; update src/pricing.ts to add them.

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -52,7 +52,10 @@ interface NickReport {
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
-  sessions: number
+  // Number of contributing JSONL transcript files (parent + each subagent file
+  // counted separately). Distinct from the "session" scope used for excess
+  // computation, which groups a parent and all its subagents together.
+  transcripts: number
   unknownModels: Set<string>
   files: string[]
 }
@@ -69,34 +72,22 @@ function emptyReport(): NickReport {
     byModel: new Map(),
     excessByModel: new Map(),
     apiDurationMs: 0,
-    sessions: 0,
+    transcripts: 0,
     unknownModels: new Set(),
     files: [],
   }
 }
 
-function addToModel(report: NickReport, model: string, u: UsageCounts): void {
-  const cur = report.byModel.get(model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
+// Single accumulator for all three UsageCounts merge sites (addToModel,
+// mergeUsageMap, and the inline loop in scanFile were all identical).
+function addToUsageMap(into: Map<string, UsageCounts>, model: string, u: UsageCounts): void {
+  const cur = into.get(model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
   cur.input += u.input
   cur.output += u.output
   cur.cache_creation_5m += u.cache_creation_5m
   cur.cache_creation_1h += u.cache_creation_1h
   cur.cache_read += u.cache_read
-  report.byModel.set(model, cur)
-}
-
-// Merge one model usage map into another (used to accumulate per-session totals
-// before computing excess).
-function mergeUsageMap(into: Map<string, UsageCounts>, from: Map<string, UsageCounts>): void {
-  for (const [model, u] of from) {
-    const cur = into.get(model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
-    cur.input += u.input
-    cur.output += u.output
-    cur.cache_creation_5m += u.cache_creation_5m
-    cur.cache_creation_1h += u.cache_creation_1h
-    cur.cache_read += u.cache_read
-    into.set(model, cur)
-  }
+  into.set(model, cur)
 }
 
 // For each model in the session map, compute the excess creation tokens
@@ -265,13 +256,7 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
       // A purely-empty usage row contributes nothing — skip so an idle
       // session doesn't get tagged as "contributed".
       if (tokens.input || tokens.output || tokens.cache_creation_5m || tokens.cache_creation_1h || tokens.cache_read) {
-        const cur = byModel.get(row.message.model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
-        cur.input += tokens.input
-        cur.output += tokens.output
-        cur.cache_creation_5m += tokens.cache_creation_5m
-        cur.cache_creation_1h += tokens.cache_creation_1h
-        cur.cache_read += tokens.cache_read
-        byModel.set(row.message.model, cur)
+        addToUsageMap(byModel, row.message.model, tokens)
         if (costFor(row.message.model, tokens) === null) {
           unknownModels.add(row.message.model)
         }
@@ -330,8 +315,8 @@ export async function collectForNick(
     const sessionByModel = new Map<string, UsageCounts>()
 
     const result = scanFile(text, seenRequestIds, seenTurnUuids, sinceTs)
-    if (result.contributed) report.sessions += 1
-    mergeUsageMap(sessionByModel, result.byModel)
+    if (result.contributed) report.transcripts += 1
+    for (const [m, u] of result.byModel) addToUsageMap(sessionByModel, m, u)
     report.apiDurationMs += result.apiDurationMs
     if (result.wallFirst) trackTs(report, result.wallFirst)
     if (result.wallLast) trackTs(report, result.wallLast)
@@ -348,11 +333,10 @@ export async function collectForNick(
       }
       report.files.push(sub)
       const subResult = scanFile(subText, seenRequestIds, seenTurnUuids, sinceTs, true)
-      // Each contributing subagent file counts as a separate session — a
-      // worker that fires off three Task subagents shows `sessions: 4`
-      // (parent + 3), which matches the "files scanned" mental model.
-      if (subResult.contributed) report.sessions += 1
-      mergeUsageMap(sessionByModel, subResult.byModel)
+      // Each contributing subagent file increments transcripts independently —
+      // a worker that fires 3 Task subagents shows `transcripts: 4` (parent + 3).
+      if (subResult.contributed) report.transcripts += 1
+      for (const [m, u] of subResult.byModel) addToUsageMap(sessionByModel, m, u)
       report.apiDurationMs += subResult.apiDurationMs
       if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
       if (subResult.wallLast) trackTs(report, subResult.wallLast)
@@ -360,7 +344,7 @@ export async function collectForNick(
     }
 
     // Merge session totals into the nick-level report and compute excess.
-    for (const [model, u] of sessionByModel) addToModel(report, model, u)
+    for (const [model, u] of sessionByModel) addToUsageMap(report.byModel, model, u)
     accumulateExcess(report, sessionByModel)
   }
   return report
@@ -437,7 +421,7 @@ function formatNick(nick: string, r: NickReport): string {
       if (ec === null) totalExcess = null
       else totalExcess += ec
     }
-    const excStr = (ec !== null && ec !== 0) || ec === null ? `, ${fmtDollars(ec)} excess` : ''
+    const excStr = ec !== 0 ? `, ${fmtDollars(ec)} excess` : ''
 
     perModel.push({
       model,
@@ -449,8 +433,8 @@ function formatNick(nick: string, r: NickReport): string {
     wallMs = Date.parse(r.wallLast) - Date.parse(r.wallFirst)
     if (wallMs < 0) wallMs = 0
   }
-  const excessPart = (totalExcess !== null && totalExcess > 0) || totalExcess === null
-    ? ` · ${fmtDollars(totalExcess)} excess`
+  const excessPart = totalExcess === null || totalExcess > 0
+    ? ` (${fmtDollars(totalExcess)} excess)`
     : ''
   const head = `${nick}: ${fmtDollars(totalCost)}${excessPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
   if (perModel.length === 0) {
@@ -467,7 +451,7 @@ Subcommands:
              <stateDir>/token-snapshots.json. Subsequent reports for the
              same <issue> only count turns after this time.
   report     For each nick, print a multi-line cost report:
-                <nick>: $X.XX · $Y.YY excess · 18m57s api / 44m42s wall
+                <nick>: $X.XX ($Y.YY excess) · 18m57s api / 44m42s wall
                   <model>: in/out/cache_r/cache_w  ($X.XX, $Y.YY excess)
              If a snapshot exists for <issue>+<nick>, only in-window turns
              count; otherwise the full transcript cumulative is reported.

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -38,12 +38,17 @@ import { readFile, mkdir, rename, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { mcpConnectionLine } from './mcp-banner.js'
-import { costFor, type UsageCounts } from './pricing.js'
+import { costFor, excessCreationCost, type UsageCounts } from './pricing.js'
 
 type ModelUsage = UsageCounts
 
 interface NickReport {
   byModel: Map<string, ModelUsage>
+  // Excess cache creation per model, summed across sessions. "Excess" = the
+  // portion of cache_creation that exceeded cache_read within a single session
+  // — tokens written but never read back. Computed per-session (not in aggregate)
+  // so a wasted write in one session isn't masked by reads in another.
+  excessByModel: Map<string, { excess5m: number; excess1h: number }>
   apiDurationMs: number
   wallFirst?: string
   wallLast?: string
@@ -62,6 +67,7 @@ interface SnapshotFile {
 function emptyReport(): NickReport {
   return {
     byModel: new Map(),
+    excessByModel: new Map(),
     apiDurationMs: 0,
     sessions: 0,
     unknownModels: new Set(),
@@ -77,6 +83,36 @@ function addToModel(report: NickReport, model: string, u: UsageCounts): void {
   cur.cache_creation_1h += u.cache_creation_1h
   cur.cache_read += u.cache_read
   report.byModel.set(model, cur)
+}
+
+// Merge one model usage map into another (used to accumulate per-session totals
+// before computing excess).
+function mergeUsageMap(into: Map<string, UsageCounts>, from: Map<string, UsageCounts>): void {
+  for (const [model, u] of from) {
+    const cur = into.get(model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
+    cur.input += u.input
+    cur.output += u.output
+    cur.cache_creation_5m += u.cache_creation_5m
+    cur.cache_creation_1h += u.cache_creation_1h
+    cur.cache_read += u.cache_read
+    into.set(model, cur)
+  }
+}
+
+// For each model in the session map, compute the excess creation tokens
+// (max(0, creation_total - cache_read)) and accumulate into report.excessByModel.
+// The excess is split between tiers proportionally to their share of creation.
+function accumulateExcess(report: NickReport, sessionByModel: Map<string, UsageCounts>): void {
+  for (const [model, u] of sessionByModel) {
+    const creationTotal = u.cache_creation_5m + u.cache_creation_1h
+    const excess = Math.max(0, creationTotal - u.cache_read)
+    if (excess === 0 || creationTotal === 0) continue
+    const ratio5m = u.cache_creation_5m / creationTotal
+    const cur = report.excessByModel.get(model) ?? { excess5m: 0, excess1h: 0 }
+    cur.excess5m += excess * ratio5m
+    cur.excess1h += excess * (1 - ratio5m)
+    report.excessByModel.set(model, cur)
+  }
 }
 
 function trackTs(report: NickReport, ts: string): void {
@@ -147,7 +183,18 @@ interface AnyRow {
   }
 }
 
-// Walk one JSONL file, accumulate into `report`. Only rows with
+// Per-file scan result returned by scanFile. The caller merges these into the
+// session-level and nick-level accumulators.
+interface ScanResult {
+  byModel: Map<string, UsageCounts>
+  apiDurationMs: number
+  wallFirst?: string
+  wallLast?: string
+  unknownModels: Set<string>
+  contributed: boolean
+}
+
+// Walk one JSONL file and return its token usage. Only rows with
 // `timestamp > sinceTs` (when sinceTs is set) contribute. `seenRequestIds`
 // is shared across files so the same API call (one requestId) is only
 // counted once — Claude Code writes one assistant row per content block
@@ -158,10 +205,20 @@ interface AnyRow {
 // their full transcripts live in `PROJECT/SESSION/subagents/agent-*.jsonl`
 // (scanned separately with `countSidechain: true`), so this is defensive
 // — older or future shapes that inline sidechain rows in the parent are
-// filtered here to avoid double-counting. Returns whether the file
-// contributed at all (used as the session-counter signal).
-function scanFile(text: string, report: NickReport, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string, countSidechain = false): boolean {
+// filtered here to avoid double-counting.
+function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
+  const byModel = new Map<string, UsageCounts>()
+  let apiDurationMs = 0
+  let wallFirst: string | undefined
+  let wallLast: string | undefined
+  const unknownModels = new Set<string>()
   let contributed = false
+
+  const trackLocal = (ts: string) => {
+    if (!wallFirst || ts < wallFirst) wallFirst = ts
+    if (!wallLast || ts > wallLast) wallLast = ts
+  }
+
   for (const line of text.split('\n')) {
     if (!line) continue
     let row: AnyRow
@@ -208,11 +265,17 @@ function scanFile(text: string, report: NickReport, seenRequestIds: Set<string>,
       // A purely-empty usage row contributes nothing — skip so an idle
       // session doesn't get tagged as "contributed".
       if (tokens.input || tokens.output || tokens.cache_creation_5m || tokens.cache_creation_1h || tokens.cache_read) {
-        addToModel(report, row.message.model, tokens)
+        const cur = byModel.get(row.message.model) ?? { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
+        cur.input += tokens.input
+        cur.output += tokens.output
+        cur.cache_creation_5m += tokens.cache_creation_5m
+        cur.cache_creation_1h += tokens.cache_creation_1h
+        cur.cache_read += tokens.cache_read
+        byModel.set(row.message.model, cur)
         if (costFor(row.message.model, tokens) === null) {
-          report.unknownModels.add(row.message.model)
+          unknownModels.add(row.message.model)
         }
-        if (ts) trackTs(report, ts)
+        if (ts) trackLocal(ts)
         contributed = true
       }
       continue
@@ -227,13 +290,13 @@ function scanFile(text: string, report: NickReport, seenRequestIds: Set<string>,
         if (seenTurnUuids.has(row.uuid)) continue
         seenTurnUuids.add(row.uuid)
       }
-      report.apiDurationMs += row.durationMs
-      if (ts) trackTs(report, ts)
+      apiDurationMs += row.durationMs
+      if (ts) trackLocal(ts)
       contributed = true
       continue
     }
   }
-  return contributed
+  return { byModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed }
 }
 
 export async function collectForNick(
@@ -259,8 +322,20 @@ export async function collectForNick(
     // skip the parse entirely.
     if (!text.includes(marker)) continue
     report.files.push(f)
-    const contributed = scanFile(text, report, seenRequestIds, seenTurnUuids, sinceTs)
-    if (contributed) report.sessions += 1
+
+    // Accumulate parent + all subagents into a session-level map before
+    // merging into the nick-level report. This lets us compute per-session
+    // excess creation (writes that weren't read back within the session)
+    // without cross-session reads masking the waste.
+    const sessionByModel = new Map<string, UsageCounts>()
+
+    const result = scanFile(text, seenRequestIds, seenTurnUuids, sinceTs)
+    if (result.contributed) report.sessions += 1
+    mergeUsageMap(sessionByModel, result.byModel)
+    report.apiDurationMs += result.apiDurationMs
+    if (result.wallFirst) trackTs(report, result.wallFirst)
+    if (result.wallLast) trackTs(report, result.wallLast)
+    for (const m of result.unknownModels) report.unknownModels.add(m)
 
     // Subagent transcripts: same nick, billed by directory locality.
     const subagentFiles = await listSubagentFiles(f)
@@ -272,12 +347,21 @@ export async function collectForNick(
         continue
       }
       report.files.push(sub)
-      const subContributed = scanFile(subText, report, seenRequestIds, seenTurnUuids, sinceTs, true)
+      const subResult = scanFile(subText, seenRequestIds, seenTurnUuids, sinceTs, true)
       // Each contributing subagent file counts as a separate session — a
       // worker that fires off three Task subagents shows `sessions: 4`
       // (parent + 3), which matches the "files scanned" mental model.
-      if (subContributed) report.sessions += 1
+      if (subResult.contributed) report.sessions += 1
+      mergeUsageMap(sessionByModel, subResult.byModel)
+      report.apiDurationMs += subResult.apiDurationMs
+      if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
+      if (subResult.wallLast) trackTs(report, subResult.wallLast)
+      for (const m of subResult.unknownModels) report.unknownModels.add(m)
     }
+
+    // Merge session totals into the nick-level report and compute excess.
+    for (const [model, u] of sessionByModel) addToModel(report, model, u)
+    accumulateExcess(report, sessionByModel)
   }
   return report
 }
@@ -335,6 +419,7 @@ function shortModel(model: string): string {
 
 function formatNick(nick: string, r: NickReport): string {
   let totalCost: number | null = 0
+  let totalExcess: number | null = 0
   const perModel: Array<{ model: string; line: string }> = []
   // Stable order so output is reproducible across runs.
   const models = [...r.byModel.keys()].sort()
@@ -345,9 +430,18 @@ function formatNick(nick: string, r: NickReport): string {
       if (c === null) totalCost = null
       else totalCost += c
     }
+
+    const exc = r.excessByModel.get(model)
+    const ec = exc ? excessCreationCost(model, exc.excess5m, exc.excess1h) : 0
+    if (totalExcess !== null) {
+      if (ec === null) totalExcess = null
+      else totalExcess += ec
+    }
+    const excStr = (ec !== null && ec !== 0) || ec === null ? `, ${fmtDollars(ec)} excess` : ''
+
     perModel.push({
       model,
-      line: `  ${shortModel(model)}: ${fmtTokens(u.input)} in / ${fmtTokens(u.output)} out / ${fmtTokens(u.cache_read)} cache_r / ${fmtTokens(u.cache_creation_5m)} cache_w_5m / ${fmtTokens(u.cache_creation_1h)} cache_w_1h  (${fmtDollars(c)})`,
+      line: `  ${shortModel(model)}: ${fmtTokens(u.input)} in / ${fmtTokens(u.output)} out / ${fmtTokens(u.cache_read)} cache_r / ${fmtTokens(u.cache_creation_5m)} cache_w_5m / ${fmtTokens(u.cache_creation_1h)} cache_w_1h  (${fmtDollars(c)}${excStr})`,
     })
   }
   let wallMs = 0
@@ -355,7 +449,10 @@ function formatNick(nick: string, r: NickReport): string {
     wallMs = Date.parse(r.wallLast) - Date.parse(r.wallFirst)
     if (wallMs < 0) wallMs = 0
   }
-  const head = `${nick}: ${fmtDollars(totalCost)} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
+  const excessPart = (totalExcess !== null && totalExcess > 0) || totalExcess === null
+    ? ` · ${fmtDollars(totalExcess)} excess`
+    : ''
+  const head = `${nick}: ${fmtDollars(totalCost)}${excessPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
   if (perModel.length === 0) {
     return `${head}\n  (no in-window activity)`
   }
@@ -370,10 +467,13 @@ Subcommands:
              <stateDir>/token-snapshots.json. Subsequent reports for the
              same <issue> only count turns after this time.
   report     For each nick, print a multi-line cost report:
-                <nick>: $X.XX · 18m57s api / 44m42s wall
-                  <model>: in/out/cache_r/cache_w  ($X.XX)
+                <nick>: $X.XX · $Y.YY excess · 18m57s api / 44m42s wall
+                  <model>: in/out/cache_r/cache_w  ($X.XX, $Y.YY excess)
              If a snapshot exists for <issue>+<nick>, only in-window turns
              count; otherwise the full transcript cumulative is reported.
+             "excess" = cost of cache writes that exceeded cache reads within
+             each session (a lower bound — only intra-session waste is
+             detected; reads in one session don't offset writes in another).
 
 Cost is an estimate. Unknown model IDs render '$?' and emit a stderr
 warning; update src/pricing.ts to add them.

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -30,6 +30,8 @@ interface Turn {
   // If true, mark the assistant row (and any paired turn_duration row)
   // with isSidechain:true.
   sidechain?: boolean
+  // Optional cache miss reason — writes message.diagnostics.cache_miss_reason.
+  cacheMissReason?: { type: string; cache_missed_input_tokens: number }
 }
 
 // Render one Turn into the (up to two) JSONL rows Claude Code emits:
@@ -54,10 +56,12 @@ function turnRows(t: Turn, forceSidechain = false): string[] {
     usage.cache_creation_input_tokens = t.cache_w ?? 0
   }
   const sidechain = forceSidechain || t.sidechain === true
+  const msg: Record<string, unknown> = { role: 'assistant', model: t.model, usage }
+  if (t.cacheMissReason) msg.diagnostics = { cache_miss_reason: t.cacheMissReason }
   const assist: Record<string, unknown> = {
     type: 'assistant',
     timestamp: t.ts,
-    message: { role: 'assistant', model: t.model, usage },
+    message: msg,
   }
   if (t.requestId) assist.requestId = t.requestId
   if (sidechain) assist.isSidechain = true
@@ -457,82 +461,74 @@ describe('token-usage', () => {
       expect(r.apiDurationMs).toBe(333)
     })
 
-    it('computes excess creation when cache writes exceed reads within a session', async () => {
+    it('parses cache_miss_reason from assistant row', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // creation_5m=1M, read=400k → excess=600k (all 5m tier)
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 400_000 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5,
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 16_200 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      const exc = r.excessByModel.get('claude-opus-4-7')!
-      expect(exc.excess5m).toBeCloseTo(600_000)
-      expect(exc.excess1h).toBeCloseTo(0)
+      const miss = r.missByModel.get('claude-opus-4-7')!
+      expect(miss.get('tools_changed')).toBe(16_200)
     })
 
-    it('records no excess when reads meet or exceed creation', async () => {
+    it('dedups miss data by requestId — same API call counted once', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // creation=1M, read=1.5M → no excess
+      // Three rows sharing a requestId (multi-part response) — miss should count once.
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 1_500_000 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_A',
+          cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 50_000 } },
+        { ts: '2026-05-16T10:00:01Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_A',
+          cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 50_000 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      expect(r.excessByModel.get('claude-opus-4-7')).toBeUndefined()
+      const miss = r.missByModel.get('claude-opus-4-7')!
+      expect(miss.get('system_changed')).toBe(50_000)
     })
 
-    it('isolates excess per session: reads in session B do not offset writes in session A', async () => {
-      // This is the key regression guard for the per-session approach vs aggregate.
-      // Session A: write 1M, read 100k → excess 900k
-      // Session B: write 200k, read 500k → excess 0 (efficient)
-      // Per-session total: 900k excess
-      // Aggregate would be: creation=1.2M, read=0.6M → 600k (undercounts A's waste)
-      const a = join(projects, '-pa')
-      const b = join(projects, '-pb')
-      await mkdir(a, { recursive: true })
-      await mkdir(b, { recursive: true })
-      await writeSessionFile(a, 's1.jsonl', 'roost-lead-pm', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 100_000 },
-      ])
-      await writeSessionFile(b, 's2.jsonl', 'roost-lead-pm', [
-        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 200_000, cache_r: 500_000 },
-      ])
-      const r = await collectForNick('roost-lead-pm', projects)
-      const exc = r.excessByModel.get('claude-opus-4-7')!
-      // Should be 900k (from session A), not 600k (aggregate) or 0 (fully masked)
-      expect(exc.excess5m).toBeCloseTo(900_000)
-      expect(exc.excess1h).toBeCloseTo(0)
-    })
-
-    it('splits excess between 5m and 1h tiers proportionally to creation mix', async () => {
+    it('accumulates miss tokens across multiple calls with different reasons', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // creation_5m=600k, creation_1h=400k, read=500k → excess=500k
-      // 5m share=60%, 1h share=40% → excess5m=300k, excess1h=200k
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 600_000, cache_w_1h: 400_000, cache_r: 500_000 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_1',
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 16_000 } },
+        { ts: '2026-05-16T10:01:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_2',
+          cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 112_000 } },
+        { ts: '2026-05-16T10:02:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_3',
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 8_000 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      const exc = r.excessByModel.get('claude-opus-4-7')!
-      expect(exc.excess5m).toBeCloseTo(300_000)
-      expect(exc.excess1h).toBeCloseTo(200_000)
+      const miss = r.missByModel.get('claude-opus-4-7')!
+      expect(miss.get('tools_changed')).toBe(24_000)
+      expect(miss.get('system_changed')).toBe(112_000)
     })
 
-    it('subagents and parent are combined for session-level excess', async () => {
+    it('miss data from subagent files flows to parent nick report', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // Parent: write 500k, read 0 → contributes 500k to session creation
-      // Subagent: write 300k, read 900k → contributes 300k creation, 900k read
-      // Session total: creation=800k, read=900k → no excess (reads exceed writes combined)
       const parent = await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 0 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_parent',
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 5_000 } },
       ])
       await writeSubagentFile(parent, 'aaa6666666666666a', [
-        { ts: '2026-05-16T10:01:00Z', model: 'claude-opus-4-7', cache_w_5m: 300_000, cache_r: 900_000 },
+        { ts: '2026-05-16T10:01:00Z', model: 'claude-haiku-4-5-20251001', input: 8, output: 4, requestId: 'req_sub',
+          cacheMissReason: { type: 'messages_changed', cache_missed_input_tokens: 3_000 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      // Combined: creation=800k, read=900k → no excess
-      expect(r.excessByModel.get('claude-opus-4-7')).toBeUndefined()
+      expect(r.missByModel.get('claude-opus-4-7')!.get('tools_changed')).toBe(5_000)
+      expect(r.missByModel.get('claude-haiku-4-5-20251001')!.get('messages_changed')).toBe(3_000)
+    })
+
+    it('no miss entry when diagnostics field is absent', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      expect(r.missByModel.size).toBe(0)
     })
   })
 
@@ -691,50 +687,55 @@ describe('token-usage', () => {
       expect(rep.out).toContain('(no in-window activity)')
     })
 
-    it('shows excess creation cost in per-model line and header when nonzero', async () => {
+    it('shows miss cost in per-model line and header when nonzero', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // Session: creation_5m=1M (Opus 4.7), read=0 → excess=1M
-      // Excess cost = 1M × $6.25/M = $6.25
+      // tools_changed miss: 1M tokens, opus-4-7 premium = ($6.25 - $0.50)/M = $5.75/M
+      // miss cost = 1M × $5.75/M = $5.75
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 0 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_1',
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 1_000_000 } },
       ])
       const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
       expect(rep.result).toBe(0)
-      // Header: shows excess
-      expect(rep.out).toContain('$6.25 excess')
-      // Per-model line: shows excess after the cost
-      expect(rep.out).toMatch(/opus-4-7:.*\$6\.25.*\$6\.25 excess/)
+      // Header shows total miss cost
+      expect(rep.out).toContain('$5.75 miss')
+      // Per-model line shows miss breakdown
+      expect(rep.out).toMatch(/opus-4-7:.*miss: 1\.0M \(\$5\.75\) \[tools_changed 1\.0M \(\$5\.75\)\]/)
     })
 
-    it('omits excess from header and per-model line when all creation is read back', async () => {
+    it('omits miss from header and per-model line when no cache misses', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // creation=500k, read=1M → read exceeds creation, no excess
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 1_000_000 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5 },
       ])
       const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
       expect(rep.result).toBe(0)
-      expect(rep.out).not.toContain('excess')
+      expect(rep.out).not.toContain('miss')
     })
 
-    it('excess is summed across sessions per nick', async () => {
+    it('miss costs are summed across sessions and reasons per nick', async () => {
       const a = join(projects, '-pa')
       const b = join(projects, '-pb')
       await mkdir(a, { recursive: true })
       await mkdir(b, { recursive: true })
-      // Session A: creation=1M, read=0 → excess=1M → $6.25
+      // Session A: tools_changed 500k tokens → $5.75/M × 500k = $2.875
       await writeSessionFile(a, 's1.jsonl', 'roost-lead-pm', [
-        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 0 },
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_A',
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 500_000 } },
       ])
-      // Session B: creation=500k, read=200k → excess=300k → $1.875 ≈ $1.88
+      // Session B: system_changed 200k tokens → $5.75/M × 200k = $1.15
       await writeSessionFile(b, 's2.jsonl', 'roost-lead-pm', [
-        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 200_000 },
+        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_B',
+          cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 200_000 } },
       ])
       const rep = await capture(() => main(['report', stateDir, '339', 'roost-lead-pm']))
-      // Total excess: (1M + 300k) × $6.25/M = $8.125 → $8.13
-      expect(rep.out).toContain('$8.13 excess')
+      // Total miss: 700k tokens → $5.75/M × 700k = $4.025 → $4.03 (rounding)
+      expect(rep.out).toContain('$4.03 miss')
+      // Both reasons appear in the per-model line, system_changed first (larger cost after sorting by tokens)
+      expect(rep.out).toContain('tools_changed')
+      expect(rep.out).toContain('system_changed')
     })
   })
 })

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -184,7 +184,7 @@ describe('token-usage', () => {
       expect(sonnet.input).toBe(20)
       expect(sonnet.output).toBe(7)
       expect(r.apiDurationMs).toBe(5500)
-      expect(r.sessions).toBe(2)
+      expect(r.transcripts).toBe(2)
       expect(r.wallFirst).toBe('2026-05-16T10:00:00Z')
       expect(r.wallLast).toBe('2026-05-16T11:00:00Z')
       expect(r.files).toHaveLength(2)
@@ -208,7 +208,7 @@ describe('token-usage', () => {
       await writeSessionFile(d, 's.jsonl', 'someone-else', [{ ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 5, output: 5 }])
       const r = await collectForNick('roost-worker-missing', projects)
       expect(r.byModel.size).toBe(0)
-      expect(r.sessions).toBe(0)
+      expect(r.transcripts).toBe(0)
       expect(r.files).toEqual([])
     })
 
@@ -236,7 +236,7 @@ describe('token-usage', () => {
       await writeFile(path, [banner, '{garbage', goodTurn, '"usage": this is not json', ''].join('\n'))
       const r = await collectForNick('roost-x', projects)
       expect(r.byModel.get('claude-opus-4-7')!.input).toBe(8)
-      expect(r.sessions).toBe(1)
+      expect(r.transcripts).toBe(1)
     })
 
     it('sinceTs filter excludes pre-window turns', async () => {
@@ -251,7 +251,7 @@ describe('token-usage', () => {
       expect(opus.input).toBe(50)
       expect(opus.output).toBe(25)
       expect(r.apiDurationMs).toBe(2_000)
-      expect(r.sessions).toBe(1)
+      expect(r.transcripts).toBe(1)
     })
 
     it('tracks unknown models for later warning', async () => {
@@ -370,7 +370,7 @@ describe('token-usage', () => {
       expect(haiku.output).toBe(100)
       expect(r.apiDurationMs).toBe(3200)
       // sessions counts parent + the contributing subagent file.
-      expect(r.sessions).toBe(2)
+      expect(r.transcripts).toBe(2)
       expect(r.files).toHaveLength(2)
       // Wall extends across both.
       expect(r.wallFirst).toBe('2026-05-16T10:00:00Z')

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -456,6 +456,84 @@ describe('token-usage', () => {
       expect(haiku.output).toBe(22)
       expect(r.apiDurationMs).toBe(333)
     })
+
+    it('computes excess creation when cache writes exceed reads within a session', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // creation_5m=1M, read=400k → excess=600k (all 5m tier)
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 400_000 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const exc = r.excessByModel.get('claude-opus-4-7')!
+      expect(exc.excess5m).toBeCloseTo(600_000)
+      expect(exc.excess1h).toBeCloseTo(0)
+    })
+
+    it('records no excess when reads meet or exceed creation', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // creation=1M, read=1.5M → no excess
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 1_500_000 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      expect(r.excessByModel.get('claude-opus-4-7')).toBeUndefined()
+    })
+
+    it('isolates excess per session: reads in session B do not offset writes in session A', async () => {
+      // This is the key regression guard for the per-session approach vs aggregate.
+      // Session A: write 1M, read 100k → excess 900k
+      // Session B: write 200k, read 500k → excess 0 (efficient)
+      // Per-session total: 900k excess
+      // Aggregate would be: creation=1.2M, read=0.6M → 600k (undercounts A's waste)
+      const a = join(projects, '-pa')
+      const b = join(projects, '-pb')
+      await mkdir(a, { recursive: true })
+      await mkdir(b, { recursive: true })
+      await writeSessionFile(a, 's1.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 100_000 },
+      ])
+      await writeSessionFile(b, 's2.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 200_000, cache_r: 500_000 },
+      ])
+      const r = await collectForNick('roost-lead-pm', projects)
+      const exc = r.excessByModel.get('claude-opus-4-7')!
+      // Should be 900k (from session A), not 600k (aggregate) or 0 (fully masked)
+      expect(exc.excess5m).toBeCloseTo(900_000)
+      expect(exc.excess1h).toBeCloseTo(0)
+    })
+
+    it('splits excess between 5m and 1h tiers proportionally to creation mix', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // creation_5m=600k, creation_1h=400k, read=500k → excess=500k
+      // 5m share=60%, 1h share=40% → excess5m=300k, excess1h=200k
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 600_000, cache_w_1h: 400_000, cache_r: 500_000 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const exc = r.excessByModel.get('claude-opus-4-7')!
+      expect(exc.excess5m).toBeCloseTo(300_000)
+      expect(exc.excess1h).toBeCloseTo(200_000)
+    })
+
+    it('subagents and parent are combined for session-level excess', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Parent: write 500k, read 0 → contributes 500k to session creation
+      // Subagent: write 300k, read 900k → contributes 300k creation, 900k read
+      // Session total: creation=800k, read=900k → no excess (reads exceed writes combined)
+      const parent = await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 0 },
+      ])
+      await writeSubagentFile(parent, 'aaa6666666666666a', [
+        { ts: '2026-05-16T10:01:00Z', model: 'claude-opus-4-7', cache_w_5m: 300_000, cache_r: 900_000 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      // Combined: creation=800k, read=900k → no excess
+      expect(r.excessByModel.get('claude-opus-4-7')).toBeUndefined()
+    })
   })
 
   describe('main: snapshot + report', () => {
@@ -611,6 +689,52 @@ describe('token-usage', () => {
       expect(rep.out).toContain('roost-lead-pm: $0.00')
       expect(rep.out).toContain('roost-apm: $0.00')
       expect(rep.out).toContain('(no in-window activity)')
+    })
+
+    it('shows excess creation cost in per-model line and header when nonzero', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Session: creation_5m=1M (Opus 4.7), read=0 → excess=1M
+      // Excess cost = 1M × $6.25/M = $6.25
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 0 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
+      expect(rep.result).toBe(0)
+      // Header: shows excess
+      expect(rep.out).toContain('$6.25 excess')
+      // Per-model line: shows excess after the cost
+      expect(rep.out).toMatch(/opus-4-7:.*\$6\.25.*\$6\.25 excess/)
+    })
+
+    it('omits excess from header and per-model line when all creation is read back', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // creation=500k, read=1M → read exceeds creation, no excess
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 1_000_000 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
+      expect(rep.result).toBe(0)
+      expect(rep.out).not.toContain('excess')
+    })
+
+    it('excess is summed across sessions per nick', async () => {
+      const a = join(projects, '-pa')
+      const b = join(projects, '-pb')
+      await mkdir(a, { recursive: true })
+      await mkdir(b, { recursive: true })
+      // Session A: creation=1M, read=0 → excess=1M → $6.25
+      await writeSessionFile(a, 's1.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 1_000_000, cache_r: 0 },
+      ])
+      // Session B: creation=500k, read=200k → excess=300k → $1.875 ≈ $1.88
+      await writeSessionFile(b, 's2.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', cache_w_5m: 500_000, cache_r: 200_000 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '339', 'roost-lead-pm']))
+      // Total excess: (1M + 300k) × $6.25/M = $8.125 → $8.13
+      expect(rep.out).toContain('$8.13 excess')
     })
   })
 })

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -464,19 +464,22 @@ describe('token-usage', () => {
     it('parses cache_miss_reason from assistant row', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
+      // No cache_w → creation total = 0 → falls back to all 5m tier.
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
         { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5,
           cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 16_200 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      const miss = r.missByModel.get('claude-opus-4-7')!
-      expect(miss.get('tools_changed')).toBe(16_200)
+      const entry = r.missByModel.get('claude-opus-4-7')!.get('tools_changed')!
+      expect(entry.tokens5m + entry.tokens1h).toBe(16_200)
+      expect(entry.tokens5m).toBe(16_200)
+      expect(entry.tokens1h).toBe(0)
     })
 
     it('dedups miss data by requestId — same API call counted once', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // Three rows sharing a requestId (multi-part response) — miss should count once.
+      // Two rows sharing a requestId (multi-part response) — miss should count once.
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
         { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, requestId: 'req_A',
           cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 50_000 } },
@@ -484,8 +487,8 @@ describe('token-usage', () => {
           cacheMissReason: { type: 'system_changed', cache_missed_input_tokens: 50_000 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      const miss = r.missByModel.get('claude-opus-4-7')!
-      expect(miss.get('system_changed')).toBe(50_000)
+      const entry = r.missByModel.get('claude-opus-4-7')!.get('system_changed')!
+      expect(entry.tokens5m + entry.tokens1h).toBe(50_000)
     })
 
     it('accumulates miss tokens across multiple calls with different reasons', async () => {
@@ -501,8 +504,10 @@ describe('token-usage', () => {
       ])
       const r = await collectForNick('roost-x', projects)
       const miss = r.missByModel.get('claude-opus-4-7')!
-      expect(miss.get('tools_changed')).toBe(24_000)
-      expect(miss.get('system_changed')).toBe(112_000)
+      const tc = miss.get('tools_changed')!
+      expect(tc.tokens5m + tc.tokens1h).toBe(24_000)
+      const sc = miss.get('system_changed')!
+      expect(sc.tokens5m + sc.tokens1h).toBe(112_000)
     })
 
     it('miss data from subagent files flows to parent nick report', async () => {
@@ -517,8 +522,10 @@ describe('token-usage', () => {
           cacheMissReason: { type: 'messages_changed', cache_missed_input_tokens: 3_000 } },
       ])
       const r = await collectForNick('roost-x', projects)
-      expect(r.missByModel.get('claude-opus-4-7')!.get('tools_changed')).toBe(5_000)
-      expect(r.missByModel.get('claude-haiku-4-5-20251001')!.get('messages_changed')).toBe(3_000)
+      const opusEntry = r.missByModel.get('claude-opus-4-7')!.get('tools_changed')!
+      expect(opusEntry.tokens5m + opusEntry.tokens1h).toBe(5_000)
+      const haikuEntry = r.missByModel.get('claude-haiku-4-5-20251001')!.get('messages_changed')!
+      expect(haikuEntry.tokens5m + haikuEntry.tokens1h).toBe(3_000)
     })
 
     it('no miss entry when diagnostics field is absent', async () => {
@@ -529,6 +536,22 @@ describe('token-usage', () => {
       ])
       const r = await collectForNick('roost-x', projects)
       expect(r.missByModel.size).toBe(0)
+    })
+
+    it('splits miss tokens by creation tier from the same row', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // creation_5m=600k, creation_1h=400k → 60/40 split
+      // miss=1M → 600k at 5m premium, 400k at 1h premium
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', requestId: 'req_1',
+          cache_w_5m: 600_000, cache_w_1h: 400_000,
+          cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 1_000_000 } },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      const entry = r.missByModel.get('claude-opus-4-7')!.get('tools_changed')!
+      expect(entry.tokens5m).toBeCloseTo(600_000)
+      expect(entry.tokens1h).toBeCloseTo(400_000)
     })
   })
 
@@ -690,18 +713,19 @@ describe('token-usage', () => {
     it('shows miss cost in per-model line and header when nonzero', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
-      // tools_changed miss: 1M tokens, opus-4-7 premium = ($6.25 - $0.50)/M = $5.75/M
-      // miss cost = 1M × $5.75/M = $5.75
+      // tools_changed miss: 1M tokens at 1h creation tier (realistic — real data shows 1h)
+      // opus-4-7 1h miss premium = ($10 - $0.50)/M = $9.50/M → 1M × $9.50/M = $9.50
       await writeSessionFile(d, 's.jsonl', 'roost-x', [
         { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_1',
+          cache_w_1h: 1_000_000,
           cacheMissReason: { type: 'tools_changed', cache_missed_input_tokens: 1_000_000 } },
       ])
       const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
       expect(rep.result).toBe(0)
       // Header shows total miss cost
-      expect(rep.out).toContain('$5.75 miss')
+      expect(rep.out).toContain('$9.50 miss')
       // Per-model line shows miss breakdown
-      expect(rep.out).toMatch(/opus-4-7:.*miss: 1\.0M \(\$5\.75\) \[tools_changed 1\.0M \(\$5\.75\)\]/)
+      expect(rep.out).toMatch(/opus-4-7:.*miss: 1\.0M \(\$9\.50\) \[tools_changed 1\.0M \(\$9\.50\)\]/)
     })
 
     it('omits miss from header and per-model line when no cache misses', async () => {


### PR DESCRIPTION
Closes #339

Adds per-session excess creation tracking to the token-usage report. "Excess creation" = cache writes that exceeded reads within a session — the lower-bound cost of cache that was written but never read back.

**Key design:** computed per-session (parent + subagents combined), not in aggregate. This matters for long-running nicks like lead-pm where aggregate reads in session B would mask wasted writes in session A — exactly the case where the metric is most needed.

**New output shape:**
```
roost-lead-pm: $14.38 · $5.62 excess · 18m57s api / 44m42s wall
  opus-4-7: 7.4k in / 63.4k out / 17.5M cache_r / 644.6k cache_w_5m / 0k cache_w_1h  ($14.38, $5.62 excess)
```
Zero excess is silent — no output change for healthy sessions.

**What "excess" is and isn't:** it's `max(0, session_creation - session_read)` per model per session, summed. It's a lower bound — intra-session waste only. Named "excess" throughout (not "cache miss") since it's a derived proxy.

**Pricing split:** excess is split between 5m/1h tiers proportionally to the session's creation mix, so the blended cost uses the correct per-tier rate.

8 new tests covering: excess detection, no-excess case, cross-session isolation (the aggregate-masking scenario), tier proportional split, subagent + parent combined for session-level excess, and output format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)