### PR TITLE
maint: rename dm-handler → dispatcher-dm-handler

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -23,7 +23,7 @@ import { defaultPluginLogger, type Plugin, type TaggedEvent } from './orchestrat
 import './orchestrator/registry.js'
 import { buildPlugins } from './orchestrator/build-plugins.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
-import { handleDm } from './orchestrator/dm-handler.js'
+import { handleDm } from './orchestrator/dispatcher-dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
 // ---- Path setup ------------------------------------------------------------
@@ -128,7 +128,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   log('orchestrator[daemon]: connected\n')
 
   // DM command handler. Channel messages are ignored; DMs flow through
-  // the allowlist + parser + mutateConfig pipeline in dm-handler.ts.
+  // the allowlist + parser + mutateConfig pipeline in dispatcher-dm-handler.ts.
   const dmHandlerDeps = {
     stateDir,
     plugins,
@@ -144,7 +144,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   client.on('message', (msg) => {
     if (!msg.isDirect) return
     handleDm(dmHandlerDeps, { sender: msg.sender, text: msg.text }).catch((e: unknown) => {
-      log(`orchestrator[daemon]: dm-handler crashed: ${e}\n`)
+      log(`orchestrator[daemon]: dispatcher-dm-handler crashed: ${e}\n`)
     })
   })
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -10,7 +10,7 @@ import {
   splitCommands,
   type Command,
   type HandlerDeps,
-} from '../dm-handler.js'
+} from '../dispatcher-dm-handler.js'
 import { loadConfig, writeConfig, type OrchestratorConfig } from '../config.js'
 import type { Plugin, PluginTickResult } from '../plugin.js'
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -17,7 +17,7 @@ import type { Plugin, PluginTickResult } from '../plugin.js'
 let dir: string
 
 beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), 'roost-dm-handler-test-'))
+  dir = await mkdtemp(join(tmpdir(), 'roost-dispatcher-dm-handler-test-'))
 })
 
 afterEach(async () => {

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -139,7 +139,7 @@ export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string
     const project = defaultProject(config)
     return [leadPmNick(project), apmNick(project)]
   } catch (e) {
-    log?.(`dm-handler: cannot resolve default allowlist (no project/repo in config): ${e}`)
+    log?.(`dispatcher-dm-handler: cannot resolve default allowlist (no project/repo in config): ${e}`)
     return []
   }
 }
@@ -204,14 +204,14 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   try {
     snapshot = await loadConfig(deps.stateDir)
   } catch (e) {
-    deps.log(`dm-handler: config load failed for ${dm.sender}: ${e}`)
+    deps.log(`dispatcher-dm-handler: config load failed for ${dm.sender}: ${e}`)
     deps.postProjectError(`[dispatcher_error] config load: ${e}`)
     return
   }
 
   const allowed = new Set(resolveAllowlist(snapshot, deps.log).map(n => n.toLowerCase()))
   if (!allowed.has(senderLower)) {
-    deps.log(`dm-handler: rejecting ${dm.sender} (not in allowlist)`)
+    deps.log(`dispatcher-dm-handler: rejecting ${dm.sender} (not in allowlist)`)
     deps.dm(dm.sender, 'not authorized; configure irc.command_senders')
     return
   }
@@ -223,7 +223,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   // the half that parsed. Report all parse errors in one reply.
   const unknowns = cmds.filter((c): c is Extract<Command, { kind: 'unknown' }> => c.kind === 'unknown')
   if (unknowns.length) {
-    for (const u of unknowns) deps.log(`dm-handler: ${dm.sender} parse: ${u.error}`)
+    for (const u of unknowns) deps.log(`dispatcher-dm-handler: ${dm.sender} parse: ${u.error}`)
     deps.dm(dm.sender, unknowns.map(u => `error: ${u.error}`).join('\n'))
     return
   }
