### PR TITLE
maint: consolidate agent-class guidance into roost spawn --help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatte
 
 The PreCompact hook (`bin/roost-compact-hook`) is opt-in via `--steer-compact` at spawn. When wired, it intercepts claude code's auto-compact (`trigger="auto"`), returns `{"decision":"block"}` to halt the directive-less default, then injects `/compact <directive>` into the tmux pane via backgrounded `tmux send-keys` — so the manual `/compact` re-fires PreCompact with `trigger="manual"` and `custom_instructions` populated, and the compactor runs with our directive. The directive is a single-line constant near the top of the hook script (one place to edit; covers the roost agent set generically — role, IRC nick, channels joined, in-flight issue/PR state, recent decisions, pending work). Long-running PM-class agents (lead-pm, associate-pm) pass `--steer-compact`; workers and reviewers don't (auto-compact rarely fires in their lifetime). The `docs/LEARNINGS.md` finding on auto-compact has the empirical investigation.
 
+## Agent class heuristic
+
+The role→flag heuristic for `--cache-ttl` and `--steer-compact` lives in the "Agent class guidance" block of `bin/roost`'s `spawn --help` output — that's the canonical source. Agent prompts (`agents/lead-pm.md`, `agents/associate-pm.md`), the roost skill, and `docs/LEARNINGS.md` §9 all point at it. Edit the `bin/roost` block if the trade-offs shift; the pointers don't need to move. Shipped artifacts (agent prompts, the skill) deliberately don't carry "edit here" instructions — they install into projects that aren't roost, where operators don't own the heuristic.
+
 ## Comments
 
 In-tree comments (code and docs) must be timeless — no PR/issue/version refs (e.g. `(#276)`, `Issue #342`, `from #136`, `since v3`). Future readers encounter them without that context. Systems of record (commit messages, PR bodies, LEARNINGS.md, dated audit reports under `docs/audit-*`) keep their refs; in-tree comments don't.

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -68,7 +68,7 @@ If you never get an affirmative, sit and wait. Do not nag.
 
 ## Six dances you own
 
-The `--cache-ttl` and `--steer-compact` choices baked into the spawn templates below follow the role→flag heuristic in `roost spawn --help` ("Agent class guidance"). Don't tune them in isolation — edit the canonical block if the trade-offs ever shift.
+The `--cache-ttl` and `--steer-compact` choices baked into the spawn templates below follow the role→flag heuristic in `roost spawn --help` ("Agent class guidance").
 
 ### Setup dance
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -68,6 +68,8 @@ If you never get an affirmative, sit and wait. Do not nag.
 
 ## Six dances you own
 
+The `--cache-ttl` and `--steer-compact` choices baked into the spawn templates below follow the role→flag heuristic in `roost spawn --help` ("Agent class guidance"). Don't tune them in isolation — edit the canonical block if the trade-offs ever shift.
+
 ### Setup dance
 
 Trigger: lead mentions you with intent like "let's do #290 with opus, and #291" or "kick off 42".
@@ -87,7 +89,6 @@ On confirmation, for each issue N:
      --prompt '/worker <project> <N> <owner>/<repo> <branch> <human-nick>' \
      --perm-irc --perm-target <project>-lead-pm
    ```
-   Workers wait through reviewer + human review cycles which routinely exceed 5 minutes, so they need 1h cache to avoid paying a fresh cache-write on each wake.
 4. Join `#<project>-issue-<N>` yourself.
 5. Snapshot lead-pm + APM cumulative token usage so the cleanup post-mortem can diff per-issue:
    ```
@@ -121,7 +122,6 @@ Trigger: a worker posts a draft PR link in an issue channel you're in.
        --perm-irc --perm-target <project>-lead-pm
      ```
    - Default to opus for review regardless of worker model. Drop to sonnet only when the lead specifies.
