### PR TITLE
fix(dispatcher): rolling 5-min window for rate-limit warning

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, fetchRateLimit, computeRateLimitWarning, type RateLimitInfo } from '../github-api.js'
+import { GhError, spawnGh, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../github-api.js'
 
 function mkErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
@@ -233,33 +233,37 @@ describe('computeRateLimitWarning', () => {
     return { remaining, limit: 5000, resetAt: Math.floor((T0 + resetInMin * MIN) / 1000) }
   }
 
+  it('returns null when history is empty', () => {
+    expect(computeRateLimitWarning(makeInfo(1000), [], T0)).toBeNull()
+  })
+
   it('returns null when remaining is unchanged (no consumption)', () => {
     const prev = { remaining: 1000, ts: T0 - 15 * SEC }
-    expect(computeRateLimitWarning(makeInfo(1000), prev, T0)).toBeNull()
+    expect(computeRateLimitWarning(makeInfo(1000), [prev], T0)).toBeNull()
   })
 
   it('returns null when remaining went up (reset happened between ticks)', () => {
     const prev = { remaining: 100, ts: T0 - 15 * SEC }
-    expect(computeRateLimitWarning(makeInfo(5000), prev, T0)).toBeNull()
+    expect(computeRateLimitWarning(makeInfo(5000), [prev], T0)).toBeNull()
   })
 
   it('returns null when reset is already in the past', () => {
     const info = { remaining: 10, limit: 5000, resetAt: Math.floor((T0 - MIN) / 1000) }
     const prev = { remaining: 100, ts: T0 - 15 * SEC }
-    expect(computeRateLimitWarning(info, prev, T0)).toBeNull()
+    expect(computeRateLimitWarning(info, [prev], T0)).toBeNull()
   })
 
   it('returns null when trajectory is fine (exhaustion after reset)', () => {
     // 10 consumed in 15s → ~40/min. 2000 remaining → 50 min to exhaustion. reset in 30min.
     // exhaustion (50m) > reset (30m) → no warning
     const prev = { remaining: 2010, ts: T0 - 15 * SEC }
-    expect(computeRateLimitWarning(makeInfo(2000, 30), prev, T0)).toBeNull()
+    expect(computeRateLimitWarning(makeInfo(2000, 30), [prev], T0)).toBeNull()
   })
 
   it('returns warning string when exhaustion is predicted before reset', () => {
     // 400 consumed in 15s → 1600/min. 200 remaining → ~0.125 min exhaustion. reset in 30min.
     const prev = { remaining: 600, ts: T0 - 15 * SEC }
-    const warning = computeRateLimitWarning(makeInfo(200, 30), prev, T0)
+    const warning = computeRateLimitWarning(makeInfo(200, 30), [prev], T0)
     expect(warning).toMatch(/rate limit warning/)
     expect(warning).toMatch(/200 calls remaining/)
     expect(warning).toMatch(/reset in 30m/)
@@ -269,14 +273,50 @@ describe('computeRateLimitWarning', () => {
   it('warning includes projected exhaustion time', () => {
     // 60 consumed in 60s → 60/min. 60 remaining → 1 min to exhaustion. reset in 30min.
     const prev = { remaining: 120, ts: T0 - 60 * SEC }
-    const warning = computeRateLimitWarning(makeInfo(60, 30), prev, T0)
+    const warning = computeRateLimitWarning(makeInfo(60, 30), [prev], T0)
     expect(warning).toMatch(/projected exhaustion in 1m/)
   })
 
   it('shows seconds for sub-minute projected exhaustion', () => {
     // 600 consumed in 60s → 600/min. 100 remaining → ~10s to exhaustion. reset in 30min.
     const prev = { remaining: 700, ts: T0 - 60 * SEC }
-    const warning = computeRateLimitWarning(makeInfo(100, 30), prev, T0)
+    const warning = computeRateLimitWarning(makeInfo(100, 30), [prev], T0)
     expect(warning).toMatch(/projected exhaustion in 10s/)
+  })
+
+  it('cold-start single entry: no warn when nothing consumed', () => {
+    // One history entry, remaining unchanged — graceful no-op.
+    const prev = { remaining: 5000, ts: T0 - 30 * SEC }
+    expect(computeRateLimitWarning(makeInfo(5000), [prev], T0)).toBeNull()
+  })
+
+  it('uses oldest history entry as anchor, smoothing across the window', () => {
+    // Burst in the middle tick inflates tick-to-tick rate, but the 5-min window
+    // dilutes it. anchor=T0-300s: 200 consumed over 300s → 40/min.
+    // minToExhaustion = 4800/40 = 120 min, reset in 60 min → no warning.
+    const history = [
+      { remaining: 5000, ts: T0 - 300 * SEC },  // oldest anchor
+      { remaining: 4900, ts: T0 - 150 * SEC },  // burst: -100 in 150s
+      { remaining: 4800, ts: T0 - 10 * SEC },   // then quiet
+    ]
+    // tick-to-tick from last entry: 0 consumed in 10s → no warn (consumed<=0)
+    // but anchor-based: 200 consumed in 300s → 40/min → 4800/40=120m > 60m reset → no warn
+    expect(computeRateLimitWarning(makeInfo(4800), history, T0)).toBeNull()
+  })
+
+  it('rolling window: a genuine sustained spike still warns', () => {
+    // 300 consumed over 300s → 60/min. 60 remaining → 1 min to exhaustion, reset in 30 min.
+    const history = [
+      { remaining: 360, ts: T0 - 300 * SEC },
+      { remaining: 260, ts: T0 - 200 * SEC },
+      { remaining: 160, ts: T0 - 100 * SEC },
+    ]
+    const warning = computeRateLimitWarning(makeInfo(60, 30), history, T0)
+    expect(warning).toMatch(/rate limit warning/)
+    expect(warning).toMatch(/~60\/min/)
+  })
+
+  it('RATE_LIMIT_WINDOW_MS is exported and equals 5 minutes', () => {
+    expect(RATE_LIMIT_WINDOW_MS).toBe(5 * 60 * 1000)
   })
 })

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -260,26 +260,32 @@ describe('computeRateLimitWarning', () => {
     expect(computeRateLimitWarning(makeInfo(2000, 30), [prev], T0)).toBeNull()
   })
 
+  it('returns null when history spans less than half the rolling window', () => {
+    // 100s < RATE_LIMIT_WINDOW_MS/2 (150s) — not enough history to trust rate.
+    const prev = { remaining: 5000, ts: T0 - 100 * SEC }
+    expect(computeRateLimitWarning(makeInfo(100, 30), [prev], T0)).toBeNull()
+  })
+
   it('returns warning string when exhaustion is predicted before reset', () => {
-    // 400 consumed in 15s → 1600/min. 200 remaining → ~0.125 min exhaustion. reset in 30min.
-    const prev = { remaining: 600, ts: T0 - 15 * SEC }
+    // 400 consumed in 160s → 150/min. 200 remaining → ~1.3 min exhaustion. reset in 30min.
+    const prev = { remaining: 600, ts: T0 - 160 * SEC }
     const warning = computeRateLimitWarning(makeInfo(200, 30), [prev], T0)
     expect(warning).toMatch(/rate limit warning/)
     expect(warning).toMatch(/200 calls remaining/)
     expect(warning).toMatch(/reset in 30m/)
-    expect(warning).toMatch(/~1600\/min/)
+    expect(warning).toMatch(/~150\/min/)
   })
 
   it('warning includes projected exhaustion time', () => {
-    // 60 consumed in 60s → 60/min. 60 remaining → 1 min to exhaustion. reset in 30min.
-    const prev = { remaining: 120, ts: T0 - 60 * SEC }
+    // 160 consumed in 160s → 60/min. 60 remaining → 1 min to exhaustion. reset in 30min.
+    const prev = { remaining: 220, ts: T0 - 160 * SEC }
     const warning = computeRateLimitWarning(makeInfo(60, 30), [prev], T0)
     expect(warning).toMatch(/projected exhaustion in 1m/)
   })
 
   it('shows seconds for sub-minute projected exhaustion', () => {
-    // 600 consumed in 60s → 600/min. 100 remaining → ~10s to exhaustion. reset in 30min.
-    const prev = { remaining: 700, ts: T0 - 60 * SEC }
+    // 1600 consumed in 160s → 600/min. 100 remaining → ~10s to exhaustion. reset in 30min.
+    const prev = { remaining: 1700, ts: T0 - 160 * SEC }
     const warning = computeRateLimitWarning(makeInfo(100, 30), [prev], T0)
     expect(warning).toMatch(/projected exhaustion in 10s/)
   })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -429,12 +429,12 @@ describe('GhPluginBase.observeRateLimit — pruning and anchor selection', () =>
 
   it('warns when rolling window rate predicts exhaustion before reset', async () => {
     const plugin = new GitHubPrsPlugin('#proj')
-    // Inject history entry 60 seconds ago with 5000 remaining.
+    // Inject history entry 160 seconds ago (> half-window threshold) with 5000 remaining.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(plugin as any)._rateLimitHistory = [
-      { remaining: 5000, ts: Date.now() - 60_000 },
+      { remaining: 5000, ts: Date.now() - 160_000 },
     ]
-    // Now 100 remaining, reset in 60 min. 4900 consumed in 60s → very high rate → warns.
+    // Now 100 remaining, reset in 60 min. 4900 consumed in 160s → very high rate → warns.
     const result = await observe(plugin, 100, 60 * 60_000)
     expect(result).toHaveLength(1)
     expect(result[0].payload.text).toMatch(/rate limit warning/)

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn } from 'bun:test'
 import { GitHubPrsPlugin } from '../prs-plugin.js'
 import { GitHubIssuesPlugin } from '../issues-plugin.js'
 import { GhPluginBase } from '../base.js'
+import { RATE_LIMIT_WINDOW_MS } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
 import type { PrSnap, IssueSnap } from '../types.js'
 import { GhScraper } from '../scraper.js'
@@ -390,5 +391,67 @@ describe('GhPluginBase.observeRateLimit integration', () => {
       scrapeSpy.mockRestore()
       observeSpy.mockRestore()
     }
+  })
+})
+
+describe('GhPluginBase.observeRateLimit — pruning and anchor selection', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function observe(plugin: GitHubPrsPlugin, remaining: number, resetInMs = 60 * 60_000) {
+    const fetch = async () => ({
+      remaining,
+      limit: 5000,
+      resetAt: Math.floor((Date.now() + resetInMs) / 1000),
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (plugin as any).observeRateLimit('#proj', fetch)
+  }
+
+  it('no warning on cold-start (first call)', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    expect(await observe(plugin, 5000)).toEqual([])
+  })
+
+  it('no warning when nothing consumed', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    await observe(plugin, 5000)
+    expect(await observe(plugin, 5000)).toEqual([])
+  })
+
+  it('prunes stale history and cold-starts after a long gap', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    // Inject a stale entry that would trigger a warning if used as anchor.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [
+      { remaining: 5000, ts: Date.now() - RATE_LIMIT_WINDOW_MS - 10_000 },
+    ]
+    // After pruning the stale entry, history is empty → cold-start → no warning.
+    expect(await observe(plugin, 100, 60 * 60_000)).toEqual([])
+  })
+
+  it('warns when rolling window rate predicts exhaustion before reset', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    // Inject history entry 60 seconds ago with 5000 remaining.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [
+      { remaining: 5000, ts: Date.now() - 60_000 },
+    ]
+    // Now 100 remaining, reset in 60 min. 4900 consumed in 60s → very high rate → warns.
+    const result = await observe(plugin, 100, 60 * 60_000)
+    expect(result).toHaveLength(1)
+    expect(result[0].payload.text).toMatch(/rate limit warning/)
+  })
+
+  it('uses oldest entry as anchor, diluting mid-window bursts', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    const now = Date.now()
+    // History: oldest=300s ago (5000), mid=10s ago (4800) — burst between mid and now would be 0.
+    // Anchor is oldest: 5000 - 4800 = 200 consumed in 300s → 40/min.
+    // 4800 remaining at 40/min → 120 min to exhaust. Reset in 60 min. 120 >= 60 → no warning.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [
+      { remaining: 5000, ts: now - 300_000 },
+      { remaining: 4800, ts: now - 10_000 },
+    ]
+    expect(await observe(plugin, 4800, 60 * 60_000)).toEqual([])
   })
 })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -395,7 +395,6 @@ describe('GhPluginBase.observeRateLimit integration', () => {
 })
 
 describe('GhPluginBase.observeRateLimit — pruning and anchor selection', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function observe(plugin: GitHubPrsPlugin, remaining: number, resetInMs = 60 * 60_000) {
     const fetch = async () => ({
       remaining,

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -3,7 +3,7 @@ import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger, type TaggedEvent } from '../../plugin.js'
-import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS } from './github-api.js'
+import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from './github-api.js'
 
 // Thin shared base for any plugin that needs GhClient but not watch-list
 // scaffolding. GhBase extends this; non-watching plugins (e.g.
@@ -37,8 +37,11 @@ export abstract class GhPluginBase extends BasePlugin {
   //
   // Runs even when the tick's own scraping failed — we want to observe the budget
   // through failures since a failing tick is often a symptom of exhaustion.
-  protected async observeRateLimit(projectChannel: string): Promise<TaggedEvent[]> {
-    const info = await fetchRateLimit(this.log)
+  protected async observeRateLimit(
+    projectChannel: string,
+    _fetch: (log: PluginLogger) => Promise<RateLimitInfo | null> = fetchRateLimit,
+  ): Promise<TaggedEvent[]> {
+    const info = await _fetch(this.log)
     if (!info) return []
 
     const now = Date.now()
@@ -51,14 +54,9 @@ export abstract class GhPluginBase extends BasePlugin {
       ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
       : null
     const delta = prev != null ? prev.remaining - info.remaining : null
-    const deltaStr = delta != null ? ` (Δ=${delta} since last tick)` : ''
+    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
     const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
     this.log(`[ratelimit] remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
-
-    if (this._rateLimitHistory.length === 0) {
-      this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
-      return []
-    }
 
     const warning = computeRateLimitWarning(info, this._rateLimitHistory, now)
     this._rateLimitHistory.push({ remaining: info.remaining, ts: now })

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -3,7 +3,7 @@ import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger, type TaggedEvent } from '../../plugin.js'
-import { GhClient, fetchRateLimit, computeRateLimitWarning } from './github-api.js'
+import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS } from './github-api.js'
 
 // Thin shared base for any plugin that needs GhClient but not watch-list
 // scaffolding. GhBase extends this; non-watching plugins (e.g.
@@ -12,8 +12,8 @@ export abstract class GhPluginBase extends BasePlugin {
   protected readonly client: GhClient
   protected readonly log: PluginLogger
 
-  // Per-instance: tracks the previous tick's rate limit snapshot for Δ/trajectory.
-  private _prevRateLimit: { remaining: number; ts: number } | null = null
+  // Per-instance: rolling history of rate limit observations (oldest first).
+  private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
 
   // Shared across instances — one warning per 10 min regardless of which plugin fires.
   // 10 min: enough signals in a 60-min reset window without spamming.
@@ -42,17 +42,26 @@ export abstract class GhPluginBase extends BasePlugin {
     if (!info) return []
 
     const now = Date.now()
-    const prev = this._prevRateLimit
+
+    // Prune history to the rolling window before computing rate.
+    const cutoff = now - RATE_LIMIT_WINDOW_MS
+    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
+
+    const prev = this._rateLimitHistory.length > 0
+      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
+      : null
     const delta = prev != null ? prev.remaining - info.remaining : null
     const deltaStr = delta != null ? ` (Δ=${delta} since last tick)` : ''
     const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
     this.log(`[ratelimit] remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
 
-    this._prevRateLimit = { remaining: info.remaining, ts: now }
+    if (this._rateLimitHistory.length === 0) {
+      this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
+      return []
+    }
 
-    if (prev == null) return []
-
-    const warning = computeRateLimitWarning(info, prev, now)
+    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now)
+    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
     if (!warning) return []
 
     const cooldownElapsed = GhPluginBase._warnedAt == null || now - GhPluginBase._warnedAt > GhPluginBase.WARN_COOLDOWN_MS

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -164,6 +164,8 @@ export function computeRateLimitWarning(
   if (consumed <= 0) return null
   const intervalMs = now - anchor.ts
   if (intervalMs <= 0) return null
+  // Require at least half the window of history before trusting the rate estimate.
+  if (intervalMs < RATE_LIMIT_WINDOW_MS / 2) return null
   const ratePerMin = consumed / (intervalMs / 60_000)
   const minToReset = (current.resetAt * 1000 - now) / 60_000
   if (minToReset <= 0) return null

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -144,17 +144,25 @@ export async function fetchRateLimit(
   }
 }
 
-// Pure trajectory computation. Returns a warning string when the current
+// Rolling window for rate computation — 5 minutes gives a stable average
+// across ticks while still catching genuine sustained spikes.
+export const RATE_LIMIT_WINDOW_MS = 5 * 60_000
+
+// Pure trajectory computation. Returns a warning string when the rolling
 // consumption rate predicts exhaustion before the reset boundary; null otherwise.
-// `prev` carries (remaining, ts) from the previous tick for the delta.
+// `history` is a time-ordered (oldest first) array of past observations, already
+// pruned to the rolling window by the caller. Uses history[0] as the anchor so
+// the rate is smoothed across the full window rather than tick-to-tick.
 export function computeRateLimitWarning(
   current: RateLimitInfo,
-  prev: { remaining: number; ts: number },
+  history: ReadonlyArray<{ remaining: number; ts: number }>,
   now: number
 ): string | null {
-  const consumed = prev.remaining - current.remaining
+  if (history.length === 0) return null
+  const anchor = history[0]
+  const consumed = anchor.remaining - current.remaining
   if (consumed <= 0) return null
-  const intervalMs = now - prev.ts
+  const intervalMs = now - anchor.ts
   if (intervalMs <= 0) return null
   const ratePerMin = consumed / (intervalMs / 60_000)
   const minToReset = (current.resetAt * 1000 - now) / 60_000


### PR DESCRIPTION
Closes #402

Replaces the tick-to-tick delta with a rolling 5-minute window as the rate anchor for the GH rate-limit warning. A single-tick burst no longer inflates `ratePerMin` enough to fire a spurious alarm — the rate is diluted across the full window. Genuine sustained spikes still warn.

**Shape of the fix:**
- `computeRateLimitWarning` now accepts `history: ReadonlyArray<{remaining, ts}>` (oldest-first, pre-pruned) and anchors on `history[0]`
- `GhPluginBase._prevRateLimit` → `_rateLimitHistory[]`; pruned to `RATE_LIMIT_WINDOW_MS` (5 min) before each tick; current observation appended after warning is computed
- Empty history (cold-start, post-gap) returns early — no div-by-zero, no spurious warn