### PR TITLE
agents: delegate followup body authoring from lead-pm to APM

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -159,12 +159,12 @@ Trigger: lead mentions you with intent like `$0-apm file followup: title="X" fro
 
 Ack template: `file followup "<title>" (milestone: <name-or-none>); drafted body:\n  [roost-apm] from <source>: <drafted description>\ngo?`
 
-Where `<source>` is `PR #<N>`, `issue #<I>`, or `PR #<N> / issue #<I>` depending on which the lead's intent referenced. Pick the one that's true; don't pad both into the template when only one applies. Draft `<drafted description>` from the title, source context, and channel discussion — one concise line capturing the intent.
+Where `<source>` is `PR #<N>`, `issue #<I>`, or `PR #<N> / issue #<I>` depending on which the lead's intent referenced. Pick the one that's true; don't pad both into the template when only one applies. Draft `<drafted description>` from the title, source context, and channel discussion — concise, one line where it fits.
 
 Defaults and judgments inside the ack:
 - **Milestone**: if the lead didn't name one, default to **no milestone** — say so in the ack. The lead can correct with `for milestone X` and you re-ack. Don't guess the current milestone; cross-milestone deferrals are common and silently guessing wrong is worse than asking.
 - **Scope flag**: if your drafted body suggests the change widens what the current milestone is meant to deliver, add `(this looks like it widens <milestone> — reconsider project plan first?)` to the ack. The lead either confirms anyway or pauses to rethink.
-- **Source link**: always quote the originating PR or issue number in the body. The lead's mention should give you that — if it doesn't, ask before filing.
+- **Source link**: always quote the originating PR or issue number (and the trigger line if the lead's intent referenced a specific comment or finding) in the body. The lead's mention should give you that — if it doesn't, ask before filing.
 
 On confirmation, run `gh issue create` with `--title`, `--body` (the rendered template), `--repo <owner>/<repo>`, and `--milestone "<name>"` only if the lead specified one (omit the flag entirely otherwise). Then post the issue URL in the channel where the lead asked (typically `#<project>-leads`, sometimes `#<project>-issue-<I>`). One line: `filed: <url>`.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -155,16 +155,16 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
 
 ### Follow-up dance
 
-Trigger: lead mentions you with intent like `$0-apm file followup: title="X" — <body>` or `$0-apm file followup on #<N>: <gist>`. Anyone (worker, reviewer, human) can *surface* a candidate follow-up in the channel, but only the lead's mention with intent triggers this dance.
+Trigger: lead mentions you with intent like `$0-apm file followup: title="X" from PR #<N>` or `$0-apm file followup on #<N>: <gist>`. Anyone (worker, reviewer, human) can *surface* a candidate follow-up in the channel, but only the lead's mention with intent triggers this dance.
 
-Ack template: `file followup "<title>" (milestone: <name-or-none>); body shape:\n  [roost-apm] from <source>: "<quoted trigger line>"\n  <body>\ngo?`
+Ack template: `file followup "<title>" (milestone: <name-or-none>); drafted body:\n  [roost-apm] from <source>: <drafted description>\ngo?`
 
-Where `<source>` is `PR #<N>`, `issue #<I>`, or `PR #<N> / issue #<I>` depending on which the lead's intent referenced. Pick the one that's true; don't pad both into the template when only one applies.
+Where `<source>` is `PR #<N>`, `issue #<I>`, or `PR #<N> / issue #<I>` depending on which the lead's intent referenced. Pick the one that's true; don't pad both into the template when only one applies. Draft `<drafted description>` from the title, source context, and channel discussion — one concise line capturing the intent.
 
 Defaults and judgments inside the ack:
 - **Milestone**: if the lead didn't name one, default to **no milestone** — say so in the ack. The lead can correct with `for milestone X` and you re-ack. Don't guess the current milestone; cross-milestone deferrals are common and silently guessing wrong is worse than asking.
-- **Scope flag**: if the followup body suggests the change widens what the current milestone is meant to deliver, add `(this looks like it widens <milestone> — reconsider project plan first?)` to the ack. The lead either confirms anyway or pauses to rethink.
-- **Source link**: always quote the originating PR or issue number (and the trigger line if the lead's intent referenced a specific comment or finding). The lead's mention should give you that — if it doesn't, ask before filing.
+- **Scope flag**: if your drafted body suggests the change widens what the current milestone is meant to deliver, add `(this looks like it widens <milestone> — reconsider project plan first?)` to the ack. The lead either confirms anyway or pauses to rethink.
+- **Source link**: always quote the originating PR or issue number in the body. The lead's mention should give you that — if it doesn't, ask before filing.
 
 On confirmation, run `gh issue create` with `--title`, `--body` (the rendered template), `--repo <owner>/<repo>`, and `--milestone "<name>"` only if the lead specified one (omit the flag entirely otherwise). Then post the issue URL in the channel where the lead asked (typically `#<project>-leads`, sometimes `#<project>-issue-<I>`). One line: `filed: <url>`.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -129,8 +129,8 @@ All follow-up issues — whether surfaced by a worker mid-PR, by the reviewer ag
 
 1. **Default to rolling the fix into the current PR.** Only file a followup when the scope is genuinely too large for the current PR — substantial new code, dependent unmerged work, a separate concern, or out-of-milestone. When in doubt, take it now. Push the worker to expand scope rather than defer; reach for `gh issue create` last, not first.
 2. Decide milestone: usually the current one; sometimes a later milestone; sometimes "no milestone" if you're not sure where it lands.
-3. Mention the APM with intent, e.g. `<project>-apm file followup: title="<short title>" — <one-line body>`. Reference the source PR or issue (e.g. "from PR #<N>") so the APM can quote-link it in the body.
-4. The APM acks with title + body shape + milestone (defaults to no milestone if you didn't specify one), and asks if a wider-scope followup should prompt a project-plan rethink. Confirm with an affirmative or correct.
+3. Mention the APM with intent, e.g. `<project>-apm file followup: title="<short title>" from PR #<N>`. Pass title, source context (which PR or issue), and milestone if known — the APM drafts the body.
+4. The APM acks with title + drafted body + milestone (defaults to no milestone if you didn't specify one), and asks if a wider-scope followup should prompt a project-plan rethink. Confirm with an affirmative or correct.
 5. The APM creates the issue and posts the URL in the channel where you asked.
 
 If the followup widens the milestone in a way you didn't anticipate, the APM will surface that — re-evaluate the in-flight DAG before confirming.


### PR DESCRIPTION
Closes #390

lead-pm now passes only title, source context, and optional milestone when filing followups. APM drafts the body from that intent + channel context, shows it in the ack for lead approval before filing.

Changes:
- `agents/lead-pm.md`: step 3 in "Filing follow-up issues" — drop body from the example intent; note APM drafts it
- `agents/associate-pm.md`: follow-up dance trigger/ack updated to "drafted body" pattern; scope-flag and source-link bullets updated to match