### PR TITLE
prompts/worker: restructure PR-lifecycle section into numbered steps

### DIFF
--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -36,10 +36,10 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 PRs start as draft and go through a reviewer pass *before* anyone flips them ready.
 
 1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
-2. **After reviewer findings post:** address them (batch into one push if there are several), then signal "addressed reviewer findings" in the channel. APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
-3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it and signal again ("addressed feedback"); APM re-requests review.
+2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback". APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
+3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review.
 
-Batch multiple changes-requested items into one push before signaling — don't ping the lead after each individual fix.
+Batch multiple changes-requested items into one push so you don't ping the lead after each individual fix; inside that push, the commits still split by theme.
 
 ## Commits
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -33,7 +33,13 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 
 ## PR lifecycle
 
-PRs start as draft. When your work is pushed, signal clearly in the channel ("pushed, ready for review" or "addressed X, ready to flip"). Lead-pm then marks it ready. Once the PR is marked ready it stays ready through the review loop — you are done with draft/ready transitions. If a reviewer or human leaves multiple changes-requested items, batch them all into one push before signaling — don't ping the lead after each individual fix.
+PRs start as draft and go through a reviewer pass *before* anyone flips them ready.
+
+1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
+2. **After reviewer findings post:** address them (batch into one push if there are several), then signal "addressed reviewer findings" in the channel. APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
+3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it and signal again ("addressed feedback"); APM re-requests review.
+
+Batch multiple changes-requested items into one push before signaling — don't ping the lead after each individual fix.
 
 ## Commits
 


### PR DESCRIPTION
## Summary

Closes #426.

Replaces the dense single-paragraph PR-lifecycle prose in `prompts/worker.md` with three numbered steps that mirror the actual flow:

1. After initial draft push: post link + stop. Lead spawns reviewer (opus). No "ready to flip" yet.
2. After reviewer findings: address, signal "addressed reviewer findings". APM marks ready + adds human reviewer. Worker never calls `gh pr ready`.
3. Human review loop: stays ready throughout. Address feedback, signal again, APM re-requests.

Same policy, clearer flow. Retains the batch-fixes guidance at the end.

This is a structural/prose rewrite — no behavioral change. The diff has been sitting uncommitted in the main tree since 2026-05-18; cleaning it up as part of 0.6.3.

## Test plan
- [ ] Eyeball the rendered prompts/worker.md to confirm the numbered list reads cleanly.