### PR TITLE
feat: GhPluginBase — thin shared base for GhClient-only plugins

### DIFF
--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -1,8 +1,13 @@
-// GhBase — shared scaffolding for the two GitHub plugins (PRs, issues).
-// Owns the agent-login set, the `<issue-channel> + entry.channels` collector,
-// and the convention that every GhBase plugin reads its watch list from a
-// `{ watched?: WatchedEntry[] }` slice under `config.plugins[name]`. Channel
-// resolution + default-channel fallback come from BasePlugin.
+// GhPluginBase — thin shared base for any plugin that needs GhClient but not
+// the watch-list scaffolding. Owns client construction and agentLogins().
+// GhBase (watch-list-flavored) extends this; non-watching plugins like
+// GitHubNewIssuesPlugin do too.
+//
+// GhBase — shared scaffolding for the two watch-list GitHub plugins (PRs, issues).
+// Owns the `<issue-channel> + entry.channels` collector and the convention that
+// every GhBase plugin reads its watch list from a `{ watched?: WatchedEntry[] }`
+// slice under `config.plugins[name]`. Channel resolution + default-channel
+// fallback come from BasePlugin.
 //
 // Also implements `handleCommand` for the two verbs both plugins support:
 // each subclass declares the target keyword it claims (`null` = bare
@@ -14,21 +19,7 @@ import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
 import { GhClient } from './github-api.js'
 
