### PR TITLE
docs: add unwatch step to release dance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ The dance:
 3. APM sets up the worktree, bumps `package.json`, commits, pushes the branch, opens the PR with `<gh-login>` as reviewer. The PR body should reference what's new since the previous tag (one or two bullet points is fine). Then DM `roost-dispatcher`: `watch pr <N>` so CI events relay to `#roost-leads`.
 4. Human approves the bump PR (this is the safety gate — same as any PR).
 5. APM acks: `bump approved + CI green, merge + tag vX.Y.Z + push tag?` Lead confirms.
-6. APM merges the bump PR, pulls main in the primary worktree, runs `git tag vX.Y.Z && git push origin vX.Y.Z`, then cleans up the bump worktree.
+6. APM merges the bump PR. DMs `roost-dispatcher`: `unwatch pr <N>` (mirrors the watch in step 3). Pulls main in the primary worktree, runs `git tag vX.Y.Z && git push origin vX.Y.Z`, then cleans up the bump worktree.
 7. The tag fires `.github/workflows/release.yml` — creates the GitHub release and pushes a formula-bump commit directly to `main` on `AvesAlight/homebrew-tap` (no PR; the action commits straight to the tap repo).
 8. APM watches the tap repo's commit log for the bump: `gh api repos/AvesAlight/homebrew-tap/commits --jq '.[0].commit.message'` (or the web UI), and reports back in `#roost-leads`.
 9. APM closes the milestone: `gh api -X PATCH /repos/<owner>/<repo>/milestones/<id> -f state=closed`, then reports confirmation in `#roost-leads`.

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -266,7 +266,7 @@ Some changes are small enough that the lead skips spawning a worker. You still h
 
 - **Setup variant**: lead says "set up #<N> for me, I'm taking it" or similar. Ack `set up #<N> (no worker), branch <branch>; go?`. On confirmation: create the branch + worktree (same as setup dance step 1), DM `<project>-dispatcher`: `watch <N>`, but skip the worker spawn. Still snapshot lead-pm + apm tokens (`roost-token-usage snapshot ... <project>-lead-pm <project>-apm`) so the cleanup diff covers the lead's own self-authored cost. Join `#<project>-issue-<N>` only if the lead asks; otherwise the conversation stays in `#<project>-leads`.
 - **Watch self-authored PR variant**: after the lead opens the PR, they mention you with the link, e.g. `$0-apm PR #<N> up, watch it and add <human>`. Proceed without ack: DM `<project>-dispatcher`: `watch pr <N> #<project>-leads` (lead-authored PRs typically have no `#<project>-issue-N`, so route events to leads), then `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <gh-login>`. Skip the reviewer-agent spawn. If `Closes #<I>` is missing, flag it in the channel after acting: `PR #<N> watched, <gh-login> added — no closing ref detected, want me to add Closes #<I>?`
-- **Ready-for-review** (re-request after CHANGES_REQUESTED) and **merge + cleanup** dances apply unchanged. For cleanup, there's no worker to terminate and the cleanup just removes the worktree, pulls main, and unwatches the PR.
+- **Ready-for-review** (re-request after CHANGES_REQUESTED) and **merge + cleanup** dances apply unchanged. For cleanup, there's no worker to terminate and the cleanup just removes the worktree, DMs `<project>-dispatcher`: `unwatch pr <N>` (mirrors the watch in the setup variant above), pulls main.
 
 ## What you do not do
 


### PR DESCRIPTION
Closes #419

Adds `unwatch pr <N>` to step 6 of the release dance, mirroring the `watch pr <N>` in step 3. Without this the dispatcher kept watching a closed PR indefinitely.