### PR TITLE
feat(orchestrator): split config.json + local overlay

### DIFF
--- a/.orchestrator/.gitignore
+++ b/.orchestrator/.gitignore
@@ -1,0 +1,11 @@
+config.local.json
+state.json
+last-tick.txt
+last-error.txt
+dispatcher.pid
+joined-channels.txt
+dispatcher-boot.log
+daemon.log
+.dispatcher.start.lock
+token-snapshots.json
+.token-snapshots.*.tmp

--- a/.orchestrator/config.example.json
+++ b/.orchestrator/config.example.json
@@ -10,8 +10,6 @@
     "interval_seconds": 60
   },
   "plugins": {
-    "github-prs": { "watched": [] },
-    "github-issues": { "watched": [] },
     "github-new-issues": { "watched": [{ "repo": "AvesAlight/roost", "channels": ["#roost-leads"] }] },
     "github-commits": { "watched": [] }
   }

--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -10,8 +10,6 @@
     "interval_seconds": 10
   },
   "plugins": {
-    "github-prs": { "watched": [] },
-    "github-issues": { "watched": [] },
     "github-new-issues": { "watched": [{ "repo": "AvesAlight/roost" }] },
     "github-commits": {
       "watched": [

--- a/.orchestrator/config.local.example.json
+++ b/.orchestrator/config.local.example.json
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "github-prs": { "watched": [] },
+    "github-issues": { "watched": [] }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Bootstrap your project, then kick off lead-pm:
 
 ```bash
 cd ~/Dev/myproject
-roost init                          # writes .orchestrator/config.json + copies role prompts
+roost init                          # writes .orchestrator/{config.json, config.local.json, .gitignore} + copies role prompts
 roost spawn myproject-lead-pm \
   --agent lead-pm \
   --channels '#myproject-leads' \
@@ -179,7 +179,7 @@ to control which issues and PRs are tracked:
 
 ```bash
 cd ~/Dev/myproject
-roost init                              # first-time: writes .orchestrator/config.json + prompts
+roost init                              # first-time: writes .orchestrator/{config.json, config.local.json, .gitignore} + prompts
 CONFIG_DIR="$(pwd)/.orchestrator"
 "$ROOST_DIR/bin/start-dispatcher" "$CONFIG_DIR"
 ```

--- a/bin/roost
+++ b/bin/roost
@@ -2,7 +2,7 @@
 # roost — manage roost-irc Claude sessions in tmux.
 #
 # Subcommands:
-#   init                    — bootstrap .orchestrator/config.json for a project
+#   init                    — bootstrap .orchestrator/ (config.json + local overlay) for a project
 #   spawn <nick> [options]  — bring up a Claude session on the roost
 #   shutdown <nick>         — kill the tmux session for that nick
 #   list                    — show all roost-prefixed tmux sessions
@@ -61,10 +61,14 @@ usage_init() {
   cat <<EOF
 Usage: roost init [options]
 
-Bootstrap .orchestrator/config.json + .gitignore for a new project and copy
-roost prompt templates to .claude/commands/ and agent definitions to
-.claude/agents/ for local customization.
+Bootstrap .orchestrator/config.json + config.local.json + .gitignore for a
+new project and copy roost prompt templates to .claude/commands/ and agent
+definitions to .claude/agents/ for local customization.
 Autodetects project name, repo, and GitHub user; each value can be overridden.
+
+config.json is tracked (shareable project shape); config.local.json is
+gitignored (dispatcher-mutated overlay for github-prs/github-issues watches
+added via DM). See docs/DISPATCHER.md.
 
 Options:
   --project NAME         Project name (default: basename of cwd, lowercased).
@@ -72,9 +76,9 @@ Options:
                          defaults to the origin remote URL.
   --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
                          Default: current gh user.
-  --force                Overwrite everything: config.json, .gitignore,
-                         .claude/commands/ prompt copies, and .claude/agents/
-                         agent copies.
+  --force                Overwrite everything: config.json, config.local.json,
+                         .gitignore, .claude/commands/ prompt copies, and
+                         .claude/agents/ agent copies.
   --force-prompts        Overwrite only .claude/commands/ prompt copies.
                          Does not touch config.json or .gitignore.
   --force-agents         Overwrite only .claude/agents/ agent copies.
@@ -301,8 +305,15 @@ _init_config_json() {
     "$1" "$2" "$3"
 }
 
+# Empty scaffold for the gitignored dispatcher-mutated overlay. The
+# dispatcher writes here when DM commands add github-prs/github-issues
+# watches; operator-set static entries belong in config.json instead.
+_init_config_local_json() {
+  printf '{\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] }\n  }\n}\n'
+}
+
 _init_gitignore() {
-  printf 'state.json\nlast-tick.txt\nlast-error.txt\ndispatcher.pid\njoined-channels.txt\ndispatcher-boot.log\ndaemon.log\n.dispatcher.start.lock\ntoken-snapshots.json\n.token-snapshots.*.tmp\n'
+  printf 'config.local.json\nstate.json\nlast-tick.txt\nlast-error.txt\ndispatcher.pid\njoined-channels.txt\ndispatcher-boot.log\ndaemon.log\n.dispatcher.start.lock\ntoken-snapshots.json\n.token-snapshots.*.tmp\n'
 }
 
 cmd_init() {
@@ -395,6 +406,7 @@ cmd_init() {
   logins_json="${logins_json}]"
 
   local config_path=".orchestrator/config.json"
+  local config_local_path=".orchestrator/config.local.json"
   local gitignore_path=".orchestrator/.gitignore"
   local prompts_dir="${ROOST_DIR}/prompts"
   local commands_dir=".claude/commands"
@@ -419,6 +431,8 @@ cmd_init() {
   if [ "$dry_run" -eq 1 ]; then
     echo "--- ${config_path} ---"
     _init_config_json "$project" "$repo" "$logins_json"
+    echo "--- ${config_local_path} ---"
+    _init_config_local_json
     echo "--- ${gitignore_path} ---"
     _init_gitignore
     if [ "$no_prompts" -eq 0 ] && [ "${#prompt_files[@]}" -gt 0 ]; then
@@ -442,9 +456,13 @@ cmd_init() {
 
   # Decide what would actually be written.
   local write_config=0
+  local write_config_local=0
   local write_gitignore=0
   if [ ! -f "$config_path" ] || [ "$force" -eq 1 ]; then
     write_config=1
+  fi
+  if [ ! -f "$config_local_path" ] || [ "$force" -eq 1 ]; then
+    write_config_local=1
   fi
   if [ ! -f "$gitignore_path" ] || [ "$force" -eq 1 ]; then
     write_gitignore=1
@@ -461,6 +479,10 @@ cmd_init() {
   if [ "$write_config" -eq 1 ]; then
     _init_config_json "$project" "$repo" "$logins_json" > "$config_path"
     echo "Wrote ${config_path}"
+  fi
+  if [ "$write_config_local" -eq 1 ]; then
+    _init_config_local_json > "$config_local_path"
+    echo "Wrote ${config_local_path}"
   fi
   if [ "$write_gitignore" -eq 1 ]; then
     _init_gitignore > "$gitignore_path"

--- a/bin/roost
+++ b/bin/roost
@@ -300,14 +300,20 @@ Example:
 EOF
 }
 
+# Tracked, shareable shape: project + repo identity + the static plugin
+# slices (github-new-issues / github-commits are operator-set, not DM-mutated).
+# The dynamic slices (github-prs / github-issues) live in the local overlay;
+# their `plugins.<name>` key in the merged config still enables them — the
+# loader unions `Object.keys(plugins)` across both files.
 _init_config_json() {
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] },\n    "github-new-issues": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
     "$1" "$2" "$3"
 }
 
-# Empty scaffold for the gitignored dispatcher-mutated overlay. The
-# dispatcher writes here when DM commands add github-prs/github-issues
-# watches; operator-set static entries belong in config.json instead.
+# Gitignored dispatcher-mutated overlay scaffold. Mirrors
+# .orchestrator/config.local.example.json: enables the two DM-driven
+# plugins with empty watch lists, ready for `watch <N>` / `watch pr <N>`
+# DMs to populate.
 _init_config_local_json() {
   printf '{\n  "plugins": {\n    "github-prs": { "watched": [] },\n    "github-issues": { "watched": [] }\n  }\n}\n'
 }

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -52,10 +52,12 @@ contribute live entries. DM commands operate on the local overlay only:
 modify tracked operator/project state.
 
 Existing operators upgrading from the single-file layout: your old
-config.json keeps working as-is. The dispatcher just stops writing to it
-on the next watch; new entries land in config.local.json. Move your
-dynamic `github-prs` / `github-issues` watches over by hand if you want a
-clean separation, or wait — they heal naturally on the next re-watch.
+config.json keeps working as-is. The dispatcher stops writing to it on
+the next watch; new entries land in config.local.json. To bring a
+tracked entry under dispatcher control, hand-edit `config.json` to
+remove it — the dispatcher will pick it up via a fresh `watch <N>`.
+There's no automatic migration: refusing to mutate tracked entries is
+the contract, not a bug.
 
 Fields:
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -21,11 +21,41 @@ See `src/orchestrator/naming.ts` for the full namespacing convention.
 
 ## Setup
 
-Copy the template, then edit:
+Run `bin/roost init` (writes both config.json and config.local.json plus the
+gitignore), or do it by hand:
 
 ```sh
 cp .orchestrator/config.example.json .orchestrator/config.json
+# config.local.json is created on first dispatcher write; an empty
+# `{"plugins":{"github-prs":{"watched":[]},"github-issues":{"watched":[]}}}`
+# is fine if you want it visible from day one.
 ```
+
+### Two-file split
+
+`.orchestrator/config.json` is **tracked** and holds the shareable project
+shape: `project`, `repo`, `agent_logins`, `irc`, the enabled plugin set,
+and any static plugin slices the team agrees on (e.g.
+`github-commits.watched`, `github-new-issues.watched`). PR-reviewed
+changes go here.
+
+`.orchestrator/config.local.json` is **gitignored** and holds the
+dispatcher-mutated overlay: PR/issue watches added via `watch <N>` DMs land
+in `plugins.github-prs.watched` / `plugins.github-issues.watched` here.
+Concurrent operators don't clobber each other's live entries.
+
+The loader merges the two files. Most fields are local-wins on conflict.
+`plugins.<name>.watched` arrays are **concatenated** — both sources
+contribute live entries. DM commands operate on the local overlay only:
+`unwatch <N>` on a tracked entry returns
+`in tracked config.json — hand-edit to remove`, since the dispatcher won't
+modify tracked operator/project state.
+
+Existing operators upgrading from the single-file layout: your old
+config.json keeps working as-is. The dispatcher just stops writing to it
+on the next watch; new entries land in config.local.json. Move your
+dynamic `github-prs` / `github-issues` watches over by hand if you want a
+clean separation, or wait — they heal naturally on the next re-watch.
 
 Fields:
 
@@ -91,8 +121,9 @@ State files in `.orchestrator/`:
 
 | File | Purpose |
 |---|---|
-| `config.json` | Tracked in git. Hand-edited or mutated via DMs to the dispatcher (`watch <N>`, `unwatch <N>`, `watch pr <N>`, etc.). |
-| `config.example.json` | Tracked. Template for forks. |
+| `config.json` | Tracked in git. Shareable project shape — hand-edited only; the dispatcher never writes here. See "Two-file split" above. |
+| `config.local.json` | Gitignored. Dispatcher-mutated overlay for DM-driven watches (`watch <N>`, `unwatch <N>`, `watch pr <N>`). Concatenated onto config.json's `plugins.<name>.watched`. |
+| `config.example.json` | Tracked. Template for `config.json` in forks. |
 | `state.json` | Last seen GH state per watched entry. Re-seedable. |
 | `last-tick.txt` | Heartbeat timestamp. Use for healthchecks. |
 | `last-error.txt` | Last fatal tick error. Cleared on success. |

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -21,33 +21,36 @@ See `src/orchestrator/naming.ts` for the full namespacing convention.
 
 ## Setup
 
-Run `bin/roost init` (writes both config.json and config.local.json plus the
-gitignore), or do it by hand:
+Run `bin/roost init` (writes both config files plus the gitignore), or do
+it by hand:
 
 ```sh
-cp .orchestrator/config.example.json .orchestrator/config.json
-# config.local.json is created on first dispatcher write; an empty
-# `{"plugins":{"github-prs":{"watched":[]},"github-issues":{"watched":[]}}}`
-# is fine if you want it visible from day one.
+cp .orchestrator/config.example.json       .orchestrator/config.json
+cp .orchestrator/config.local.example.json .orchestrator/config.local.json
 ```
 
 ### Two-file split
 
 `.orchestrator/config.json` is **tracked** and holds the shareable project
-shape: `project`, `repo`, `agent_logins`, `irc`, the enabled plugin set,
-and any static plugin slices the team agrees on (e.g.
-`github-commits.watched`, `github-new-issues.watched`). PR-reviewed
-changes go here.
+shape: `project`, `repo`, `agent_logins`, `irc`, plus the static plugin
+slices the team agrees on — currently `github-new-issues.watched` and
+`github-commits.watched`. PR-reviewed changes go here.
+`config.example.json` mirrors that shape as a fork template.
 
 `.orchestrator/config.local.json` is **gitignored** and holds the
 dispatcher-mutated overlay: PR/issue watches added via `watch <N>` DMs land
 in `plugins.github-prs.watched` / `plugins.github-issues.watched` here.
 Concurrent operators don't clobber each other's live entries.
+`config.local.example.json` is the tracked template for it — empty
+`github-prs` / `github-issues` slices that enable the two DM-driven
+plugins out of the box.
 
-The loader merges the two files. Most fields are local-wins on conflict.
-`plugins.<name>.watched` arrays are **concatenated** — both sources
-contribute live entries. DM commands operate on the local overlay only:
-`unwatch <N>` on a tracked entry returns
+The loader merges the two files. The enabled plugin set is the **union**
+of `Object.keys(plugins)` across both, so a slice that lives only in the
+local overlay still enables its plugin. Most fields are local-wins on
+conflict; `plugins.<name>.watched` arrays are **concatenated** — both
+sources contribute live entries. DM commands operate on the local overlay
+only: `unwatch <N>` on a tracked entry returns
 `in tracked config.json — hand-edit to remove`, since the dispatcher won't
 modify tracked operator/project state.
 
@@ -123,9 +126,10 @@ State files in `.orchestrator/`:
 
 | File | Purpose |
 |---|---|
-| `config.json` | Tracked in git. Shareable project shape — hand-edited only; the dispatcher never writes here. See "Two-file split" above. |
+| `config.json` | Tracked in git. Shareable project shape (static slices only — `github-new-issues`, `github-commits`). Hand-edited only; the dispatcher never writes here. See "Two-file split" above. |
 | `config.local.json` | Gitignored. Dispatcher-mutated overlay for DM-driven watches (`watch <N>`, `unwatch <N>`, `watch pr <N>`). Concatenated onto config.json's `plugins.<name>.watched`. |
-| `config.example.json` | Tracked. Template for `config.json` in forks. |
+| `config.example.json` | Tracked. Template for `config.json` in forks (static shape). |
+| `config.local.example.json` | Tracked. Template for `config.local.json` — empty `github-prs` / `github-issues` scaffolds that enable the DM-driven plugins. |
 | `state.json` | Last seen GH state per watched entry. Re-seedable. |
 | `last-tick.txt` | Heartbeat timestamp. Use for healthchecks. |
 | `last-error.txt` | Last fatal tick error. Cleared on success. |

--- a/src/orchestrator/__tests__/config.test.ts
+++ b/src/orchestrator/__tests__/config.test.ts
@@ -74,6 +74,17 @@ describe('mergeConfigs', () => {
     )
     expect(Object.keys(merged.plugins!).sort()).toEqual(['github-commits', 'github-prs'])
   })
+
+  it('clones concatenated watched entries — mutating a merged entry does not leak into base/local', () => {
+    const baseSlice = { watched: [{ number: 1, channels: ['#a'] }] }
+    const localSlice = { watched: [{ number: 2, channels: ['#b'] }] }
+    const merged = mergeConfigs({ plugins: { x: baseSlice } }, { plugins: { x: localSlice } })
+    const mergedEntries = (merged.plugins!.x as { watched: { number: number; channels: string[] }[] }).watched
+    mergedEntries[0].channels.push('#leaked')
+    mergedEntries[1].channels.push('#leaked')
+    expect(baseSlice.watched[0].channels).toEqual(['#a'])
+    expect(localSlice.watched[0].channels).toEqual(['#b'])
+  })
 })
 
 describe('loadConfig (with overlay)', () => {
@@ -174,6 +185,16 @@ describe('mutateConfig', () => {
     await writeFile(join(dir, 'config.local.json'), JSON.stringify({ repo: 'preserved/repo' }))
     await mutateConfig(dir, () => { /* no-op */ })
     expect((await loadLocalOverlay(dir)).repo).toBe('preserved/repo')
+  })
+
+  it('freezes base so accidental mutations throw at the bug site', async () => {
+    await expect(
+      mutateConfig(dir, (base) => {
+        // Strict mode (TS modules are always strict) makes this throw.
+        base.repo = 'accidental/write'
+      })
+    ).rejects.toThrow()
+    expect((await loadConfigBase(dir)).repo).toBeUndefined()
   })
 })
 

--- a/src/orchestrator/__tests__/config.test.ts
+++ b/src/orchestrator/__tests__/config.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtemp, rm, readFile } from 'node:fs/promises'
-import { readdirSync } from 'node:fs'
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises'
+import { readdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { loadConfig, writeConfig, mutateConfig, assertEntryRepoMode } from '../config.js'
+import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfig, writeConfig, writeLocalConfig, assertEntryRepoMode } from '../config.js'
 
 let dir: string
 
@@ -30,38 +30,123 @@ describe('writeConfig', () => {
   })
 })
 
+describe('mergeConfigs', () => {
+  it('returns the base unchanged when overlay is empty', () => {
+    const base = { project: 'p', repo: 'o/r', plugins: { x: { watched: [{ number: 1 }] } } }
+    expect(mergeConfigs(base, {})).toEqual(base)
+  })
+
+  it('local wins on top-level scalars', () => {
+    const merged = mergeConfigs({ project: 'base', repo: 'o/r' }, { project: 'local' })
+    expect(merged).toEqual({ project: 'local', repo: 'o/r' })
+  })
+
+  it('merges irc per-field (local-wins, base fills gaps)', () => {
+    const merged = mergeConfigs(
+      { irc: { server: 'a', port: 6667 } },
+      { irc: { server: 'b' } }
+    )
+    expect(merged.irc).toEqual({ server: 'b', port: 6667 })
+  })
+
+  it('concatenates plugins.<name>.watched arrays', () => {
+    const merged = mergeConfigs(
+      { plugins: { 'github-prs': { watched: [{ number: 1 }, { number: 2 }] } } },
+      { plugins: { 'github-prs': { watched: [{ number: 3 }] } } }
+    )
+    expect((merged.plugins!['github-prs'] as { watched: unknown[] }).watched).toEqual([
+      { number: 1 }, { number: 2 }, { number: 3 },
+    ])
+  })
+
+  it('preserves sibling slice keys with overlay-wins for non-watched fields', () => {
+    const merged = mergeConfigs(
+      { plugins: { x: { watched: [{ number: 1 }], other: 'base' } } },
+      { plugins: { x: { other: 'local' } } }
+    )
+    expect(merged.plugins!.x).toEqual({ watched: [{ number: 1 }], other: 'local' })
+  })
+
+  it('keeps a plugin slice that exists only on one side', () => {
+    const merged = mergeConfigs(
+      { plugins: { 'github-commits': { watched: [{ number: 9 }] } } },
+      { plugins: { 'github-prs': { watched: [{ number: 1 }] } } }
+    )
+    expect(Object.keys(merged.plugins!).sort()).toEqual(['github-commits', 'github-prs'])
+  })
+})
+
+describe('loadConfig (with overlay)', () => {
+  it('treats missing config.local.json as an empty overlay', async () => {
+    await writeConfig(dir, { project: 'p', plugins: { x: { watched: [{ number: 1 }] } } })
+    expect(await loadLocalOverlay(dir)).toEqual({})
+    const merged = await loadConfig(dir)
+    expect(merged.project).toBe('p')
+    expect((merged.plugins!.x as { watched: unknown[] }).watched).toEqual([{ number: 1 }])
+  })
+
+  it('concatenates watched arrays across files', async () => {
+    await writeConfig(dir, { plugins: { 'github-prs': { watched: [{ number: 1 }] } } })
+    await writeLocalConfig(dir, { plugins: { 'github-prs': { watched: [{ number: 2 }] } } })
+    const merged = await loadConfig(dir)
+    expect((merged.plugins!['github-prs'] as { watched: unknown[] }).watched).toEqual([
+      { number: 1 }, { number: 2 },
+    ])
+  })
+
+  it('local overlay wins on top-level scalars', async () => {
+    await writeConfig(dir, { project: 'base', repo: 'o/r' })
+    await writeLocalConfig(dir, { project: 'local' })
+    const merged = await loadConfig(dir)
+    expect(merged).toEqual({ project: 'local', repo: 'o/r' })
+  })
+})
+
 describe('mutateConfig', () => {
   beforeEach(async () => {
     await writeConfig(dir, { project: 'initial' })
   })
 
-  it('applies fn and persists the result', async () => {
-    await mutateConfig(dir, (c) => { c.repo = 'org/repo' })
-    const config = await loadConfig(dir)
-    expect(config.project).toBe('initial')
-    expect(config.repo).toBe('org/repo')
+  it('applies fn and persists only to config.local.json', async () => {
+    await mutateConfig(dir, (_base, local) => { local.repo = 'org/repo' })
+    expect((await loadConfigBase(dir)).repo).toBeUndefined()
+    expect((await loadLocalOverlay(dir)).repo).toBe('org/repo')
+    const merged = await loadConfig(dir)
+    expect(merged.project).toBe('initial')
+    expect(merged.repo).toBe('org/repo')
+  })
+
+  it('does not touch config.json bytes', async () => {
+    const before = await readFile(join(dir, 'config.json'), 'utf8')
+    await mutateConfig(dir, (_base, local) => {
+      local.plugins ??= {}
+      local.plugins['github-prs'] = { watched: [{ number: 7 }] }
+    })
+    const after = await readFile(join(dir, 'config.json'), 'utf8')
+    expect(after).toBe(before)
+    expect(existsSync(join(dir, 'config.local.json'))).toBe(true)
   })
 
   it('serializes concurrent callers — no lost updates', async () => {
     await writeConfig(dir, { project: '0' })
-    const bump = () => mutateConfig(dir, async (c) => {
-      const n = parseInt(c.project ?? '0', 10)
+    const bump = () => mutateConfig(dir, async (_base, local) => {
+      const n = parseInt(local.project ?? '0', 10)
       await new Promise(r => setTimeout(r, 5))
-      c.project = String(n + 1)
+      local.project = String(n + 1)
     })
     await Promise.all([bump(), bump()])
-    const config = await loadConfig(dir)
-    expect(config.project).toBe('2')
+    const merged = await loadConfig(dir)
+    expect(merged.project).toBe('2')
   })
 
   it('serializes an async fn that awaits in the middle', async () => {
     await writeConfig(dir, { project: '0' })
     const order: string[] = []
-    const tagged = (tag: string) => mutateConfig(dir, async (c) => {
+    const tagged = (tag: string) => mutateConfig(dir, async (_base, local) => {
       order.push(`${tag}-start`)
       await new Promise(r => setTimeout(r, 5))
       order.push(`${tag}-end`)
-      c.project = tag
+      local.project = tag
     })
     await Promise.all([tagged('a'), tagged('b')])
     const aStart = order.indexOf('a-start')
@@ -77,11 +162,18 @@ describe('mutateConfig', () => {
     await expect(
       mutateConfig(dir, () => { throw new Error('boom') })
     ).rejects.toThrow('boom')
-    const config = await loadConfig(dir)
-    expect(config.project).toBe('initial')
+    const merged = await loadConfig(dir)
+    expect(merged.project).toBe('initial')
+    expect(existsSync(join(dir, 'config.local.json'))).toBe(false)
     // Queue not poisoned: next mutate succeeds
-    await mutateConfig(dir, (c) => { c.project = 'after-error' })
+    await mutateConfig(dir, (_base, local) => { local.project = 'after-error' })
     expect((await loadConfig(dir)).project).toBe('after-error')
+  })
+
+  it('preserves an already-on-disk local overlay even when fn does nothing', async () => {
+    await writeFile(join(dir, 'config.local.json'), JSON.stringify({ repo: 'preserved/repo' }))
+    await mutateConfig(dir, () => { /* no-op */ })
+    expect((await loadLocalOverlay(dir)).repo).toBe('preserved/repo')
   })
 })
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -11,7 +11,7 @@ import {
   type Command,
   type HandlerDeps,
 } from '../dispatcher-dm-handler.js'
-import { loadConfig, writeConfig, type OrchestratorConfig } from '../config.js'
+import { loadConfig, loadConfigBase, loadLocalOverlay, writeConfig, type OrchestratorConfig } from '../config.js'
 import type { Plugin, PluginTickResult } from '../plugin.js'
 
 let dir: string
@@ -175,22 +175,26 @@ interface FakeIrc {
 // tests can assert routing precisely without depending on slice schemas.
 class StubPlugin implements Plugin {
   readonly name: string
-  readonly handled: Array<{ cmd: Command; configSnapshot: OrchestratorConfig }> = []
-  constructor(name: string, private readonly target: string | null, private readonly behavior?: (cmd: Command, config: OrchestratorConfig) => string | null) {
+  readonly handled: Array<{ cmd: Command; mergedSnapshot: OrchestratorConfig; localSnapshot: OrchestratorConfig }> = []
+  constructor(name: string, private readonly target: string | null, private readonly behavior?: (cmd: Command, merged: OrchestratorConfig, local: OrchestratorConfig) => string | null) {
     this.name = name
   }
   desiredChannels(): string[] { return [] }
   async runTick(): Promise<PluginTickResult> {
     return { state: null, taggedEvents: [], channels: [] }
   }
-  handleCommand(config: OrchestratorConfig, cmd: Command): string | null {
-    this.handled.push({ cmd, configSnapshot: JSON.parse(JSON.stringify(config)) as OrchestratorConfig })
-    if (this.behavior) return this.behavior(cmd, config)
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    this.handled.push({
+      cmd,
+      mergedSnapshot: JSON.parse(JSON.stringify(merged)) as OrchestratorConfig,
+      localSnapshot: JSON.parse(JSON.stringify(local)) as OrchestratorConfig,
+    })
+    if (this.behavior) return this.behavior(cmd, merged, local)
     if (cmd.kind === 'list') return `${this.name}: list-section`
     if (cmd.kind === 'help') return `${this.name}: help-section`
     if (cmd.kind === 'watch' && cmd.target === this.target) {
-      config.plugins ??= {}
-      config.plugins[this.name] = { watched: cmd.number }
+      local.plugins ??= {}
+      local.plugins[this.name] = { watched: cmd.number }
       return `${this.name}: watched ${cmd.number}`
     }
     if (cmd.kind === 'unwatch' && cmd.target === this.target) {
@@ -322,6 +326,46 @@ describe('handleDm — routing', () => {
     const config = await loadConfig(dir)
     expect(config.plugins?.['issues']).toEqual({ watched: 5 })
     expect(config.plugins?.['prs']).toEqual({ watched: 10 })
+  })
+
+  it('writes go to config.local.json, never config.json', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const baseBefore = await loadConfigBase(dir)
+    const { deps } = makeDeps(dir, [new StubPlugin('issues', null), new StubPlugin('prs', 'pr')])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5\nwatch pr 10' })
+    const baseAfter = await loadConfigBase(dir)
+    expect(baseAfter).toEqual(baseBefore)
+    const overlay = await loadLocalOverlay(dir)
+    expect(overlay.plugins?.['issues']).toEqual({ watched: 5 })
+    expect(overlay.plugins?.['prs']).toEqual({ watched: 10 })
+  })
+
+  it('re-merges base+local before each cmd so in-batch dedup sees prior writes', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    // A plugin that appends a number to its local watched list and refuses
+    // duplicates against the merged view — mimicking GhBase semantics.
+    class ListishPlugin implements Plugin {
+      readonly name = 'listish'
+      desiredChannels(): string[] { return [] }
+      async runTick(): Promise<PluginTickResult> {
+        return { state: null, taggedEvents: [], channels: [] }
+      }
+      handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+        if (cmd.kind !== 'watch' || cmd.target !== null) return null
+        const mergedWatched = (merged.plugins?.['listish'] as { watched?: number[] } | undefined)?.watched ?? []
+        if (mergedWatched.includes(cmd.number)) return `already watching ${cmd.number}`
+        local.plugins ??= {}
+        const slice = (local.plugins['listish'] as { watched?: number[] } | undefined) ?? {}
+        slice.watched = [...(slice.watched ?? []), cmd.number]
+        local.plugins['listish'] = slice
+        return `watching ${cmd.number}`
+      }
+    }
+    const { deps, irc } = makeDeps(dir, [new ListishPlugin()])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5; watch 5' })
+    expect(irc.dms[0].text).toBe('watching 5\n\nalready watching 5')
+    const overlay = await loadLocalOverlay(dir)
+    expect((overlay.plugins?.['listish'] as { watched: number[] }).watched).toEqual([5])
   })
 
   it('empty-body DMs are ignored silently', async () => {

--- a/src/orchestrator/__tests__/init-template.test.ts
+++ b/src/orchestrator/__tests__/init-template.test.ts
@@ -1,28 +1,43 @@
-// Regression guard: the config shape bin/roost's _init_config_json emits must
-// not throw on first tick. If this test breaks, the init template needs
-// updating alongside the plugin change.
+// Regression guard: the merged shape that `bin/roost init` emits across
+// config.json + config.local.json must not throw on first tick. If this
+// test breaks, the init templates need updating alongside the plugin
+// change.
 import { describe, it, expect } from 'bun:test'
 import { buildPlugins } from '../build-plugins.js'
-import type { OrchestratorConfig } from '../config.js'
+import { mergeConfigs, type OrchestratorConfig } from '../config.js'
 import '../registry.js'
 
-// Mirrors _init_config_json in bin/roost verbatim (minus irc + agent_logins
-// which the orchestrator doesn't touch during a tick).
+// Mirrors `_init_config_json` in bin/roost — tracked, static slices only.
 const INIT_CONFIG: OrchestratorConfig = {
   project: 'my-project',
   repo: 'org/repo',
   plugins: {
-    'github-prs': { watched: [] },
-    'github-issues': { watched: [] },
     'github-new-issues': { watched: [] },
     'github-commits': { watched: [] },
   },
 }
 
+// Mirrors `_init_config_local_json` in bin/roost — gitignored overlay
+// with the DM-driven plugin slices.
+const INIT_LOCAL: OrchestratorConfig = {
+  plugins: {
+    'github-prs': { watched: [] },
+    'github-issues': { watched: [] },
+  },
+}
+
 describe('bin/roost init template', () => {
+  it('merged shape enables all four built-in plugins', () => {
+    const merged = mergeConfigs(INIT_CONFIG, INIT_LOCAL)
+    expect(Object.keys(merged.plugins ?? {}).sort()).toEqual([
+      'github-commits', 'github-issues', 'github-new-issues', 'github-prs',
+    ])
+  })
+
   it('all plugins no-op on first tick without throwing', async () => {
-    const plugins = buildPlugins(INIT_CONFIG, '#my-project-leads', () => {})
-    const results = await Promise.all(plugins.map(p => p.runTick(INIT_CONFIG, null)))
+    const merged = mergeConfigs(INIT_CONFIG, INIT_LOCAL)
+    const plugins = buildPlugins(merged, '#my-project-leads', () => {})
+    const results = await Promise.all(plugins.map(p => p.runTick(merged, null)))
     for (const result of results) {
       expect(result.taggedEvents).toHaveLength(0)
     }

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -150,11 +150,15 @@ function mergePluginSlice(base: unknown, local: unknown): unknown {
   if (typeof base !== 'object' || typeof local !== 'object' || Array.isArray(base) || Array.isArray(local)) {
     return local
   }
+  // structuredClone the concatenated entries so a plugin author who
+  // mutates an entry on the merged view can't reach back into base or
+  // local and silently corrupt persistent state. The contract says
+  // "mutate local only" — this enforces it by reference.
   const merged = { ...(base as Record<string, unknown>), ...(local as Record<string, unknown>) }
   const baseWatched = (base as Record<string, unknown>).watched
   const localWatched = (local as Record<string, unknown>).watched
   if (Array.isArray(baseWatched) && Array.isArray(localWatched)) {
-    merged.watched = [...baseWatched, ...localWatched]
+    merged.watched = structuredClone([...baseWatched, ...localWatched])
   }
   return merged
 }
@@ -235,6 +239,12 @@ export async function mutateConfig(
   try {
     await prev.catch(() => {})
     const [base, local] = await Promise.all([loadConfigBase(stateDir), loadLocalOverlay(stateDir)])
+    // Freeze base so an accidental mutation in `fn` throws at the bug
+    // site instead of silently vanishing on the next write (only `local`
+    // is persisted back to disk). Shallow freeze is enough here — nested
+    // slices that get reached from base mostly arrive through the merged
+    // view (which is cloned in mergePluginSlice for `watched`).
+    Object.freeze(base)
     await fn(base, local)
     await writeLocalConfig(stateDir, local)
   } finally {

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -61,7 +61,13 @@ function sortedJson(value: unknown): string {
   }, 2) + '\n'
 }
 
-export async function loadConfig(stateDir: string): Promise<OrchestratorConfig> {
+// Two-file split: config.json (tracked, operator/project) + config.local.json
+// (gitignored, dispatcher-mutated overlay). loadConfig returns the merged view;
+// dispatcher writes never touch config.json. Operators can hand-edit either —
+// re-watching a tracked entry is a no-op (idempotent), unwatching one is
+// refused (hand-edit config.json to remove). See DISPATCHER.md.
+
+export async function loadConfigBase(stateDir: string): Promise<OrchestratorConfig> {
   const path = join(stateDir, 'config.json')
   const file = Bun.file(path)
   if (!(await file.exists())) throw new Error(`config missing: ${path}`)
@@ -97,6 +103,62 @@ export function assertEntryRepoMode(
   }
 }
 
+export async function loadLocalOverlay(stateDir: string): Promise<OrchestratorConfig> {
+  const path = join(stateDir, 'config.local.json')
+  const file = Bun.file(path)
+  if (!(await file.exists())) return {}
+  return file.json() as Promise<OrchestratorConfig>
+}
+
+export async function loadConfig(stateDir: string): Promise<OrchestratorConfig> {
+  const [base, local] = await Promise.all([loadConfigBase(stateDir), loadLocalOverlay(stateDir)])
+  return mergeConfigs(base, local)
+}
+
+// Local-wins on conflict for every field except `plugins.<name>.watched`,
+// which is concatenated (both sources contribute live entries). `irc` is
+// merged at the field level so operators can override a single nested key
+// without restating the whole block.
+export function mergeConfigs(base: OrchestratorConfig, local: OrchestratorConfig): OrchestratorConfig {
+  const result: OrchestratorConfig = { ...base }
+  if (local.project !== undefined) result.project = local.project
+  if (local.repo !== undefined) result.repo = local.repo
+  if (local.agent_logins !== undefined) result.agent_logins = local.agent_logins
+  if (local.plugin_paths !== undefined) result.plugin_paths = local.plugin_paths
+  if (base.irc !== undefined || local.irc !== undefined) {
+    result.irc = { ...base.irc, ...local.irc }
+  }
+  if (base.plugins !== undefined || local.plugins !== undefined) {
+    const merged: Record<string, unknown> = {}
+    const names = new Set([
+      ...Object.keys(base.plugins ?? {}),
+      ...Object.keys(local.plugins ?? {}),
+    ])
+    for (const name of names) {
+      const b = base.plugins?.[name]
+      const l = local.plugins?.[name]
+      merged[name] = mergePluginSlice(b, l)
+    }
+    result.plugins = merged
+  }
+  return result
+}
+
+function mergePluginSlice(base: unknown, local: unknown): unknown {
+  if (base == null) return local
+  if (local == null) return base
+  if (typeof base !== 'object' || typeof local !== 'object' || Array.isArray(base) || Array.isArray(local)) {
+    return local
+  }
+  const merged = { ...(base as Record<string, unknown>), ...(local as Record<string, unknown>) }
+  const baseWatched = (base as Record<string, unknown>).watched
+  const localWatched = (local as Record<string, unknown>).watched
+  if (Array.isArray(baseWatched) && Array.isArray(localWatched)) {
+    merged.watched = [...baseWatched, ...localWatched]
+  }
+  return merged
+}
+
 export async function loadState(stateDir: string): Promise<OrchestratorState | null> {
   const path = join(stateDir, 'state.json')
   const file = Bun.file(path)
@@ -125,16 +187,25 @@ export async function writeState(stateDir: string, state: OrchestratorState): Pr
   }
 }
 
-// Raw atomic write. Use mutateConfig for any read-modify-write — it
-// serializes concurrent callers in-process.
+// Raw atomic write of config.json. Used by `bin/roost init` and tests —
+// dispatcher-side mutations write through mutateConfig (which targets
+// config.local.json instead, keeping config.json reviewer-tracked).
 export async function writeConfig(stateDir: string, config: OrchestratorConfig): Promise<void> {
+  await writeAtomic(stateDir, 'config.json', config)
+}
+
+export async function writeLocalConfig(stateDir: string, local: OrchestratorConfig): Promise<void> {
+  await writeAtomic(stateDir, 'config.local.json', local)
+}
+
+async function writeAtomic(stateDir: string, name: string, value: OrchestratorConfig): Promise<void> {
   await mkdir(stateDir, { recursive: true })
-  // tmp must share a filesystem with config.json so rename is atomic;
+  // tmp must share a filesystem with the target so rename is atomic;
   // os.tmpdir() can be a different mount on macOS.
-  const tmp = join(stateDir, `.config.${process.pid}.${Date.now()}.tmp`)
+  const tmp = join(stateDir, `.${name}.${process.pid}.${Date.now()}.tmp`)
   try {
-    await Bun.write(tmp, sortedJson(config))
-    await rename(tmp, join(stateDir, 'config.json'))
+    await Bun.write(tmp, sortedJson(value))
+    await rename(tmp, join(stateDir, name))
   } catch (e) {
     try { await unlink(tmp) } catch { /* ignore */ }
     throw e
@@ -150,18 +221,22 @@ export async function writeConfig(stateDir: string, config: OrchestratorConfig):
 // dispatcher runs are on the operator.
 let configMutex: Promise<void> = Promise.resolve()
 
+// Reads base + local, hands both to the callback, writes only the local
+// overlay back. Callers should mutate `local` for any change they want
+// persisted; `base` is provided so handlers can re-merge inside the
+// callback to see prior in-batch mutations (see dispatcher-dm-handler).
 export async function mutateConfig(
   stateDir: string,
-  fn: (config: OrchestratorConfig) => void | Promise<void>
+  fn: (base: OrchestratorConfig, local: OrchestratorConfig) => void | Promise<void>
 ): Promise<void> {
   const prev = configMutex
   let release!: () => void
   configMutex = new Promise(r => { release = r })
   try {
     await prev.catch(() => {})
-    const config = await loadConfig(stateDir)
-    await fn(config)
-    await writeConfig(stateDir, config)
+    const [base, local] = await Promise.all([loadConfigBase(stateDir), loadLocalOverlay(stateDir)])
+    await fn(base, local)
+    await writeLocalConfig(stateDir, local)
   } finally {
     release()
   }

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -14,7 +14,7 @@
 // DM, plugin.handleCommand throws bubble up as [dispatcher_error] on the
 // project channel.
 
-import { loadConfig, mutateConfig, type OrchestratorConfig } from './config.js'
+import { loadConfig, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
 import { assertRepoModeAll, type Plugin } from './plugin.js'
 
@@ -155,19 +155,21 @@ function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' }>): 
     : `unwatch ${target}<N>`
 }
 
-// Ask every plugin to handle `cmd` against the (in-progress) config.
-// Returns the coalesced reply (or null if every plugin abstained — caller
-// surfaces "no plugin handles ..."). watch/unwatch should match exactly
-// one plugin; list/help broadcast to all and join with `\n\n`.
+// Ask every plugin to handle `cmd` against the merged config view, with
+// `local` as the writable overlay. Returns the coalesced reply (or null if
+// every plugin abstained — caller surfaces "no plugin handles ...").
+// watch/unwatch should match exactly one plugin; list/help broadcast to
+// all and join with `\n\n`.
 async function routeOne(
-  config: OrchestratorConfig,
+  merged: OrchestratorConfig,
+  local: OrchestratorConfig,
   cmd: Command,
   plugins: Plugin[],
 ): Promise<string | null> {
   if (cmd.kind === 'unknown') return `error: ${cmd.error}`
   const replies: string[] = []
   for (const p of plugins) {
-    const reply = await p.handleCommand?.(config, cmd)
+    const reply = await p.handleCommand?.(merged, local, cmd)
     if (reply !== null && reply !== undefined) replies.push(reply)
   }
   if (replies.length === 0) return null
@@ -231,12 +233,21 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
 
   const isPureRead = cmds.every(c => c.kind === 'list' || c.kind === 'help')
 
-  // Pure-read path: route against the snapshot, no fsync.
+  // Pure-read path: route against the snapshot, no fsync. The local
+  // overlay is also read-only here — list/help never mutate.
   if (isPureRead) {
+    let localSnapshot: OrchestratorConfig
+    try {
+      localSnapshot = await loadLocalOverlay(deps.stateDir)
+    } catch (e) {
+      deps.log(`dispatcher-dm-handler: local overlay load failed for ${dm.sender}: ${e}`)
+      deps.postProjectError(`[dispatcher_error] config.local load: ${e}`)
+      return
+    }
     const replies: string[] = []
     for (const cmd of cmds) {
       try {
-        const reply = await routeOne(snapshot, cmd, deps.plugins)
+        const reply = await routeOne(snapshot, localSnapshot, cmd, deps.plugins)
         if (reply !== null) replies.push(reply)
         deps.log(`dispatcher-dm-handler: ${dm.sender} cmd=${cmd.kind}`)
       } catch (e) {
@@ -249,14 +260,18 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
     return
   }
 
-  // Write path: one mutateConfig call wraps the whole batch.
+  // Write path: one mutateConfig call wraps the whole batch. We re-merge
+  // base + local before each plugin call so in-batch mutations (e.g. two
+  // `watch pr 5` lines in one DM) see prior writes when checking
+  // idempotency.
   const replies: string[] = []
   let writeFailed = false
   try {
-    await mutateConfig(deps.stateDir, async (config) => {
+    await mutateConfig(deps.stateDir, async (base, local) => {
       for (const cmd of cmds) {
+        const merged = mergeConfigs(base, local)
         try {
-          const reply = await routeOne(config, cmd, deps.plugins)
+          const reply = await routeOne(merged, local, cmd, deps.plugins)
           if (reply !== null) {
             replies.push(reply)
           } else if (cmd.kind === 'watch' || cmd.kind === 'unwatch') {

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -5,9 +5,10 @@
 // agnostic to the source plugin's event vocabulary.
 //
 // Plugins may also opt in to inbound DM commands via `handleCommand`: see
-// dispatcher-dm-handler.ts for the routing layer. Plugins mutate their own slice
-// (config.plugins[name]) in place inside the dispatcher's mutateConfig
-// callback; dispatcher-dm-handler never touches slice shapes.
+// dispatcher-dm-handler.ts for the routing layer. `handleCommand` receives
+// both the merged config (for idempotency / list views) and the local
+// overlay (for mutations) — config.json is read-only from the dispatcher,
+// so any state change must be made on the local overlay.
 import type { Command } from './dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from './config.js'
 
@@ -53,16 +54,18 @@ export interface Plugin {
   // including dynamic discoveries like PR linked-issues). Seeding is signaled
   // by `prevState === null`.
   runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
-  // Optional: handle a parsed DM command (see dispatcher-dm-handler.ts). Plugins mutate
-  // their own slice (config.plugins[name]) in place — the call site is wrapped
-  // in mutateConfig so writes are atomic across plugins. Return a reply line
-  // when this plugin handles the command, null when it doesn't apply.
-  // Implementations MUST NOT throw: deterministic failures (e.g. malformed
-  // slice) must come back as an `"error: ..."` string. The router will treat
-  // a thrown exception as a bug and surface a [dispatcher_error]. Both watch
-  // list and help are broadcast to every enabled plugin; replies are joined
-  // with `\n\n`.
-  handleCommand?(config: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
+  // Optional: handle a parsed DM command (see dispatcher-dm-handler.ts).
+  // `merged` is the live view (config.json + config.local.json with
+  // `plugins.<name>.watched` arrays concatenated); `local` is the
+  // gitignored overlay this plugin should mutate. Plugins MUST only mutate
+  // `local.plugins[name]` — config.json is read-only from the dispatcher.
+  // Return a reply line when this plugin handles the command, null when it
+  // doesn't apply. Implementations MUST NOT throw: deterministic failures
+  // (e.g. malformed slice) must come back as an `"error: ..."` string. The
+  // router will treat a thrown exception as a bug and surface a
+  // [dispatcher_error]. Both watch list and help are broadcast to every
+  // enabled plugin; replies are joined with `\n\n`.
+  handleCommand?(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
   // Optional: assert this plugin's own slice respects the active repo mode
   // (single vs multi). Plugins that own a `watched`/`repo` shape implement
   // this to enforce their own constraints; plugins that are cross-repo by
@@ -76,7 +79,7 @@ export abstract class BasePlugin implements Plugin {
   constructor(protected readonly defaultChannel: string) {}
   abstract desiredChannels(config: OrchestratorConfig): string[]
   abstract runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
-  handleCommand?(config: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
+  handleCommand?(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
 
   // Union auto-detected channels with the entry's declared channels;
   // fall back to the default channel if both are empty (defensive for any

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -449,6 +449,23 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     expect(issues().handleCommand!({}, {}, { kind: 'list' })).toContain('(none)')
   })
 
+  it('list dedupes duplicate numbers (concat-merge artifact) and unions channels', () => {
+    // Simulates the post-upgrade case where the same number lives in both
+    // base and local — the loader concatenates rather than deduping, so
+    // the display layer has to do it.
+    const merged: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [
+        { number: 5, channels: ['#a'] },
+        { number: 5, channels: ['#b'] },
+        { number: 6 },
+      ] } },
+    }
+    const out = issues().handleCommand!(merged, {}, { kind: 'list' })!
+    expect(out).toContain('github-issues (2):')
+    expect(out).toContain('  #5 + #a #b')
+    expect(out).toContain('  #6')
+  })
+
   it('help returns this plugin\'s usage block', () => {
     const out = issues().handleCommand!({}, {}, { kind: 'help' })!
     expect(out).toContain('github-issues commands')

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -362,75 +362,95 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   const singleRepo = (extra: Partial<OrchestratorConfig> = {}): OrchestratorConfig =>
     ({ repo: 'org/r', ...extra })
 
-  it('claims bare watch (target=null)', () => {
-    const config = singleRepo()
-    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: [] })
+  it('claims bare watch (target=null) and writes to local', () => {
+    const merged: OrchestratorConfig = singleRepo()
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: [] })
     expect(out).toMatch(/watching issue #5/)
-    expect((config.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+    expect((local.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
+    expect(merged.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('ignores `watch pr` (returns null)', () => {
-    const config = singleRepo()
-    const out = issues().handleCommand!(config, { kind: 'watch', target: 'pr', number: 5, channels: [] })
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(singleRepo(), local, { kind: 'watch', target: 'pr', number: 5, channels: [] })
     expect(out).toBeNull()
-    expect(config.plugins?.['github-issues']).toBeUndefined()
+    expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
-  it('is idempotent on duplicate watch', () => {
-    const config = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
-    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: [] })
+  it('is idempotent on duplicate watch (entry visible via merged)', () => {
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: [] })
     expect(out).toMatch(/already watching/)
+    expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
-  it('appends + dedupes channels onto existing entry', () => {
-    const config = singleRepo({
-      plugins: { 'github-issues': { watched: [{ number: 5, channels: ['#a'] }] } },
-    })
-    issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
-    const entry = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
+  it('appends + dedupes channels onto the local entry', () => {
+    const slice = { watched: [{ number: 5, channels: ['#a'] }] }
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
+    const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
+    issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    const entry = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
     expect(entry.channels).toEqual(['#a', '#b'])
+  })
+
+  it('refuses to add channels to a tracked-only entry', () => {
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#x'] })
+    expect(out).toBe('issue #5 in tracked config.json — hand-edit to add channels')
+    expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('no-op channel add does not dirty entry.channels', () => {
     const before = ['#a', '#b']
-    const config = singleRepo({
-      plugins: { 'github-issues': { watched: [{ number: 5, channels: before }] } },
-    })
-    const out = issues().handleCommand!(config, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    const slice = { watched: [{ number: 5, channels: before }] }
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
+    const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
     expect(out).toMatch(/channels unchanged/)
-    const after = (config.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
+    const after = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
     expect(after).toBe(before)
   })
 
-  it('removes an entry on unwatch', () => {
-    const config = singleRepo({
+  it('removes a local entry on unwatch', () => {
+    const local: OrchestratorConfig = {
       plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
-    })
-    issues().handleCommand!(config, { kind: 'unwatch', target: null, number: 5 })
-    expect((config.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
+    }
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } } })
+    issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5 })
+    expect((local.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
+  })
+
+  it('refuses to unwatch a tracked-only entry', () => {
+    const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5 })
+    expect(out).toBe('issue #5 in tracked config.json — hand-edit to remove')
   })
 
   it('reports not-watching on unwatch of unknown entry', () => {
-    const out = issues().handleCommand!(singleRepo(), { kind: 'unwatch', target: null, number: 5 })
+    const out = issues().handleCommand!(singleRepo(), {}, { kind: 'unwatch', target: null, number: 5 })
     expect(out).toMatch(/not watching/)
   })
 
-  it('list returns the github-issues section', () => {
-    const config = singleRepo({
+  it('list returns the github-issues section from the merged view', () => {
+    const merged: OrchestratorConfig = {
       plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6, channels: ['#a'] }] } },
-    })
-    const out = issues().handleCommand!(config, { kind: 'list' })
+    }
+    const out = issues().handleCommand!(merged, {}, { kind: 'list' })
     expect(out).toContain('github-issues (2):')
     expect(out).toContain('  #5')
     expect(out).toContain('  #6 + #a')
   })
 
   it('list reports (none) for empty slice', () => {
-    expect(issues().handleCommand!(singleRepo(), { kind: 'list' })).toContain('(none)')
+    expect(issues().handleCommand!({}, {}, { kind: 'list' })).toContain('(none)')
   })
 
   it('help returns this plugin\'s usage block', () => {
-    const out = issues().handleCommand!(singleRepo(), { kind: 'help' })!
+    const out = issues().handleCommand!({}, {}, { kind: 'help' })!
     expect(out).toContain('github-issues commands')
     expect(out).toMatch(/watch <N>/)
     expect(out).toMatch(/unwatch <N>/)
@@ -441,34 +461,41 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
 
 describe('GhBase.handleCommand — multi-repo mode rejection', () => {
   it('rejects bare watch in multi-repo mode and points at the known followup', () => {
-    const config: OrchestratorConfig = { project: 'p' }
+    const merged: OrchestratorConfig = { project: 'p' }
+    const local: OrchestratorConfig = {}
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
-      config,
+      merged,
+      local,
       { kind: 'watch', target: null, number: 5, channels: [] },
     )
     expect(out).toMatch(/multi-repo mode/)
     expect(out).toMatch(/cross-repo DM grammar/)
-    expect(config.plugins?.['github-issues']).toBeUndefined()
+    expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('rejects unwatch in multi-repo mode', () => {
-    const config: OrchestratorConfig = {
+    const merged: OrchestratorConfig = {
       project: 'p',
       plugins: { 'github-issues': { watched: [{ number: 5, repo: 'org/a' }] } },
     }
+    const local: OrchestratorConfig = {
+      plugins: { 'github-issues': { watched: [{ number: 5, repo: 'org/a' }] } },
+    }
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
-      config,
+      merged,
+      local,
       { kind: 'unwatch', target: null, number: 5 },
     )
     expect(out).toMatch(/multi-repo mode/)
     // Slice untouched on rejection.
-    expect((config.plugins!['github-issues'] as { watched: unknown[] }).watched).toHaveLength(1)
+    expect((local.plugins!['github-issues'] as { watched: unknown[] }).watched).toHaveLength(1)
   })
 
   it('rejects `watch pr` in multi-repo mode', () => {
-    const config: OrchestratorConfig = { project: 'p' }
+    const merged: OrchestratorConfig = { project: 'p' }
     const out = new GitHubPrsPlugin('#proj').handleCommand!(
-      config,
+      merged,
+      {},
       { kind: 'watch', target: 'pr', number: 10, channels: [] },
     )
     expect(out).toMatch(/multi-repo mode/)
@@ -478,21 +505,22 @@ describe('GhBase.handleCommand — multi-repo mode rejection', () => {
 describe('GhBase.handleCommand — prs plugin (target=pr)', () => {
   const prs = () => new GitHubPrsPlugin('#proj')
 
-  it('claims `watch pr` (target=pr)', () => {
-    const config: OrchestratorConfig = { repo: 'org/r' }
-    const out = prs().handleCommand!(config, { kind: 'watch', target: 'pr', number: 10, channels: ['#x'] })
+  it('claims `watch pr` (target=pr) and writes to local', () => {
+    const merged: OrchestratorConfig = { repo: 'org/r' }
+    const local: OrchestratorConfig = {}
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, channels: ['#x'] })
     expect(out).toMatch(/watching pr #10 \+ #x/)
-    expect(config.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
-    expect(config.plugins?.['github-issues']).toBeUndefined()
+    expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
+    expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('ignores bare watch (returns null)', () => {
-    const out = prs().handleCommand!({ repo: 'org/r' }, { kind: 'watch', target: null, number: 10, channels: [] })
+    const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'watch', target: null, number: 10, channels: [] })
     expect(out).toBeNull()
   })
 
   it('help mentions `pr <N>` form', () => {
-    const out = prs().handleCommand!({ repo: 'org/r' }, { kind: 'help' })!
+    const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'help' })!
     expect(out).toContain('github-prs commands')
     expect(out).toMatch(/watch pr <N>/)
     expect(out).toMatch(/unwatch pr <N>/)

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -122,78 +122,92 @@ export abstract class GhBase extends GhPluginBase {
   // ---- DM command handling --------------------------------------------
 
   // Inbound DM command surface. The dispatcher (dispatcher-dm-handler.ts) calls this
-  // once per parsed command inside its mutateConfig pass — we mutate our
-  // own slice in place. Returns the reply line(s) when we handle the
-  // command, null when the command isn't ours. Never throws.
-  handleCommand(config: OrchestratorConfig, cmd: Command): string | null {
-    if (cmd.kind === 'list') return this.formatListSection(config)
+  // once per parsed command inside its mutateConfig pass. Reads consult
+  // `merged` (config.json + config.local.json union); writes target `local`
+  // — config.json is read-only from the dispatcher. Returns the reply line
+  // when we handle the command, null when it isn't ours. Never throws.
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
     if (cmd.kind === 'help') return this.formatHelpSection()
     if (cmd.kind === 'watch') {
       if (cmd.target !== this.target) return null
-      return this.applyWatch(config, cmd.number, cmd.channels)
+      return this.applyWatch(merged, local, cmd.number, cmd.channels)
     }
     if (cmd.kind === 'unwatch') {
       if (cmd.target !== this.target) return null
-      return this.applyUnwatch(config, cmd.number)
+      return this.applyUnwatch(merged, local, cmd.number)
     }
     return null
   }
 
-  // Read-or-create the typed slice under `config.plugins[name]`. Plugins
+  // Read-or-create the typed slice under `local.plugins[name]`. Plugins
   // own their slice shape; this is the one mutation seam.
-  private slice(config: OrchestratorConfig): GhPluginConfig {
-    config.plugins ??= {}
-    const existing = config.plugins[this.name]
+  private localSlice(local: OrchestratorConfig): GhPluginConfig {
+    local.plugins ??= {}
+    const existing = local.plugins[this.name]
     if (existing && typeof existing === 'object') return existing as GhPluginConfig
     const fresh: GhPluginConfig = {}
-    config.plugins[this.name] = fresh
+    local.plugins[this.name] = fresh
     return fresh
   }
 
-  private applyWatch(config: OrchestratorConfig, number: number, channels: string[]): string {
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number, channels: string[]): string {
     // Multi-repo mode has no inherit target for entry.repo — the bare DM
     // grammar can't disambiguate, so reject it. A cross-repo DM grammar is
     // a known followup; until then, edit the watched list in config.json.
-    if (isMultiRepo(config)) {
+    if (isMultiRepo(merged)) {
       return `error: cannot watch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`watch <N>\` has no repo; cross-repo DM grammar is a known followup`
     }
-    const slice = this.slice(config)
-    slice.watched ??= []
-    const watched = slice.watched
-    let entry = watched.find(e => e.number === number)
-    if (!entry) {
-      entry = { number }
+    const mergedEntries = this.watched(merged)
+    const inMerged = mergedEntries.find(e => e.number === number)
+    if (!inMerged) {
+      const slice = this.localSlice(local)
+      slice.watched ??= []
+      const entry: WatchedEntry = { number }
       if (channels.length) entry.channels = [...channels]
-      watched.push(entry)
+      slice.watched.push(entry)
       return channels.length
         ? `watching ${this.label} #${number} + ${channels.join(' ')}`
         : `watching ${this.label} #${number}`
     }
     if (!channels.length) return `already watching ${this.label} #${number}`
-    const existing = new Set(entry.channels ?? [])
+    // Adding channels: only the local-overlay entry is writable. If the
+    // number lives only in tracked config.json, surface the hand-edit
+    // requirement instead of silently failing.
+    const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []
+    const localEntry = localEntries.find(e => e.number === number)
+    if (!localEntry) {
+      return `${this.label} #${number} in tracked config.json — hand-edit to add channels`
+    }
+    const existing = new Set(localEntry.channels ?? [])
     const added: string[] = []
     for (const c of channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
     if (!added.length) return `${this.label} #${number} channels unchanged`
-    entry.channels = [...existing]
+    localEntry.channels = [...existing]
     return `${this.label} #${number} + ${added.join(' ')}`
   }
 
-  private applyUnwatch(config: OrchestratorConfig, number: number): string {
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number): string {
     // Same multi-repo restriction as applyWatch: bare `unwatch <N>` is
     // ambiguous when N can live in multiple repos.
-    if (isMultiRepo(config)) {
+    if (isMultiRepo(merged)) {
       return `error: cannot unwatch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`unwatch <N>\` has no repo; cross-repo DM grammar is a known followup`
     }
-    const slice = this.slice(config)
-    const watched = slice.watched ?? []
-    const idx = watched.findIndex(e => e.number === number)
-    if (idx < 0) return `not watching ${this.label} #${number}`
-    watched.splice(idx, 1)
-    return `unwatched ${this.label} #${number}`
+    const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []
+    const localIdx = localEntries.findIndex(e => e.number === number)
+    if (localIdx >= 0) {
+      localEntries.splice(localIdx, 1)
+      return `unwatched ${this.label} #${number}`
+    }
+    const inMerged = this.watched(merged).some(e => e.number === number)
+    if (inMerged) {
+      return `${this.label} #${number} in tracked config.json — hand-edit to remove`
+    }
+    return `not watching ${this.label} #${number}`
   }
 
-  private formatListSection(config: OrchestratorConfig): string {
-    const entries = this.watched(config)
+  private formatListSection(merged: OrchestratorConfig): string {
+    const entries = this.watched(merged)
     const header = `${this.name} (${entries.length}):`
     if (!entries.length) return `${header}\n  (none)`
     const lines = entries.map(e => {

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -74,6 +74,12 @@ interface GhPluginConfig {
   watched?: WatchedEntry[]
 }
 
+// Shared phrasing for "this watch lives in the tracked file; the dispatcher
+// won't touch it". Centralized so a rename of config.json (or a future
+// path knob) only flips one string.
+const trackedRefusal = (label: string, n: number, action: string) =>
+  `${label} #${n} in tracked config.json — hand-edit to ${action}`
+
 // Watch-list scaffolding for the two GitHub plugins (PRs, issues). Owns the
 // `<issue-channel> + entry.channels` collector, `{ watched?: WatchedEntry[] }`
 // slice convention, and `handleCommand` for watch/unwatch/list/help.
@@ -177,7 +183,7 @@ export abstract class GhBase extends GhPluginBase {
     const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []
     const localEntry = localEntries.find(e => e.number === number)
     if (!localEntry) {
-      return `${this.label} #${number} in tracked config.json — hand-edit to add channels`
+      return trackedRefusal(this.label, number, 'add channels')
     }
     const existing = new Set(localEntry.channels ?? [])
     const added: string[] = []
@@ -201,7 +207,7 @@ export abstract class GhBase extends GhPluginBase {
     }
     const inMerged = this.watched(merged).some(e => e.number === number)
     if (inMerged) {
-      return `${this.label} #${number} in tracked config.json — hand-edit to remove`
+      return trackedRefusal(this.label, number, 'remove')
     }
     return `not watching ${this.label} #${number}`
   }

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -213,12 +213,28 @@ export abstract class GhBase extends GhPluginBase {
   }
 
   private formatListSection(merged: OrchestratorConfig): string {
+    // Concat-merged watched lists can carry the same number from both
+    // base and local (e.g. post-upgrade reconcile). Dedup by number with
+    // a channel union so the operator-visible reply matches what's
+    // actually being scraped.
     const entries = this.watched(merged)
-    const header = `${this.name} (${entries.length}):`
-    if (!entries.length) return `${header}\n  (none)`
-    const lines = entries.map(e => {
-      const chans = e.channels?.length ? ` + ${e.channels.join(' ')}` : ''
-      return `  #${e.number}${chans}`
+    const byNumber = new Map<number, { number: number; channels: Set<string> }>()
+    const order: number[] = []
+    for (const e of entries) {
+      let bucket = byNumber.get(e.number)
+      if (!bucket) {
+        bucket = { number: e.number, channels: new Set<string>() }
+        byNumber.set(e.number, bucket)
+        order.push(e.number)
+      }
+      for (const c of e.channels ?? []) bucket.channels.add(c)
+    }
+    const header = `${this.name} (${byNumber.size}):`
+    if (!byNumber.size) return `${header}\n  (none)`
+    const lines = order.map(n => {
+      const bucket = byNumber.get(n)!
+      const chans = bucket.channels.size ? ` + ${[...bucket.channels].join(' ')}` : ''
+      return `  #${n}${chans}`
     })
     return [header, ...lines].join('\n')
   }

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -132,7 +132,9 @@ setup "https://github.com/TestOwner/myproject.git"
 cd "$TDIR"
 dry_out="$(roost_init --dry-run 2>/dev/null)"
 if echo "$dry_out" | grep -q '"project"' \
-    && [ ! -f "${TDIR}/.orchestrator/config.json" ]; then
+    && echo "$dry_out" | grep -q 'config.local.json' \
+    && [ ! -f "${TDIR}/.orchestrator/config.json" ] \
+    && [ ! -f "${TDIR}/.orchestrator/config.local.json" ]; then
   ok "--dry-run: no files written, content printed"
 else
   fail "--dry-run: no files written, content printed"
@@ -211,12 +213,46 @@ teardown
 setup "https://github.com/TestOwner/myproject.git"
 cd "$TDIR"
 roost_init >/dev/null 2>&1
-if grep -q 'state.json'     "${TDIR}/.orchestrator/.gitignore" \
+if grep -q 'config.local.json' "${TDIR}/.orchestrator/.gitignore" \
+    && grep -q 'state.json'     "${TDIR}/.orchestrator/.gitignore" \
     && grep -q 'last-tick.txt'  "${TDIR}/.orchestrator/.gitignore" \
-    && grep -q 'last-error.txt' "${TDIR}/.orchestrator/.gitignore"; then
-  ok ".gitignore: correct entries"
+    && grep -q 'last-error.txt' "${TDIR}/.orchestrator/.gitignore" \
+    && ! grep -q '^config\.json$' "${TDIR}/.orchestrator/.gitignore"; then
+  ok ".gitignore: covers config.local.json + state, leaves config.json tracked"
 else
-  fail ".gitignore: correct entries"
+  fail ".gitignore: covers config.local.json + state, leaves config.json tracked"
+fi
+cd - >/dev/null
+teardown
+
+# --- config.local.json scaffold written ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+roost_init >/dev/null 2>&1
+if [ -f "${TDIR}/.orchestrator/config.local.json" ] \
+    && grep -q '"github-prs"' "${TDIR}/.orchestrator/config.local.json" \
+    && grep -q '"github-issues"' "${TDIR}/.orchestrator/config.local.json"; then
+  ok "config.local.json: scaffold written"
+else
+  fail "config.local.json: scaffold written"
+fi
+cd - >/dev/null
+teardown
+
+# --- --force overwrites config.local.json too ---
+
+setup "https://github.com/TestOwner/myproject.git"
+cd "$TDIR"
+mkdir -p .orchestrator
+echo '{"old": true}' > .orchestrator/config.json
+echo '{"stale": true}' > .orchestrator/config.local.json
+if roost_init --force >/dev/null 2>&1 \
+    && grep -q '"github-prs"' "${TDIR}/.orchestrator/config.local.json" \
+    && ! grep -q '"stale"' "${TDIR}/.orchestrator/config.local.json"; then
+  ok "--force: overwrites config.local.json"
+else
+  fail "--force: overwrites config.local.json"
 fi
 cd - >/dev/null
 teardown


### PR DESCRIPTION
Closes #450

## Summary
- `.orchestrator/config.json` is the tracked, shareable project shape: project / repo / agent_logins / irc + the static plugin slices (`github-new-issues`, `github-commits`). PR-reviewable.
- `.orchestrator/config.local.json` is gitignored — dispatcher-mutated overlay for DM-driven watches (`github-prs.watched`, `github-issues.watched`). Concurrent operators don't clobber each other's live entries.
- Loader (`loadConfig`) merges both: enabled plugin set is `Object.keys(plugins)` union; `plugins.<name>.watched` arrays are **concatenated**; other fields local-wins. `mutateConfig` writes only to `config.local.json`.
- `Plugin.handleCommand(merged, local, cmd)` signature change. `GhBase.applyUnwatch` refuses unwatches against tracked-only entries; the dispatcher won't modify operator-tracked state. `formatListSection` dedupes by number with channel-union so post-upgrade reconcile isn't visually confusing.
- `bin/roost init` writes both files; `_init_gitignore` lists `config.local.json` (not `config.json`). Templates split: `config.example.json` (static) + `config.local.example.json` (DM-driven) make the convention visible to new operators.
- Loader defenses: `structuredClone` on concatenated watched entries + `Object.freeze(base)` inside `mutateConfig` so a future plugin author can't silently corrupt persistent state.

## Operator migration
Existing operators upgrading from the single-file layout: your old `config.json` keeps working as-is. The dispatcher stops writing to it on the next watch; new entries land in `config.local.json`. To bring a tracked entry under dispatcher control, hand-edit `config.json` to remove it — the dispatcher will pick it up via a fresh `watch <N>`. There's no automatic migration; refusing to mutate tracked entries is the contract, not a bug.

## Test plan
- [x] 576/576 bun tests pass (merge/concat + write-target + base-frozen + clone-isolation tests; updated GhBase tests for the merged/local split contract + dedup; dispatcher-dm-handler covers `writes go to config.local.json` + in-batch dedup via re-merge).
- [x] 30/30 `test/init_test.sh` cases pass (`config.local.json` scaffold; `--force` overwrites it; gitignore covers it and leaves `config.json` tracked).
- [x] 6/6 `test/start-dispatcher_test.sh` cases pass.
- [x] `bun run typecheck` clean. `bun run lint` clean.
- [ ] Smoke: `bin/roost init` in a tmpdir writes both files and the new gitignore.
- [ ] Manual: live dispatcher receives `watch pr 999` DM → `config.local.json` grows the entry; `config.json` byte-identical; `unwatch <tracked-N>` returns the hand-edit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)