### PR TITLE
ci: fire on all branch pushes + require status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Closes #383

Drop `branches: [main]` from the push trigger so CI fires on every branch push regardless of PR state. When `mergeable=CONFLICTING`, GitHub can't generate `refs/pull/N/merge` and `pull_request` events stop firing — this closes that gap.

The existing concurrency group deduplicates back-to-back runs on the same ref.

**Branch protection (part 2):** requires admin rights to set via API — I have `maintain` but not `admin`. The protection rule (require `test` check on main) needs to be applied by @AlexSc or promoted to admin. The exact API call is:

```
gh api --method PUT /repos/AvesAlight/roost/branches/main/protection \
  --field required_status_checks='{"strict":false,"contexts":["test"]}' \
  --field enforce_admins=false \
  --field required_pull_request_reviews=null \
  --field restrictions=null
```