### PR TITLE
maint: bump package.json to 0.6.2 ahead of v0.6.2 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps version to 0.6.2.

What's new since v0.6.1:
- Historian dance: APM scribes lead postmortems to closed issues, proposes learnings for filing to `.claude/rules/project-learnings.md` (auto-loaded into future sessions) — #410 / PR #417
- APM release dance: watch bump PR via dispatcher + close milestone after tap-bump confirms — #412 / PR #416