### PR TITLE
maint: bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps package.json to 0.6.1.

What's new since v0.6.0:
- fish shell support (`--login` flag + `string collect` prompt read)
- IRCv3 CHATHISTORY LATEST detection (no negotiate, no cursor-mode break)
- sh/dash prompt-read fix (`$(cat)` instead of `$(<file)`)
- dispatcher rate-limit warning uses rolling 5-min window
- `roost spawn --help` agent-class guidance block (canonical, self-contained)
- dm-handler → dispatcher-dm-handler rename
- timeless-comment rule in CLAUDE.md + sweep
- APM trust boundaries + proactive-ack codified in agent prompts