### PR TITLE
feat(init): allow roost init outside a git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ CONFIG_DIR="$(pwd)/.orchestrator"
 "$ROOST_DIR/bin/start-dispatcher" "$CONFIG_DIR"
 ```
 
+To manage multiple repos from a shared directory instead:
+
+```bash
+mkdir ~/Dev/shared && cd ~/Dev/shared
+roost init --project myapp --repo Owner/myapp
+```
+
 DM the dispatcher (`<project>-dispatcher`) to manage the watch list:
 `watch <N>`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`,
 `watch list`, `help`. The dispatcher's allowlist defaults to

--- a/bin/roost
+++ b/bin/roost
@@ -363,7 +363,7 @@ cmd_init() {
         exit 1
       fi
     else
-      echo "error: not inside a git repo and --repo not provided — pass --repo <owner>/<repo> to set the watched repo explicitly" >&2
+      echo "error: not inside a git repo and \`--repo\` not provided — pass \`--repo Owner/repo\` to set the watched repo explicitly" >&2
       exit 1
     fi
   fi

--- a/bin/roost
+++ b/bin/roost
@@ -68,7 +68,8 @@ Autodetects project name, repo, and GitHub user; each value can be overridden.
 
 Options:
   --project NAME         Project name (default: basename of cwd, lowercased).
-  --repo OWNER/REPO      GitHub repo (default: parsed from git origin remote).
+  --repo OWNER/REPO      GitHub repo. Required outside a git repo; inside one
+                         defaults to the origin remote URL.
   --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
                          Default: current gh user.
   --force                Overwrite everything: config.json, .gitignore,
@@ -333,11 +334,6 @@ cmd_init() {
     esac
   done
 
-  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-    echo "error: not inside a git repo — run \`git init\` first or \`cd\` to a git repo" >&2
-    exit 1
-  fi
-
   if ! gh auth status &>/dev/null; then
     echo "error: gh is not authenticated — run \`gh auth login\` first" >&2
     exit 1
@@ -354,15 +350,20 @@ cmd_init() {
   fi
 
   if [ -z "$repo" ]; then
-    local url
-    if ! url="$(git remote get-url origin 2>/dev/null)"; then
-      echo "error: no \`origin\` remote and no \`--repo\` flag — pass \`--repo Owner/repo\` or run \`git remote add origin ...\`" >&2
-      exit 1
-    fi
-    url="${url%.git}"
-    repo="$(printf '%s' "$url" | sed -E 's|.*[:/]([^/:]+/[^/]+)$|\1|')"
-    if [ "$repo" = "$url" ]; then
-      echo "error: could not parse Owner/repo from remote URL: ${url} — pass \`--repo Owner/repo\` explicitly" >&2
+    if git rev-parse --is-inside-work-tree &>/dev/null; then
+      local url
+      if ! url="$(git remote get-url origin 2>/dev/null)"; then
+        echo "error: no \`origin\` remote and no \`--repo\` flag — pass \`--repo Owner/repo\` or run \`git remote add origin ...\`" >&2
+        exit 1
+      fi
+      url="${url%.git}"
+      repo="$(printf '%s' "$url" | sed -E 's|.*[:/]([^/:]+/[^/]+)$|\1|')"
+      if [ "$repo" = "$url" ]; then
+        echo "error: could not parse Owner/repo from remote URL: ${url} — pass \`--repo Owner/repo\` explicitly" >&2
+        exit 1
+      fi
+    else
+      echo "error: not inside a git repo and --repo not provided — pass --repo <owner>/<repo> to set the watched repo explicitly" >&2
       exit 1
     fi
   fi

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -235,17 +235,51 @@ fi
 cd - >/dev/null
 teardown
 
-# --- error: not a git repo ---
+# --- outside-git + --repo: succeeds ---
 
 TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
 STUBS="${TDIR}/.stubs"
 mkdir -p "$STUBS"
-# gh stub not needed — should fail before gh is called
+cat > "${STUBS}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "auth status")  exit 0 ;;
+  "api user")     echo "testuser" ;;
+  "repo view")    exit 0 ;;
+  *)              echo "gh-stub: unhandled: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "${STUBS}/gh"
 cd "$TDIR"
-if ! "${ROOST_BIN}" init >/dev/null 2>&1; then
-  ok "error: not a git repo"
+if PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init --repo "SomeOwner/cross-repo" >/dev/null 2>&1 \
+    && grep -q '"repo": "SomeOwner/cross-repo"' "${TDIR}/.orchestrator/config.json"; then
+  ok "outside-git + --repo: succeeds"
 else
-  fail "error: not a git repo"
+  fail "outside-git + --repo: succeeds"
+fi
+cd - >/dev/null
+rm -rf "$TDIR"
+
+# --- error: outside git and no --repo ---
+
+TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
+STUBS="${TDIR}/.stubs"
+mkdir -p "$STUBS"
+cat > "${STUBS}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "auth status")  exit 0 ;;
+  *)              echo "gh-stub: unhandled: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "${STUBS}/gh"
+cd "$TDIR"
+err_out="$(PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init 2>&1)"
+exit_code=$?
+if [ "$exit_code" -ne 0 ] && echo "$err_out" | grep -q "not inside a git repo and"; then
+  ok "error: outside git and no --repo"
+else
+  fail "error: outside git and no --repo"
 fi
 cd - >/dev/null
 rm -rf "$TDIR"


### PR DESCRIPTION
Closes #415

Drops the hard git-repo guard from `cmd_init`. `--repo` is now required when not inside a git repo (error message is actionable and names the flag); inside a git repo, origin remote auto-detection still works as before. `.orchestrator/.gitignore` is still written — harmless outside git and useful if the dir is later `git init`d.