### PR TITLE
maint: bump package.json to 0.5.12 ahead of v0.5.12 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump package.json from 0.5.11 to 0.5.12 ahead of the v0.5.12 tag
- Picks up the cache-miss cost reporting from #355 (the reason alex asked for the cut)

## Test plan
- [ ] CI green
- [ ] After merge, tag v0.5.12 from main and let the release workflow ship the GH release + tap bump