### PR TITLE
feat: support fish shell (--login + string-collect prompt read)

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -97,7 +97,7 @@ Usage: roost spawn <nick> [options]
 
 Bring up a Claude Code session on the roost. Joins the specified channels
 and dismisses the dev-channels prompt automatically. Sessions launch under
-the user's login shell (from \$SHELL) so .bash_profile / .zprofile / fish config.fish loads — required for RVM, nvm, asdf, and similar toolchains.
+the user's login shell (from \$SHELL) so .bash_profile / .zprofile / ~/.config/fish/config.fish loads — required for RVM, nvm, asdf, and similar toolchains.
 Permission mode handling splits by path. With --agent the wrapper passes
 no --permission-mode and claude code reads \`permissionMode:\` natively
 from the agent's frontmatter. With --model (or the default opus) the
@@ -782,18 +782,12 @@ cmd_spawn() {
     trap 'rm -rf "${ROOST_DATA_DIR}"' EXIT
   fi
 
-  require_tmux
-  require_ircd
-
-  if tmux has-session -t "${session_name}" 2>/dev/null; then
-    echo "error: tmux session '${session_name}' already exists" >&2
-    echo "  shutdown first: roost shutdown ${nick}" >&2
-    exit 3
-  fi
-
-  # bash/zsh/fish: login shell loads the user's profile before claude, required
-  # for RVM / nvm / asdf toolchains. sh/dash: no -l, no profile load. Env vars
-  # go through tmux -e so the inner command stays a clean string.
+  # bash/zsh: -l loads .bash_profile / .zprofile before claude. fish loads
+  # config.fish on every invocation regardless of --login (the flag only flips
+  # `status is-login`); we still pass --login so any profile config gated on it
+  # runs. sh/dash: no -l, no profile load. All three populate the env that
+  # RVM / nvm / asdf etc. require. Env vars go through tmux -e so the inner
+  # command stays a clean string.
   local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}" -e "ROOST_DIR=${ROOST_DIR}")
   tmux_env+=(-e "ROOST_IRC_SERVER=${IRC_HOST}")
   case "${cache_ttl}" in
@@ -829,6 +823,9 @@ cmd_spawn() {
   # we use unquoted `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string
   # collect emits a single argument with newlines preserved, which fish hands
   # to claude as one arg even unquoted.
+  #
+  # Done before require_tmux/require_ircd so the ROOST_SPAWN_KEEP_DATA_DIR=1
+  # test seam can surface the assembled command without an IRC daemon running.
   local mcp_flag=""
   local channel_server="server:plugin:roost:roost-irc"
   if [ -n "${mcp_config}" ]; then
