### PR TITLE
maint: bump version to 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps package.json 0.6.2 → 0.6.3 for the v0.6.3 release.

What's new since v0.6.2:
- external plugin discovery via plugin_paths (#255)
- multi-repo commit polling via github-commits plugin (#414)
- roost init outside a git repo (#415)
- worker prompt PR lifecycle restructured (#427)
- release dance + CLAUDE.md sync for github-commits (#428)
- date-stamped model IDs in pricing.ts (#429)
- model alias warning + bare-alias enforcement (#430)
- homebrew-tap commit watch (#439)