### PR TITLE
maint: bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump `package.json` from 0.5.13 → 0.6.0.

What shipped this cycle:
- #351 GhClient/GhScraper restructure
- #366 tools_changed investigation + LEARNINGS doc
- #368 auto-compact intercept via PreCompact hook (`--steer-compact`)
- #369 cache-ttl knob (`--cache-ttl 5m|1h`)
- #378 login shell portability (no longer hardcoded to zsh)
- #383 CI fires on all branch pushes (drop branch filter from push trigger)