### PR TITLE
maint: bump package.json to 0.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps `package.json` to `0.5.13` ahead of the v0.5.13 tag.

What's new since v0.5.12:
- #355: token-usage cost estimates + cache miss attribution (per-model, per-type breakdown)
- #356: GhPluginBase extraction — thin shared base for GitHub-client-only plugins
- #357/#365: GH API rate limit observability, landed in GhPluginBase
- #359: CLAUDE.md — APM owns release mechanics (documented)
- #364: associate-pm.md + lead-pm.md agent improvements
- #367: compaction stats in `roost-token-usage` report (pre/post/dur; call cost documented as not capturable)
- #370: lead-pm prompt — prefer opus for research/investigation issues
- #372: LEARNINGS Finding I — tools_changed cache miss investigation outcome + decision to eat the miss