### PR TITLE
feat(new-issues): multi-repo watched list

### DIFF
--- a/.orchestrator/config.example.json
+++ b/.orchestrator/config.example.json
@@ -12,7 +12,7 @@
   "plugins": {
     "github-prs": { "watched": [] },
     "github-issues": { "watched": [] },
-    "github-new-issues": {},
+    "github-new-issues": { "watched": [{ "repo": "AvesAlight/roost", "channels": ["#roost-leads"] }] },
     "github-commits": { "watched": [] }
   }
 }

--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -12,7 +12,7 @@
   "plugins": {
     "github-prs": { "watched": [] },
     "github-issues": { "watched": [] },
-    "github-new-issues": {},
+    "github-new-issues": { "watched": [{ "repo": "AvesAlight/roost" }] },
     "github-commits": {
       "watched": [
         {

--- a/bin/roost
+++ b/bin/roost
@@ -297,7 +297,7 @@ EOF
 }
 
 _init_config_json() {
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] },\n    "github-new-issues": {},\n    "github-commits": { "watched": [] }\n  }\n}\n' \
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] },\n    "github-new-issues": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
     "$1" "$2" "$3"
 }
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -38,7 +38,7 @@ Fields:
 | `plugin_paths` | Optional `[path, ...]` of external plugin modules to load before the registry is walked. Relative paths resolve against `.orchestrator/`. See [PLUGINS.md](./PLUGINS.md). |
 | `plugins.github-prs.watched` | `[{"number": N, "repo"?: "OWNER/NAME", "channels"?: [...]}]` |
 | `plugins.github-issues.watched` | Same shape as `plugins.github-prs.watched`. |
-| `plugins.github-new-issues` | Repo-wide new-issue feed: `{"repo"?: "OWNER/NAME", "channels"?: [...]}` (both optional; default = `repo` at top level + project channel). |
+| `plugins.github-new-issues.watched` | `[{"repo": "OWNER/NAME", "channels"?: [...]}]`. Multi-repo new-issue feed — `repo` required per entry, `channels` defaults to the project channel. |
 | `plugins.github-commits.watched` | `[{"repo": "OWNER/NAME", "branch"?: "main", "path"?: "Formula/x.rb", "channels"?: [...]}]`. Multi-repo commit feed — `repo` required per entry, `branch` defaults to `main`, optional `path` filters to commits touching that file, `channels` defaults to the project channel. State key is `<repo>@<branch>` (or `<repo>@<branch>:<path>` when path is set). |
 
 For watched entries, `repo` defaults to the top-level value. `channels` adds
@@ -51,10 +51,10 @@ fallback. The first-party set shipped in this repo is `github-prs`,
 loaded via `plugin_paths` (see [PLUGINS.md](./PLUGINS.md)) before the registry
 is walked, so their names become available alongside the built-ins.
 
-`github-new-issues` needs an explicit `plugins.github-new-issues`
-entry to run. `bin/roost init` writes one for new projects; for existing
-projects, add `"github-new-issues": {}` to enable the repo-wide new-issue
-feed on the project channel.
+`github-new-issues` needs an explicit `plugins.github-new-issues` entry with
+at least one `watched` entry to run. `bin/roost init` writes one for new
+projects; for existing projects add a `watched` list naming each repo to
+watch.
 
 ## Running
 

