### PR TITLE
APM release dance: watch bump PR + close milestone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,13 +86,14 @@ The dance:
 
 1. Lead-pm mentions APM in `#roost-leads`: `<project>-apm cut vX.Y.Z`.
 2. APM acks: `bump <old> → vX.Y.Z, branch maint/bump-version-X.Y.Z, PR + add <human>; go?` Lead confirms.
-3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine).
+3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine). Then DM `<project>-dispatcher`: `watch pr <N>` so CI events relay to `#<project>-leads`.
 4. Human approves the bump PR (this is the safety gate — same as any PR).
 5. APM acks: `bump approved + CI green, merge + tag vX.Y.Z + push tag?` Lead confirms.
 6. APM merges the bump PR, pulls main in the primary worktree, runs `git tag vX.Y.Z && git push origin vX.Y.Z`, then cleans up the bump worktree.
 7. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
 8. APM watches the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI), and reports back in `#roost-leads`.
-9. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code (lead-pm flags this; not the APM's job).
+9. APM closes the milestone: `gh api -X PATCH /repos/<owner>/<repo>/milestones/<id> -f state=closed`, then reports confirmation in `#<project>-leads`.
+10. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code (lead-pm flags this; not the APM's job).
 
 The version bump and the tag are separate steps — the workflow only fires on tag push, and only tags that don't contain a hyphen (so `v1.0.0-rc1` is skipped).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,13 +86,13 @@ The dance:
 
 1. Lead-pm mentions APM in `#roost-leads`: `<project>-apm cut vX.Y.Z`.
 2. APM acks: `bump <old> → vX.Y.Z, branch maint/bump-version-X.Y.Z, PR + add <human>; go?` Lead confirms.
-3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine). Then DM `<project>-dispatcher`: `watch pr <N>` so CI events relay to `#<project>-leads`.
+3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine). Then DM `roost-dispatcher`: `watch pr <N>` so CI events relay to `#roost-leads`.
 4. Human approves the bump PR (this is the safety gate — same as any PR).
 5. APM acks: `bump approved + CI green, merge + tag vX.Y.Z + push tag?` Lead confirms.
 6. APM merges the bump PR, pulls main in the primary worktree, runs `git tag vX.Y.Z && git push origin vX.Y.Z`, then cleans up the bump worktree.
 7. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
 8. APM watches the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI), and reports back in `#roost-leads`.
-9. APM closes the milestone: `gh api -X PATCH /repos/<owner>/<repo>/milestones/<id> -f state=closed`, then reports confirmation in `#<project>-leads`.
+9. APM closes the milestone: `gh api -X PATCH /repos/<owner>/<repo>/milestones/<id> -f state=closed`, then reports confirmation in `#roost-leads`.
 10. Operators on the box: `brew upgrade roost`, then restart any running dispatchers so they pick up new code (lead-pm flags this; not the APM's job).
 
 The version bump and the tag are separate steps — the workflow only fires on tag push, and only tags that don't contain a hyphen (so `v1.0.0-rc1` is skipped).


### PR DESCRIPTION
Closes #412

Adds two missing steps to the APM release dance in CLAUDE.md:

1. **Watch bump PR** (step 3): After opening the PR, DM dispatcher `watch pr <N>` so CI events relay to leads
2. **Close milestone** (new step 9): After tap-bump confirms, close via `gh api -X PATCH /repos/<owner>/<repo>/milestones/<id> -f state=closed`

Both gaps surfaced during 0.6.1 release. Renumbered old step 9 → 10.