-   - Reviewers are one-shot (read PR → post findings → shut down), so 5m cache suffices and is half the cost of 1h.
    - Post in the issue channel: `reviewer spawned for PR #<N>`.
 4. **Missing link** (`closingIssuesReferences` empty): ack before acting. Template: `draft PR #<N> up — no linked issue detected, want me to add Closes #<I>? (then I'll spawn reviewer)`. On confirmation: `gh pr edit <N> --repo <owner>/<repo> --body "..."` with the corrected body — preserve the existing body shape (add `Closes #<I>` as the first line, leave everything else in place). Re-query `closingIssuesReferences` after the edit to confirm the link took, then proceed as in the happy path.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -59,7 +59,7 @@ Pass the same `<human>` / `<gh-login>` values you parsed from your own initial p
 
 (`roost spawn` errors out if you pass `--model` alongside `--agent`; see `roost spawn --help`.) On boot the APM will start the dispatcher daemon if it isn't already running, then post a hello in `#<project>-leads`. If the hello doesn't arrive within a minute, check the APM session.
 
-See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — that's the canonical source for what to pass with `--cache-ttl` and `--steer-compact`, and the only place to edit if the trade-offs ever shift.
+See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — what to pass with `--cache-ttl` and `--steer-compact` for each agent class.
 
 ## Working In Channels
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -59,9 +59,7 @@ Pass the same `<human>` / `<gh-login>` values you parsed from your own initial p
 
 (`roost spawn` errors out if you pass `--model` alongside `--agent`; see `roost spawn --help`.) On boot the APM will start the dispatcher daemon if it isn't already running, then post a hello in `#<project>-leads`. If the hello doesn't arrive within a minute, check the APM session.
 
-Cache-TTL is explicit at the call site — no wrapper default. Heuristic: **one-shot agents (reviewers, single-prompt workers) → `--cache-ttl 5m`; anything with multi-turn work (the APM, workers awaiting human review, you) → `--cache-ttl 1h`.** Workers in particular wait through review cycles that routinely exceed 5 minutes, so they need 1h to avoid paying a fresh cache-write per wake. 1h writes cost 2x the 5m rate, so don't reach for it on truly ephemeral spawns.
-
-`--steer-compact` opts the APM (and you, when you spawn yourself) into roost's auto-compact intercept: claude code's auto-compact gets blocked and redirected to a manual `/compact` with a directive that asks the compactor to retain role + nick, channels joined, in-flight issue/PR state, recent decisions, and pending work. Long-running PM-class agents need it. Workers and reviewers spawned by the APM do NOT pass it — they're short-lived enough that auto-compact is unlikely to fire, and the default behavior is fine.
+See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — that's the canonical source for what to pass with `--cache-ttl` and `--steer-compact`, and the only place to edit if the trade-offs ever shift.
 
 ## Working In Channels
 

--- a/bin/roost
+++ b/bin/roost
@@ -186,8 +186,8 @@ Agent class guidance:
   would be lost across a directive-less auto-compact:
     --steer-compact --cache-ttl 1h
   Workers — multi-turn through reviewer + human review cycles that
