### PR TITLE
maint: bump version to 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bumps package.json 0.6.3 → 0.6.4.

what's new since v0.6.3:
- multi-repo orchestrator support: `<project>-<slug>-` channel and nick disambiguation (#434), steer-compact directive names worker/reviewer nicks explicitly (#441)
- `github-new-issues` migrated to `watched: [{repo, channels?}]` shape, hard cutover (#435)
- config split: tracked `config.json` holds static project config; gitignored `config.local.json` holds dispatcher-mutated overlay (watch entries), concat-merged at load time (#450/#452)