### PR TITLE
fix(spawn): use $(cat) for sh/dash prompt-read

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -827,14 +827,13 @@ cmd_spawn() {
   # isn't absorbed by --dangerously-load-development-channels (variadic flag —
   # eats all subsequent non-flag args).
   #
-  # The read syntax is shell-flavored: bash/zsh use `$(< "$ROOST_PROMPT_FILE")`
-  # (a bash/zsh shorthand); sh/dash use `$(cat "$ROOST_PROMPT_FILE")` (POSIX
-  # portable — `$(<file)` is an empty redirection in sh/dash); fish has no
-  # `$(< file)` shorthand and treats unquoted `(...)` as command substitution
-  # but treats bare `(...)` inside double quotes as a literal, so we use
-  # unquoted `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string
-  # collect emits a single argument with newlines preserved, which fish hands
-  # to claude as one arg even unquoted.
+  # The read syntax is shell-flavored: everywhere outside fish we use
+  # `$(cat "$ROOST_PROMPT_FILE")` (POSIX portable); fish has no `$(...)` syntax
+  # and treats unquoted `(...)` as command substitution but treats bare `(...)`
+  # inside double quotes as a literal, so we use unquoted
+  # `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string collect emits
+  # a single argument with newlines preserved, which fish hands to claude as
+  # one arg even unquoted.
   #
   # Done before require_tmux/require_ircd so the ROOST_SPAWN_KEEP_DATA_DIR=1
   # test seam can surface the assembled command without an IRC daemon running.
@@ -865,9 +864,8 @@ cmd_spawn() {
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016
     case "${shell_basename}" in
-      fish)    inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
-      sh|dash) inner_cmd="${inner_cmd} --"' "$(cat "$ROOST_PROMPT_FILE")"' ;;
-      bash|zsh) inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
+      fish) inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
+      *)    inner_cmd="${inner_cmd} --"' "$(cat "$ROOST_PROMPT_FILE")"' ;;
     esac
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")
   fi

--- a/bin/roost
+++ b/bin/roost
@@ -827,10 +827,12 @@ cmd_spawn() {
   # isn't absorbed by --dangerously-load-development-channels (variadic flag —
   # eats all subsequent non-flag args).
   #
-  # The read syntax is shell-flavored: bash/zsh use `$(< "$ROOST_PROMPT_FILE")`;
-  # fish has no `$(< file)` shorthand and treats unquoted `(...)` as command
-  # substitution but treats bare `(...)` inside double quotes as a literal, so
-  # we use unquoted `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string
+  # The read syntax is shell-flavored: bash/zsh use `$(< "$ROOST_PROMPT_FILE")`
+  # (a bash/zsh shorthand); sh/dash use `$(cat "$ROOST_PROMPT_FILE")` (POSIX
+  # portable — `$(<file)` is an empty redirection in sh/dash); fish has no
+  # `$(< file)` shorthand and treats unquoted `(...)` as command substitution
+  # but treats bare `(...)` inside double quotes as a literal, so we use
+  # unquoted `(string collect <$ROOST_PROMPT_FILE)` (fish 3.1+) — string
   # collect emits a single argument with newlines preserved, which fish hands
   # to claude as one arg even unquoted.
   #

--- a/bin/roost
+++ b/bin/roost
@@ -867,7 +867,7 @@ cmd_spawn() {
     case "${shell_basename}" in
       fish)    inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
       sh|dash) inner_cmd="${inner_cmd} --"' "$(cat "$ROOST_PROMPT_FILE")"' ;;
-      *)       inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
+      bash|zsh) inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
     esac
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")
   fi

--- a/bin/roost
+++ b/bin/roost
@@ -863,8 +863,9 @@ cmd_spawn() {
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016
     case "${shell_basename}" in
-      fish) inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
-      *)    inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
+      fish)    inner_cmd="${inner_cmd} --"' (string collect <$ROOST_PROMPT_FILE)' ;;
+      sh|dash) inner_cmd="${inner_cmd} --"' "$(cat "$ROOST_PROMPT_FILE")"' ;;
+      *)       inner_cmd="${inner_cmd} --"' "$(< "$ROOST_PROMPT_FILE")"' ;;
     esac
     tmux_env+=(-e "ROOST_PROMPT_FILE=${prompt_file}")
   fi

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -308,6 +308,38 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
+# -- Test 18d: sh uses $(cat ...) prompt-read syntax, not $(< file) -----------
+
+setup
+out="$(SHELL=/bin/sh ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF '$(cat "$ROOST_PROMPT_FILE")' \
+    && ! echo "$inner_cmd" | grep -qF '$(< "$ROOST_PROMPT_FILE")'; then
+  ok "SHELL=sh + --prompt: inner_cmd uses \$(cat ...), not \$(<file)"
+else
+  fail "SHELL=sh + --prompt: inner_cmd uses \$(cat ...), not \$(<file)" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 18e: dash uses $(cat ...) prompt-read syntax, not $(< file) ---------
+
+setup
+out="$(SHELL=/bin/dash ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF '$(cat "$ROOST_PROMPT_FILE")' \
+    && ! echo "$inner_cmd" | grep -qF '$(< "$ROOST_PROMPT_FILE")'; then
+  ok "SHELL=dash + --prompt: inner_cmd uses \$(cat ...), not \$(<file)"
+else
+  fail "SHELL=dash + --prompt: inner_cmd uses \$(cat ...), not \$(<file)" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
 # -- Test 19: --steer-compact wires PreCompact + writes session-name.txt -----
 # ROOST_SPAWN_KEEP_DATA_DIR=1 keeps the data-dir alive after a preflight
 # failure (tmux session not actually created), so we can inspect what the

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -292,18 +292,18 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
-# -- Test 18c: bash keeps the $(< file) prompt-read syntax --------------------
+# -- Test 18c: bash uses $(cat ...) prompt-read syntax ------------------------
 
 setup
 out="$(SHELL=/bin/bash ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --prompt hello 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && echo "$inner_cmd" | grep -qF '$(< "$ROOST_PROMPT_FILE")' \
+    && echo "$inner_cmd" | grep -qF '$(cat "$ROOST_PROMPT_FILE")' \
     && ! echo "$inner_cmd" | grep -qF '(string collect <$ROOST_PROMPT_FILE)'; then
-  ok "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect"
+  ok "SHELL=bash + --prompt: inner_cmd uses \$(cat ...), not string-collect"
 else
-  fail "SHELL=bash + --prompt: inner_cmd uses \$(<file), not string-collect" "inner_cmd=$inner_cmd"
+  fail "SHELL=bash + --prompt: inner_cmd uses \$(cat ...), not string-collect" "inner_cmd=$inner_cmd"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown


### PR DESCRIPTION
Closes #398

`$(<file)` is bash/zsh-only. sh/dash treats it as an empty redirection, so `--prompt` passed an empty string to claude when `SHELL=sh` or `SHELL=dash`.

Added `sh|dash)` branch to the shell-flavor case in `bin/roost` using `$(cat "$ROOST_PROMPT_FILE")` (POSIX-portable). Tests 18d/18e cover the new branches specifically, distinguishing sh and dash from the bash catchall.