### PR TITLE
feat(orchestrator): external plugin discovery via plugin_paths

### DIFF
--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -35,6 +35,7 @@ Fields:
 | `irc.server` / `irc.port` | IRCv3 server address. Defaults to `127.0.0.1:6667`. |
 | `irc.interval_seconds` | Tick interval. Min 5s; 60s is sane for most repos. |
 | `plugins.<name>` | Per-plugin config slice. Keys list the enabled plugins (in emission order). |
+| `plugin_paths` | Optional `[path, ...]` of external plugin modules to load before the registry is walked. Relative paths resolve against `.orchestrator/`. See [PLUGINS.md](./PLUGINS.md). |
 | `plugins.github-prs.watched` | `[{"number": N, "repo"?: "OWNER/NAME", "channels"?: [...]}]` |
 | `plugins.github-issues.watched` | Same shape as `plugins.github-prs.watched`. |
 | `plugins.github-new-issues` | Repo-wide new-issue feed: `{"repo"?: "OWNER/NAME", "channels"?: [...]}` (both optional; default = `repo` at top level + project channel). |
@@ -45,9 +46,10 @@ destinations on top of the auto-routed `#<project>-issue-N` (PR events also go
 to `#<project>-issue-N` for each linked issue).
 
 A plugin not listed under `plugins` is not instantiated — there is no top-level