--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -36,7 +36,7 @@ describe('buildPlugins', () => {
       project: 'proj',
       repo: 'org/repo',
       plugins: {
-        'github-new-issues': {},
+        'github-new-issues': { watched: [] },
         'github-prs': { watched: [] },
         'github-issues': { watched: [] },
       },

--- a/src/orchestrator/__tests__/init-template.test.ts
+++ b/src/orchestrator/__tests__/init-template.test.ts
@@ -1,0 +1,30 @@
+// Regression guard: the config shape bin/roost's _init_config_json emits must
+// not throw on first tick. If this test breaks, the init template needs
+// updating alongside the plugin change.
+import { describe, it, expect } from 'bun:test'
+import { buildPlugins } from '../build-plugins.js'
+import type { OrchestratorConfig } from '../config.js'
+import '../registry.js'
+
+// Mirrors _init_config_json in bin/roost verbatim (minus irc + agent_logins
+// which the orchestrator doesn't touch during a tick).
+const INIT_CONFIG: OrchestratorConfig = {
+  project: 'my-project',
+  repo: 'org/repo',
+  plugins: {
+    'github-prs': { watched: [] },
+    'github-issues': { watched: [] },
+    'github-new-issues': { watched: [] },
+    'github-commits': { watched: [] },
+  },
+}
+
+describe('bin/roost init template', () => {
+  it('all plugins no-op on first tick without throwing', async () => {
+    const plugins = buildPlugins(INIT_CONFIG, '#my-project-leads', () => {})
+    const results = await Promise.all(plugins.map(p => p.runTick(INIT_CONFIG, null)))
+    for (const result of results) {
+      expect(result.taggedEvents).toHaveLength(0)
+    }
+  })
+})

--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -110,20 +110,22 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('throws when watched list is empty', async () => {
+  it('no-ops when watched list is empty — matches commits-plugin empty-list semantics', async () => {
     const config: OrchestratorConfig = {
       project: 'proj',
       plugins: { 'github-new-issues': { watched: [] } },
     }
-    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/watched list is empty/)
+    const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
   })
 
-  it('throws when watched is absent', async () => {
+  it('no-ops when watched is absent', async () => {
     const config: OrchestratorConfig = {
       project: 'proj',
       plugins: { 'github-new-issues': {} },
     }
-    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/watched list is empty/)
+    const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
   })
 
   it('orders announcements by issue number', async () => {
@@ -208,6 +210,21 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
       expect(texts.some(t => t.includes('org/new'))).toBe(false)
       // org/new numbers should be seeded into state
       expect((result.state as NewIssuesPluginState).repos['org/new']).toEqual([10, 11])
+    } finally { spy.mockRestore() }
+  })
+
+  it('carries forward removed-entry state — remove-then-readd does not replay history', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue([issue(5)])
+    try {
+      // org/gone is no longer in watched, but was in prev state
+      const config = baseConfig()
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(
+        config,
+        { repos: { 'org/repo': [], 'org/gone': [10, 11] } },
+      )
+      const state = result.state as NewIssuesPluginState
+      // org/gone watermarks carried forward even though not in watched
+      expect(state.repos['org/gone']).toEqual([10, 11])
     } finally { spy.mockRestore() }
   })
 

--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -18,7 +18,7 @@ function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorCo
   return {
     project: 'proj',
     repo: 'org/repo',
-    plugins: { 'github-new-issues': {} },
+    plugins: { 'github-new-issues': { watched: [{ repo: 'org/repo' }] } },
     ...overrides,
   }
 }
@@ -29,21 +29,24 @@ function stubFetch(response: GhRepoIssue[]) {
   return spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue(response)
 }
 
+function prevState(numbers: number[], repo = 'org/repo'): NewIssuesPluginState {
+  return { repos: { [repo]: numbers } }
+}
+
 describe('GitHubNewIssuesPlugin.runTick', () => {
   it('seeds without emitting on first run (prev === null)', async () => {
     const spy = stubFetch([issue(1), issue(2), issue(3)])
     try {
       const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), null)
       expect(result.taggedEvents).toHaveLength(0)
-      expect((result.state as NewIssuesPluginState).seen_issue_numbers).toEqual([1, 2, 3])
+      expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1, 2, 3])
     } finally { spy.mockRestore() }
   })
 
   it('emits a oneline announcement for issues new since last tick', async () => {
     const spy = stubFetch([issue(1), issue(2), issue(3)])
     try {
-      const prevState: NewIssuesPluginState = { seen_issue_numbers: [1] }
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([1]))
       expect(result.taggedEvents).toHaveLength(2)
       expect(result.taggedEvents[0]?.payload).toEqual({
         kind: 'oneline',
@@ -59,16 +62,16 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   it('routes announcements to the project channel by default', async () => {
     const spy = stubFetch([issue(5)])
     try {
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
       expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
     } finally { spy.mockRestore() }
   })
 
-  it('honors slice.channels override when set', async () => {
+  it('honors entry.channels override when set', async () => {
     const spy = stubFetch([issue(5)])
     try {
-      const config = baseConfig({ plugins: { 'github-new-issues': { channels: ['#triage', '#leads'] } } })
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, { seen_issue_numbers: [] })
+      const config = baseConfig({ plugins: { 'github-new-issues': { watched: [{ repo: 'org/repo', channels: ['#triage', '#leads'] }] } } })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, prevState([]))
       expect(result.taggedEvents[0]?.channels).toEqual(['#triage', '#leads'])
     } finally { spy.mockRestore() }
   })
@@ -76,7 +79,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   it('emits a defensive per-event channel copy — sibling mutation does not leak', async () => {
     const spy = stubFetch([issue(1), issue(2)])
     try {
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
       result.taggedEvents[0]?.channels.push('#tampered')
       expect(result.taggedEvents[1]?.channels).toEqual(['#proj-leads'])
     } finally { spy.mockRestore() }
@@ -85,7 +88,7 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   it('includes labels in the announcement when present', async () => {
     const spy = stubFetch([issue(7, { labels: [{ name: 'bug' }, { name: 'priority:high' }] })])
     try {
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
       const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
       expect(text).toBe('new issue org/repo#7: Issue 7 [bug, priority:high] — https://github.com/org/repo/issues/7')
     } finally { spy.mockRestore() }
@@ -94,61 +97,128 @@ describe('GitHubNewIssuesPlugin.runTick', () => {
   it('accumulates seen numbers across ticks', async () => {
     const spy = stubFetch([issue(1), issue(2)])
     try {
-      const prevState: NewIssuesPluginState = { seen_issue_numbers: [5] }
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
-      expect((result.state as NewIssuesPluginState).seen_issue_numbers).toEqual([1, 2, 5])
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([5]))
+      expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1, 2, 5])
     } finally { spy.mockRestore() }
   })
 
   it('does not re-announce issues already in seen', async () => {
     const spy = stubFetch([issue(1), issue(2)])
     try {
-      const prevState: NewIssuesPluginState = { seen_issue_numbers: [1, 2] }
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState)
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([1, 2]))
       expect(result.taggedEvents).toHaveLength(0)
     } finally { spy.mockRestore() }
   })
 
-  it('uses slice.repo when set, falls back to config.repo otherwise', async () => {
-    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue([])
-    try {
-      const config: OrchestratorConfig = {
-        project: 'proj',
-        repo: 'org/main',
-        plugins: { 'github-new-issues': { repo: 'org/feed-source' } },
-      }
-      await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)
-      expect(spy).toHaveBeenCalledWith('org/feed-source')
-    } finally { spy.mockRestore() }
+  it('throws when watched list is empty', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-new-issues': { watched: [] } },
+    }
+    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/watched list is empty/)
   })
 
-  it('throws when neither slice.repo nor config.repo is set', async () => {
+  it('throws when watched is absent', async () => {
     const config: OrchestratorConfig = {
       project: 'proj',
       plugins: { 'github-new-issues': {} },
     }
-    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/no repo/)
-  })
-
-  it('desiredChannels returns empty without slice.channels — orchestrator unions in the project channel', () => {
-    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
-    expect(plugin.desiredChannels(baseConfig())).toEqual([])
-  })
-
-  it('desiredChannels surfaces slice.channels so the orchestrator joins them at boot', () => {
-    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
-    const config = baseConfig({ plugins: { 'github-new-issues': { channels: ['#triage'] } } })
-    expect(plugin.desiredChannels(config)).toEqual(['#triage'])
+    await expect(new GitHubNewIssuesPlugin('#proj-leads').runTick(config, null)).rejects.toThrow(/watched list is empty/)
   })
 
   it('orders announcements by issue number', async () => {
     const spy = stubFetch([issue(20), issue(5), issue(11)])
     try {
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), { seen_issue_numbers: [] })
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
       const numbers = result.taggedEvents.map(e =>
         ((e.payload as { kind: 'oneline'; text: string }).text.match(/#(\d+)/)?.[1])
       )
       expect(numbers).toEqual(['5', '11', '20'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('desiredChannels returns empty when no entry has channels', () => {
+    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
+    expect(plugin.desiredChannels(baseConfig())).toEqual([])
+  })
+
+  it('desiredChannels unions channels across all watched entries', () => {
+    const plugin = new GitHubNewIssuesPlugin('#proj-leads')
+    const config = baseConfig({
+      plugins: {
+        'github-new-issues': {
+          watched: [
+            { repo: 'org/repo', channels: ['#triage'] },
+            { repo: 'org/other', channels: ['#triage', '#leads'] },
+          ],
+        },
+      },
+    })
+    expect(plugin.desiredChannels(config)).toEqual(['#triage', '#leads'])
+  })
+
+  it('polls each watched repo independently', async () => {
+    const calls: string[] = []
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockImplementation(async (repo: string) => {
+      calls.push(repo)
+      return repo === 'org/a' ? [issue(1)] : [issue(2)]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'github-new-issues': {
+            watched: [
+              { repo: 'org/a' },
+              { repo: 'org/b' },
+            ],
+          },
+        },
+      }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, { repos: { 'org/a': [], 'org/b': [] } })
+      expect(calls).toEqual(['org/a', 'org/b'])
+      expect(result.taggedEvents).toHaveLength(2)
+      expect((result.taggedEvents[0]?.payload as { text: string }).text).toContain('org/a#1')
+      expect((result.taggedEvents[1]?.payload as { text: string }).text).toContain('org/b#2')
+    } finally { spy.mockRestore() }
+  })
+
+  it('seeds a new repo entry without emitting when added to an existing config', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockImplementation(async (repo: string) => {
+      return repo === 'org/a' ? [issue(1)] : [issue(10), issue(11)]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'github-new-issues': {
+            watched: [
+              { repo: 'org/a' },
+              { repo: 'org/new' },
+            ],
+          },
+        },
+      }
+      // prev state only has org/a — org/new is brand new
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(config, { repos: { 'org/a': [] } })
+      // org/a should emit (prev known, issue 1 is new)
+      // org/new should NOT emit (first observation)
+      const texts = result.taggedEvents.map(e => (e.payload as { text: string }).text)
+      expect(texts.every(t => t.includes('org/a'))).toBe(true)
+      expect(texts.some(t => t.includes('org/new'))).toBe(false)
+      // org/new numbers should be seeded into state
+      expect((result.state as NewIssuesPluginState).repos['org/new']).toEqual([10, 11])
+    } finally { spy.mockRestore() }
+  })
+
+  it('treats old flat state format as null and re-seeds', async () => {
+    const spy = stubFetch([issue(1), issue(2)])
+    try {
+      const oldState = { seen_issue_numbers: [1, 2, 3] }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(baseConfig(), oldState)
+      // Re-seeded: no events emitted
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1, 2])
     } finally { spy.mockRestore() }
   })
 })

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -1,82 +1,103 @@
-// Project-level issue triage feed. Polls the repo for open issues and emits a
-// oneline announcement to the project channel the first time a given issue
-// number is observed. Sibling to `github-issues`: that plugin routes activity
-// for hand-watched issues; this one surfaces brand-new issues so the team
-// doesn't have to notice them manually.
+// Project-level issue triage feed. Polls a configured list of repos for open
+// issues and emits a oneline announcement to the per-entry channels the first
+// time a given issue number is observed in that repo. Sibling to
+// `github-issues`: that plugin routes activity for hand-watched issues; this
+// one surfaces brand-new issues so the team doesn't have to notice them
+// manually.
 //
-// Enabled by an explicit `plugins.github-new-issues` slice in config —
-// empty object is fine. `bin/roost init` writes one for new projects;
+// Enabled by an explicit `plugins.github-new-issues` slice in config with at
+// least one `watched` entry. `bin/roost init` writes one for new projects;
 // existing projects need an operator edit (or the example.json refresh) to
 // pick this up.
 //
-// State slice: `{ seen_issue_numbers: number[] }`. Seeding (`prev===null`)
-// captures the current open set without emitting — only ticks after seed
-// announce. Closed issues that re-open will re-announce only if they were
-// pruned from `seen` (we don't prune today, so closed-then-reopened is
-// silently suppressed; that's fine, the operator can `watch <N>` for it).
+// State slice: `{ repos: Record<string, number[]> }` keyed by repo slug.
+// Seeding (`prev===null`) and first-observation of a new repo entry
+// (`prev.repos[repo]===undefined`) both capture the current open set without
+// emitting — only ticks after seed announce. Closed issues that re-open will
+// re-announce only if they were pruned from `seen` (we don't prune today, so
+// closed-then-reopened is silently suppressed; the operator can `watch <N>`
+// for it).
 import type { OrchestratorConfig } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
 import { labelNames, type GhRepoIssue } from './github-api.js'
 import { GhPluginBase } from './base.js'
 
-interface NewIssuesPluginConfig {
-  repo?: string
+export interface NewIssuesWatchEntry {
+  repo: string
   channels?: string[]
 }
 
+interface NewIssuesPluginConfig {
+  watched?: NewIssuesWatchEntry[]
+}
+
 export interface NewIssuesPluginState {
-  seen_issue_numbers: number[]
+  repos: Record<string, number[]>
 }
 
 export class GitHubNewIssuesPlugin extends GhPluginBase {
   readonly name = 'github-new-issues'
 
-  // Project channel is unioned in by the orchestrator, so the default case
-  // returns []. An explicit slice.channels override is surfaced here so those
-  // channels join at boot.
+  // Project channel is unioned in by the orchestrator. Explicit per-entry
+  // channels are surfaced here so they join at boot.
   desiredChannels(config: OrchestratorConfig): string[] {
     const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
-    return slice.channels?.length ? [...slice.channels] : []
+    const chans = new Set<string>()
+    for (const entry of slice.watched ?? []) {
+      for (const c of entry.channels ?? []) chans.add(c)
+    }
+    return [...chans]
   }
 
   async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
     const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
-    const repo = slice.repo ?? config.repo
-    if (!repo) throw new Error('github-new-issues: no repo (set `repo` at top level or under plugins.github-new-issues)')
+    const watchEntries = slice.watched ?? []
+    if (!watchEntries.length) throw new Error('github-new-issues: watched list is empty (add at least one {repo} entry)')
 
-    const announcementChannels = slice.channels?.length
-      ? [...slice.channels]
-      : [resolveProjectChannel(config)]
+    // State migration: old flat format (`seen_issue_numbers` present, `repos` absent) re-seeds cleanly.
+    const prev = (prevState != null && typeof prevState === 'object' && 'repos' in prevState)
+      ? prevState as NewIssuesPluginState
+      : null
 
-    const issues = await this.client.fetchRepoOpenIssues(repo)
-    const currentNumbers = issues
-      .map(i => i.number)
-      .filter((n): n is number => n != null)
-      .sort((a, b) => a - b)
-
-    const prev = prevState as NewIssuesPluginState | null
-    const seen = new Set<number>(prev?.seen_issue_numbers ?? [])
     const taggedEvents: TaggedEvent[] = []
+    const nextRepos: Record<string, number[]> = {}
 
-    if (prev !== null) {
-      const newIssues = issues
-        .filter(i => i.number != null && !seen.has(i.number))
-        .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))
-      for (const issue of newIssues) {
-        taggedEvents.push({
-          // Per-event copy so a downstream mutation of one event's channel
-          // list can't leak into siblings.
-          channels: [...announcementChannels],
-          payload: { kind: 'oneline', text: formatNewIssue(repo, issue) },
-        })
+    for (const entry of watchEntries) {
+      const { repo, channels } = entry
+      const announcementChannels = channels?.length
+        ? [...channels]
+        : [resolveProjectChannel(config)]
+
+      const issues = await this.client.fetchRepoOpenIssues(repo)
+      const currentNumbers = issues
+        .map(i => i.number)
+        .filter((n): n is number => n != null)
+        .sort((a, b) => a - b)
+
+      // First observation of this repo (or full re-seed): capture without emitting.
+      const isFirstForRepo = prev === null || prev.repos[repo] === undefined
+      const seen = new Set<number>(prev?.repos[repo] ?? [])
+
+      if (!isFirstForRepo) {
+        const newIssues = issues
+          .filter(i => i.number != null && !seen.has(i.number))
+          .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))
+        for (const issue of newIssues) {
+          taggedEvents.push({
+            // Per-event copy so a downstream mutation of one event's channel
+            // list can't leak into siblings.
+            channels: [...announcementChannels],
+            payload: { kind: 'oneline', text: formatNewIssue(repo, issue) },
+          })
+        }
       }
+
+      for (const n of currentNumbers) seen.add(n)
+      nextRepos[repo] = [...seen].sort((a, b) => a - b)
     }
 
-    // Always merge — even on seed — so seen accumulates from tick 1.
-    for (const n of currentNumbers) seen.add(n)
-
-    const state: NewIssuesPluginState = { seen_issue_numbers: [...seen].sort((a, b) => a - b) }
+    const state: NewIssuesPluginState = { repos: nextRepos }
     taggedEvents.push(...await this.observeRateLimit(resolveProjectChannel(config)))
     return { state, taggedEvents, channels: [] }
   }

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -5,18 +5,18 @@
 // one surfaces brand-new issues so the team doesn't have to notice them
 // manually.
 //