-interface GhPluginConfig {
-  watched?: WatchedEntry[]
-}
-
-export abstract class GhBase extends BasePlugin {
-  // Target keyword this plugin claims for watch/unwatch. `null` = no keyword
-  // (bare `watch <N>`). The dispatcher's parser is target-agnostic; plugins
-  // declare which keyword (if any) they own here.
-  protected abstract readonly target: string | null
-  // Singular noun used in reply lines (e.g. "issue", "pr"). Plural is the
-  // plugin name slice.
-  protected abstract readonly label: string
-
-  // Shared gh handle — owns the PluginLogger so individual fetch/snapshot/
-  // scrape callsites stay log-free.
+export abstract class GhPluginBase extends BasePlugin {
   protected readonly client: GhClient
 
   constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
@@ -39,6 +30,20 @@ export abstract class GhBase extends BasePlugin {
   protected agentLogins(config: OrchestratorConfig): Set<string> {
     return new Set(config.agent_logins ?? [])
   }
+}
+
+interface GhPluginConfig {
+  watched?: WatchedEntry[]
+}
+
+export abstract class GhBase extends GhPluginBase {
+  // Target keyword this plugin claims for watch/unwatch. `null` = no keyword
+  // (bare `watch <N>`). The dispatcher's parser is target-agnostic; plugins
+  // declare which keyword (if any) they own here.
+  protected abstract readonly target: string | null
+  // Singular noun used in reply lines (e.g. "issue", "pr"). Plural is the
+  // plugin name slice.
+  protected abstract readonly label: string
 
   // The plugin's `watched` list from `config.plugins[name].watched` — the
   // shared shape for every GhBase plugin.

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -1,17 +1,3 @@
-// GhPluginBase — thin shared base for any plugin that needs GhClient but not
-// the watch-list scaffolding. Owns client construction and agentLogins().
-// GhBase (watch-list-flavored) extends this; non-watching plugins like
-// GitHubNewIssuesPlugin do too.
-//
-// GhBase — shared scaffolding for the two watch-list GitHub plugins (PRs, issues).
-// Owns the `<issue-channel> + entry.channels` collector and the convention that
-// every GhBase plugin reads its watch list from a `{ watched?: WatchedEntry[] }`
-// slice under `config.plugins[name]`. Channel resolution + default-channel
-// fallback come from BasePlugin.
-//
-// Also implements `handleCommand` for the two verbs both plugins support:
-// each subclass declares the target keyword it claims (`null` = bare
-// `watch <N>`, `'pr'` = `watch pr <N>`) and a label used in reply text.
 import type { Command } from '../../dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
@@ -19,6 +5,9 @@ import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
 import { GhClient } from './github-api.js'
 
+// Thin shared base for any plugin that needs GhClient but not watch-list
+// scaffolding. GhBase extends this; non-watching plugins (e.g.
+// GitHubNewIssuesPlugin) extend it directly.
 export abstract class GhPluginBase extends BasePlugin {
   protected readonly client: GhClient
 
@@ -36,6 +25,10 @@ interface GhPluginConfig {
   watched?: WatchedEntry[]
 }
 
+// Watch-list scaffolding for the two GitHub plugins (PRs, issues). Owns the
+// `<issue-channel> + entry.channels` collector, `{ watched?: WatchedEntry[] }`
+// slice convention, and `handleCommand` for watch/unwatch/list/help.
+// Each subclass declares the target keyword it claims and a singular label.
 export abstract class GhBase extends GhPluginBase {
   // Target keyword this plugin claims for watch/unwatch. `null` = no keyword
   // (bare `watch <N>`). The dispatcher's parser is target-agnostic; plugins

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -222,7 +222,7 @@ export function labelNames(labels: GhLabel[] | null | undefined): string[] {
 // GhClient — per-plugin handle that owns the PluginLogger and exposes the
 // fetch surface as instance methods. Every gh call lands in spawnGh via the
 // private api()/graphql() shape helpers, so retry stays the universal contract.
-// Plugins construct one at boot (see GhBase) and pass it down through
+// Plugins construct one at boot (see GhPluginBase) and pass it down through
 // snapshot/scraper instead of threading `log` through each callsite.
 export class GhClient {
   constructor(private readonly log: PluginLogger) {}

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -15,9 +15,10 @@
 // pruned from `seen` (we don't prune today, so closed-then-reopened is
 // silently suppressed; that's fine, the operator can `watch <N>` for it).
 import type { OrchestratorConfig } from '../../config.js'
-import { BasePlugin, type PluginLogger, type PluginTickResult, type TaggedEvent, defaultPluginLogger } from '../../plugin.js'
+import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
-import { GhClient, labelNames, type GhRepoIssue } from './github-api.js'
+import { labelNames, type GhRepoIssue } from './github-api.js'
+import { GhPluginBase } from './base.js'
 
 interface NewIssuesPluginConfig {
   repo?: string
@@ -28,19 +29,8 @@ export interface NewIssuesPluginState {
   seen_issue_numbers: number[]
 }
 
-export class GitHubNewIssuesPlugin extends BasePlugin {
+export class GitHubNewIssuesPlugin extends GhPluginBase {
   readonly name = 'github-new-issues'
-
-  // Owns the GhClient the same way GhBase does — see #338/#348 for the
-  // refactor. Not extending GhBase because that scaffolding is built around
-  // a per-entry `watched` slice and this plugin doesn't have one. A thinner
-  // shared base could be a future cleanup if more GhClient-only plugins land.
-  protected readonly client: GhClient
-
-  constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
-    super(defaultChannel)
-    this.client = new GhClient(log)
-  }
 
   // Project channel is unioned in by the orchestrator, so the default case
   // returns []. An explicit slice.channels override is surfaced here so those


### PR DESCRIPTION
Closes #356

Extracts `client: GhClient` and `agentLogins()` from `GhBase` into a new `GhPluginBase`. `GhBase` extends it; `GitHubNewIssuesPlugin` switches from `BasePlugin` + duplicated constructor to `GhPluginBase`.

The comment `GitHubNewIssuesPlugin` carried — "a thinner shared base could be a future cleanup if more GhClient-only plugins land" — is now the implementation.

Sets up #351 cleanly: `scrapePr`/`scrapeIssue` can become methods on `GhPluginBase` without touching the class hierarchy again.