### PR TITLE
surface compaction stats in roost-token-usage report

### DIFF
--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -117,6 +117,13 @@ function addToMissMap(into: Map<string, Map<string, MissCounts>>, from: Map<stri
   }
 }
 
+function mergeCompactions(into: CompactionStats, from: CompactionStats): void {
+  into.count += from.count
+  into.preTokens += from.preTokens
+  into.postTokens += from.postTokens
+  into.durationMs += from.durationMs
+}
+
 function trackTs(report: NickReport, ts: string): void {
   if (!report.wallFirst || ts < report.wallFirst) report.wallFirst = ts
   if (!report.wallLast || ts > report.wallLast) report.wallLast = ts
@@ -226,23 +233,11 @@ interface ScanResult {
 // — older or future shapes that inline sidechain rows in the parent are
 // filtered here to avoid double-counting.
 //
-// Known gaps vs Claude Code's `/usage` panel (#334): /usage is fed by a
-// live in-process tracker, this scanner is fed by the post-hoc JSONL.
-// Categories the JSONL doesn't expose (and we therefore don't count):
-//   - Compaction API calls. compact_boundary carries preTokens/postTokens
-//     + durationMs but no input/output/cache_r/cache_w breakdown; we
-//     surface the aggregate so the gap is visible but cannot price it.
-//   - Mid-stream / retried API calls — if the server responds and the
-//     client retries (rate-limit, transient error), the abandoned call's
-//     usage is billed but never reaches the JSONL.
-//   - Per-iteration token deltas that aren't reflected in the outer usage
-//     block. The `usage.iterations[]` array sums to the outer block in
-//     current shapes, so this is a forward-compat hedge, not a today-gap.
-//   - Server-side aggregates (e.g. ephemeral cached-input that expired and
-//     was re-counted as input on resend) that /usage may pull from a
-//     billing endpoint, not the wire usage block.
-// Dollar impact in practice is ~3% on a $7 session (input + cache_r) —
-// definitional, not a correctness issue. See AvesAlight/roost#334.
+// Compaction handling: a `system/compact_boundary` row marks an auto-
+// compaction. It carries preTokens/postTokens + durationMs but no per-
+// field usage block — the summary API call itself isn't logged. We
+// aggregate the markers so the gap is visible, without pricing it.
+// See AvesAlight/roost#334 for the broader /usage-panel gap taxonomy.
 function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, seenCompactUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
   const missByModel = new Map<string, Map<string, MissCounts>>()
@@ -410,10 +405,7 @@ export async function collectForNick(
     if (result.wallFirst) trackTs(report, result.wallFirst)
     if (result.wallLast) trackTs(report, result.wallLast)
     for (const m of result.unknownModels) report.unknownModels.add(m)
-    report.compactions.count += result.compactions.count
-    report.compactions.preTokens += result.compactions.preTokens
-    report.compactions.postTokens += result.compactions.postTokens
-    report.compactions.durationMs += result.compactions.durationMs
+    mergeCompactions(report.compactions, result.compactions)
 
     // Subagent transcripts: same nick, billed by directory locality.
     const subagentFiles = await listSubagentFiles(f)
@@ -435,10 +427,7 @@ export async function collectForNick(
       if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
       if (subResult.wallLast) trackTs(report, subResult.wallLast)
       for (const m of subResult.unknownModels) report.unknownModels.add(m)
-      report.compactions.count += subResult.compactions.count
-      report.compactions.preTokens += subResult.compactions.preTokens
-      report.compactions.postTokens += subResult.compactions.postTokens
-      report.compactions.durationMs += subResult.compactions.durationMs
+      mergeCompactions(report.compactions, subResult.compactions)
     }
   }
   return report

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -45,6 +45,13 @@ type ModelUsage = UsageCounts
 // is read from the creation block on the same JSONL row that reported the miss.
 type MissCounts = { tokens5m: number; tokens1h: number }
 
+// Aggregate of compact_boundary rows for a nick. Each compaction is one
+// summarization API call whose own usage block is NOT logged in the JSONL —
+// only the pre/post context-size totals and the wall duration are. We surface
+// what's available so the gap is visible; we do not synthesize a per-field
+// usage from preTokens because the input/cache_r split is unknowable here.
+interface CompactionStats { count: number; preTokens: number; postTokens: number; durationMs: number }
+
 interface NickReport {
   byModel: Map<string, ModelUsage>
   // Direct cache miss data from message.diagnostics.cache_miss_reason.
@@ -60,6 +67,7 @@ interface NickReport {
   transcripts: number
   unknownModels: Set<string>
   files: string[]
+  compactions: CompactionStats
 }
 
 interface SnapshotFile {
@@ -77,6 +85,7 @@ function emptyReport(): NickReport {
     transcripts: 0,
     unknownModels: new Set(),
     files: [],
+    compactions: { count: 0, preTokens: 0, postTokens: 0, durationMs: 0 },
   }
 }
 
@@ -159,6 +168,15 @@ interface AnyRow {
   requestId?: string
   uuid?: string
   isSidechain?: boolean
+  // system/compact_boundary rows: emitted when Claude Code auto-compacts the
+  // conversation. preTokens/postTokens describe the context size; durationMs
+  // is the compaction API call's wall time. No per-field usage block.
+  compactMetadata?: {
+    trigger?: string
+    preTokens?: number
+    postTokens?: number
+    durationMs?: number
+  }
   message?: {
     model?: string
     usage?: {
@@ -192,6 +210,7 @@ interface ScanResult {
   wallLast?: string
   unknownModels: Set<string>
   contributed: boolean
+  compactions: CompactionStats
 }
 
 // Walk one JSONL file and return its token usage. Only rows with
@@ -206,13 +225,32 @@ interface ScanResult {
 // (scanned separately with `countSidechain: true`), so this is defensive
 // — older or future shapes that inline sidechain rows in the parent are
 // filtered here to avoid double-counting.
-function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
+//
+// Known gaps vs Claude Code's `/usage` panel (#334): /usage is fed by a
+// live in-process tracker, this scanner is fed by the post-hoc JSONL.
+// Categories the JSONL doesn't expose (and we therefore don't count):
+//   - Compaction API calls. compact_boundary carries preTokens/postTokens
+//     + durationMs but no input/output/cache_r/cache_w breakdown; we
+//     surface the aggregate so the gap is visible but cannot price it.
+//   - Mid-stream / retried API calls — if the server responds and the
+//     client retries (rate-limit, transient error), the abandoned call's
+//     usage is billed but never reaches the JSONL.
+//   - Per-iteration token deltas that aren't reflected in the outer usage
+//     block. The `usage.iterations[]` array sums to the outer block in
+//     current shapes, so this is a forward-compat hedge, not a today-gap.
+//   - Server-side aggregates (e.g. ephemeral cached-input that expired and
+//     was re-counted as input on resend) that /usage may pull from a
+//     billing endpoint, not the wire usage block.
+// Dollar impact in practice is ~3% on a $7 session (input + cache_r) —
+// definitional, not a correctness issue. See AvesAlight/roost#334.
+function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, seenCompactUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
   const missByModel = new Map<string, Map<string, MissCounts>>()
   let apiDurationMs = 0
   let wallFirst: string | undefined
   let wallLast: string | undefined
   const unknownModels = new Set<string>()
+  const compactions: CompactionStats = { count: 0, preTokens: 0, postTokens: 0, durationMs: 0 }
   let contributed = false
 
   const trackLocal = (ts: string) => {
@@ -317,8 +355,26 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
       contributed = true
       continue
     }
+
+    // System compact_boundary row: marks an auto-compaction. The summary
+    // API call's per-field usage is not in the JSONL, so we only surface
+    // the available aggregates (pre/post context size, wall duration).
+    // Dedup by uuid so a forked/resumed transcript doesn't re-add it.
+    if (row.type === 'system' && row.subtype === 'compact_boundary' && row.compactMetadata) {
+      if (row.uuid) {
+        if (seenCompactUuids.has(row.uuid)) continue
+        seenCompactUuids.add(row.uuid)
+      }
+      compactions.count += 1
+      compactions.preTokens += row.compactMetadata.preTokens ?? 0
+      compactions.postTokens += row.compactMetadata.postTokens ?? 0
+      compactions.durationMs += row.compactMetadata.durationMs ?? 0
+      if (ts) trackLocal(ts)
+      contributed = true
+      continue
+    }
   }
-  return { byModel, missByModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed }
+  return { byModel, missByModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed, compactions }
 }
 
 export async function collectForNick(
@@ -329,10 +385,11 @@ export async function collectForNick(
   const marker = markerFor(nick)
   const files = await listSessionFiles(projectsRoot)
   const report = emptyReport()
-  // Scan-wide so a requestId / turn uuid shared across forked or resumed
-  // transcripts is only counted once.
+  // Scan-wide so a requestId / turn uuid / compact_boundary uuid shared
+  // across forked or resumed transcripts is only counted once.
   const seenRequestIds = new Set<string>()
   const seenTurnUuids = new Set<string>()
+  const seenCompactUuids = new Set<string>()
   for (const f of files) {
     let text: string
     try {
@@ -345,7 +402,7 @@ export async function collectForNick(
     if (!text.includes(marker)) continue
     report.files.push(f)
 
-    const result = scanFile(text, seenRequestIds, seenTurnUuids, sinceTs)
+    const result = scanFile(text, seenRequestIds, seenTurnUuids, seenCompactUuids, sinceTs)
     if (result.contributed) report.transcripts += 1
     for (const [m, u] of result.byModel) addToUsageMap(report.byModel, m, u)
     addToMissMap(report.missByModel, result.missByModel)
@@ -353,6 +410,10 @@ export async function collectForNick(
     if (result.wallFirst) trackTs(report, result.wallFirst)
     if (result.wallLast) trackTs(report, result.wallLast)
     for (const m of result.unknownModels) report.unknownModels.add(m)
+    report.compactions.count += result.compactions.count
+    report.compactions.preTokens += result.compactions.preTokens
+    report.compactions.postTokens += result.compactions.postTokens
+    report.compactions.durationMs += result.compactions.durationMs
 
     // Subagent transcripts: same nick, billed by directory locality.
     const subagentFiles = await listSubagentFiles(f)
@@ -364,7 +425,7 @@ export async function collectForNick(
         continue
       }
       report.files.push(sub)
-      const subResult = scanFile(subText, seenRequestIds, seenTurnUuids, sinceTs, true)
+      const subResult = scanFile(subText, seenRequestIds, seenTurnUuids, seenCompactUuids, sinceTs, true)
       // Each contributing subagent file increments transcripts independently —
       // a worker that fires 3 Task subagents shows `transcripts: 4` (parent + 3).
       if (subResult.contributed) report.transcripts += 1
@@ -374,6 +435,10 @@ export async function collectForNick(
       if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
       if (subResult.wallLast) trackTs(report, subResult.wallLast)
       for (const m of subResult.unknownModels) report.unknownModels.add(m)
+      report.compactions.count += subResult.compactions.count
+      report.compactions.preTokens += subResult.compactions.preTokens
+      report.compactions.postTokens += subResult.compactions.postTokens
+      report.compactions.durationMs += subResult.compactions.durationMs
     }
   }
   return report
@@ -481,10 +546,19 @@ function formatNick(nick: string, r: NickReport): string {
     ? ` (${fmtDollars(totalMissCost)} miss)`
     : ''
   const head = `${nick}: ${fmtDollars(totalCost)}${missPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
+  // Compaction is its own line — surface what the JSONL gives us (pre/post
+  // context size, total wall) and explicitly call out that the API call's
+  // input/output isn't captured. See scanFile's "Known gaps" comment.
+  const compactionLine = r.compactions.count > 0
+    ? `  compaction: ${r.compactions.count}× (pre ${fmtTokens(r.compactions.preTokens)} → post ${fmtTokens(r.compactions.postTokens)}, ${fmtDuration(r.compactions.durationMs)}; call cost not captured)`
+    : null
   if (perModel.length === 0) {
-    return `${head}\n  (no in-window activity)`
+    const tail = compactionLine ?? '  (no in-window activity)'
+    return `${head}\n${tail}`
   }
-  return [head, ...perModel.map((p) => p.line)].join('\n')
+  const lines = [head, ...perModel.map((p) => p.line)]
+  if (compactionLine) lines.push(compactionLine)
+  return lines.join('\n')
 }
 
 function usage(stream: NodeJS.WriteStream): void {

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -34,6 +34,32 @@ interface Turn {
   cacheMissReason?: { type: string; cache_missed_input_tokens: number }
 }
 
+// A compact_boundary marker that auto-compaction writes into the JSONL.
+// We dedup by uuid across files — same as turn_duration rows.
+interface CompactBoundary {
+  ts: string
+  uuid?: string
+  preTokens: number
+  postTokens: number
+  durationMs: number
+}
+
+function compactBoundaryRow(c: CompactBoundary): string {
+  const row: Record<string, unknown> = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    timestamp: c.ts,
+    compactMetadata: {
+      trigger: 'auto',
+      preTokens: c.preTokens,
+      postTokens: c.postTokens,
+      durationMs: c.durationMs,
+    },
+  }
+  if (c.uuid) row.uuid = c.uuid
+  return JSON.stringify(row)
+}
+
 // Render one Turn into the (up to two) JSONL rows Claude Code emits:
 // an `assistant` row carrying the usage block, and — when apiDurationMs
 // is set — a `system/turn_duration` companion. `forceSidechain` stamps
@@ -82,12 +108,14 @@ function turnRows(t: Turn, forceSidechain = false): string[] {
 
 // Build a session JSONL containing the MCP banner for `nick` followed by the
 // given assistant turns (and an optional per-turn `system/turn_duration`
-// row using the same ts). Returns the written file path.
+// row using the same ts). Returns the written file path. Extra rows
+// (e.g. compact_boundary) get appended after the turns.
 async function writeSessionFile(
   dir: string,
   filename: string,
   nick: string,
   turns: Turn[],
+  extras: { compactBoundaries?: CompactBoundary[] } = {},
 ): Promise<string> {
   const lines: string[] = []
   lines.push(JSON.stringify({ type: 'permission-mode', permissionMode: 'auto' }))
@@ -99,6 +127,7 @@ async function writeSessionFile(
     },
   }))
   for (const t of turns) lines.push(...turnRows(t))
+  for (const c of extras.compactBoundaries ?? []) lines.push(compactBoundaryRow(c))
   const path = join(dir, filename)
   await writeFile(path, lines.join('\n') + '\n')
   return path
@@ -538,6 +567,56 @@ describe('token-usage', () => {
       expect(r.missByModel.size).toBe(0)
     })
 
+    it('aggregates compact_boundary markers into compactions stats', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1 },
+      ], {
+        compactBoundaries: [
+          { ts: '2026-05-16T10:30:00Z', uuid: 'compact_1', preTokens: 200_000, postTokens: 10_000, durationMs: 90_000 },
+          { ts: '2026-05-16T11:30:00Z', uuid: 'compact_2', preTokens: 150_000, postTokens: 8_000, durationMs: 60_000 },
+        ],
+      })
+      const r = await collectForNick('roost-x', projects)
+      expect(r.compactions.count).toBe(2)
+      expect(r.compactions.preTokens).toBe(350_000)
+      expect(r.compactions.postTokens).toBe(18_000)
+      expect(r.compactions.durationMs).toBe(150_000)
+    })
+
+    it('dedups compact_boundary rows by uuid across forked transcripts', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      const shared: CompactBoundary = { ts: '2026-05-16T10:30:00Z', uuid: 'compact_shared', preTokens: 100_000, postTokens: 5_000, durationMs: 50_000 }
+      await writeSessionFile(d, 'fork-a.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1 },
+      ], { compactBoundaries: [shared] })
+      await writeSessionFile(d, 'fork-b.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1 },
+      ], { compactBoundaries: [shared] })
+      const r = await collectForNick('roost-x', projects)
+      // Counted once, not twice.
+      expect(r.compactions.count).toBe(1)
+      expect(r.compactions.preTokens).toBe(100_000)
+    })
+
+    it('sinceTs excludes pre-window compact_boundary rows', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', input: 5, output: 5 },
+      ], {
+        compactBoundaries: [
+          { ts: '2026-05-16T09:00:00Z', uuid: 'pre', preTokens: 999_000, postTokens: 99_000, durationMs: 99_000 },
+          { ts: '2026-05-16T11:30:00Z', uuid: 'post', preTokens: 200_000, postTokens: 10_000, durationMs: 80_000 },
+        ],
+      })
+      const r = await collectForNick('roost-lead-pm', projects, '2026-05-16T10:00:00Z')
+      expect(r.compactions.count).toBe(1)
+      expect(r.compactions.preTokens).toBe(200_000)
+    })
+
     it('splits miss tokens by creation tier from the same row', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
@@ -737,6 +816,31 @@ describe('token-usage', () => {
       const rep = await capture(() => main(['report', stateDir, '339', 'roost-x']))
       expect(rep.result).toBe(0)
       expect(rep.out).not.toContain('miss')
+    })
+
+    it('report renders compaction line when nick has compact_boundary rows', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-lead-pm', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 100, output: 50, apiDurationMs: 5000 },
+      ], {
+        compactBoundaries: [
+          { ts: '2026-05-16T10:30:00Z', uuid: 'c1', preTokens: 268_000, postTokens: 12_000, durationMs: 131_000 },
+        ],
+      })
+      const rep = await capture(() => main(['report', stateDir, '334', 'roost-lead-pm']))
+      expect(rep.result).toBe(0)
+      expect(rep.out).toContain('compaction: 1× (pre 268k → post 12k, 2m11s; call cost not captured)')
+    })
+
+    it('report omits compaction line when nick has no compactions', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '334', 'roost-x']))
+      expect(rep.out).not.toContain('compaction')
     })
 
     it('miss costs are summed across sessions and reasons per nick', async () => {


### PR DESCRIPTION
## Summary
- Aggregate `system/compact_boundary` rows per nick and surface as a `compaction: N× (pre X → post Y, dur; call cost not captured)` line in the report. The summarization API call's per-field usage isn't in the JSONL, so we don't try to price it.

## Scope note
This PR does **not** close #334. Deep binary analysis (see closing comment on #334) couldn't pin worker-331's specific input_tokens 30x gap from static reading — that's a runtime-instrumentation question, decoupled from the compaction work shipping here. Compaction handling is its own valuable deliverable: any session that auto-compacts loses the summary API call's cost from our JSONL view, and this surfaces what's available without faking precision on what isn't.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test test/token-usage.test.ts` — 42 pass (5 new compaction-specific tests)
- [x] Live run against a compacted-session nick renders the new line:
      `compaction: 1× (pre 267k → post 11k, 1m46s; call cost not captured)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)