### PR TITLE
ops(dispatcher): watch homebrew-tap Formula/roost.rb for release commits

### DIFF
--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -11,6 +11,17 @@
   },
   "plugins": {
     "github-prs": { "watched": [] },
-    "github-issues": { "watched": [] }
+    "github-issues": { "watched": [] },
+    "github-new-issues": {},
+    "github-commits": {
+      "watched": [
+        {
+          "repo": "AvesAlight/homebrew-tap",
+          "branch": "main",
+          "path": "Formula/roost.rb",
+          "channels": ["#roost-leads"]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes the release-dance loop locally. Adds a `github-commits` watch on `AvesAlight/homebrew-tap` / `Formula/roost.rb` at branch `main`, routed to `#roost-leads`. After the release workflow commits a formula bump on tag-push, the dispatcher will announce that commit in `#roost-leads` and the APM no longer needs to manually poll the tap repo (step 8 of the release dance).

Also brings the checked-in `.orchestrator/config.json` up to current init-template shape — adds the `github-new-issues` and `github-commits` plugin slots that were introduced after the file was last touched on this branch.

Source: PR #432 review from AlexSc — "we should be following homebrew-tap locally".

## Test plan
- [ ] Restart the running dispatcher after merge so it picks up the new `github-commits` entry.
- [ ] On the next release, confirm the tap-bump commit shows up in `#roost-leads` without manual polling.