### PR TITLE
steer-compact: name worker/reviewer nick patterns in directive

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -286,7 +286,7 @@ Every per-project artifact carries a `<project>-` prefix:
 - Leads channel: `#<project>-leads`
 - Issue channel: `#<project>-issue-<N>`
 - Worker nick: `<project>-worker-<N>`
-- Reviewer nick: `<project>-reviewer-<N>`
+- Reviewer nick: `<project>-reviewer-<PR>`
 - Dispatcher nick: `<project>-dispatcher`
 - Your own nick: `<project>-apm`
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -37,7 +37,7 @@ Every per-project artifact carries a `<project>-` prefix:
 - Leads channel: `#<project>-leads`
 - Issue channel: `#<project>-issue-<N>`
 - Worker nick: `<project>-worker-<N>`
-- Reviewer nick: `<project>-reviewer-<N>`
+- Reviewer nick: `<project>-reviewer-<PR>`
 - Associate-pm nick: `<project>-apm`
 - Dispatcher nick: `<project>-dispatcher` (set in `.orchestrator/config.json`)
 

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -21,7 +21,7 @@ set -u
 # if we ever tune it. Single-line, semicolon-separated — passed as the
 # `/compact` argument; the compactor treats it as a behavior hint for the
 # summary it produces (not verbatim retention).
-DIRECTIVE='retain: agent role and IRC nick; channels currently joined; in-flight GitHub issue and PR numbers and the state of each (worker spawned, draft, reviewed, merged), each worker'"'"'s nick (<project>-worker-<issue-number>), and each reviewer'"'"'s nick (<project>-reviewer-<PR-number>); recent decisions, design pivots, and blockers from the project leads channel; pending work the agent committed to or is waiting on'
+DIRECTIVE='retain: agent role and IRC nick; channels currently joined; in-flight GitHub issue and PR numbers and the state of each (worker spawned, draft, reviewed, merged), each worker'"'"'s nick (<project>-worker-<issue-number>), and each reviewer'"'"'s nick (<project>-reviewer-<PR-number>); recently-completed issues (post-merge, pre-cleanup) with their worker and reviewer nicks; recent decisions, design pivots, and blockers from the project leads channel; pending work the agent committed to or is waiting on'
 
 log() { echo "roost-compact-hook: $*" >&2; }
 

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -21,7 +21,7 @@ set -u
 # if we ever tune it. Single-line, semicolon-separated — passed as the
 # `/compact` argument; the compactor treats it as a behavior hint for the
 # summary it produces (not verbatim retention).
-DIRECTIVE='retain: agent role and IRC nick; channels currently joined; in-flight GitHub issue and PR numbers and the state of each (worker spawned, draft, reviewed, merged); recent decisions, design pivots, and blockers from the project leads channel; pending work the agent committed to or is waiting on'
+DIRECTIVE='retain: agent role and IRC nick; channels currently joined; in-flight GitHub issue and PR numbers and the state of each (worker spawned, draft, reviewed, merged), each worker'"'"'s nick (<project>-worker-<issue-number>), and each reviewer'"'"'s nick (<project>-reviewer-<PR-number>); recent decisions, design pivots, and blockers from the project leads channel; pending work the agent committed to or is waiting on'
 
 log() { echo "roost-compact-hook: $*" >&2; }
 


### PR DESCRIPTION
Closes #441

One-line fix to the DIRECTIVE constant in `bin/roost-compact-hook`. After compaction, an agent lost the distinction that worker nicks key off the issue number and reviewer nicks key off the PR number. Directive now says so explicitly.

293 → 406 chars; well under any soft cap on `custom_instructions`.

All 6 existing compact-hook tests pass.