@@ -237,9 +237,9 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
       try {
         const reply = await routeOne(snapshot, cmd, deps.plugins)
         if (reply !== null) replies.push(reply)
-        deps.log(`dm-handler: ${dm.sender} cmd=${cmd.kind}`)
+        deps.log(`dispatcher-dm-handler: ${dm.sender} cmd=${cmd.kind}`)
       } catch (e) {
-        deps.log(`dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
+        deps.log(`dispatcher-dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
         deps.postProjectError(`[dispatcher_error] handleCommand(${cmd.kind}): ${e}`)
         replies.push(`error: handler crashed on ${cmd.kind}`)
       }
@@ -262,7 +262,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
             replies.push(unmatchedReply(cmd, deps.plugins))
           }
         } catch (e) {
-          deps.log(`dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
+          deps.log(`dispatcher-dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
           deps.postProjectError(`[dispatcher_error] handleCommand(${cmd.kind}): ${e}`)
           replies.push(`error: handler crashed on ${cmd.kind}`)
         }
@@ -270,7 +270,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
     })
   } catch (e) {
     writeFailed = true
-    deps.log(`dm-handler: mutateConfig failed for ${dm.sender}: ${e}`)
+    deps.log(`dispatcher-dm-handler: mutateConfig failed for ${dm.sender}: ${e}`)
     deps.postProjectError(`[dispatcher_error] config write: ${e}`)
     deps.dm(dm.sender, `error: failed to update config — ${e}`)
   }
@@ -278,7 +278,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   if (writeFailed) return
   for (const cmd of cmds) {
     const summary = `cmd=${cmd.kind}${'target' in cmd ? ` target=${cmd.target ?? '(default)'}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
-    deps.log(`dm-handler: ${dm.sender} ${summary}`)
+    deps.log(`dispatcher-dm-handler: ${dm.sender} ${summary}`)
   }
   deps.dm(dm.sender, replies.join('\n\n'))
 }

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -5,10 +5,10 @@
 // agnostic to the source plugin's event vocabulary.
 //
 // Plugins may also opt in to inbound DM commands via `handleCommand`: see
-// dm-handler.ts for the routing layer. Plugins mutate their own slice
+// dispatcher-dm-handler.ts for the routing layer. Plugins mutate their own slice
 // (config.plugins[name]) in place inside the dispatcher's mutateConfig
-// callback; dm-handler never touches slice shapes.
-import type { Command } from './dm-handler.js'
+// callback; dispatcher-dm-handler never touches slice shapes.
+import type { Command } from './dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from './config.js'
 
 // Pre-formatted payload variants. Plugins decide one-line vs. multi-line;
@@ -43,7 +43,7 @@ export interface Plugin {
   // including dynamic discoveries like PR linked-issues). Seeding is signaled
   // by `prevState === null`.
   runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
-  // Optional: handle a parsed DM command (see dm-handler.ts). Plugins mutate
+  // Optional: handle a parsed DM command (see dispatcher-dm-handler.ts). Plugins mutate
   // their own slice (config.plugins[name]) in place — the call site is wrapped
   // in mutateConfig so writes are atomic across plugins. Return a reply line
   // when this plugin handles the command, null when it doesn't apply.

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -1,4 +1,4 @@
-import type { Command } from '../../dm-handler.js'
+import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
 import { defaultProject, issueChannel } from '../../naming.js'
@@ -102,7 +102,7 @@ export abstract class GhBase extends GhPluginBase {
 
   // ---- DM command handling --------------------------------------------
 
-  // Inbound DM command surface. The dispatcher (dm-handler.ts) calls this
+  // Inbound DM command surface. The dispatcher (dispatcher-dm-handler.ts) calls this
   // once per parsed command inside its mutateConfig pass — we mutate our
   // own slice in place. Returns the reply line(s) when we handle the
   // command, null when the command isn't ours. Never throws.


### PR DESCRIPTION
Closes #395

Renames `src/orchestrator/dm-handler.ts` → `dispatcher-dm-handler.ts` (and the matching test file). Updates all import paths, comments, and log prefixes throughout. No logic changes.

The old name looked generic enough that it was nearly deleted as defunct watcher code; the new name makes its role (dispatcher's DM control surface for APM ↔ dispatcher watch/unwatch flow) self-evident.