### PR TITLE
docs: hand off release mechanics to APM in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,23 @@ Roost is a Claude Code plugin. Hook scripts live in `bin/` inside the plugin roo
 
 ## Releasing
 
-To cut a release:
+In this repo the APM owns the release mechanics. Lead-pm decides *when* to cut and *which* version; APM types the commands.
 
-1. Bump `package.json` version on a `maint/bump-version-X.Y.Z` branch, PR, merge.
-2. From main, after the bump merges: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-3. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
-4. Watch the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI).
-5. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code.
+The dance:
+
+1. Lead-pm mentions APM in `#roost-leads`: `<project>-apm cut vX.Y.Z`.
+2. APM acks: `bump <old> → vX.Y.Z, branch maint/bump-version-X.Y.Z, PR + add <human>; go?` Lead confirms.
+3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine).
+4. Human approves the bump PR (this is the safety gate — same as any PR).
+5. APM acks: `bump approved + CI green, merge + tag vX.Y.Z + push tag?` Lead confirms.
+6. APM merges the bump PR, pulls main in the primary worktree, runs `git tag vX.Y.Z && git push origin vX.Y.Z`, then cleans up the bump worktree.
+7. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
+8. APM watches the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI), and reports back in `#roost-leads`.
+9. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code (lead-pm flags this; not the APM's job).
 
 The version bump and the tag are separate steps — the workflow only fires on tag push, and only tags that don't contain a hyphen (so `v1.0.0-rc1` is skipped).
+
+What APM does NOT own: deciding when to release, deciding the version number, force-pushing tags, or pushing direct to main.
 
 ## Committing
 


### PR DESCRIPTION
## Summary
- Replace the linear "to cut a release" steps with the lead↔APM dance: lead decides when + version, APM types the commands
- Human PR approval stays the safety gate; tag push and tap-bump observation move to APM
- Explicit carve-outs: APM does NOT decide when/version, force-push tags, or push direct to main

Per alex in #roost-leads.

## Test plan
- [ ] Review wording against next actual release cycle to see if the dance maps cleanly