@@ -863,10 +860,22 @@ cmd_spawn() {
   fi
   # Same test seam as the data-dir echo above: surface the assembled inner
   # command so the spawn_test.sh shell-flavor regressions can grep for the
-  # prompt-read syntax that matches the resolved shell.
+  # prompt-read syntax that matches the resolved shell. Stage it to a file
+  # too so tests can read it deterministically without parsing stdout.
   if [ "${ROOST_SPAWN_KEEP_DATA_DIR:-0}" = "1" ]; then
     echo "  inner cmd (preflight): ${inner_cmd}"
+    printf '%s' "${inner_cmd}" > "${ROOST_DATA_DIR}/inner-cmd.txt"
   fi
+
+  require_tmux
+  require_ircd
+
+  if tmux has-session -t "${session_name}" 2>/dev/null; then
+    echo "error: tmux session '${session_name}' already exists" >&2
+    echo "  shutdown first: roost shutdown ${nick}" >&2
+    exit 3
+  fi
+
   tmux new-session -d -s "${session_name}" -x 200 -y 50 -c "${cwd}" \
     "${tmux_env[@]}" \
     "exec ${shell_invoke} $(printf '%q' "${inner_cmd}")"

--- a/bin/roost
+++ b/bin/roost
@@ -97,7 +97,7 @@ Usage: roost spawn <nick> [options]
 
 Bring up a Claude Code session on the roost. Joins the specified channels
 and dismisses the dev-channels prompt automatically. Sessions launch under
-the user's login shell (from \$SHELL) so .bash_profile / .zprofile loads — required for RVM, nvm, asdf, and similar toolchains.
+the user's login shell (from \$SHELL) so .bash_profile / .zprofile / fish config.fish loads — required for RVM, nvm, asdf, and similar toolchains.
 Permission mode handling splits by path. With --agent the wrapper passes
 no --permission-mode and claude code reads \`permissionMode:\` natively
 from the agent's frontmatter. With --model (or the default opus) the
@@ -668,16 +668,18 @@ cmd_spawn() {
     esac
   fi
   # Resolve login shell from $SHELL (fallback /bin/sh). bash/zsh load the
-  # user's profile via -l; sh/dash don't support -l.
+  # user's profile via -l; fish uses --login for the same effect; sh/dash
+  # don't support -l.
   local login_shell="${SHELL:-/bin/sh}"
   local shell_basename
   shell_basename="$(basename "${login_shell}")"
   local shell_invoke
   case "${shell_basename}" in
     bash|zsh) shell_invoke="${login_shell} -l -c" ;;
+    fish)     shell_invoke="${login_shell} --login -c" ;;
     sh|dash)  shell_invoke="${login_shell} -c" ;;
     *)
-      echo "error: unsupported login shell '${shell_basename}' (SHELL=${login_shell}). Supported: bash, zsh, sh, dash. See https://github.com/AvesAlight/roost/issues/378" >&2
+      echo "error: unsupported login shell '${shell_basename}' (SHELL=${login_shell}). Supported: bash, zsh, fish (3.1+), sh, dash." >&2
       exit 1
       ;;
   esac
@@ -789,8 +791,8 @@ cmd_spawn() {
     exit 3
   fi
 
-  # bash/zsh: login shell loads the user's profile before claude, required for
-  # RVM / nvm / asdf toolchains. sh/dash: no -l, no profile load. Env vars
+  # bash/zsh/fish: login shell loads the user's profile before claude, required
+  # for RVM / nvm / asdf toolchains. sh/dash: no -l, no profile load. Env vars
   # go through tmux -e so the inner command stays a clean string.
   local tmux_env=(-e "ROOST_IRC_NICK=${nick}" -e "ROOST_IRC_CHANNELS=${channels}" -e "ROOST_DATA_DIR=${ROOST_DATA_DIR}" -e "ROOST_DIR=${ROOST_DIR}")
   tmux_env+=(-e "ROOST_IRC_SERVER=${IRC_HOST}")
@@ -812,14 +814,21 @@ cmd_spawn() {
   fi
 
   # Build the inner command. Bash expands its own ${vars} here, then we
-  # append the prompt placeholder as a single-quoted literal so $(...) is
-  # evaluated by the login shell — not bash and not the tmux shell.
+  # append the prompt placeholder as a single-quoted literal so the file-read
+  # is evaluated by the login shell — not bash and not the tmux shell.
   # Embedding multi-line file contents directly via printf %q produces
   # $'...' ANSI-C quoting, which doesn't survive the shell-layer chain
   # (bash → tmux shell → login shell -c). Reading the file inside the login
-  # shell via $(< $ROOST_PROMPT_FILE) sidesteps that entirely. The leading `--`
-  # is required so the prompt isn't absorbed by --dangerously-load-development-channels
-  # (variadic flag — eats all subsequent non-flag args).
+  # shell sidesteps that entirely. The leading `--` is required so the prompt
+  # isn't absorbed by --dangerously-load-development-channels (variadic flag —
+  # eats all subsequent non-flag args).
+  #
+  # The read syntax is shell-flavored: bash/zsh use `$(< "$ROOST_PROMPT_FILE")`;
+  # fish has no `$(< file)` shorthand and treats unquoted `(...)` as command
+  # substitution but treats bare `(...)` inside double quotes as a literal, so
+  # we use unquoted `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string
+  # collect emits a single argument with newlines preserved, which fish hands
+  # to claude as one arg even unquoted.
   local mcp_flag=""
   local channel_server="server:plugin:roost:roost-irc"
   if [ -n "${mcp_config}" ]; then
@@ -846,8 +855,17 @@ cmd_spawn() {
   if [ -n "${prompt_file}" ]; then
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016
-    inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"'
+    case "${shell_basename}" in
+      fish) inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
+      *)    inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
+    esac
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")
+  fi
+  # Same test seam as the data-dir echo above: surface the assembled inner
+  # command so the spawn_test.sh shell-flavor regressions can grep for the
+  # prompt-read syntax that matches the resolved shell.
+  if [ "${ROOST_SPAWN_KEEP_DATA_DIR:-0}" = "1" ]; then
+    echo "  inner cmd (preflight): ${inner_cmd}"
   fi
   tmux new-session -d -s "${session_name}" -x 200 -y 50 -c "${cwd}" \
     "${tmux_env[@]}" \

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -271,20 +271,23 @@ fi
 teardown
 
 # -- Test 18b: fish picks the fish-flavored prompt-read syntax ----------------