-// Enabled by an explicit `plugins.github-new-issues` slice in config with at
-// least one `watched` entry. `bin/roost init` writes one for new projects;
-// existing projects need an operator edit (or the example.json refresh) to
-// pick this up.
+// Enabled by an explicit `plugins.github-new-issues` slice in config.
+// Empty or absent `watched` is a no-op (matches commits-plugin). `bin/roost
+// init` writes one for new projects; existing projects need an operator edit
+// (or the example.json refresh) to pick this up.
 //
 // State slice: `{ repos: Record<string, number[]> }` keyed by repo slug.
 // Seeding (`prev===null`) and first-observation of a new repo entry
 // (`prev.repos[repo]===undefined`) both capture the current open set without
-// emitting — only ticks after seed announce. Closed issues that re-open will
-// re-announce only if they were pruned from `seen` (we don't prune today, so
-// closed-then-reopened is silently suppressed; the operator can `watch <N>`
-// for it).
+// emitting — only ticks after seed announce. Removed entries are carried
+// forward in state (matches commits-plugin) so remove-then-readd doesn't
+// replay history. Closed issues that re-open will re-announce only if pruned
+// from `seen` (we don't prune today; the operator can `watch <N>` for it).
 import type { OrchestratorConfig } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
@@ -53,7 +53,9 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
   async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
     const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
     const watchEntries = slice.watched ?? []
