### PR TITLE
docs+comments: codify and enforce timeless-comment rule

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,9 +23,9 @@ from `irssi` and see everything.
 ```
 
 The channel-of-record for an active piece of work is `#issue-NNN`,
-not `#pr-NNN` — issues outlive any single PR attempt (PR #75 closed
-+ PR #76 restart on the same C-718 means the channel needs to be
-stable across restarts; per-issue gives that, per-PR doesn't).
+not `#pr-NNN` — issues outlive any single PR attempt (a PR close +
+restart on the same issue means the channel needs to be stable across
+restarts; per-issue gives that, per-PR doesn't).
 
 ## Channels
 
@@ -33,7 +33,7 @@ stable across restarts; per-issue gives that, per-PR doesn't).
 |-------------------|---------|
 | `#staff`          | Standing senior agents (senior PO, CoS, finance, sales, opsmanager, tooldev). Cross-cutting only. |
 | `#leads-{proj}`   | One per project. Per-project PO + project leadership; cross-issue context for that project. |
-| `#issue-{NNN}`    | One per active issue. Dispatcher publishes events directly. Worker joins on pickup, leaves on completion. Reviewer joins on CI green, leaves on conclude. Per-project PO is here continuously (observation, not on-demand). Stable across PR restarts (PR #75 closed → PR #76 fresh start = same `#issue-NNN`). |
+| `#issue-{NNN}`    | One per active issue. Dispatcher publishes events directly. Worker joins on pickup, leaves on completion. Reviewer joins on CI green, leaves on conclude. Per-project PO is here continuously (observation, not on-demand). Stable across PR restarts (old PR closes, new PR opens = same `#issue-NNN`). |
 
 ## Identities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The PreCompact hook (`bin/roost-compact-hook`) is opt-in via `--steer-compact` a
 
 ## Comments
 
-In-tree comments (code and docs) must be timeless — no PR/issue/version refs (e.g. `(#276)`, `Issue #342`, `from #136`, `since v3`). Future readers encounter them without that context. Systems of record (commit messages, PR bodies, LEARNINGS.md) keep their refs; in-tree comments don't.
+In-tree comments (code and docs) must be timeless — no PR/issue/version refs (e.g. `(#276)`, `Issue #342`, `from #136`, `since v3`). Future readers encounter them without that context. Systems of record (commit messages, PR bodies, LEARNINGS.md, dated audit reports under `docs/audit-*`) keep their refs; in-tree comments don't.
 
 ## Code quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatte
 
 The PreCompact hook (`bin/roost-compact-hook`) is opt-in via `--steer-compact` at spawn. When wired, it intercepts claude code's auto-compact (`trigger="auto"`), returns `{"decision":"block"}` to halt the directive-less default, then injects `/compact <directive>` into the tmux pane via backgrounded `tmux send-keys` — so the manual `/compact` re-fires PreCompact with `trigger="manual"` and `custom_instructions` populated, and the compactor runs with our directive. The directive is a single-line constant near the top of the hook script (one place to edit; covers the roost agent set generically — role, IRC nick, channels joined, in-flight issue/PR state, recent decisions, pending work). Long-running PM-class agents (lead-pm, associate-pm) pass `--steer-compact`; workers and reviewers don't (auto-compact rarely fires in their lifetime). The `docs/LEARNINGS.md` finding on auto-compact has the empirical investigation.
 
+## Comments
+
+In-tree comments (code and docs) must be timeless — no PR/issue/version refs (e.g. `(#276)`, `Issue #342`, `from #136`, `since v3`). Future readers encounter them without that context. Systems of record (commit messages, PR bodies, LEARNINGS.md) keep their refs; in-tree comments don't.
+
 ## Code quality
 
 ```
@@ -37,7 +41,7 @@ Requires ergo (IRCv3 server). Install with `bin/install-ergo` or set `ERGO_BIN` 
 
 **Never pipe `bun test` through `tail`, `head`, or `grep`.** The shell returns the *last* command's exit code, which is always 0 for those filters — so `bun test ... | tail -N` reports success even when bun failed. The pipe also buffers the entire run until exit, masking hangs. If you need to trim noisy output, write the full result to a file and read it: `bun test ... > /tmp/out 2>&1; echo "exit=$?"; tail -N /tmp/out`. The exit code is the only honest signal.
 
-**Bun-specific footgun (issue #170, upstream report TBD):** when an unhandled promise rejection arrives from a test the runner has already abandoned, bun 1.2.20 deadlocks the runner (no subsequent test runs, process never exits). Any test helper that resolves/rejects via a `setTimeout(reject, ...)` race against the user's `await` will hit this if the user's await is ever aborted (test timeout, prior failure, etc.). Wrap such promises with `suppressLateRejection` from `test/helpers/tool.ts`: it pre-attaches a no-op `.catch()` so an abandoned rejection is silently absorbed, while a still-active `await` still throws normally. The existing wait-style helpers in `test/helpers/mcp-core.ts` and `test/helpers/peer.ts` already use it.
+**Bun-specific footgun:** when an unhandled promise rejection arrives from a test the runner has already abandoned, bun 1.2.20 deadlocks the runner (no subsequent test runs, process never exits). Any test helper that resolves/rejects via a `setTimeout(reject, ...)` race against the user's `await` will hit this if the user's await is ever aborted (test timeout, prior failure, etc.). Wrap such promises with `suppressLateRejection` from `test/helpers/tool.ts`: it pre-attaches a no-op `.catch()` so an abandoned rejection is silently absorbed, while a still-active `await` still throws normally. The existing wait-style helpers in `test/helpers/mcp-core.ts` and `test/helpers/peer.ts` already use it.
 
 ## Worktrees
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -13,7 +13,7 @@ config at your own repo / channel set.
 
 Each watched item routes to `#<project>-issue-{number}`. The project channel
 (default `#<project>-leads`) is a fallback for errors and project-level events.
-See `src/orchestrator/naming.ts` for the full namespacing convention (#196).
+See `src/orchestrator/naming.ts` for the full namespacing convention.
 
 ## Setup
 
@@ -46,9 +46,9 @@ to `#<project>-issue-N` for each linked issue).
 A plugin not listed under `plugins` is not instantiated — there is no top-level
 fallback. The supported set is the first-party plugins shipped in this repo
 (`github-prs`, `github-issues`, `github-new-issues`); external plugin discovery
-is tracked in #255.
+is not yet supported.
 
-`github-new-issues` (added in #342) needs an explicit `plugins.github-new-issues`
+`github-new-issues` needs an explicit `plugins.github-new-issues`
 entry to run. `bin/roost init` writes one for new projects; for existing
 projects, add `"github-new-issues": {}` to enable the repo-wide new-issue
 feed on the project channel.

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -44,7 +44,7 @@ const PASSIVE_SENTINEL = 'roost-irc MCP is passive: a sibling MCP in the same RO
 
 const REPLY_REMINDER = "Your text output isn't surfaced to humans or other agents in the channel — use channel_message / direct_message to reply."
 const UNREAD_HINT = '(post a message to those channels/peers or call channel_ack to clear)'
-// 1/7 — midpoint of the 1/5–1/10 range from #136. Random rate avoids the
+// 1/7 — midpoint of a 1/5–1/10 range. Random rate avoids the
 // pattern-match-and-ignore failure mode of a fixed cadence.
 const REMINDER_PROBABILITY = 1 / 7
 
@@ -506,7 +506,7 @@ async function runOwnerMcp(args: {
   // Permbot runs in-process when --perm-irc is on. Same MCP, second IRC
   // connection on nick `permbot-${NICK}`. Lifecycle = MCP lifecycle, so a
   // crashed nested-claude spawn can no longer kick the worker's permbot
-  // off via nick collision (#188). The hook stays a separate process and
+  // off via nick collision. The hook stays a separate process and
   // talks to us over the unix socket as before.
   const PERM_SOCK = process.env['ROOST_PERM_SOCK'] ?? ''
   const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 
 const execFileP = promisify(execFile)
 
-// Bumped to 3 in #116 — split GitHub plugin into Prs/Issues, each owns its
+// Schema version 3: GitHub plugin split into Prs/Issues; each owns its
 // own state slice. Schema bumps trigger a one-time re-seed via loadState().
 export const SCHEMA_VERSION = 3
 
@@ -140,8 +140,8 @@ export async function writeHeartbeat(stateDir: string): Promise<void> {
 // Dispatcher PID file. JSON `{pid, started_at_ms, cmdline}`. Only `pid` is
 // contractual today — `bin/start-dispatcher` reads it for the front-door
 // liveness check. `started_at_ms` and `cmdline` are written for operator
-// inspection and as the substrate for future readers (e.g. #302 shutdown
-// helper) — extend with care once a consumer lands.
+// inspection and as the substrate for future tooling (e.g. a shutdown helper)
+// — extend with care once a consumer lands.
 export const DISPATCHER_PID_FILE = 'dispatcher.pid'
 
 export interface DispatcherPidInfo {

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -46,7 +46,7 @@ const VERBS = new Set(['watch', 'unwatch', 'help'])
 
 // Split a raw inbound body into individual command lines. Newlines /
 // semicolons / commas are all separators — matches the watcher prompt
-// grammar (operator-facing UX since the haiku watcher).
+// grammar (operator-facing UX for DM commands).
 export function splitCommands(text: string): string[] {
   return text
     .split(/[\n;,]+/)

--- a/src/orchestrator/dm-handler.ts
+++ b/src/orchestrator/dm-handler.ts
@@ -46,7 +46,7 @@ const VERBS = new Set(['watch', 'unwatch', 'help'])
 
 // Split a raw inbound body into individual command lines. Newlines /
 // semicolons / commas are all separators — matches the watcher prompt
-// grammar (operator-facing UX for DM commands).
+// grammar.
 export function splitCommands(text: string): string[] {
   return text
     .split(/[\n;,]+/)

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -3,7 +3,7 @@
 // to carry a project prefix so two projects sharing one ergo + one tmux do
 // not collide. Single source of truth for the prefix shape.
 //
-// Format choice (#196): project-first (`#<project>-leads`, `#<project>-issue-N`,
+// Format: project-first (`#<project>-leads`, `#<project>-issue-N`,
 // `<project>-worker-N`). Project-first groups every channel for one project
 // together in irssi/weechat `/list`, which is the dogfooding ergonomic.
 

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -2,7 +2,7 @@
 // oneline announcement to the project channel the first time a given issue
 // number is observed. Sibling to `github-issues`: that plugin routes activity
 // for hand-watched issues; this one surfaces brand-new issues so the team
-// doesn't have to notice them manually. Issue #342.
+// doesn't have to notice them manually.
 //
 // Enabled by an explicit `plugins.github-new-issues` slice in config —
 // empty object is fine. `bin/roost init` writes one for new projects;

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -248,7 +248,7 @@ export function startPermbot(
       // Tear down on disconnect. The hook's askDaemon detects the missing
       // socket and falls back to a transient-DM + emit('ask'), so the
       // worker degrades cleanly. Owner-gate eliminates the collision-driven
-      // disconnect that motivated #188; if a real network drop becomes a
+      // disconnect; if a real network drop becomes a
       // recurring failure mode, add auto-reconnect as a followup.
       log('IRC connection lost, shutting down')
       stop()

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -247,9 +247,8 @@ export function startPermbot(
     } else if (kind === 'disconnected') {
       // Tear down on disconnect. The hook's askDaemon detects the missing
       // socket and falls back to a transient-DM + emit('ask'), so the
-      // worker degrades cleanly. Owner-gate eliminates the collision-driven
-      // disconnect; if a real network drop becomes a
-      // recurring failure mode, add auto-reconnect as a followup.
+      // worker degrades cleanly. Owner-gate eliminates the collision-driven disconnect;
+      // if a real network drop becomes a recurring failure mode, add auto-reconnect.
       log('IRC connection lost, shutting down')
       stop()
     } else if (kind === 'cap-missing') {

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -218,7 +218,7 @@ if (import.meta.main) {
   // the operator to approve them. Anything else falls through to the gate.
   if (PASSTHROUGH_PREFIXES.some(p => toolName.startsWith(p))) emit('allow', 'roost-irc passthrough')
 
-  // Owner-gate short-circuit (#188): nested claudes inherit the parent's
+  // Owner-gate short-circuit: nested claudes inherit the parent's
   // ROOST_DATA_DIR via tmux env, so the unix socket path resolves to the
   // owner's permbot. Routing a nested-claude's prompt there would DM the
   // operator about a tool call they didn't initiate. Defer to the local

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 // PreToolUse hook with a Bash matcher. Closes the bypass where Claude Code's
-// structural safety analyzer skips PermissionRequest (issue #276) and shows
+// structural safety analyzer skips PermissionRequest and shows
 // a terminal-only prompt that workers spawned with --perm-irc never see.
 // PreToolUse fires *before* the analyzer, so a routing decision here takes
 // precedence over the analyzer's TUI path.
@@ -35,8 +35,7 @@ const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
 // keep in sync with src/permission-prompt.ts (SOCKET_SAFETY_TIMEOUT)
 const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOST_PERM_TIMEOUT_SECS'] ?? '570')))
 
-// bashMissKind labels lifted from the 2.1.139 binary (issue #276). These are
-// roost's *approximations* of the harness's classification — not literal
+// bashMissKind labels approximate the harness's Bash safety classifier — not literal
 // `decisionReason` strings. We collapse several harness kinds (e.g.
 // cd-git-compound / cd-compound-write / cd-compound-redirect → `cd-compound`)
 // and rename others (`semantics` → `newline-hash` for legibility in operator
@@ -170,7 +169,7 @@ if (import.meta.main) {
   const kind = classifyBash(command)
   if (kind === null) passthrough()
 
-  // Owner-gate short-circuit (#188): nested claudes inherit ROOST_DATA_DIR
+  // Owner-gate short-circuit: nested claudes inherit ROOST_DATA_DIR
   // via tmux env and would otherwise route the parent's prompt to the
   // owner's permbot. Fall through to the local TUI for non-owner sessions.
   if (DATA_DIR && SESSION_ID) {

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -237,7 +237,6 @@ interface ScanResult {
 // compaction. It carries preTokens/postTokens + durationMs but no per-
 // field usage block — the summary API call itself isn't logged. We
 // aggregate the markers so the gap is visible, without pricing it.
-// See AvesAlight/roost#334 for the broader /usage-panel gap taxonomy.
 function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, seenCompactUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
   const missByModel = new Map<string, Map<string, MissCounts>>()

--- a/test/compact-hook_test.sh
+++ b/test/compact-hook_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests for bin/roost-compact-hook (PreCompact intercept, issue #368).
+# Tests for bin/roost-compact-hook (PreCompact intercept).
 # Plain bash — covers the two branches: auto (block + inject the baked-in
 # DIRECTIVE constant), manual (pass through + SIGUSR1). Uses a mock tmux on
 # PATH so we don't need a real pane.

--- a/test/helpers/mcp-core.ts
+++ b/test/helpers/mcp-core.ts
@@ -30,7 +30,7 @@ export type MessageNotification = ChannelNotification & { meta: MessageNotificat
 // is optional and ignored if undefined; if set, all must match. An empty
 // `MessageMatch` ({}) matches any message notification — useful as a
 // wait-for-any-message form. Centralizing this avoids the per-site inline
-// predicate pattern that bit #246: a wire-shape change is a one-file edit
+// predicate pattern: any wire-shape change is a one-file edit
 // here, and the helper enforces the positive `event === 'message'`
 // discriminator.
 export interface MessageMatch {

--- a/test/helpers/tool.ts
+++ b/test/helpers/tool.ts
@@ -6,8 +6,8 @@ export function toolText(result: unknown): string {
 export const sleep = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
 
 // Bun 1.2.20 deadlocks the runner when an unhandled promise rejection arrives
-// from a test the runner has already abandoned (see issue #170 / upstream
-// report TBD). Our timeout-based test helpers race the user's `await` against
+// from a test the runner has already abandoned. Our timeout-based test helpers
+// race the user's `await` against
 // bun's test timeout; if bun aborts first, the helper's setTimeout still fires
 // and the reject() becomes unhandled. Pre-attaching a no-op .catch keeps the
 // rejection "handled" without affecting an active `await` — that consumer


### PR DESCRIPTION
Closes #385

Adds `## Comments` to CLAUDE.md: in-tree comments must not reference PR/issue numbers or version-specific timeframes.

Sweeps `bin/`, `src/`, `agents/`, `ARCHITECTURE.md` — removed/reworded all existing violations (`(#188)`, `issue #276`, `Issue #342`, `from #136`, `#302`, `#116`, `#196`, "since the haiku watcher", etc.).

[roost-worker-385]