### PR TITLE
feat(help): surface --steer-compact and --cache-ttl heuristics in spawn help

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ roost init                          # writes .orchestrator/config.json + copies 
 roost spawn myproject-lead-pm \
   --agent lead-pm \
   --channels '#myproject-leads' \
+  --steer-compact --cache-ttl 1h \
   --prompt 'milestone=<milestone> human=<your-nick> gh-login=<your-gh-login>'
 ```
 

--- a/bin/roost
+++ b/bin/roost
@@ -186,11 +186,10 @@ Options:
 Agent class guidance:
   PM agents (lead-pm, associate-pm) — long-running, need compact steering:
     --steer-compact --cache-ttl 1h
-  Workers awaiting review — multi-turn:
+  Workers (post-PR, waiting through reviewer + human review cycles):
     --cache-ttl 1h
   One-shot agents (reviewers, single-prompt workers):
     --cache-ttl 5m
-  (1h cache writes cost 2x the 5m rate; don't use it for ephemeral spawns.)
 
 Examples:
   roost spawn worker-1 -c '#my-channel' --cwd ~/Dev/myproject
@@ -500,6 +499,7 @@ cmd_init() {
   printf '  roost spawn %s-lead-pm \\\n' "$project"
   printf '    --agent lead-pm \\\n'
   printf "    --channels '#%s-leads' \\\n" "$project"
+  printf '    --steer-compact --cache-ttl 1h \\\n'
   printf "    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'\n"
 }
 

--- a/bin/roost
+++ b/bin/roost
@@ -50,6 +50,7 @@ Quick start:
   roost spawn <project>-lead-pm \\
     --agent lead-pm \\
     --channels '#<project>-leads' \\
+    --steer-compact --cache-ttl 1h \\
     --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'
 
 Run 'roost <command> --help' for per-command usage.
@@ -181,6 +182,15 @@ Options:
                              --prompt.
   -- <args...>               Pass remaining args directly to claude.
                              Use for --chrome, --system-prompt, etc.
+
+Agent class guidance:
+  PM agents (lead-pm, associate-pm) — long-running, need compact steering:
+    --steer-compact --cache-ttl 1h
+  Workers awaiting review — multi-turn:
+    --cache-ttl 1h
+  One-shot agents (reviewers, single-prompt workers):
+    --cache-ttl 5m
+  (1h cache writes cost 2x the 5m rate; don't use it for ephemeral spawns.)
 
 Examples:
   roost spawn worker-1 -c '#my-channel' --cwd ~/Dev/myproject


### PR DESCRIPTION
Closes #389

Quick-start templates in `bin/roost` and `README.md` were missing `--steer-compact --cache-ttl 1h` for the lead-pm spawn — operators copy-pasting those got a suboptimal PM session with no compact steering and no cache TTL. Also adds a guidance block to `roost spawn --help` mapping agent class → recommended flags, so the heuristic is visible at the point of use without digging into agent docs.

Changes:
- `bin/roost` `usage()` quick start: add `--steer-compact --cache-ttl 1h` to lead-pm template
- `bin/roost` `usage_spawn()`: add "Agent class guidance" block before examples
- `README.md`: same flag addition to the lead-pm quick-start snippet

[roost-worker-389]