-# inner_cmd (preflight) is surfaced under ROOST_SPAWN_KEEP_DATA_DIR=1. fish
-# must use `(string collect <$ROOST_PROMPT_FILE)` — `$(< file)` is bash/zsh
-# shorthand fish doesn't grok.
+# inner-cmd.txt is staged to the data dir under ROOST_SPAWN_KEEP_DATA_DIR=1,
+# before require_tmux/require_ircd — so the assertion works in CI where no
+# IRC daemon is listening. fish must use `(string collect <$ROOST_PROMPT_FILE)`
+# — `$(< file)` is bash/zsh shorthand fish doesn't grok.
 
 setup
 out="$(SHELL=/usr/local/bin/fish ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
 # Unquoted (string collect ...) is required: fish treats bare (...) inside
 # double quotes as a literal, so quoting would silently disable substitution.
-if echo "$out" | grep -qF -- '-- (string collect <$ROOST_PROMPT_FILE)' \
-    && ! echo "$out" | grep -qF '$(< "$ROOST_PROMPT_FILE")'; then
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF -- '-- (string collect <$ROOST_PROMPT_FILE)' \
+    && ! echo "$inner_cmd" | grep -qF '$(< "$ROOST_PROMPT_FILE")'; then
   ok "SHELL=fish + --prompt: inner_cmd uses unquoted string-collect, not \$(<file)"
 else
-  fail "SHELL=fish + --prompt: inner_cmd uses unquoted string-collect, not \$(<file)" "out=$out"
+  fail "SHELL=fish + --prompt: inner_cmd uses unquoted string-collect, not \$(<file)" "inner_cmd=$inner_cmd"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
@@ -294,11 +297,13 @@ teardown
 setup
 out="$(SHELL=/bin/bash ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
-if echo "$out" | grep -qF '$(< "$ROOST_PROMPT_FILE")' \
-    && ! echo "$out" | grep -qF '(string collect <$ROOST_PROMPT_FILE)'; then
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF '$(< "$ROOST_PROMPT_FILE")' \
+    && ! echo "$inner_cmd" | grep -qF '(string collect <$ROOST_PROMPT_FILE)'; then
   ok "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect"
 else
-  fail "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect" "out=$out"
+  fail "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect" "inner_cmd=$inner_cmd"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -18,6 +18,9 @@ setup() {
 
 teardown() {
   rm -rf "$TDIR"
+  # On dev boxes with ergo running, shell-resolution tests pass through to a
+  # real tmux new-session — kill it so the next test gets a fresh "roost-testnick".
+  tmux kill-session -t "roost-testnick" 2>/dev/null || true
   trap - EXIT
   TDIR=""
 }
@@ -244,11 +247,60 @@ teardown
 
 setup
 err="$(SHELL=/bin/tcsh "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1)"; exit_code=$?
-if [ "$exit_code" -ne 0 ] && echo "$err" | grep -q "unsupported login shell"; then
-  ok "unsupported SHELL: exits non-zero with clear message"
+if [ "$exit_code" -ne 0 ] \
+    && echo "$err" | grep -q "unsupported login shell" \
+    && echo "$err" | grep -q "bash, zsh, fish (3.1+), sh, dash"; then
+  ok "unsupported SHELL: exits non-zero with clear self-contained message"
 else