-  routinely exceed 5 minutes; short-lived enough that auto-compact
-  rarely fires:
+  routinely exceed 5 minutes, so \`--cache-ttl 1h\`. But short-lived
+  enough that auto-compact rarely fires, so no \`--steer-compact\`:
     --cache-ttl 1h
   One-shot agents (reviewers, single-prompt workers) — read input,
   post output, shut down inside 5 minutes:

--- a/bin/roost
+++ b/bin/roost
@@ -136,12 +136,8 @@ Options:
                              \`ENABLE_PROMPT_CACHING_1H=1\` for 1h).
                              No wrapper default — if unset, neither env
                              var is injected and claude-code's native
-                             cache behavior applies. Caller picks per
-                             session: \`5m\` for one-shot agents (reviewers,
-                             single-prompt workers); \`1h\` for anything with
-                             multi-turn work (workers awaiting human
-                             review, lead-pm, APM, dispatcher).
-                             1h cache writes cost 2x the 5m rate.
+                             cache behavior applies. See "Agent class
+                             guidance" below for which value to pick.
   --steer-compact            Opt in to roost's auto-compact intercept.
                              Wires a PreCompact hook that, on
                              \`trigger=auto\`, blocks the directive-less
@@ -149,13 +145,8 @@ Options:
                              \`/compact <directive>\` into the agent's
                              own tmux pane — so the compactor runs with
                              our directive instead of the empty default.
-                             Use this for long-running agents whose
-                             runtime state would be lost across a
-                             directive-less auto-compact (lead-pm,
-                             associate-pm). Short-lived agents
-                             (workers, reviewers) should omit the flag
-                             and let claude code's native auto-compact
-                             run unmodified.
+                             See "Agent class guidance" below for which
+                             agents need this.
   --cwd PATH                 Working directory for the spawned session.
                              Default: current directory. Pass a worktree
                              path so RVM/bundler/nvm resolve correctly
@@ -184,12 +175,26 @@ Options:
                              Use for --chrome, --system-prompt, etc.
 
 Agent class guidance:
-  PM agents (lead-pm, associate-pm) — long-running, need compact steering:
+  Pick --cache-ttl and --steer-compact by session lifetime and cache
+  reuse. 1h cache writes cost 2x the 5m rate, so reach for 1h only when
+  the session genuinely idles past 5 minutes. --steer-compact preserves
+  runtime state across auto-compact; long-running agents need it,
+  short-lived ones don't (auto-compact rarely fires in their lifetime).
+
+  PM agents (lead-pm, associate-pm) — long-running, idle through review
+  loops and message-relay timescales that blow past 5m; runtime state
+  would be lost across a directive-less auto-compact:
     --steer-compact --cache-ttl 1h
-  Workers (post-PR, waiting through reviewer + human review cycles):
+  Workers — multi-turn through reviewer + human review cycles that
+  routinely exceed 5 minutes; short-lived enough that auto-compact
+  rarely fires:
     --cache-ttl 1h
-  One-shot agents (reviewers, single-prompt workers):
+  One-shot agents (reviewers, single-prompt workers) — read input,
+  post output, shut down inside 5 minutes:
     --cache-ttl 5m
+
+  Unset is legal for ad-hoc/sandbox spawns where the cost shape isn't
+  worth thinking about — claude-code's native cache behavior applies.
 
 Examples:
   roost spawn worker-1 -c '#my-channel' --cwd ~/Dev/myproject

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -704,22 +704,12 @@ are spawned via `--model` but routinely sit through reviewer + human
 review cycles that exceed 5 minutes. Pinning them at 5m means they
 pay a fresh cache-write on each wake — exactly the cost we wanted to
 avoid. Rather than carry edge cases per role, we dropped the default
-entirely. Heuristic that goes in the docs:
+entirely.
 
-- **One-shot agents → `--cache-ttl 5m`.** Reviewers (read PR → post
-  findings → shut down) and single-prompt workers fit here. The 5m
-  write is half the cost of 1h and the session won't outlive it
-  anyway.
-- **Multi-turn agents → `--cache-ttl 1h`.** Workers awaiting human
-  review, lead-pm, APM, the dispatcher. These idle through review-loop
-  and message-relay timescales that blow past 5m.
-- **Unset is legal.** No env var is injected and claude-code's native
-  cache behavior applies. Useful for ad-hoc/sandbox spawns where the
-  cost shape isn't worth thinking about.
-
-Refs at the spawn call sites: `agents/lead-pm.md` (APM spawn pins 1h),
-`agents/associate-pm.md` (worker spawn template pins 1h, reviewer
-template pins 5m).
+The role→flag heuristic itself lives in `roost spawn --help`
+("Agent class guidance") — that's the canonical source operators read
+when picking flags, and the only place to edit if the trade-offs ever
+shift. Agent prompts and the roost skill point at it.
 
 Acceptance: the next wave's cost reports should show reviewers and
 one-shot writes in the 5m bucket; workers, lead-pm, and APM in the 1h

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -62,8 +62,8 @@ Defaults:
 - `--steer-compact`: opt-in. Wires a PreCompact hook that intercepts
   claude code's auto-compact and redirects it as a manual `/compact`
   with a directive (so the compactor runs with `custom_instructions`
-  rather than its empty default). See `roost spawn --help` for which
-  agents need this.
+  rather than its empty default). See `roost spawn --help`
+  ("Agent class guidance") for which agents need this.
 
 The wrapper handles the `ROOST_IRC_*` env vars, the
 `--dangerously-load-development-channels server:roost-irc` flag, the

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -52,23 +52,18 @@ Defaults:
   in both paths.
 - cache-ttl: no wrapper default — if unset, neither env var is
   injected and claude-code's native cache behavior applies. Caller
-  picks per session. Heuristic: one-shot agents (reviewers,
-  single-prompt workers) → `--cache-ttl 5m`; multi-turn agents
-  (workers awaiting human review, lead-pm, APM, dispatcher)
-  → `--cache-ttl 1h`. Translated to claude-code's env knobs in the
+  picks per session. Translated to claude-code's env knobs in the
   spawned session: `FORCE_PROMPT_CACHING_5M=1` or
-  `ENABLE_PROMPT_CACHING_1H=1`. 1h writes cost 2x the 5m rate.
+  `ENABLE_PROMPT_CACHING_1H=1`. See `roost spawn --help`
+  ("Agent class guidance") for the role→flag heuristic.
 - cwd: current directory at spawn time
 - session name: `roost-<nick>`
 - mcp server: auto-loaded via plugin (override with `--mcp-config`)
 - `--steer-compact`: opt-in. Wires a PreCompact hook that intercepts
   claude code's auto-compact and redirects it as a manual `/compact`
   with a directive (so the compactor runs with `custom_instructions`
-  rather than its empty default). Pass on long-running PM-class
-  agents (lead-pm, associate-pm) whose runtime state would otherwise
-  be lost across a directive-less auto-compact. Workers and
-  reviewers are short-lived enough that the default behavior is
-  fine — omit the flag.
+  rather than its empty default). See `roost spawn --help` for which
+  agents need this.
 
 The wrapper handles the `ROOST_IRC_*` env vars, the
 `--dangerously-load-development-channels server:roost-irc` flag, the


### PR DESCRIPTION
Closes #407

## Summary

The role→flag heuristic (`--cache-ttl`, `--steer-compact`) used to live in 7+ places. Any cost-ratio or trade-off shift needed N coordinated edits. Reviewer-404 flagged it.

Now: `roost spawn --help` "Agent class guidance" is canonical and self-contained. Every other restatement points at it.

## Changes

- `bin/roost` — `--cache-ttl` and `--steer-compact` flag descriptions keep mechanism only (env-var translation, hook plumbing); pointer to "Agent class guidance". That block itself expanded to be self-contained: per-role rationale, cost ratio, lifetime/idle framing — operator picks flags without flipping to LEARNINGS or any agent prompt.
- `agents/lead-pm.md` — two heuristic paragraphs collapsed to one pointer line.
- `agents/associate-pm.md` — inline "workers wait through cycles" / "reviewers are one-shot" justifications dropped; single pointer at the top of "Six dances".
- `skills/roost/SKILL.md` — `cache-ttl` + `--steer-compact` bullets keep what each is, point at help for which to pick.
- `docs/LEARNINGS.md` §9 — heuristic enumeration replaced with pointer. Kept the empirical narrative (why no wrapper default, the failed default-by-spawn-path attempt) — that's system-of-record content, not duplication.
- Recipes left alone: `README.md`, the top-level Quick Start, and `cmd_init`'s "Next step" all show the canonical lead-pm invocation as-is. They apply the heuristic, they don't restate it.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bash test/spawn_test.sh` — 23/23 PASS
- [x] `roost spawn --help` renders cleanly; "Agent class guidance" block stands alone
- [ ] Reviewer pass: confirm operator-eye-test on the new self-contained block

🤖 Generated with Claude Code