-    if (!watchEntries.length) throw new Error('github-new-issues: watched list is empty (add at least one {repo} entry)')
+    // Empty or absent watched is a no-op — matches commits-plugin semantics so
+    // an init-stub `{ "watched": [] }` is harmless.
+    if (!watchEntries.length) return { state: prevState ?? { repos: {} }, taggedEvents: [], channels: [] }
 
     // State migration: old flat format (`seen_issue_numbers` present, `repos` absent) re-seeds cleanly.
     const prev = (prevState != null && typeof prevState === 'object' && 'repos' in prevState)
@@ -61,7 +63,9 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
       : null
 
     const taggedEvents: TaggedEvent[] = []
-    const nextRepos: Record<string, number[]> = {}
+    // Carry forward all repos from prev (matches commits-plugin state retention:
+    // remove-then-readd doesn't replay history).
+    const nextRepos: Record<string, number[]> = prev ? { ...prev.repos } : {}
 
     for (const entry of watchEntries) {
       const { repo, channels } = entry


### PR DESCRIPTION
Closes #435

Migrates `github-new-issues` from a single-repo `{repo?, channels?}` config to the `watched: [{repo, channels?}]` shape used by every other GitHub plugin. Hard cutover — `repo` is required per entry, no `config.repo` fallback.

State changes from `{seen_issue_numbers: number[]}` to `{repos: Record<string, number[]>}` keyed by repo. Old flat state re-seeds without blasting historical notifications. A new repo added to `watched` mid-flight seeds silently on its first tick.

- 16 tests pass (existing updated + multi-repo, new-entry seeding, old-state-format migration)
- `docs/DISPATCHER.md` table entry updated
- `.orchestrator/config.example.json` updated to show `watched` format