-  fail "unsupported SHELL: exits non-zero with clear message" "exit=$exit_code err=$err"
+  fail "unsupported SHELL: exits non-zero with clear self-contained message" "exit=$exit_code err=$err"
 fi
+teardown
+
+# -- Test 18a: SHELL=fish is accepted, banner shows shell: fish ---------------
+# Path doesn't need to exist — shell selection happens by basename before tmux
+# preflight, so /usr/local/bin/fish is treated as fish regardless of presence.
+
+setup
+err="$(SHELL=/usr/local/bin/fish "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$err" | grep -q "unsupported login shell" \
+    && echo "$err" | grep -q "shell: fish"; then
+  ok "SHELL=fish: shell resolution accepted, banner shows shell: fish"
+else
+  fail "SHELL=fish: shell resolution accepted, banner shows shell: fish" "err=$err"
+fi
+teardown
+
+# -- Test 18b: fish picks the fish-flavored prompt-read syntax ----------------
+# inner_cmd (preflight) is surfaced under ROOST_SPAWN_KEEP_DATA_DIR=1. fish
+# must use `(string collect <$ROOST_PROMPT_FILE)` — `$(< file)` is bash/zsh
+# shorthand fish doesn't grok.
+
+setup
+out="$(SHELL=/usr/local/bin/fish ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+# Unquoted (string collect ...) is required: fish treats bare (...) inside
+# double quotes as a literal, so quoting would silently disable substitution.
+if echo "$out" | grep -qF -- '-- (string collect <$ROOST_PROMPT_FILE)' \
+    && ! echo "$out" | grep -qF '$(< "$ROOST_PROMPT_FILE")'; then
+  ok "SHELL=fish + --prompt: inner_cmd uses unquoted string-collect, not \$(<file)"
+else
+  fail "SHELL=fish + --prompt: inner_cmd uses unquoted string-collect, not \$(<file)" "out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 18c: bash keeps the $(< file) prompt-read syntax --------------------
+
+setup
+out="$(SHELL=/bin/bash ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if echo "$out" | grep -qF '$(< "$ROOST_PROMPT_FILE")' \
+    && ! echo "$out" | grep -qF '(string collect <$ROOST_PROMPT_FILE)'; then
+  ok "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect"
+else
+  fail "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect" "out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
 # -- Test 19: --steer-compact wires PreCompact + writes session-name.txt -----


### PR DESCRIPTION
Closes #381

fish was dropped from supported shells in #380 because `$(< file)` (the prompt-file read shorthand) is bash/zsh-only and produces an empty prompt under fish. This restores fish properly:

- `bin/roost`: fish branch in shell-resolution case (`--login -c`, not `-l`); error message dropped the closed-issue URL in favor of a self-contained supported-shell list (per #380 review B3).
- Prompt-file read is shell-flavored: bash/zsh keep `$(< "$FILE")`; fish uses unquoted `(string collect <$FILE)` (3.1+). fish treats bare `(...)` inside double quotes as a literal — only `$(…)` does command-substitution-in-quotes and that's 3.4+, so unquoted + `string collect` (which emits one arg even unquoted) is the broadly-compatible shape.
- `test/spawn_test.sh`: SHELL=fish accepted; fish + --prompt picks the string-collect form; bash + --prompt keeps `$(< …)`. Test seam `ROOST_SPAWN_KEEP_DATA_DIR=1` now also echoes the assembled inner_cmd. teardown kills any leftover `roost-testnick` tmux so the bash/fish tests don't leak sessions on dev boxes with ergo running.

End-to-end verified locally with fish 4.7.1: the assembled inner_cmd, re-quoted via `printf %q` and dispatched through `fish --login -c`, hands claude the prompt body as a single multi-line argument.

## Test plan
- [x] `bash test/spawn_test.sh` — 23 pass, 0 fail (incl. 3 new fish tests)
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] Manual: full `fish --login -c "<inner_cmd>"` chain feeds prompt as single arg
- [ ] Reviewer pass

[roost-worker-381]