-fallback. The supported set is the first-party plugins shipped in this repo
-(`github-prs`, `github-issues`, `github-new-issues`, `github-commits`); external
-plugin discovery is not yet supported.
+fallback. The first-party set shipped in this repo is `github-prs`,
+`github-issues`, `github-new-issues`, `github-commits`. External plugins are
+loaded via `plugin_paths` (see [PLUGINS.md](./PLUGINS.md)) before the registry
+is walked, so their names become available alongside the built-ins.
 
 `github-new-issues` needs an explicit `plugins.github-new-issues`
 entry to run. `bin/roost init` writes one for new projects; for existing

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -100,6 +100,65 @@ Relative `plugin_paths` resolve against `.orchestrator/` (the directory containi
 
 These crash the dispatcher loudly rather than silently dropping events. Fix the path / publish the module / correct the config, then retry.
 
+## Development workflow
+
+A day-1 loop for a fresh external plugin repo:
+
+1. **Bootstrap the repo.** `bun init` (or pnpm/npm equivalent). Add roost via one of the [install patterns](#installing-roostplugin-in-an-external-project) below — `bun link` from a roost checkout for tight dev loops, git-dep for stable consumption.
+
+2. **Write the module.** A single file, top-level `registerPlugin(name, factory)`, no default export. See [Minimal example](#minimal-example).
+
+3. **Wire into a target project's `.orchestrator/config.json`.** `plugin_paths` points at the module file (relative to the config dir, or absolute):
+
+   ```json
+   {
+     "project": "demo",
+     "plugin_paths": ["/abs/path/to/my-plugin-repo/src/my-plugin.ts"],
+     "plugins": { "my-plugin": { /* your slice */ } }
+   }
+   ```
+
+4. **Dry-run the dispatcher.** Prints the `TaggedEvent` JSON to stdout — no IRC connection, no state written:
+
+   ```sh
+   "$(roost root)/bin/dispatcher" --dry-run --config-dir .orchestrator
+   ```
+
+   (From a roost checkout: `bin/dispatcher --dry-run --config-dir .orchestrator`.)
+
+5. **Iterate.** Edit the plugin file, re-run step 4. The loader re-imports each boot; for a continuously running daemon, restart it (`bin/stop-dispatcher` + `bin/start-dispatcher`).
+
+## Testing
+
+**Unit tests.** Construct the plugin directly and drive its methods. Use `bun:test`'s `spyOn(...).mockImplementation(...)` to stub network calls. Canonical reference: `src/orchestrator/plugins/github/__tests__/commits-plugin.test.ts`.
+
+The shape:
+
+```ts
+import { describe, it, expect } from 'bun:test'
+import { MyPlugin } from '../my-plugin.js'
+import type { PluginConfig } from 'roost/plugin'
+
+const config: PluginConfig = { plugins: { 'my-plugin': { rooms: ['#x'] } } }
+
+describe('MyPlugin.runTick', () => {
+  it('seeds without emitting on first run', async () => {
+    const result = await new MyPlugin('#proj-leads').runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
+  })
+
+  it('emits on the second tick when state changes', async () => {
+    const prev = { /* ... */ }
+    const result = await new MyPlugin('#proj-leads').runTick(config, prev)
+    expect(result.taggedEvents[0]?.channels).toEqual(['#x'])
+  })
+})
+```
+
+Two ticks (seed + normal) cover the common case. Mock external IO at the boundary the plugin owns; assert on `state` and `taggedEvents`.
+
+**Integration tests** are optional — a running dispatcher against a test IRC server with only your plugin loaded. Worth it only if your plugin's correctness depends on the dispatch layer (channel sync, DM handling). Most plugins don't.
+
 ## Installing `roost/plugin` in an external project
 
 Roost ships via Homebrew tap, not npm, so the import path `'roost/plugin'` doesn't resolve out of the box. Two patterns work today:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,12 +1,12 @@
 # Writing a roost plugin
 
-A plugin is the unit of extension for the dispatcher (`src/orchestrator.ts`). Each plugin owns symmetric slices of `config.plugins[name]` and `state.plugins[name]`, declares which IRC channels it wants joined, and on each tick returns pre-routed, pre-formatted events for the dispatcher to write.
+A plugin polls a source on each dispatcher tick and returns IRC events. It owns a config slice at `config.plugins[name]` and a state slice at `state.plugins[name]`. The same name keys both.
 
-The built-ins (`github-prs`, `github-issues`, `github-new-issues`, `github-commits`) all use the same seam. External plugins are loaded the same way — they just live outside this repo.
+The built-ins (`github-prs`, `github-issues`, `github-new-issues`, `github-commits`) all use this contract. External plugins load via `plugin_paths` in your dispatcher config and use the same contract.
 
 ## The seam
 
-External plugins import from `roost/plugin` — never deep `src/orchestrator/...` paths. The set re-exported there is the stable surface; everything else is internal.
+Import from `roost/plugin`. Deep imports into `src/orchestrator/...` are not supported and may change.
 
 ```ts
 import {
@@ -23,26 +23,24 @@ import {
 } from 'roost/plugin'
 ```
 
-`PluginConfig` is intentionally narrow — `{ plugins?: Record<string, unknown> }`. The dispatcher passes the full orchestrator config at runtime (project/repo/irc/etc. are all present on the value), but declaring your method parameters as `PluginConfig` keeps your code honest about reading only your own slice via `BasePlugin.pluginConfig<T>(config)`. It's a convention, not a fence — but it's the convention the seam is shaped around. Anything you need at config time goes in your slice.
+`PluginConfig` is `{ plugins?: Record<string, unknown> }`. The dispatcher passes the full config at runtime. Type your method parameters as `PluginConfig` and read your slice via `BasePlugin.pluginConfig<T>(config)`. Put everything else you need in your slice.
 
 ## Contract
 
-Four methods (one optional):
-
 | Method | Purpose |
 |---|---|
-| `name` | Slot key for both `config.plugins[name]` and `state.plugins[name]`. Must match the string passed to `registerPlugin`. |
-| `desiredChannels(config)` | Synchronous, config-only view of channels to join at boot, before the first tick. Excludes the project/default channel (orchestrator adds it). |
-| `runTick(config, prevState)` | Returns `{ state, taggedEvents, channels }`. `prevState === null` signals a seed tick. `channels` is the comprehensive post-scrape set. |
-| `handleCommand?(config, cmd)` | Optional DM handler. Return a reply line when this plugin owns the command, `null` otherwise. MUST NOT throw — return `"error: ..."` for deterministic failures. |
+| `name` | Slot key for both slices. Must match the string passed to `registerPlugin`. |
+| `desiredChannels(config)` | Channels to join at boot. The orchestrator adds the project channel. |
+| `runTick(config, prevState)` | Returns `{ state, taggedEvents, channels }`. `prevState === null` on a seed tick. `channels` is the post-scrape set. |
+| `handleCommand?(config, cmd)` | Optional. Returns a reply when this plugin owns the command, `null` otherwise. Return `"error: ..."` on failure. Don't throw. |
 
-The dispatcher writes each `TaggedEvent` to every channel in `event.channels`. Event kinds are plugin-internal — pick whatever vocabulary fits your source.
+The dispatcher writes each `TaggedEvent` to every channel in `event.channels`. Event kind strings are yours.
 
-## The register-on-load handshake
+## Register on load
 
-The loader treats each `plugin_paths` entry as a side-effect import. The module **must** call `registerPlugin(name, factory)` at top level; the orchestrator then sees the new name when it walks `config.plugins`. If the registration is buried inside a function or a default export, the dispatcher will fail with `unknown plugin in config: <name>`.
+Each `plugin_paths` entry is imported for its side effects. The module must call `registerPlugin(name, factory)` at the top level. If you bury the call in a function or a default export, the dispatcher fails with `unknown plugin in config: <name>`.
 
-Names collide loudly: `registerPlugin` throws on a duplicate. Built-ins are non-negotiable; external plugins pick a unique name (a short scoped slug works — e.g. `acme-deploys`, `linear-issues`).
+`registerPlugin` throws on duplicate names. Built-in names are reserved. Pick a unique slug like `acme-deploys` or `linear-issues`.
 
 ## Minimal example
 
@@ -90,21 +88,19 @@ Operator config:
 }
 ```
 
-Relative `plugin_paths` resolve against `.orchestrator/` (the directory containing `config.json`), so configs stay portable across operator checkouts. Absolute paths work too — the loader runs `path.resolve` either way.
+Relative `plugin_paths` resolve against `.orchestrator/`. Absolute paths work too.
 
 ## Failure modes (all fatal at boot)
 
-- A `plugin_paths` entry that doesn't import (missing file, syntax error, throw at top level).
-- A duplicate `registerPlugin` name — internal or external collisions both throw.
-- A `config.plugins[name]` key with no matching registration (`unknown plugin in config: <name>. available: ...`).
-
-These crash the dispatcher loudly rather than silently dropping events. Fix the path / publish the module / correct the config, then retry.
+- `plugin_paths` entry won't import: missing file, syntax error, top-level throw.
+- Duplicate `registerPlugin` name.
+- `config.plugins[name]` with no matching registration: `unknown plugin in config: <name>. available: ...`.
 
 ## Development workflow
 
-A day-1 loop for a fresh external plugin repo:
+From a fresh repo:
 
-1. **Bootstrap the repo.** `bun init` (or pnpm/npm equivalent). Add roost via one of the [install patterns](#installing-roostplugin-in-an-external-project) below — `bun link` from a roost checkout for tight dev loops, git-dep for stable consumption.
+1. **Bootstrap.** `bun init` (or pnpm/npm). Add roost via one of the [install patterns](#installing-roostplugin) below: `bun link` for dev, git-dep for stable consumption.
 
 2. **Write the module.** A single file, top-level `registerPlugin(name, factory)`, no default export. See [Minimal example](#minimal-example).
 
@@ -118,21 +114,19 @@ A day-1 loop for a fresh external plugin repo:
    }
    ```
 
-4. **Dry-run the dispatcher.** Prints the `TaggedEvent` JSON to stdout — no IRC connection, no state written:
+4. **Dry-run the dispatcher.** Prints `TaggedEvent` JSON to stdout. No IRC, no state written.
 
    ```sh
    "$(roost root)/bin/dispatcher" --dry-run --config-dir .orchestrator
    ```
 
-   (From a roost checkout: `bin/dispatcher --dry-run --config-dir .orchestrator`.)
+   From a roost checkout: `bin/dispatcher --dry-run --config-dir .orchestrator`.
 
-5. **Iterate.** Edit the plugin file, re-run step 4. The loader re-imports each boot; for a continuously running daemon, restart it (`bin/stop-dispatcher` + `bin/start-dispatcher`).
+5. **Iterate.** Edit and re-run step 4. For a running daemon, restart it: `bin/stop-dispatcher` then `bin/start-dispatcher`.
 
 ## Testing
 
-**Unit tests.** Construct the plugin directly and drive its methods. Use `bun:test`'s `spyOn(...).mockImplementation(...)` to stub network calls. Canonical reference: `src/orchestrator/plugins/github/__tests__/commits-plugin.test.ts`.
-
-The shape:
+**Unit tests.** Construct the plugin and call its methods. Stub network calls with `bun:test`'s `spyOn(...).mockImplementation(...)`. Reference: `src/orchestrator/plugins/github/__tests__/commits-plugin.test.ts`.
 
 ```ts
 import { describe, it, expect } from 'bun:test'
@@ -155,23 +149,23 @@ describe('MyPlugin.runTick', () => {
 })
 ```
 
-Two ticks (seed + normal) cover the common case. Mock external IO at the boundary the plugin owns; assert on `state` and `taggedEvents`.
+Mock IO at the boundary your plugin owns. Assert on `state` and `taggedEvents`.
 
-**Integration tests** are optional — a running dispatcher against a test IRC server with only your plugin loaded. Worth it only if your plugin's correctness depends on the dispatch layer (channel sync, DM handling). Most plugins don't.
+**Integration tests** are optional. Spin up a test IRC server and run the dispatcher with only your plugin loaded. Worth doing only if your plugin depends on the dispatch layer (channel sync, DM handling).
 
-## Installing `roost/plugin` in an external project
+## Installing `roost/plugin`
 
-Roost ships via Homebrew tap, not npm, so the import path `'roost/plugin'` doesn't resolve out of the box. Two patterns work today:
+Roost ships via Homebrew tap, not npm. The import path `'roost/plugin'` doesn't resolve out of the box. Two ways to fix it:
 
-- **`bun link` from a roost checkout** — clone roost, `bun link` in the roost root, `bun link roost` in your project. Picks up the `exports` map.
-- **Git dependency** — pin roost in your `package.json`:
+- **`bun link`.** Clone roost, `bun link` in its root, `bun link roost` in your project.
+- **Git dependency.** Pin roost in your `package.json`:
 
   ```json
   { "dependencies": { "roost": "github:AvesAlight/roost#<tag>" } }
   ```
 
-Either way, the resolved package exposes only `roost/plugin`. Deep imports into `src/orchestrator/...` are not part of the supported surface and may change.
+Both expose only `roost/plugin`. Deep imports may change.
 
 ## Versioning
 
-There is no compile-time API version check yet. The seam is stable in spirit — `Plugin`, `BasePlugin`, `TaggedEvent`, `PluginTickResult` haven't changed shape since they landed — but changes will be signalled via the roost release notes and the tag your git dep is pinned to. A `requires` field on the factory may land once a second project actually ships an external plugin and we have something concrete to coordinate against.
+No compile-time API check yet. The seam types (`Plugin`, `BasePlugin`, `TaggedEvent`, `PluginTickResult`) haven't changed shape since they landed. Pin a tag if you need stability. A `requires` field may land once a second external plugin exists.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,116 @@
+# Writing a roost plugin
+
+A plugin is the unit of extension for the dispatcher (`src/orchestrator.ts`). Each plugin owns symmetric slices of `config.plugins[name]` and `state.plugins[name]`, declares which IRC channels it wants joined, and on each tick returns pre-routed, pre-formatted events for the dispatcher to write.
+
+The built-ins (`github-prs`, `github-issues`, `github-new-issues`, `github-commits`) all use the same seam. External plugins are loaded the same way — they just live outside this repo.
+
+## The seam
+
+External plugins import from `roost/plugin` — never deep `src/orchestrator/...` paths. The set re-exported there is the stable surface; everything else is internal.
+
+```ts
+import {
+  BasePlugin,
+  registerPlugin,
+  type Plugin,
+  type PluginConfig,
+  type PluginTickResult,
+  type TaggedEvent,
+  type WatchedEntry,
+  resolveRepoEntry,
+} from 'roost/plugin'
+```
+
+`PluginConfig` is intentionally narrow — `{ plugins?: Record<string, unknown> }`. Your plugin only sees its own slice via `BasePlugin.pluginConfig<T>(config)`; the wider orchestrator config shape (project/repo/irc/etc.) is not part of the public seam. Anything you need at config time goes in your slice.
+
+## Contract
+
+Four methods (one optional):
+
+| Method | Purpose |
+|---|---|
+| `name` | Slot key for both `config.plugins[name]` and `state.plugins[name]`. Must match the string passed to `registerPlugin`. |
+| `desiredChannels(config)` | Synchronous, config-only view of channels to join at boot, before the first tick. Excludes the project/default channel (orchestrator adds it). |
+| `runTick(config, prevState)` | Returns `{ state, taggedEvents, channels }`. `prevState === null` signals a seed tick. `channels` is the comprehensive post-scrape set. |
+| `handleCommand?(config, cmd)` | Optional DM handler. Return a reply line when this plugin owns the command, `null` otherwise. MUST NOT throw — return `"error: ..."` for deterministic failures. |
+
+The dispatcher writes each `TaggedEvent` to every channel in `event.channels`. Event kinds are plugin-internal — pick whatever vocabulary fits your source.
+
+## The register-on-load handshake
+
+The loader treats each `plugin_paths` entry as a side-effect import. The module **must** call `registerPlugin(name, factory)` at top level; the orchestrator then sees the new name when it walks `config.plugins`. If the registration is buried inside a function or a default export, the dispatcher will fail with `unknown plugin in config: <name>`.
+
+Names collide loudly: `registerPlugin` throws on a duplicate. Built-ins are non-negotiable; external plugins pick a unique name (a short scoped slug works — e.g. `acme-deploys`, `linear-issues`).
+
+## Minimal example
+
+```ts
+// my-plugin.ts
+import { BasePlugin, registerPlugin, type PluginConfig, type PluginTickResult } from 'roost/plugin'
+
+interface MySlice {
+  rooms?: string[]
+}
+
+class MyPlugin extends BasePlugin {
+  readonly name = 'acme-pulse'
+
+  desiredChannels(config: PluginConfig): string[] {
+    return this.pluginConfig<MySlice>(config)?.rooms ?? []
+  }
+
+  async runTick(config: PluginConfig): Promise<PluginTickResult> {
+    const rooms = this.pluginConfig<MySlice>(config)?.rooms ?? []
+    return {
+      state: null,
+      taggedEvents: rooms.map(channel => ({
+        channels: [channel],
+        payload: { kind: 'oneline', text: '[acme_pulse] still alive' },
+      })),
+      channels: rooms,
+    }
+  }
+}
+
+registerPlugin('acme-pulse', (defaultChannel) => new MyPlugin(defaultChannel))
+```
+
+Operator config:
+
+```json
+{
+  "project": "acme",
+  "irc": { "nick": "acme-dispatcher" },
+  "plugin_paths": ["../plugins/my-plugin.ts"],
+  "plugins": {
+    "acme-pulse": { "rooms": ["#acme-pulse"] }
+  }
+}
+```
+
+Relative `plugin_paths` resolve against `.orchestrator/` (the directory containing `config.json`), so configs stay portable across operator checkouts. Absolute paths work too — the loader runs `path.resolve` either way.
+
+## Failure modes (all fatal at boot)
+
+- A `plugin_paths` entry that doesn't import (missing file, syntax error, throw at top level).
+- A duplicate `registerPlugin` name — internal or external collisions both throw.
+- A `config.plugins[name]` key with no matching registration (`unknown plugin in config: <name>. available: ...`).
+
+These crash the dispatcher loudly rather than silently dropping events. Fix the path / publish the module / correct the config, then retry.
+
+## Installing `roost/plugin` in an external project
+
+Roost ships via Homebrew tap, not npm, so the import path `'roost/plugin'` doesn't resolve out of the box. Two patterns work today:
+
+- **`bun link` from a roost checkout** — clone roost, `bun link` in the roost root, `bun link roost` in your project. Picks up the `exports` map.
+- **Git dependency** — pin roost in your `package.json`:
+
+  ```json
+  { "dependencies": { "roost": "github:AvesAlight/roost#v0.6.3" } }
+  ```
+
+Either way, the resolved package exposes only `roost/plugin`. Deep imports into `src/orchestrator/...` are not part of the supported surface and may change.
+
+## Versioning
+
+There is no compile-time API version check yet. The seam is stable in spirit — `Plugin`, `BasePlugin`, `TaggedEvent`, `PluginTickResult` haven't changed shape since they landed — but changes will be signalled via the roost release notes and the tag your git dep is pinned to. A `requires` field on the factory may land once a second project actually ships an external plugin and we have something concrete to coordinate against.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -16,12 +16,14 @@ import {
   type PluginConfig,
   type PluginTickResult,
   type TaggedEvent,
-  type WatchedEntry,
-  resolveRepoEntry,
+  type TaggedEventPayload,
+  type PluginFactory,
+  type PluginLogger,
+  type Command,
 } from 'roost/plugin'
 ```
 
-`PluginConfig` is intentionally narrow — `{ plugins?: Record<string, unknown> }`. Your plugin only sees its own slice via `BasePlugin.pluginConfig<T>(config)`; the wider orchestrator config shape (project/repo/irc/etc.) is not part of the public seam. Anything you need at config time goes in your slice.
+`PluginConfig` is intentionally narrow — `{ plugins?: Record<string, unknown> }`. The dispatcher passes the full orchestrator config at runtime (project/repo/irc/etc. are all present on the value), but declaring your method parameters as `PluginConfig` keeps your code honest about reading only your own slice via `BasePlugin.pluginConfig<T>(config)`. It's a convention, not a fence — but it's the convention the seam is shaped around. Anything you need at config time goes in your slice.
 
 ## Contract
 
@@ -106,7 +108,7 @@ Roost ships via Homebrew tap, not npm, so the import path `'roost/plugin'` doesn
 - **Git dependency** — pin roost in your `package.json`:
 
   ```json
-  { "dependencies": { "roost": "github:AvesAlight/roost#v0.6.3" } }
+  { "dependencies": { "roost": "github:AvesAlight/roost#<tag>" } }
   ```
 
 Either way, the resolved package exposes only `roost/plugin`. Deep imports into `src/orchestrator/...` are not part of the supported surface and may change.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.2",
   "license": "Apache-2.0",
   "type": "module",
+  "exports": {
+    "./plugin": "./src/orchestrator/plugin-api.ts"
+  },
   "scripts": {
     "test": "bun test",
     "lint": "eslint src/ test/ && shellcheck bin/*",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -22,6 +22,7 @@ import { dispatchTaggedEvents, connectAndWait } from './orchestrator/dispatch.js
 import { defaultPluginLogger, type Plugin, type TaggedEvent } from './orchestrator/plugin.js'
 import './orchestrator/registry.js'
 import { buildPlugins } from './orchestrator/build-plugins.js'
+import { loadExternalPlugins } from './orchestrator/load-external-plugins.js'
 import { resolveProjectChannel } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dispatcher-dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
@@ -112,6 +113,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   const port = ircCfg.port ?? 6667
   const interval = Math.max(5, ircCfg.interval_seconds ?? 60) * 1000
 
+  await loadExternalPlugins(stateDir, config.plugin_paths)
   const plugins = buildPlugins(config, projectChannel, log)
   const initialChannels = bootChannels(plugins, config, projectChannel)
   log(`orchestrator[daemon]: starting nick=${nick} server=${server}:${port} channels=${initialChannels.join(',')} interval=${interval / 1000}s\n`)
@@ -247,6 +249,7 @@ async function runDispatchIrc(stateDir: string, seed: boolean): Promise<void> {
   const server = ircCfg.server ?? '127.0.0.1'
   const port = ircCfg.port ?? 6667
 
+  await loadExternalPlugins(stateDir, config.plugin_paths)
   const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
   const channels = bootChannels(plugins, config, projectChannel)
 
@@ -304,6 +307,7 @@ async function main(): Promise<void> {
     // One-shot: fetch + diff, print events JSON
     const config = await loadConfig(stateDir)
     const projectChannel = resolveProjectChannel(config)
+    await loadExternalPlugins(stateDir, config.plugin_paths)
     const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
     const result = await runOneTick(stateDir, config, plugins, {
       seed: values['seed'] as boolean,

--- a/src/orchestrator/__tests__/load-external-plugins.test.ts
+++ b/src/orchestrator/__tests__/load-external-plugins.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadExternalPlugins } from '../load-external-plugins.js'
+import { getPluginFactory, unregisterPlugin } from '../plugin.js'
+
+// Each test gets a fresh temp dir + fresh plugin name so module-import caching
+// (ESM caches by resolved URL) doesn't carry registrations between tests.
+let workDir: string
+let pluginCounter = 0
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'roost-loader-'))
+})
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true })
+})
+
+function uniquePluginName(): string {
+  pluginCounter += 1
+  return `ext-plugin-${process.pid}-${pluginCounter}`
+}
+
+async function writePluginModule(absPath: string, pluginName: string): Promise<void> {
+  await mkdir(join(absPath, '..'), { recursive: true })
+  const src = `
+import { registerPlugin, BasePlugin } from '${join(import.meta.dir, '..', 'plugin.ts')}'
+class P extends BasePlugin {
+  name = '${pluginName}'
+  desiredChannels() { return [] }
+  async runTick() { return { state: null, taggedEvents: [], channels: [] } }
+}
+registerPlugin('${pluginName}', (dc) => new P(dc))
+`
+  await writeFile(absPath, src, 'utf8')
+}
+
+describe('loadExternalPlugins', () => {
+  it('is a no-op when plugin_paths is undefined', async () => {
+    await loadExternalPlugins(workDir, undefined)
+  })
+
+  it('is a no-op when plugin_paths is empty', async () => {
+    await loadExternalPlugins(workDir, [])
+  })
+
+  it('loads an absolute path and registers its plugin', async () => {
+    const name = uniquePluginName()
+    const file = join(workDir, 'abs-plugin.ts')
+    await writePluginModule(file, name)
+    try {
+      await loadExternalPlugins(workDir, [file])
+      expect(getPluginFactory(name)).toBeTypeOf('function')
+    } finally {
+      unregisterPlugin(name)
+    }
+  })
+
+  it('resolves a relative path against the config dir', async () => {
+    const name = uniquePluginName()
+    const subdir = join(workDir, 'sub')
+    await mkdir(subdir, { recursive: true })
+    const file = join(subdir, 'rel-plugin.ts')
+    await writePluginModule(file, name)
+    try {
+      // Relative to workDir (the simulated `.orchestrator/`).
+      await loadExternalPlugins(workDir, ['./sub/rel-plugin.ts'])
+      expect(getPluginFactory(name)).toBeTypeOf('function')
+    } finally {
+      unregisterPlugin(name)
+    }
+  })
+
+  it('crashes on a missing path so a bad config fails loud at boot', async () => {
+    await expect(
+      loadExternalPlugins(workDir, ['./does-not-exist.ts'])
+    ).rejects.toThrow()
+  })
+
+  it('crashes when the module throws on a duplicate name', async () => {
+    const name = uniquePluginName()
+    const fileA = join(workDir, 'a.ts')
+    const fileB = join(workDir, 'b.ts')
+    await writePluginModule(fileA, name)
+    await writePluginModule(fileB, name)
+    try {
+      await expect(
+        loadExternalPlugins(workDir, [fileA, fileB])
+      ).rejects.toThrow(/already registered/)
+    } finally {
+      unregisterPlugin(name)
+    }
+  })
+})

--- a/src/orchestrator/__tests__/plugin.test.ts
+++ b/src/orchestrator/__tests__/plugin.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
 import {
   BasePlugin,
   type PluginTickResult,
   type TaggedEvent,
   registerPlugin,
+  unregisterPlugin,
   getPluginFactory,
 } from '../plugin.js'
 import { resolveRepoEntry, type OrchestratorConfig } from '../config.js'
@@ -95,9 +96,16 @@ class StubPlugin extends BasePlugin {
 }
 
 describe('registry + plugin-owned events + per-plugin config (end-to-end)', () => {
-  it('builds a stub plugin from config, ticks, and dispatches to its channels', async () => {
+  // registerPlugin throws on duplicate, so register the stub once for the
+  // whole describe block and clean up after.
+  beforeAll(() => {
     registerPlugin('stub', (defaultChannel) => new StubPlugin(defaultChannel))
+  })
+  afterAll(() => {
+    unregisterPlugin('stub')
+  })
 
+  it('builds a stub plugin from config, ticks, and dispatches to its channels', async () => {
     const factory = getPluginFactory('stub')
     expect(factory).toBeTypeOf('function')
     const plugin = factory!('#default-leads', () => {})
@@ -132,7 +140,6 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
   })
 
   it('passes prevState through under the plugin name slice across ticks', async () => {
-    registerPlugin('stub', (defaultChannel) => new StubPlugin(defaultChannel))
     const plugin = getPluginFactory('stub')!('#default-leads', () => {})
     const config: OrchestratorConfig = { plugins: { stub: { rooms: ['#room'] } } }
 
@@ -153,7 +160,6 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
   // state silently disappears across ticks. These assertions are the cheap
   // guard against that drift.
   it('couples class name to registry key for the stub plugin', () => {
-    registerPlugin('stub', (defaultChannel) => new StubPlugin(defaultChannel))
     expect(getPluginFactory('stub')!('#x', () => {}).name).toBe('stub')
   })
 
@@ -161,5 +167,27 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
     await import('../registry.js')
     expect(getPluginFactory('github-prs')!('#x', () => {}).name).toBe('github-prs')
     expect(getPluginFactory('github-issues')!('#x', () => {}).name).toBe('github-issues')
+  })
+})
+
+describe('registerPlugin collision guard', () => {
+  it('throws when a name is registered twice', () => {
+    registerPlugin('collide', (dc) => new StubPlugin(dc))
+    try {
+      expect(() => registerPlugin('collide', (dc) => new StubPlugin(dc))).toThrow(/already registered: collide/)
+    } finally {
+      unregisterPlugin('collide')
+    }
+  })
+
+  it('rejects an external attempt to shadow a built-in name', async () => {
+    await import('../registry.js')
+    expect(() => registerPlugin('github-prs', (dc) => new StubPlugin(dc))).toThrow(/already registered: github-prs/)
+  })
+
+  it('unregisterPlugin returns true when present, false when absent', () => {
+    registerPlugin('ephemeral', (dc) => new StubPlugin(dc))
+    expect(unregisterPlugin('ephemeral')).toBe(true)
+    expect(unregisterPlugin('ephemeral')).toBe(false)
   })
 })

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -36,6 +36,12 @@ export interface OrchestratorConfig {
   // of enabled plugins is `Object.keys(plugins)`. Each slice is shaped by
   // the owning plugin — typed locally via BasePlugin.pluginConfig.
   plugins?: Record<string, unknown>
+  // External plugin modules to load before `buildPlugins`. Each entry is a
+  // path to a module that calls `registerPlugin(name, factory)` at top
+  // level. Relative paths resolve against the config directory
+  // (`.orchestrator/`); absolute paths pass through unchanged. A failing
+  // import is fatal — see docs/PLUGINS.md.
+  plugin_paths?: string[]
 }
 
 export interface OrchestratorState {

--- a/src/orchestrator/load-external-plugins.ts
+++ b/src/orchestrator/load-external-plugins.ts
@@ -1,0 +1,24 @@
+// External plugin loader. Each path in `config.plugin_paths` is dynamically
+// imported before `buildPlugins` runs. The module is expected to call
+// `registerPlugin(name, factory)` at top level (side-effect import); the
+// orchestrator then sees the new name when it walks `config.plugins`.
+//
+// Relative paths resolve against the config directory (`.orchestrator/`),
+// so a config like `"plugin_paths": ["../plugins/my-scraper.ts"]` is
+// portable across operators. Absolute paths pass through unchanged.
+//
+// An import or registration failure is fatal: the dispatcher would
+// otherwise silently drop events for the missing plugin. Crash loud at
+// boot, fix the path / publish the module, retry.
+import { isAbsolute, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export async function loadExternalPlugins(stateDir: string, paths: string[] | undefined): Promise<void> {
+  if (!paths || paths.length === 0) return
+  for (const p of paths) {
+    const abs = isAbsolute(p) ? p : resolve(stateDir, p)
+    // pathToFileURL keeps ESM `import()` happy on absolute paths; without it
+    // node treats `/foo/bar.ts` as a bare specifier on some platforms.
+    await import(pathToFileURL(abs).href)
+  }
+}

--- a/src/orchestrator/plugin-api.ts
+++ b/src/orchestrator/plugin-api.ts
@@ -1,12 +1,14 @@
 // Stable public surface for external plugins. Reach here via the
 // `roost/plugin` exports map — never the deep `src/orchestrator/...`
-// paths. The set re-exported below is the seam: extending or trimming it
-// is a deliberate API change. See docs/PLUGINS.md.
+// paths. Intentionally minimal: extend a plugin, register it, type its
+// methods. Registry-read (`getPluginFactory`), the stderr logger fallback
+// (`defaultPluginLogger`), and the github-shaped watch-list helpers
+// (`WatchedEntry` / `resolveRepoEntry`) stay internal — externals don't
+// need them and adding them back is a deliberate API change. See
+// docs/PLUGINS.md.
 export {
   BasePlugin,
   registerPlugin,
-  getPluginFactory,
-  defaultPluginLogger,
   type Plugin,
   type PluginConfig,
   type PluginFactory,
@@ -15,7 +17,5 @@ export {
   type TaggedEvent,
   type TaggedEventPayload,
 } from './plugin.js'
-
-export { resolveRepoEntry, type WatchedEntry } from './config.js'
 
 export type { Command } from './dispatcher-dm-handler.js'

--- a/src/orchestrator/plugin-api.ts
+++ b/src/orchestrator/plugin-api.ts
@@ -1,0 +1,21 @@
+// Stable public surface for external plugins. Reach here via the
+// `roost/plugin` exports map — never the deep `src/orchestrator/...`
+// paths. The set re-exported below is the seam: extending or trimming it
+// is a deliberate API change. See docs/PLUGINS.md.
+export {
+  BasePlugin,
+  registerPlugin,
+  getPluginFactory,
+  defaultPluginLogger,
+  type Plugin,
+  type PluginConfig,
+  type PluginFactory,
+  type PluginLogger,
+  type PluginTickResult,
+  type TaggedEvent,
+  type TaggedEventPayload,
+} from './plugin.js'
+
+export { resolveRepoEntry, type WatchedEntry } from './config.js'
+
+export type { Command } from './dispatcher-dm-handler.js'

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -11,6 +11,16 @@
 import type { Command } from './dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from './config.js'
 
+// Narrow view of the orchestrator config that the plugin seam exposes
+// publicly. External plugins type their method parameters with this so they
+// only see their own slice path — never the wider OrchestratorConfig shape
+// (project/repo/irc/etc.). OrchestratorConfig is structurally assignable to
+// PluginConfig, so internal callers passing OrchestratorConfig still satisfy
+// external implementations that declare PluginConfig.
+export interface PluginConfig {
+  plugins?: Record<string, unknown>
+}
+
 // Pre-formatted payload variants. Plugins decide one-line vs. multi-line;
 // the dispatcher only knows how to write each variant to IRC.
 export type TaggedEventPayload =
@@ -96,8 +106,24 @@ export type PluginFactory = (defaultChannel: string, log: PluginLogger) => Plugi
 
 const REGISTRY = new Map<string, PluginFactory>()
 
+// Throws on duplicate name — silent overwrite would let one plugin
+// shadow another's state slice (registry key === state.plugins[name] key)
+// and cause hours of "where did my events go" debugging. Built-ins register
+// once at process boot via side-effect import of `registry.ts`; external
+// plugins register at top level of their module when loaded by the loader.
+// Test cleanup uses `unregisterPlugin`.
 export function registerPlugin(name: string, factory: PluginFactory): void {
+  if (REGISTRY.has(name)) {
+    throw new Error(`plugin already registered: ${name}`)
+  }
   REGISTRY.set(name, factory)
+}
+
+// Test-only escape hatch. Not exported from `plugin-api.ts` — external
+// plugins have no reason to deregister themselves. Returns true if the name
+// was registered, false if absent.
+export function unregisterPlugin(name: string): boolean {
+  return REGISTRY.delete(name)
 }
 
 export function getPluginFactory(name: string): PluginFactory | undefined {


### PR DESCRIPTION
Closes #255

## Summary

- `config.plugin_paths: string[]` — loader imports each entry before `buildPlugins` walks `config.plugins`. Relative paths resolve against `.orchestrator/`; absolute paths pass through. Side-effect `registerPlugin(name, factory)` at the module's top level makes the external name available alongside the built-ins.
- `roost/plugin` exports map — minimal public seam: 2 values (`BasePlugin`, `registerPlugin`) + 8 types (`Plugin`, `PluginConfig`, `PluginFactory`, `PluginLogger`, `PluginTickResult`, `TaggedEvent`, `TaggedEventPayload`, `Command`). External plugins type their method parameters against `PluginConfig` (the narrow `{ plugins? }` slice view); the runtime passes the full orchestrator config, so it's a convention rather than enforcement.
- `registerPlugin` now throws on duplicate names. Silent overwrite would shadow another plugin's state slice. `unregisterPlugin` added for test cleanup; not part of the public surface.
- `docs/PLUGINS.md` covers the seam, contract, register-on-load handshake, minimal example, and fatal failure modes. `docs/DISPATCHER.md` drops the "not yet supported" line.

## What's out of scope

Per the issue body, **versioning** (a `requires` check on the factory) is deferred — there's no published API surface tagged with a semver yet and no concrete second plugin to coordinate against. Worth doing once a real external plugin exists; called out in PLUGINS.md.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 552 pass, 0 fail
- [x] New `load-external-plugins.test.ts` covers: no-op (undefined / empty), absolute path, relative path resolved against config dir, missing path crashes, duplicate-name throw via two modules
- [x] `plugin.test.ts` updated for the throw-on-duplicate behavior (stub registers once in `beforeAll` + cleans up in `afterAll`); adds collision-guard tests (external can't shadow built-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)