### PR TITLE
feat(dispatcher): cross-repo + whole-repo DM grammar

### DIFF
--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -62,6 +62,12 @@ remove it — the dispatcher will pick it up via a fresh `watch <N>`.
 There's no automatic migration: refusing to mutate tracked entries is
 the contract, not a bug.
 
+Promoting a local entry to tracked is the reverse: hand-edit
+`config.json` to add it, then DM `unwatch <N>` (or `unwatch repo …` /
+`unwatch new-issues …`) to prune the local copy. Skipping the unwatch
+leaves the same key in both files — concat-merge would scrape it twice
+and `watch list` shows the duplicate.
+
 Fields:
 
 | Field | Meaning |

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -126,8 +126,8 @@ State files in `.orchestrator/`:
 
 | File | Purpose |
 |---|---|
-| `config.json` | Tracked in git. Shareable project shape (static slices only — `github-new-issues`, `github-commits`). Hand-edited only; the dispatcher never writes here. See "Two-file split" above. |
-| `config.local.json` | Gitignored. Dispatcher-mutated overlay for DM-driven watches (`watch <N>`, `unwatch <N>`, `watch pr <N>`). Concatenated onto config.json's `plugins.<name>.watched`. |
+| `config.json` | Tracked in git. Shareable project shape (operator-curated slices — `github-new-issues`, `github-commits`, plus any per-PR/issue entries the team agrees on). Hand-edited only; the dispatcher never writes here. See "Two-file split" above. |
+| `config.local.json` | Gitignored. Dispatcher-mutated overlay for DM-driven watches. Concatenated onto config.json's `plugins.<name>.watched`. Every first-party plugin can both seed entries via tracked config.json **and** accept DM additions to the overlay — see "DM grammar" below. |
 | `config.example.json` | Tracked. Template for `config.json` in forks (static shape). |
 | `config.local.example.json` | Tracked. Template for `config.local.json` — empty `github-prs` / `github-issues` scaffolds that enable the DM-driven plugins. |
 | `state.json` | Last seen GH state per watched entry. Re-seedable. |
@@ -166,6 +166,61 @@ bin/stop-dispatcher <config-dir>
 ```
 
 Sends SIGTERM and waits up to 30s (override with `STOP_TIMEOUT=<seconds>`). No SIGKILL escalation — if the daemon hangs past 30s, kill it manually. Idempotent — exits 0 if no live dispatcher is found.
+
+## DM grammar
+
+The dispatcher accepts a small command grammar via direct message from
+nicks in `irc.command_senders` (defaults to lead-pm + APM). Plugins claim
+target keywords; the parser is target-agnostic.
+
+```
+watch [<target>] <N> [<owner>/<repo>] [#chan ...]      # github-prs, github-issues
+unwatch [<target>] <N> [<owner>/<repo>]
+watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  # github-commits (target=repo), github-new-issues (target=new-issues; no @/: allowed)
+unwatch <target> <owner>/<repo>[@<branch>[:<path>]]
+watch list      # every plugin's active entries
+help            # synopsis + per-plugin help
+```
+
+Target keywords currently claimed by first-party plugins:
+
+| `<target>` | Plugin | Grammar |
+|---|---|---|
+| (none) | `github-issues` | `watch <N> [<owner>/<repo>] [#chan ...]` |
+| `pr` | `github-prs` | `watch pr <N> [<owner>/<repo>] [#chan ...]` |
+| `repo` | `github-commits` | `watch repo <owner>/<repo>[@<branch>[:<path>]] [#chan ...]` |
+| `new-issues` | `github-new-issues` | `watch new-issues <owner>/<repo> [#chan ...]` |
+
+Notes:
+
+- The optional `<owner>/<repo>` positional after `<N>` is the cross-repo
+  knob — it pins one PR/issue to a non-default repo. Disambiguated from
+  channels by containing `/` (channels start with `#`). Omitting it
+  inherits `config.repo`; in multi-repo mode (`config.repo` unset) the
+  bare form is rejected.
+- The repo-shape grammar (`<owner>/<repo>[@<branch>[:<path>]]`) mirrors
+  the github-commits state key, so a daemon.log line copy-pastes into a
+  DM. Branch defaults to `main` when omitted; path is optional.
+- DM additions land in `config.local.json` only. Re-watching a tracked
+  entry is idempotent; unwatching a tracked entry is refused with
+  `… in tracked config.json — hand-edit to remove`.
+
+### Repo-mode invariant — tracked-strict, local-loose
+
+Plugins that own a `watched`/`repo` shape enforce a single-vs-multi-repo
+invariant: in single-repo mode (top-level `repo` set), entries' `repo`
+must be absent or equal `config.repo`; in multi-repo mode (top-level
+`repo` unset), every entry must carry its own `repo`. **This check
+runs only against tracked `config.json` entries.** Local-overlay
+entries (DM-driven) bypass it — the DM parser validates OWNER/REPO
+shape at write time, so the overlay is parser-clean by construction.
+
+The split lets an operator running a single-repo dispatcher use
+`watch pr 5 OtherOrg/other` to watch a cross-repo PR without losing
+the typo-guard on hand-edited tracked entries. See
+`Plugin.assertRepoMode` (`src/orchestrator/plugin.ts`) for the
+contract and `assertEntryRepoMode` (`src/orchestrator/config.ts`) for
+the mode invariants.
 
 ## Events dispatched
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -207,20 +207,20 @@ Notes:
 
 ### Repo-mode invariant — tracked-strict, local-loose
 
-Plugins that own a `watched`/`repo` shape enforce a single-vs-multi-repo
-invariant: in single-repo mode (top-level `repo` set), entries' `repo`
-must be absent or equal `config.repo`; in multi-repo mode (top-level
-`repo` unset), every entry must carry its own `repo`. **This check
-runs only against tracked `config.json` entries.** Local-overlay
-entries (DM-driven) bypass it — the DM parser validates OWNER/REPO
-shape at write time, so the overlay is parser-clean by construction.
+The repo-mode invariant runs only against tracked `config.json` entries
+— local-overlay entries (DM-driven) bypass it because the DM parser
+validates OWNER/REPO shape at write time, leaving the overlay
+parser-clean by construction.
 
-The split lets an operator running a single-repo dispatcher use
-`watch pr 5 OtherOrg/other` to watch a cross-repo PR without losing
-the typo-guard on hand-edited tracked entries. See
-`Plugin.assertRepoMode` (`src/orchestrator/plugin.ts`) for the
-contract and `assertEntryRepoMode` (`src/orchestrator/config.ts`) for
-the mode invariants.
+Plugins that own a `watched`/`repo` shape enforce a single-vs-multi-repo
+check: in single-repo mode (top-level `repo` set), entries' `repo` must
+be absent or equal `config.repo`; in multi-repo mode (top-level `repo`
+unset), every entry must carry its own `repo`. The tracked-only rule lets
+an operator running a single-repo dispatcher use `watch pr 5 OtherOrg/r`
+to watch a cross-repo PR without losing the typo-guard on hand-edited
+tracked entries. See `Plugin.assertRepoMode`
+(`src/orchestrator/plugin.ts`) for the contract and `assertEntryRepoMode`
+(`src/orchestrator/config.ts`) for the mode invariants.
 
 ## Events dispatched
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -4,6 +4,7 @@ import { parseArgs } from 'node:util'
 import { mkdir } from 'node:fs/promises'
 import {
   loadConfig,
+  loadConfigBase,
   loadState,
   writeState,
   writeHeartbeat,
@@ -115,7 +116,7 @@ async function runDaemon(stateDir: string): Promise<void> {
 
   await loadExternalPlugins(stateDir, config.plugin_paths)
   const plugins = buildPlugins(config, projectChannel, log)
-  assertRepoModeAll(plugins, config)
+  assertRepoModeAll(plugins, await loadConfigBase(stateDir))
   const initialChannels = bootChannels(plugins, config, projectChannel)
   log(`orchestrator[daemon]: starting nick=${nick} server=${server}:${port} channels=${initialChannels.join(',')} interval=${interval / 1000}s\n`)
 
@@ -174,7 +175,7 @@ async function runDaemon(stateDir: string): Promise<void> {
     const tickStart = Date.now()
     try {
       const next = await loadConfig(stateDir)
-      assertRepoModeAll(plugins, next)
+      assertRepoModeAll(plugins, await loadConfigBase(stateDir))
       config = next
     } catch (e) {
       log(`orchestrator[daemon]: config load failed: ${e}\n`)
@@ -254,7 +255,7 @@ async function runDispatchIrc(stateDir: string, seed: boolean): Promise<void> {
 
   await loadExternalPlugins(stateDir, config.plugin_paths)
   const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
-  assertRepoModeAll(plugins, config)
+  assertRepoModeAll(plugins, await loadConfigBase(stateDir))
   const channels = bootChannels(plugins, config, projectChannel)
 
   const client = new RoostIrcClientImpl({
@@ -313,7 +314,7 @@ async function main(): Promise<void> {
     const projectChannel = resolveProjectChannel(config)
     await loadExternalPlugins(stateDir, config.plugin_paths)
     const plugins = buildPlugins(config, projectChannel, defaultPluginLogger)
-    assertRepoModeAll(plugins, config)
+    assertRepoModeAll(plugins, await loadConfigBase(stateDir))
     const result = await runOneTick(stateDir, config, plugins, {
       seed: values['seed'] as boolean,
       dryRun: values['dry-run'] as boolean,

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -170,6 +170,24 @@ describe('parseCommand', () => {
       expect(cmd.kind).toBe('unknown')
       expect(cmd.error).toMatch(/channels must match/)
     })
+
+    it('rejects a channel before the repo positional (positional must precede channels)', () => {
+      // `#chan` in the repo slot is a #-prefixed token that doesn't match
+      // OWNER_REPO_RE; it falls through to channels and the trailing
+      // `org/r` then fails CHANNEL_RE. Locks in the "repo before channels"
+      // ordering so a future loosening doesn't accidentally accept both.
+      const cmd = parseCommand('watch pr 5 #chan org/r') as Extract<Command, { kind: 'unknown' }>
+      expect(cmd.kind).toBe('unknown')
+      expect(cmd.error).toMatch(/channels must match/)
+    })
+
+    it('rejects unwatch with a trailing channel even when a repo positional is present', () => {
+      // Without repo: `unwatch pr 5 #x` already errors. The repo positional
+      // mustn't carve a loophole that lets channels sneak in.
+      const cmd = parseCommand('unwatch pr 5 org/r #x') as Extract<Command, { kind: 'unknown' }>
+      expect(cmd.kind).toBe('unknown')
+      expect(cmd.error).toMatch(/no channel arguments/)
+    })
   })
 
   describe('repo-shape grammar (watch/unwatch <target> <owner>/<repo>[@branch[:path]])', () => {

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -36,27 +36,27 @@ describe('splitCommands', () => {
 
 describe('parseCommand', () => {
   it('parses bare watch as target=null', () => {
-    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', target: null, number: 5, channels: [] })
+    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', target: null, number: 5, repo: null, channels: [] })
   })
 
   it('parses watch with channels', () => {
     expect(parseCommand('watch 5 #foo #bar')).toEqual({
-      kind: 'watch', target: null, number: 5, channels: ['#foo', '#bar'],
+      kind: 'watch', target: null, number: 5, repo: null, channels: ['#foo', '#bar'],
     })
   })
 
   it('parses unwatch with target=null', () => {
-    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', target: null, number: 5 })
+    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', target: null, number: 5, repo: null })
   })
 
   it('parses target keyword from any non-numeric first token', () => {
-    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, channels: [] })
-    expect(parseCommand('watch linear 99')).toEqual({ kind: 'watch', target: 'linear', number: 99, channels: [] })
-    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', target: 'pr', number: 10 })
+    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] })
+    expect(parseCommand('watch linear 99')).toEqual({ kind: 'watch', target: 'linear', number: 99, repo: null, channels: [] })
+    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', target: 'pr', number: 10, repo: null })
   })
 
   it('lowercases the target keyword', () => {
-    expect(parseCommand('watch PR 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, channels: [] })
+    expect(parseCommand('watch PR 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] })
   })
 
   it('parses watch list', () => {
@@ -68,7 +68,7 @@ describe('parseCommand', () => {
   })
 
   it('is case-insensitive on verbs', () => {
-    expect(parseCommand('WATCH 5')).toEqual({ kind: 'watch', target: null, number: 5, channels: [] })
+    expect(parseCommand('WATCH 5')).toEqual({ kind: 'watch', target: null, number: 5, repo: null, channels: [] })
     expect(parseCommand('Help')).toEqual({ kind: 'help' })
   })
 
@@ -124,17 +124,110 @@ describe('parseCommand', () => {
     expect(cmd.error).toMatch(/unknown command/)
   })
 
-  it('requires a number for watch/unwatch', () => {
+  it('requires a number or repo-shape spec for watch/unwatch', () => {
     expect(parseCommand('watch').kind).toBe('unknown')
     expect(parseCommand('watch pr').kind).toBe('unknown')
+  })
+
+  describe('repo positional on per-N grammar', () => {
+    // Regression for the load-bearing disambiguation: `#chan` after a number
+    // must NOT be misread as a repo positional. Channel sigil is `#`; repo
+    // positional requires `/`. Keep this paired with the `org/repo #chan`
+    // case below — both shapes are the entire reason the repo positional is
+    // safe to add unannotated.
+    it('does NOT grab a #channel as a repo positional', () => {
+      expect(parseCommand('watch pr 5 #chan')).toEqual({
+        kind: 'watch', target: 'pr', number: 5, repo: null, channels: ['#chan'],
+      })
+    })
+
+    it('parses bare <owner>/<repo> after the number', () => {
+      expect(parseCommand('watch pr 5 org/repo')).toEqual({
+        kind: 'watch', target: 'pr', number: 5, repo: 'org/repo', channels: [],
+      })
+    })
+
+    it('parses <owner>/<repo> before channels', () => {
+      expect(parseCommand('watch pr 5 org/repo #chan #other')).toEqual({
+        kind: 'watch', target: 'pr', number: 5, repo: 'org/repo', channels: ['#chan', '#other'],
+      })
+    })
+
+    it('attaches repo to unwatch', () => {
+      expect(parseCommand('unwatch pr 5 org/repo')).toEqual({
+        kind: 'unwatch', target: 'pr', number: 5, repo: 'org/repo',
+      })
+    })
+
+    it('accepts repo without a target keyword', () => {
+      expect(parseCommand('watch 5 org/repo #chan')).toEqual({
+        kind: 'watch', target: null, number: 5, repo: 'org/repo', channels: ['#chan'],
+      })
+    })
+
+    it('only one repo positional allowed; second token is treated as a (malformed) channel', () => {
+      const cmd = parseCommand('watch pr 5 org/a org/b') as Extract<Command, { kind: 'unknown' }>
+      expect(cmd.kind).toBe('unknown')
+      expect(cmd.error).toMatch(/channels must match/)
+    })
+  })
+
+  describe('repo-shape grammar (watch/unwatch <target> <owner>/<repo>[@branch[:path]])', () => {
+    it('parses bare <owner>/<repo>', () => {
+      expect(parseCommand('watch repo org/r')).toEqual({
+        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: [],
+      })
+    })
+
+    it('parses @branch', () => {
+      expect(parseCommand('watch repo org/r@develop')).toEqual({
+        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: null, channels: [],
+      })
+    })
+
+    it('parses :path without branch', () => {
+      expect(parseCommand('watch repo org/r:Formula/x.rb')).toEqual({
+        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: 'Formula/x.rb', channels: [],
+      })
+    })
+
+    it('parses @branch:path', () => {
+      expect(parseCommand('watch repo org/r@develop:Formula/x.rb #chan')).toEqual({
+        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb', channels: ['#chan'],
+      })
+    })
+
+    it('parses unwatch-repo with the same shape', () => {
+      expect(parseCommand('unwatch repo org/r@develop:Formula/x.rb')).toEqual({
+        kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb',
+      })
+    })
+
+    it('accepts non-`repo` target (new-issues style)', () => {
+      expect(parseCommand('watch new-issues org/r #chan')).toEqual({
+        kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
+      })
+    })
+
+    it('accepts target=null repo-shape (no plugin will claim it but parser is generic)', () => {
+      expect(parseCommand('watch org/r')).toEqual({
+        kind: 'watch-repo', target: null, repo: 'org/r', branch: null, path: null, channels: [],
+      })
+    })
+
+    it('rejects unwatch-repo with channel args', () => {
+      const cmd = parseCommand('unwatch repo org/r #x') as Extract<Command, { kind: 'unknown' }>
+      expect(cmd.kind).toBe('unknown')
+      expect(cmd.error).toMatch(/no channel arguments/)
+    })
   })
 })
 
 describe('parseCommands', () => {
   it('parses multi-line input', () => {
     expect(parseCommands('watch 5; unwatch pr 10')).toEqual([
-      { kind: 'watch', target: null, number: 5, channels: [] },
-      { kind: 'unwatch', target: 'pr', number: 10 },
+      { kind: 'watch', target: null, number: 5, repo: null, channels: [] },
+      { kind: 'unwatch', target: 'pr', number: 10, repo: null },
     ])
   })
 })
@@ -276,13 +369,14 @@ describe('handleDm — routing', () => {
     expect(irc.dms[0].text).toBe('issues: list-section\n\nprs: list-section')
   })
 
-  it('broadcasts `help` to every plugin and joins with \\n\\n', async () => {
+  it('broadcasts `help` to every plugin and joins with \\n\\n, prepending the dispatcher synopsis', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
     const issues = new StubPlugin('issues', null)
     const prs = new StubPlugin('prs', 'pr')
     const { deps, irc } = makeDeps(dir, [issues, prs])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'help' })
-    expect(irc.dms[0].text).toBe('issues: help-section\n\nprs: help-section')
+    expect(irc.dms[0].text).toContain('dispatcher DM grammar')
+    expect(irc.dms[0].text).toContain('issues: help-section\n\nprs: help-section')
   })
 
   it('surfaces "no plugin handles" when no plugin claims a target', async () => {
@@ -293,6 +387,22 @@ describe('handleDm — routing', () => {
     expect(irc.dms).toHaveLength(1)
     expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear <N>/)
     expect(irc.dms[0].text).toMatch(/enabled plugins: issues/)
+  })
+
+  it('surfaces "no plugin handles" with the repo positional in the grammar shape', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch linear 99 org/r' })
+    expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear <N> <owner>\/<repo>/)
+  })
+
+  it('surfaces "no plugin handles" for a watch-repo when no plugin claims it', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch repo org/r' })
+    expect(irc.dms[0].text).toMatch(/no plugin handles `watch repo <owner>\/<repo>/)
   })
 
   it('any parse error aborts the batch — no plugin called', async () => {

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -79,7 +79,13 @@ export async function loadConfigBase(stateDir: string): Promise<OrchestratorConf
 // github-new-issues' slice repo). Throws on violation with a uniform
 // error message; plugins call it inside their own `assertRepoMode`.
 //
-// Mode invariants:
+// Only runs against TRACKED entries (config.json) — local-overlay entries
+// bypass this check by design and may pin any repo. The mode invariant is
+// primarily a typo guard for operator hand-edits; local writes go through
+// the DM parser which validates OWNER/REPO shape, so they're parser-clean
+// by construction. See `Plugin.assertRepoMode` for the rationale.
+//
+// Mode invariants (applied to tracked entries):
 //   single-repo (topRepo set):   entryRepo must be absent or equal topRepo.
 //   multi-repo  (topRepo unset): entryRepo must be set — no inherit target.
 export function assertEntryRepoMode(

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -79,11 +79,10 @@ export async function loadConfigBase(stateDir: string): Promise<OrchestratorConf
 // github-new-issues' slice repo). Throws on violation with a uniform
 // error message; plugins call it inside their own `assertRepoMode`.
 //
-// Only runs against TRACKED entries (config.json) — local-overlay entries
-// bypass this check by design and may pin any repo. The mode invariant is
-// primarily a typo guard for operator hand-edits; local writes go through
-// the DM parser which validates OWNER/REPO shape, so they're parser-clean
-// by construction. See `Plugin.assertRepoMode` for the rationale.
+// The repo-mode invariant runs only against tracked `config.json` entries
+// — local-overlay entries (DM-driven) bypass it because the DM parser
+// validates OWNER/REPO shape at write time, leaving the overlay
+// parser-clean by construction.
 //
 // Mode invariants (applied to tracked entries):
 //   single-repo (topRepo set):   entryRepo must be absent or equal topRepo.

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -14,13 +14,15 @@
 // DM, plugin.handleCommand throws bubble up as [dispatcher_error] on the
 // project channel.
 
-import { loadConfig, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
+import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
 import { assertRepoModeAll, type Plugin } from './plugin.js'
 
 export type Command =
-  | { kind: 'watch'; target: string | null; number: number; channels: string[] }
-  | { kind: 'unwatch'; target: string | null; number: number }
+  | { kind: 'watch'; target: string | null; number: number; repo: string | null; channels: string[] }
+  | { kind: 'unwatch'; target: string | null; number: number; repo: string | null }
+  | { kind: 'watch-repo'; target: string | null; repo: string; branch: string | null; path: string | null; channels: string[] }
+  | { kind: 'unwatch-repo'; target: string | null; repo: string; branch: string | null; path: string | null }
   | { kind: 'list' }
   | { kind: 'help' }
   | { kind: 'unknown'; raw: string; error: string }
@@ -37,6 +39,19 @@ export interface HandlerDeps {
 }
 
 const CHANNEL_RE = /^#[^\s,#]+$/
+
+// Bare `<owner>/<repo>` used as the optional repo positional after a number
+// in the per-N grammar (`watch pr 5 org/repo [#chan ...]`). The `/` is
+// load-bearing for parser disambiguation — channels start with `#`, repo
+// args contain `/`, numbers are all digits.
+const OWNER_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+// Full repo-shape spec for the whole-repo grammar (`watch repo
+// org/r[@branch[:path]]`). Branch defaults to the plugin's convention when
+// omitted (github-commits uses `main`); path is optional. `@` separates
+// branch from owner/repo to match the github-commits state-key shape
+// (`<repo>@<branch>:<path>`) so log lines and DM input use the same string.
+const REPO_SPEC_RE = /^([A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*)(?:@([^:@\s]+))?(?::([^\s]+))?$/
 
 // Verbs reserved for the dispatcher grammar — plugins can't override the
 // surface, but they decide what each verb does for their slice.
@@ -76,39 +91,81 @@ export function parseCommand(line: string): Command {
   return { kind: 'unknown', raw: line, error: `unknown command: ${tokens[0]}` }
 }
 
-// Parses `[target] <num> [#chan ...]` for watch, `[target] <num>` for unwatch.
-// `target` is whatever non-numeric keyword precedes the number (e.g. `pr`);
-// plugins choose which target keyword they claim, including `null` for the
-// bare form (no target keyword at all).
+// Parses two grammar shapes after the verb:
+//   per-N : `[target] <num> [<owner>/<repo>] [#chan ...]`  (watch/unwatch)
+//   repo  : `[target] <owner>/<repo>[@<branch>[:<path>]] [#chan ...]`
+// `target` is whatever non-numeric, non-repo-shape keyword precedes the spec
+// (e.g. `pr`, `repo`, `new-issues`); plugins claim which keyword they own
+// (including `null` for the bare form). Shape selection is driven by the
+// spec token — a number emits `watch`/`unwatch`, a repo-shape token emits
+// `watch-repo`/`unwatch-repo`.
 function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: string[]): Command {
   let target: string | null = null
   let i = 0
-  // First token: either the number (no target keyword) or a target keyword
-  // followed by the number. `pr` today; future plugins (linear, etc.) can
-  // claim other words without touching the parser.
-  if (rest[0] !== undefined && !/^\d+$/.test(rest[0])) {
-    if (VERBS.has(rest[0].toLowerCase())) {
-      return { kind: 'unknown', raw, error: `${verb}: "${rest[0]}" is a reserved verb, not a target` }
+  // Optional target keyword: first token that is neither a number nor a
+  // repo-shape spec. `repo`/`new-issues`/`pr`/etc. all flow through here —
+  // the parser stays target-agnostic; plugins decide what they claim.
+  const first = rest[0]
+  if (first !== undefined && !/^\d+$/.test(first) && !REPO_SPEC_RE.test(first)) {
+    if (VERBS.has(first.toLowerCase())) {
+      return { kind: 'unknown', raw, error: `${verb}: "${first}" is a reserved verb, not a target` }
     }
-    target = rest[0].toLowerCase()
+    target = first.toLowerCase()
     i = 1
   }
 
-  const numTok = rest[i]
-  if (numTok === undefined) {
-    return { kind: 'unknown', raw, error: `${verb} requires an issue/PR number` }
-  }
-  const number = parseInt(numTok, 10)
-  if (number <= 0 || String(number) !== numTok) {
-    return { kind: 'unknown', raw, error: `${verb}: "${numTok}" is not a positive integer` }
+  const specTok = rest[i]
+  if (specTok === undefined) {
+    return { kind: 'unknown', raw, error: `${verb} requires an issue/PR number or <owner>/<repo> spec` }
   }
 
-  const channels = rest.slice(i + 1)
+  // Repo-shape spec: `owner/repo[@branch][:path]`. Selected over number
+  // when the token contains a `/`. Channels (which start with `#`) and
+  // numbers can never match this pattern, so disambiguation is purely on
+  // shape — no lookahead needed.
+  const repoMatch = specTok.match(REPO_SPEC_RE)
+  if (repoMatch) {
+    const repo = repoMatch[1]
+    const branch = repoMatch[2] ?? null
+    const path = repoMatch[3] ?? null
+    const channels = rest.slice(i + 1)
+    if (verb === 'unwatch') {
+      if (channels.length) {
+        return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
+      }
+      return { kind: 'unwatch-repo', target, repo, branch, path }
+    }
+    for (const c of channels) {
+      if (!CHANNEL_RE.test(c)) {
+        return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
+      }
+    }
+    return { kind: 'watch-repo', target, repo, branch, path, channels }
+  }
+
+  // Number-shape spec.
+  const number = parseInt(specTok, 10)
+  if (number <= 0 || String(number) !== specTok) {
+    return { kind: 'unknown', raw, error: `${verb}: "${specTok}" is not a positive integer or <owner>/<repo> spec` }
+  }
+  i += 1
+
+  // Optional repo positional after the number. Disambiguated from channels
+  // by containing `/` (channels start with `#`); `@branch` and `:path`
+  // are not allowed in this slot — per-N entries pin one PR/issue, not a
+  // branch/path. Exactly one repo positional permitted.
+  let repo: string | null = null
+  if (rest[i] !== undefined && OWNER_REPO_RE.test(rest[i])) {
+    repo = rest[i]
+    i += 1
+  }
+
+  const channels = rest.slice(i)
   if (verb === 'unwatch') {
     if (channels.length) {
       return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
     }
-    return { kind: 'unwatch', target, number }
+    return { kind: 'unwatch', target, number, repo }
   }
 
   for (const c of channels) {
@@ -116,7 +173,7 @@ function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: strin
       return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
     }
   }
-  return { kind: 'watch', target, number, channels }
+  return { kind: 'watch', target, number, repo, channels }
 }
 
 export function parseCommands(text: string): Command[] {
@@ -148,11 +205,14 @@ export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string
 
 // One DM-able description of a watch/unwatch the parser produced, used
 // only in the "no plugin handles..." reply. Matches the user's input shape.
-function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' }>): string {
+function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'watch-repo' | 'unwatch-repo' }>): string {
   const target = cmd.target ? `${cmd.target} ` : ''
+  if (cmd.kind === 'watch-repo') return `watch ${target}<owner>/<repo>[@<branch>[:<path>]] [#chan ...]`
+  if (cmd.kind === 'unwatch-repo') return `unwatch ${target}<owner>/<repo>[@<branch>[:<path>]]`
+  const repoSlot = cmd.repo != null ? ' <owner>/<repo>' : ''
   return cmd.kind === 'watch'
-    ? `watch ${target}<N> [#chan ...]`
-    : `unwatch ${target}<N>`
+    ? `watch ${target}<N>${repoSlot} [#chan ...]`
+    : `unwatch ${target}<N>${repoSlot}`
 }
 
 // Ask every plugin to handle `cmd` against the merged config view, with
@@ -172,14 +232,29 @@ async function routeOne(
     const reply = await p.handleCommand?.(merged, local, cmd)
     if (reply !== null && reply !== undefined) replies.push(reply)
   }
+  // Help always gets the dispatcher synopsis at the top so operators can
+  // discover the grammar from one entry — per-plugin sections trail.
+  if (cmd.kind === 'help') return [HELP_SYNOPSIS, ...replies].join('\n\n')
   if (replies.length === 0) return null
-  // list/help broadcast to all enabled plugins — separate sections with a
+  // list broadcasts to all enabled plugins — separate sections with a
   // blank line so the output is readable when multiple plugins contribute.
-  const sep = cmd.kind === 'list' || cmd.kind === 'help' ? '\n\n' : '\n'
+  const sep = cmd.kind === 'list' ? '\n\n' : '\n'
   return replies.join(sep)
 }
 
-function unmatchedReply(cmd: Extract<Command, { kind: 'watch' | 'unwatch' }>, plugins: Plugin[]): string {
+const HELP_SYNOPSIS = [
+  'dispatcher DM grammar (one per line, or `;`/`,`-separated):',
+  '  watch [<target>] <N> [<owner>/<repo>] [#chan ...]',
+  '  unwatch [<target>] <N> [<owner>/<repo>]',
+  '  watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]',
+  '  unwatch <target> <owner>/<repo>[@<branch>[:<path>]]',
+  '  watch list                 — every plugin\'s active entries',
+  '  help                       — this synopsis + per-plugin commands',
+  '',
+  '<target> is plugin-claimed (`pr`, `repo`, `new-issues`, …). per-plugin help:',
+].join('\n')
+
+function unmatchedReply(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'watch-repo' | 'unwatch-repo' }>, plugins: Plugin[]): string {
   const names = plugins.map(p => p.name).sort().join(', ') || '(none)'
   return `error: no plugin handles \`${describeCommand(cmd)}\` — enabled plugins: ${names}`
 }
@@ -205,7 +280,9 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   let snapshot: OrchestratorConfig
   try {
     snapshot = await loadConfig(deps.stateDir)
-    assertRepoModeAll(deps.plugins, snapshot)
+    // Strict invariant runs against tracked entries only; local overlay
+    // entries are parser-validated on write. See Plugin.assertRepoMode docs.
+    assertRepoModeAll(deps.plugins, await loadConfigBase(deps.stateDir))
   } catch (e) {
     deps.log(`dispatcher-dm-handler: config load failed for ${dm.sender}: ${e}`)
     deps.postProjectError(`[dispatcher_error] config load: ${e}`)
@@ -274,7 +351,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
           const reply = await routeOne(merged, local, cmd, deps.plugins)
           if (reply !== null) {
             replies.push(reply)
-          } else if (cmd.kind === 'watch' || cmd.kind === 'unwatch') {
+          } else if (cmd.kind === 'watch' || cmd.kind === 'unwatch' || cmd.kind === 'watch-repo' || cmd.kind === 'unwatch-repo') {
             replies.push(unmatchedReply(cmd, deps.plugins))
           }
         } catch (e) {
@@ -293,8 +370,13 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
 
   if (writeFailed) return
   for (const cmd of cmds) {
-    const summary = `cmd=${cmd.kind}${'target' in cmd ? ` target=${cmd.target ?? '(default)'}` : ''}${'number' in cmd ? ` n=${cmd.number}` : ''}`
-    deps.log(`dispatcher-dm-handler: ${dm.sender} ${summary}`)
+    const parts = [`cmd=${cmd.kind}`]
+    if ('target' in cmd) parts.push(`target=${cmd.target ?? '(default)'}`)
+    if ('number' in cmd) parts.push(`n=${cmd.number}`)
+    if ('repo' in cmd && cmd.repo) parts.push(`repo=${cmd.repo}`)
+    if ('branch' in cmd && cmd.branch) parts.push(`branch=${cmd.branch}`)
+    if ('path' in cmd && cmd.path) parts.push(`path=${cmd.path}`)
+    deps.log(`dispatcher-dm-handler: ${dm.sender} ${parts.join(' ')}`)
   }
   deps.dm(dm.sender, replies.join('\n\n'))
 }

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -220,6 +220,19 @@ function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'wa
 // every plugin abstained — caller surfaces "no plugin handles ...").
 // watch/unwatch should match exactly one plugin; list/help broadcast to
 // all and join with `\n\n`.
+
+const HELP_SYNOPSIS = [
+  'dispatcher DM grammar (one per line, or `;`/`,`-separated):',
+  '  watch [<target>] <N> [<owner>/<repo>] [#chan ...]',
+  '  unwatch [<target>] <N> [<owner>/<repo>]',
+  '  watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]',
+  '  unwatch <target> <owner>/<repo>[@<branch>[:<path>]]',
+  '  watch list                 — every plugin\'s active entries',
+  '  help                       — this synopsis + per-plugin commands',
+  '',
+  '<target> is plugin-claimed (`pr`, `repo`, `new-issues`, …). per-plugin help:',
+].join('\n')
+
 async function routeOne(
   merged: OrchestratorConfig,
   local: OrchestratorConfig,
@@ -241,18 +254,6 @@ async function routeOne(
   const sep = cmd.kind === 'list' ? '\n\n' : '\n'
   return replies.join(sep)
 }
-
-const HELP_SYNOPSIS = [
-  'dispatcher DM grammar (one per line, or `;`/`,`-separated):',
-  '  watch [<target>] <N> [<owner>/<repo>] [#chan ...]',
-  '  unwatch [<target>] <N> [<owner>/<repo>]',
-  '  watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]',
-  '  unwatch <target> <owner>/<repo>[@<branch>[:<path>]]',
-  '  watch list                 — every plugin\'s active entries',
-  '  help                       — this synopsis + per-plugin commands',
-  '',
-  '<target> is plugin-claimed (`pr`, `repo`, `new-issues`, …). per-plugin help:',
-].join('\n')
 
 function unmatchedReply(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'watch-repo' | 'unwatch-repo' }>, plugins: Plugin[]): string {
   const names = plugins.map(p => p.name).sort().join(', ') || '(none)'

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -72,13 +72,10 @@ export interface Plugin {
   // design (e.g. github-commits) omit it. Throw on violation — the caller
   // surfaces the message. Called after config load and per-tick reload.
   //
-  // `base` is the TRACKED config.json contents only — local-overlay entries
-  // (config.local.json) bypass this check by design. The mode invariant is
-  // a typo guard for operator hand-edits; local-overlay entries are written
-  // exclusively through the DM parser (which validates OWNER/REPO shape) and
-  // so are parser-clean by construction. Loosening the invariant for local
-  // entries is what lets `watch pr 5 org/other` land in single-repo mode
-  // without forcing the operator to leave config.repo unset.
+  // The repo-mode invariant runs only against tracked `config.json` entries
+  // — local-overlay entries (DM-driven) bypass it because the DM parser
+  // validates OWNER/REPO shape at write time, leaving the overlay
+  // parser-clean by construction.
   assertRepoMode?(base: OrchestratorConfig): void
 }
 
@@ -155,11 +152,8 @@ export function registeredPluginNames(): string[] {
 // Core is plugin-agnostic — it doesn't know about `watched[*].repo` or
 // `slice.repo`; the plugins that own those shapes enforce their own rules.
 // Called by every config-load site so an operator hand-edit is caught on
-// the next tick / DM rather than only at boot.
-//
-// `base` is the TRACKED config.json contents — local-overlay entries skip
-// this check by design (parser-validated on write). See the doc comment on
-// `Plugin.assertRepoMode` for the rationale.
+// the next tick / DM rather than only at boot. See `Plugin.assertRepoMode`
+// for the tracked-only contract.
 export function assertRepoModeAll(plugins: Plugin[], base: OrchestratorConfig): void {
   for (const p of plugins) p.assertRepoMode?.(base)
 }

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -71,7 +71,15 @@ export interface Plugin {
   // this to enforce their own constraints; plugins that are cross-repo by
   // design (e.g. github-commits) omit it. Throw on violation — the caller
   // surfaces the message. Called after config load and per-tick reload.
-  assertRepoMode?(config: OrchestratorConfig): void
+  //
+  // `base` is the TRACKED config.json contents only — local-overlay entries
+  // (config.local.json) bypass this check by design. The mode invariant is
+  // a typo guard for operator hand-edits; local-overlay entries are written
+  // exclusively through the DM parser (which validates OWNER/REPO shape) and
+  // so are parser-clean by construction. Loosening the invariant for local
+  // entries is what lets `watch pr 5 org/other` land in single-repo mode
+  // without forcing the operator to leave config.repo unset.
+  assertRepoMode?(base: OrchestratorConfig): void
 }
 
 export abstract class BasePlugin implements Plugin {
@@ -148,6 +156,10 @@ export function registeredPluginNames(): string[] {
 // `slice.repo`; the plugins that own those shapes enforce their own rules.
 // Called by every config-load site so an operator hand-edit is caught on
 // the next tick / DM rather than only at boot.
-export function assertRepoModeAll(plugins: Plugin[], config: OrchestratorConfig): void {
-  for (const p of plugins) p.assertRepoMode?.(config)
+//
+// `base` is the TRACKED config.json contents — local-overlay entries skip
+// this check by design (parser-validated on write). See the doc comment on
+// `Plugin.assertRepoMode` for the rationale.
+export function assertRepoModeAll(plugins: Plugin[], base: OrchestratorConfig): void {
+  for (const p of plugins) p.assertRepoMode?.(base)
 }

--- a/src/orchestrator/plugins/_shared.ts
+++ b/src/orchestrator/plugins/_shared.ts
@@ -1,0 +1,12 @@
+// Cross-plugin reply phrasing. Centralized here so a rename of
+// `config.json` (or the broader operator-facing terminology) only flips
+// one place — first-party plugins import from here rather than each
+// re-coining the same line.
+
+// Refusal line for "you tried to mutate a tracked entry; only the
+// gitignored overlay is dispatcher-writable". `labelStr` is the
+// plugin's already-formatted entry id (e.g. `pr #5`, `repo org/r@main`)
+// so the surrounding sentence stays uniform across plugins.
+export function trackedRefusal(labelStr: string, action: string): string {
+  return `${labelStr} in tracked config.json — hand-edit to ${action}`
+}

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn } from 'bun:test'
 import { GitHubPrsPlugin } from '../prs-plugin.js'
 import { GitHubIssuesPlugin } from '../issues-plugin.js'
 import { GitHubNewIssuesPlugin } from '../new-issues-plugin.js'
+import { GitHubCommitsPlugin } from '../commits-plugin.js'
 import { GhPluginBase } from '../base.js'
 import { RATE_LIMIT_WINDOW_MS } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
@@ -365,7 +366,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('claims bare watch (target=null) and writes to local', () => {
     const merged: OrchestratorConfig = singleRepo()
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: [] })
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: [] })
     expect(out).toMatch(/watching issue #5/)
     expect((local.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
     expect(merged.plugins?.['github-issues']).toBeUndefined()
@@ -373,7 +374,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
 
   it('ignores `watch pr` (returns null)', () => {
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(singleRepo(), local, { kind: 'watch', target: 'pr', number: 5, channels: [] })
+    const out = issues().handleCommand!(singleRepo(), local, { kind: 'watch', target: 'pr', number: 5, repo: null, channels: [] })
     expect(out).toBeNull()
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -381,7 +382,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('is idempotent on duplicate watch (entry visible via merged)', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: [] })
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: [] })
     expect(out).toMatch(/already watching/)
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -390,7 +391,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     const slice = { watched: [{ number: 5, channels: ['#a'] }] }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
     const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
-    issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#a', '#b'] })
     const entry = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
     expect(entry.channels).toEqual(['#a', '#b'])
   })
@@ -398,7 +399,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('refuses to add channels to a tracked-only entry', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#x'] })
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#x'] })
     expect(out).toBe('issue #5 in tracked config.json — hand-edit to add channels')
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -408,7 +409,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     const slice = { watched: [{ number: 5, channels: before }] }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
     const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, channels: ['#a', '#b'] })
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#a', '#b'] })
     expect(out).toMatch(/channels unchanged/)
     const after = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
     expect(after).toBe(before)
@@ -419,19 +420,19 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
       plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
     }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } } })
-    issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5 })
+    issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5, repo: null })
     expect((local.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
   })
 
   it('refuses to unwatch a tracked-only entry', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5 })
+    const out = issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5, repo: null })
     expect(out).toBe('issue #5 in tracked config.json — hand-edit to remove')
   })
 
   it('reports not-watching on unwatch of unknown entry', () => {
-    const out = issues().handleCommand!(singleRepo(), {}, { kind: 'unwatch', target: null, number: 5 })
+    const out = issues().handleCommand!(singleRepo(), {}, { kind: 'unwatch', target: null, number: 5, repo: null })
     expect(out).toMatch(/not watching/)
   })
 
@@ -476,21 +477,21 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   })
 })
 
-describe('GhBase.handleCommand — multi-repo mode rejection', () => {
-  it('rejects bare watch in multi-repo mode and points at the known followup', () => {
+describe('GhBase.handleCommand — multi-repo mode (bare watch only)', () => {
+  it('rejects bare watch and points at the repo-arg fix', () => {
     const merged: OrchestratorConfig = { project: 'p' }
     const local: OrchestratorConfig = {}
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
       merged,
       local,
-      { kind: 'watch', target: null, number: 5, channels: [] },
+      { kind: 'watch', target: null, number: 5, repo: null, channels: [] },
     )
     expect(out).toMatch(/multi-repo mode/)
-    expect(out).toMatch(/cross-repo DM grammar/)
+    expect(out).toMatch(/<owner>\/<repo>/)
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
-  it('rejects unwatch in multi-repo mode', () => {
+  it('rejects bare unwatch', () => {
     const merged: OrchestratorConfig = {
       project: 'p',
       plugins: { 'github-issues': { watched: [{ number: 5, repo: 'org/a' }] } },
@@ -501,21 +502,33 @@ describe('GhBase.handleCommand — multi-repo mode rejection', () => {
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
       merged,
       local,
-      { kind: 'unwatch', target: null, number: 5 },
+      { kind: 'unwatch', target: null, number: 5, repo: null },
     )
     expect(out).toMatch(/multi-repo mode/)
-    // Slice untouched on rejection.
     expect((local.plugins!['github-issues'] as { watched: unknown[] }).watched).toHaveLength(1)
   })
 
-  it('rejects `watch pr` in multi-repo mode', () => {
+  it('rejects bare `watch pr`', () => {
     const merged: OrchestratorConfig = { project: 'p' }
     const out = new GitHubPrsPlugin('#proj').handleCommand!(
       merged,
       {},
-      { kind: 'watch', target: 'pr', number: 10, channels: [] },
+      { kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] },
     )
     expect(out).toMatch(/multi-repo mode/)
+  })
+
+  it('ACCEPTS `watch pr <N> <owner>/<repo>` — repo disambiguates', () => {
+    const merged: OrchestratorConfig = { project: 'p' }
+    const local: OrchestratorConfig = {}
+    const out = new GitHubPrsPlugin('#proj').handleCommand!(
+      merged,
+      local,
+      { kind: 'watch', target: 'pr', number: 10, repo: 'org/a', channels: [] },
+    )
+    expect(out).toMatch(/watching pr org\/a#10/)
+    expect((local.plugins!['github-prs'] as { watched: { number: number; repo: string }[] }).watched)
+      .toEqual([{ number: 10, repo: 'org/a' }])
   })
 })
 
@@ -525,22 +538,267 @@ describe('GhBase.handleCommand — prs plugin (target=pr)', () => {
   it('claims `watch pr` (target=pr) and writes to local', () => {
     const merged: OrchestratorConfig = { repo: 'org/r' }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, channels: ['#x'] })
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: null, channels: ['#x'] })
     expect(out).toMatch(/watching pr #10 \+ #x/)
     expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('ignores bare watch (returns null)', () => {
-    const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'watch', target: null, number: 10, channels: [] })
+    const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'watch', target: null, number: 10, repo: null, channels: [] })
     expect(out).toBeNull()
   })
 
-  it('help mentions `pr <N>` form', () => {
+  it('help mentions `pr <N>` form with the optional repo positional', () => {
     const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'help' })!
     expect(out).toContain('github-prs commands')
-    expect(out).toMatch(/watch pr <N>/)
-    expect(out).toMatch(/unwatch pr <N>/)
+    expect(out).toMatch(/watch pr <N> \[<owner>\/<repo>\]/)
+    expect(out).toMatch(/unwatch pr <N> \[<owner>\/<repo>\]/)
+  })
+})
+
+describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)', () => {
+  const prs = () => new GitHubPrsPlugin('#proj')
+  const issues = () => new GitHubIssuesPlugin('#proj')
+
+  it('creates a cross-repo entry, displays repo prefix, pins repo on the stored entry', () => {
+    const merged: OrchestratorConfig = { repo: 'org/main' }
+    const local: OrchestratorConfig = {}
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    expect(out).toBe('watching pr org/other#10')
+    expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, repo: 'org/other' }] })
+  })
+
+  it('explicit repo that matches config.repo is equivalent to bare — no entry.repo, no prefix', () => {
+    const merged: OrchestratorConfig = { repo: 'org/main' }
+    const local: OrchestratorConfig = {}
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/main', channels: [] })
+    expect(out).toBe('watching pr #10')
+    expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10 }] })
+  })
+
+  it('bare and cross-repo with the same number are two distinct entries', () => {
+    const merged: OrchestratorConfig = {
+      repo: 'org/main',
+      plugins: { 'github-prs': { watched: [{ number: 10 }] } },
+    }
+    const local: OrchestratorConfig = {}
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    expect(out).toBe('watching pr org/other#10')
+    expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, repo: 'org/other' }] })
+  })
+
+  it('idempotent on duplicate cross-repo watch', () => {
+    const slice = { watched: [{ number: 10, repo: 'org/other' }] }
+    const merged: OrchestratorConfig = { repo: 'org/main', plugins: { 'github-prs': slice } }
+    const out = prs().handleCommand!(merged, { plugins: { 'github-prs': slice } }, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    expect(out).toBe('already watching pr org/other#10')
+  })
+
+  it('refuses to add channels to a tracked-only cross-repo entry, with repo in the message', () => {
+    const merged: OrchestratorConfig = {
+      repo: 'org/main',
+      plugins: { 'github-prs': { watched: [{ number: 10, repo: 'org/other' }] } },
+    }
+    const local: OrchestratorConfig = {}
+    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: ['#x'] })
+    expect(out).toBe('pr org/other#10 in tracked config.json — hand-edit to add channels')
+  })
+
+  it('cross-repo unwatch removes the local entry only', () => {
+    const local: OrchestratorConfig = {
+      plugins: { 'github-prs': { watched: [{ number: 10, repo: 'org/other' }, { number: 10 }] } },
+    }
+    const merged: OrchestratorConfig = {
+      repo: 'org/main',
+      plugins: { 'github-prs': { watched: [{ number: 10, repo: 'org/other' }, { number: 10 }] } },
+    }
+    const out = prs().handleCommand!(merged, local, { kind: 'unwatch', target: 'pr', number: 10, repo: 'org/other' })
+    expect(out).toBe('unwatched pr org/other#10')
+    expect((local.plugins!['github-prs'] as { watched: unknown[] }).watched).toEqual([{ number: 10 }])
+  })
+
+  it('list shows cross-repo entries with a repo prefix and bare entries without', () => {
+    const merged: OrchestratorConfig = {
+      repo: 'org/main',
+      plugins: { 'github-prs': { watched: [
+        { number: 1 },
+        { number: 2, repo: 'org/other' },
+        { number: 3, repo: 'org/main' },
+      ] } },
+    }
+    const out = prs().handleCommand!(merged, {}, { kind: 'list' })!
+    expect(out).toContain('github-prs (3):')
+    expect(out).toContain('  #1')
+    expect(out).toContain('  org/other#2')
+    expect(out).toContain('  #3')
+  })
+
+  it('multi-repo mode + repo arg creates a cross-repo entry (parser-clean local)', () => {
+    const merged: OrchestratorConfig = { project: 'p' }
+    const local: OrchestratorConfig = {}
+    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 7, repo: 'org/a', channels: [] })
+    expect(out).toBe('watching issue org/a#7')
+    expect(local.plugins?.['github-issues']).toEqual({ watched: [{ number: 7, repo: 'org/a' }] })
+  })
+})
+
+describe('github-commits handleCommand', () => {
+  const commits = () => new GitHubCommitsPlugin('#proj-leads')
+
+  it('writes a watch-repo entry to local with explicit branch+path', () => {
+    const local: OrchestratorConfig = {}
+    const out = commits().handleCommand!({}, local, {
+      kind: 'watch-repo', target: 'repo', repo: 'AvesAlight/homebrew-tap', branch: 'main', path: 'Formula/roost.rb', channels: [],
+    })
+    expect(out).toBe('watching repo AvesAlight/homebrew-tap@main:Formula/roost.rb')
+    expect(local.plugins?.['github-commits']).toEqual({ watched: [{
+      repo: 'AvesAlight/homebrew-tap', branch: 'main', path: 'Formula/roost.rb',
+    }] })
+  })
+
+  it('writes a watch-repo entry with implicit branch (omits entry.branch)', () => {
+    const local: OrchestratorConfig = {}
+    const out = commits().handleCommand!({}, local, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
+    })
+    expect(out).toBe('watching repo org/r@main + #chan')
+    expect(local.plugins?.['github-commits']).toEqual({ watched: [{ repo: 'org/r', channels: ['#chan'] }] })
+  })
+
+  it('treats implicit (null) branch as equivalent to explicit "main" for dedup', () => {
+    const slice = { watched: [{ repo: 'org/r' }] }
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': slice } }
+    const local: OrchestratorConfig = { plugins: { 'github-commits': slice } }
+    const out = commits().handleCommand!(merged, local, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'main', path: null, channels: [],
+    })
+    expect(out).toBe('already watching repo org/r@main')
+  })
+
+  it('different branches are distinct entries', () => {
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }] } } }
+    const local: OrchestratorConfig = {}
+    const out = commits().handleCommand!(merged, local, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: null, channels: [],
+    })
+    expect(out).toBe('watching repo org/r@develop')
+    expect(local.plugins?.['github-commits']).toEqual({ watched: [{ repo: 'org/r', branch: 'develop' }] })
+  })
+
+  it('refuses to add channels to a tracked-only entry', () => {
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r', branch: 'main', path: 'x.rb' }] } } }
+    const out = commits().handleCommand!(merged, {}, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'main', path: 'x.rb', channels: ['#c'],
+    })
+    expect(out).toBe('repo org/r@main:x.rb in tracked config.json — hand-edit to add channels')
+  })
+
+  it('augments + dedups channels on a local entry', () => {
+    const slice = { watched: [{ repo: 'org/r', channels: ['#a'] }] }
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': slice } }
+    const local: OrchestratorConfig = { plugins: { 'github-commits': slice } }
+    const out = commits().handleCommand!(merged, local, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: ['#a', '#b'],
+    })
+    expect(out).toBe('repo org/r@main + #b')
+    expect((local.plugins!['github-commits'] as { watched: { channels: string[] }[] }).watched[0].channels)
+      .toEqual(['#a', '#b'])
+  })
+
+  it('removes a local entry on unwatch', () => {
+    const local: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }, { repo: 'org/s' }] } } }
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }, { repo: 'org/s' }] } } }
+    const out = commits().handleCommand!(merged, local, {
+      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
+    })
+    expect(out).toBe('unwatched repo org/r@main')
+    expect((local.plugins!['github-commits'] as { watched: { repo: string }[] }).watched)
+      .toEqual([{ repo: 'org/s' }])
+  })
+
+  it('refuses to unwatch a tracked-only entry', () => {
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }] } } }
+    const out = commits().handleCommand!(merged, {}, {
+      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
+    })
+    expect(out).toBe('repo org/r@main in tracked config.json — hand-edit to remove')
+  })
+
+  it('reports not-watching on unknown entry', () => {
+    const out = commits().handleCommand!({}, {}, {
+      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
+    })
+    expect(out).toBe('not watching repo org/r@main')
+  })
+
+  it('ignores commands with target!=repo', () => {
+    expect(commits().handleCommand!({}, {}, {
+      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: [],
+    })).toBeNull()
+    expect(commits().handleCommand!({}, {}, {
+      kind: 'watch', target: null, number: 5, repo: null, channels: [],
+    })).toBeNull()
+  })
+
+  it('list returns the entry list in canonical form', () => {
+    const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [
+      { repo: 'org/r' },
+      { repo: 'org/s', branch: 'develop', path: 'a/b.rb', channels: ['#x'] },
+    ] } } }
+    const out = commits().handleCommand!(merged, {}, { kind: 'list' })!
+    expect(out).toContain('github-commits (2):')
+    expect(out).toContain('  org/r@main')
+    expect(out).toContain('  org/s@develop:a/b.rb + #x')
+  })
+
+  it('help mentions the watch repo / unwatch repo forms', () => {
+    const out = commits().handleCommand!({}, {}, { kind: 'help' })!
+    expect(out).toContain('github-commits commands')
+    expect(out).toMatch(/watch repo <owner>\/<repo>\[@<branch>\[:<path>\]\]/)
+  })
+})
+
+describe('github-new-issues handleCommand', () => {
+  const plugin = () => new GitHubNewIssuesPlugin('#proj-leads')
+
+  it('writes a new-issues entry to local', () => {
+    const local: OrchestratorConfig = {}
+    const out = plugin().handleCommand!({}, local, {
+      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
+    })
+    expect(out).toBe('watching new-issues org/r + #chan')
+    expect(local.plugins?.['github-new-issues']).toEqual({ watched: [{ repo: 'org/r', channels: ['#chan'] }] })
+  })
+
+  it('rejects @branch/:path — new-issues entries are repo-only', () => {
+    const out = plugin().handleCommand!({}, {}, {
+      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: 'main', path: null, channels: [],
+    })
+    expect(out).toMatch(/does not support @branch/)
+  })
+
+  it('idempotent on duplicate', () => {
+    const slice = { watched: [{ repo: 'org/r' }] }
+    const merged: OrchestratorConfig = { plugins: { 'github-new-issues': slice } }
+    const out = plugin().handleCommand!(merged, { plugins: { 'github-new-issues': slice } }, {
+      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: [],
+    })
+    expect(out).toBe('already watching new-issues org/r')
+  })
+
+  it('refuses to unwatch a tracked-only entry', () => {
+    const merged: OrchestratorConfig = { plugins: { 'github-new-issues': { watched: [{ repo: 'org/r' }] } } }
+    const out = plugin().handleCommand!(merged, {}, {
+      kind: 'unwatch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null,
+    })
+    expect(out).toBe('new-issues org/r in tracked config.json — hand-edit to remove')
+  })
+
+  it('ignores target=repo (claimed by github-commits)', () => {
+    expect(plugin().handleCommand!({}, {}, {
+      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: [],
+    })).toBeNull()
   })
 })
 

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -3,6 +3,7 @@ import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { assertEntryRepoMode, resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger, type TaggedEvent } from '../../plugin.js'
+import { trackedRefusal } from '../_shared.js'
 import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from './github-api.js'
 
 // Thin shared base for any plugin that needs GhClient but not watch-list
@@ -92,12 +93,6 @@ function effectiveRepo(entryRepo: string | undefined, defaultRepo: string | unde
   return entryRepo ?? defaultRepo ?? null
 }
 
-// Shared phrasing for "this watch lives in the tracked file; the dispatcher
-// won't touch it". Centralized so a rename of config.json (or a future
-// path knob) only flips one string.
-const trackedRefusal = (labelStr: string, action: string) =>
-  `${labelStr} in tracked config.json — hand-edit to ${action}`
-
 // Watch-list scaffolding for the two GitHub plugins (PRs, issues). Owns the
 // `<issue-channel> + entry.channels` collector, `{ watched?: WatchedEntry[] }`
 // slice convention, and `handleCommand` for watch/unwatch/list/help.
@@ -121,9 +116,14 @@ export abstract class GhBase extends GhPluginBase {
   // entry's repo (when set) must equal config.repo; in multi mode every entry
   // must carry its own repo. The dispatcher calls this after every config
   // load — boot, tick reload, and DM snapshot.
-  assertRepoMode(config: OrchestratorConfig): void {
-    const topRepo = config.repo
-    for (const entry of this.watched(config)) {
+  //
+  // The repo-mode invariant runs only against tracked `config.json` entries
+  // — local-overlay entries (DM-driven) bypass it because the DM parser
+  // validates OWNER/REPO shape at write time, leaving the overlay
+  // parser-clean by construction.
+  assertRepoMode(base: OrchestratorConfig): void {
+    const topRepo = base.repo
+    for (const entry of this.watched(base)) {
       const id = typeof entry.number === 'number' ? `#${entry.number}` : '(unknown)'
       assertEntryRepoMode(this.name, id, entry.repo, topRepo)
     }
@@ -183,7 +183,8 @@ export abstract class GhBase extends GhPluginBase {
     const defaultRepo = merged.repo
     const effective = effectiveRepo(repo ?? undefined, defaultRepo)
     if (effective === null) {
-      return `error: cannot watch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`watch <N>\` has no repo; supply \`watch ${this.target ?? '<target>'} <N> <owner>/<repo>\``
+      const verbForm = this.target ? `watch ${this.target} <N>` : 'watch <N>'
+      return `error: cannot watch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`${verbForm}\` has no repo; supply \`${verbForm} <owner>/<repo>\``
     }
     // Dedup by (number, effective repo) — `watch pr 5` and `watch pr 5
     // org/other` are distinct entries in single-repo mode.
@@ -223,7 +224,8 @@ export abstract class GhBase extends GhPluginBase {
     const defaultRepo = merged.repo
     const effective = effectiveRepo(repo ?? undefined, defaultRepo)
     if (effective === null) {
-      return `error: cannot unwatch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`unwatch <N>\` has no repo; supply \`unwatch ${this.target ?? '<target>'} <N> <owner>/<repo>\``
+      const verbForm = this.target ? `unwatch ${this.target} <N>` : 'unwatch <N>'
+      return `error: cannot unwatch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`${verbForm}\` has no repo; supply \`${verbForm} <owner>/<repo>\``
     }
     const labelStr = formatEntryLabel(this.label, number, effective, defaultRepo)
     const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -1,7 +1,7 @@
 import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { assertEntryRepoMode, resolveRepoEntry } from '../../config.js'
-import { channelSlug, defaultProject, isMultiRepo, issueChannel } from '../../naming.js'
+import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type PluginLogger, type TaggedEvent } from '../../plugin.js'
 import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from './github-api.js'
 
@@ -74,11 +74,29 @@ interface GhPluginConfig {
   watched?: WatchedEntry[]
 }
 
+// Format a `<label> #<N>` or `<label> <owner>/<repo>#<N>` string. Bare `#N`
+// when the entry's effective repo is the same as `config.repo`; cross-repo
+// when it differs (including all multi-repo entries, where `defaultRepo`
+// is undefined). Same shape used in success, idempotent, and refusal
+// replies so a future grep finds them all.
+function formatEntryLabel(label: string, number: number, repo: string | undefined, defaultRepo: string | undefined): string {
+  const isCross = repo != null && repo !== defaultRepo
+  return isCross ? `${label} ${repo}#${number}` : `${label} #${number}`
+}
+
+// "Effective" repo for an entry — the value `resolveRepoEntry` would
+// produce. Used for dedup and reply formatting; returns null when the
+// entry has no repo and there's no default (multi-mode bare-watch),
+// which the caller rejects before dedup.
+function effectiveRepo(entryRepo: string | undefined, defaultRepo: string | undefined): string | null {
+  return entryRepo ?? defaultRepo ?? null
+}
+
 // Shared phrasing for "this watch lives in the tracked file; the dispatcher
 // won't touch it". Centralized so a rename of config.json (or a future
 // path knob) only flips one string.
-const trackedRefusal = (label: string, n: number, action: string) =>
-  `${label} #${n} in tracked config.json — hand-edit to ${action}`
+const trackedRefusal = (labelStr: string, action: string) =>
+  `${labelStr} in tracked config.json — hand-edit to ${action}`
 
 // Watch-list scaffolding for the two GitHub plugins (PRs, issues). Owns the
 // `<issue-channel> + entry.channels` collector, `{ watched?: WatchedEntry[] }`
@@ -137,11 +155,11 @@ export abstract class GhBase extends GhPluginBase {
     if (cmd.kind === 'help') return this.formatHelpSection()
     if (cmd.kind === 'watch') {
       if (cmd.target !== this.target) return null
-      return this.applyWatch(merged, local, cmd.number, cmd.channels)
+      return this.applyWatch(merged, local, cmd.number, cmd.repo, cmd.channels)
     }
     if (cmd.kind === 'unwatch') {
       if (cmd.target !== this.target) return null
-      return this.applyUnwatch(merged, local, cmd.number)
+      return this.applyUnwatch(merged, local, cmd.number, cmd.repo)
     }
     return null
   }
@@ -157,84 +175,98 @@ export abstract class GhBase extends GhPluginBase {
     return fresh
   }
 
-  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number, channels: string[]): string {
-    // Multi-repo mode has no inherit target for entry.repo — the bare DM
-    // grammar can't disambiguate, so reject it. A cross-repo DM grammar is
-    // a known followup; until then, edit the watched list in config.json.
-    if (isMultiRepo(merged)) {
-      return `error: cannot watch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`watch <N>\` has no repo; cross-repo DM grammar is a known followup`
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number, repo: string | null, channels: string[]): string {
+    // Resolve the entry's effective repo. Bare `watch <N>` in multi-repo
+    // mode has no inherit target — the DM grammar now lets the operator
+    // supply `<owner>/<repo>` to disambiguate, so the rejection points at
+    // that fix.
+    const defaultRepo = merged.repo
+    const effective = effectiveRepo(repo ?? undefined, defaultRepo)
+    if (effective === null) {
+      return `error: cannot watch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`watch <N>\` has no repo; supply \`watch ${this.target ?? '<target>'} <N> <owner>/<repo>\``
     }
-    const mergedEntries = this.watched(merged)
-    const inMerged = mergedEntries.find(e => e.number === number)
+    // Dedup by (number, effective repo) — `watch pr 5` and `watch pr 5
+    // org/other` are distinct entries in single-repo mode.
+    const inMerged = this.watched(merged).find(e => e.number === number && effectiveRepo(e.repo, defaultRepo) === effective)
+    const labelStr = formatEntryLabel(this.label, number, effective, defaultRepo)
     if (!inMerged) {
       const slice = this.localSlice(local)
       slice.watched ??= []
       const entry: WatchedEntry = { number }
+      // Only pin entry.repo when it'd differ from config.repo — otherwise
+      // leave it bare so a future config.repo change inherits cleanly.
+      if (effective !== defaultRepo) entry.repo = effective
       if (channels.length) entry.channels = [...channels]
       slice.watched.push(entry)
       return channels.length
-        ? `watching ${this.label} #${number} + ${channels.join(' ')}`
-        : `watching ${this.label} #${number}`
+        ? `watching ${labelStr} + ${channels.join(' ')}`
+        : `watching ${labelStr}`
     }
-    if (!channels.length) return `already watching ${this.label} #${number}`
+    if (!channels.length) return `already watching ${labelStr}`
     // Adding channels: only the local-overlay entry is writable. If the
-    // number lives only in tracked config.json, surface the hand-edit
-    // requirement instead of silently failing.
+    // matched entry lives only in tracked config.json, surface the
+    // hand-edit requirement instead of silently failing.
     const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []
-    const localEntry = localEntries.find(e => e.number === number)
+    const localEntry = localEntries.find(e => e.number === number && effectiveRepo(e.repo, defaultRepo) === effective)
     if (!localEntry) {
-      return trackedRefusal(this.label, number, 'add channels')
+      return trackedRefusal(labelStr, 'add channels')
     }
     const existing = new Set(localEntry.channels ?? [])
     const added: string[] = []
     for (const c of channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
-    if (!added.length) return `${this.label} #${number} channels unchanged`
+    if (!added.length) return `${labelStr} channels unchanged`
     localEntry.channels = [...existing]
-    return `${this.label} #${number} + ${added.join(' ')}`
+    return `${labelStr} + ${added.join(' ')}`
   }
 
-  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number): string {
-    // Same multi-repo restriction as applyWatch: bare `unwatch <N>` is
-    // ambiguous when N can live in multiple repos.
-    if (isMultiRepo(merged)) {
-      return `error: cannot unwatch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`unwatch <N>\` has no repo; cross-repo DM grammar is a known followup`
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, number: number, repo: string | null): string {
+    const defaultRepo = merged.repo
+    const effective = effectiveRepo(repo ?? undefined, defaultRepo)
+    if (effective === null) {
+      return `error: cannot unwatch ${this.label} #${number} in multi-repo mode (no config.repo) — bare \`unwatch <N>\` has no repo; supply \`unwatch ${this.target ?? '<target>'} <N> <owner>/<repo>\``
     }
+    const labelStr = formatEntryLabel(this.label, number, effective, defaultRepo)
     const localEntries = this.pluginConfig<GhPluginConfig>(local)?.watched ?? []
-    const localIdx = localEntries.findIndex(e => e.number === number)
+    const localIdx = localEntries.findIndex(e => e.number === number && effectiveRepo(e.repo, defaultRepo) === effective)
     if (localIdx >= 0) {
       localEntries.splice(localIdx, 1)
-      return `unwatched ${this.label} #${number}`
+      return `unwatched ${labelStr}`
     }
-    const inMerged = this.watched(merged).some(e => e.number === number)
+    const inMerged = this.watched(merged).some(e => e.number === number && effectiveRepo(e.repo, defaultRepo) === effective)
     if (inMerged) {
-      return trackedRefusal(this.label, number, 'remove')
+      return trackedRefusal(labelStr, 'remove')
     }
-    return `not watching ${this.label} #${number}`
+    return `not watching ${labelStr}`
   }
 
   private formatListSection(merged: OrchestratorConfig): string {
-    // Concat-merged watched lists can carry the same number from both
-    // base and local (e.g. post-upgrade reconcile). Dedup by number with
-    // a channel union so the operator-visible reply matches what's
-    // actually being scraped.
+    // Concat-merged watched lists can carry the same (number, repo) from
+    // both base and local (e.g. post-upgrade reconcile). Dedup by the
+    // (effective-repo, number) tuple with a channel union so the
+    // operator-visible reply matches what's actually being scraped.
+    const defaultRepo = merged.repo
     const entries = this.watched(merged)
-    const byNumber = new Map<number, { number: number; channels: Set<string> }>()
-    const order: number[] = []
+    const byKey = new Map<string, { number: number; repo: string | null; channels: Set<string> }>()
+    const order: string[] = []
     for (const e of entries) {
-      let bucket = byNumber.get(e.number)
+      const eff = effectiveRepo(e.repo, defaultRepo)
+      const key = `${eff ?? '<no-repo>'}#${e.number}`
+      let bucket = byKey.get(key)
       if (!bucket) {
-        bucket = { number: e.number, channels: new Set<string>() }
-        byNumber.set(e.number, bucket)
-        order.push(e.number)
+        bucket = { number: e.number, repo: eff, channels: new Set<string>() }
+        byKey.set(key, bucket)
+        order.push(key)
       }
       for (const c of e.channels ?? []) bucket.channels.add(c)
     }
-    const header = `${this.name} (${byNumber.size}):`
-    if (!byNumber.size) return `${header}\n  (none)`
-    const lines = order.map(n => {
-      const bucket = byNumber.get(n)!
+    const header = `${this.name} (${byKey.size}):`
+    if (!byKey.size) return `${header}\n  (none)`
+    const lines = order.map(k => {
+      const bucket = byKey.get(k)!
+      const isCross = bucket.repo != null && bucket.repo !== defaultRepo
+      const idStr = isCross ? `${bucket.repo}#${bucket.number}` : `#${bucket.number}`
       const chans = bucket.channels.size ? ` + ${[...bucket.channels].join(' ')}` : ''
-      return `  #${n}${chans}`
+      return `  ${idStr}${chans}`
     })
     return [header, ...lines].join('\n')
   }
@@ -243,9 +275,9 @@ export abstract class GhBase extends GhPluginBase {
     const t = this.target ? `${this.target} ` : ''
     return [
       `${this.name} commands (DM only):`,
-      `  watch ${t}<N> [#chan ...]    — watch ${this.label} N, route extra channels`,
-      `  unwatch ${t}<N>              — stop watching ${this.label} N`,
-      `  watch list                  — include this plugin's watched ${this.name} in the reply`,
+      `  watch ${t}<N> [<owner>/<repo>] [#chan ...]   — watch ${this.label} N (optionally in a non-default repo)`,
+      `  unwatch ${t}<N> [<owner>/<repo>]             — stop watching ${this.label} N`,
+      `  watch list                                  — include this plugin's watched ${this.name} in the reply`,
     ].join('\n')
   }
 }

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -24,6 +24,7 @@ import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
+import { trackedRefusal } from '../_shared.js'
 import type { GhCommit } from './github-api.js'
 import { GhPluginBase } from './base.js'
 
@@ -74,9 +75,6 @@ function matchesEntry(e: CommitWatchEntry, repo: string, branch: string | null, 
     && (e.branch ?? DEFAULT_BRANCH) === (branch ?? DEFAULT_BRANCH)
     && (e.path ?? null) === path
 }
-
-const trackedRefusal = (labelStr: string, action: string) =>
-  `${labelStr} in tracked config.json — hand-edit to ${action}`
 
 function shortSha(sha: string): string {
   return sha.slice(0, 7)

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -4,9 +4,10 @@
 // the GH release workflow auto-commits a formula bump to the homebrew tap,
 // and watching that commit closes the manual-poll gap for the APM.
 //
-// Static config only. No DM grammar — the parser is verb+number-shaped and
-// commits have no number; for the set-and-forget tap case operator config-edit
-// is fine.
+// DM grammar: claims target=`repo`. Operators can `watch repo
+// <owner>/<repo>[@<branch>[:<path>]] [#chan ...]` / `unwatch repo …`. The
+// repo-spec shape mirrors the state key (`<repo>@<branch>[:<path>]`) so a
+// canonical line in daemon.log copy-pastes into a DM.
 //
 // State slice: `{ commits: { "<key>": { last_sha } } }` where key is
 // `<repo>@<branch>` (or `<repo>@<branch>:<path>` when a path filter is set).
@@ -19,6 +20,7 @@
 // (the tap-bump dance polls a different repo than the dispatcher's own). The
 // per-watch plugins' single-vs-multi invariant does not apply here.
 
+import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
@@ -56,6 +58,26 @@ function entryKey(entry: CommitWatchEntry): string {
   return entry.path ? `${entry.repo}@${branch}:${entry.path}` : `${entry.repo}@${branch}`
 }
 
+// Canonical display form for a `(repo, branch?, path?)` triple, matching
+// the state-key shape. Always includes `@<branch>` (so the operator sees
+// the default they got) and `:<path>` when set.
+function formatRepoSpec(repo: string, branch: string | undefined | null, path: string | undefined | null): string {
+  const b = branch ?? DEFAULT_BRANCH
+  return path ? `repo ${repo}@${b}:${path}` : `repo ${repo}@${b}`
+}
+
+// Match key for DM watch/unwatch lookup. Two entries collide iff their
+// `(repo, effective branch, path)` are identical — same shape as
+// `entryKey` but on parsed cmd fields rather than a stored entry.
+function matchesEntry(e: CommitWatchEntry, repo: string, branch: string | null, path: string | null): boolean {
+  return e.repo === repo
+    && (e.branch ?? DEFAULT_BRANCH) === (branch ?? DEFAULT_BRANCH)
+    && (e.path ?? null) === path
+}
+
+const trackedRefusal = (labelStr: string, action: string) =>
+  `${labelStr} in tracked config.json — hand-edit to ${action}`
+
 function shortSha(sha: string): string {
   return sha.slice(0, 7)
 }
@@ -76,6 +98,114 @@ function formatCommit(entry: CommitWatchEntry, commit: GhCommit, sha: string): s
 
 export class GitHubCommitsPlugin extends GhPluginBase {
   readonly name = 'github-commits'
+
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'watch-repo') {
+      if (cmd.target !== 'repo') return null
+      return this.applyWatchRepo(merged, local, cmd.repo, cmd.branch, cmd.path, cmd.channels)
+    }
+    if (cmd.kind === 'unwatch-repo') {
+      if (cmd.target !== 'repo') return null
+      return this.applyUnwatchRepo(merged, local, cmd.repo, cmd.branch, cmd.path)
+    }
+    return null
+  }
+
+  private localSlice(local: OrchestratorConfig): CommitsPluginConfig {
+    local.plugins ??= {}
+    const existing = local.plugins[this.name]
+    if (existing && typeof existing === 'object') return existing as CommitsPluginConfig
+    const fresh: CommitsPluginConfig = {}
+    local.plugins[this.name] = fresh
+    return fresh
+  }
+
+  private mergedWatched(config: OrchestratorConfig): CommitWatchEntry[] {
+    return this.pluginConfig<CommitsPluginConfig>(config)?.watched ?? []
+  }
+
+  private applyWatchRepo(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string, branch: string | null, path: string | null, channels: string[]): string {
+    const labelStr = formatRepoSpec(repo, branch, path)
+    const inMerged = this.mergedWatched(merged).find(e => matchesEntry(e, repo, branch, path))
+    if (!inMerged) {
+      const slice = this.localSlice(local)
+      slice.watched ??= []
+      const entry: CommitWatchEntry = { repo }
+      // Only pin branch on the entry when explicit — leaves the default
+      // (`main`) implicit so a future DEFAULT_BRANCH bump propagates.
+      if (branch !== null) entry.branch = branch
+      if (path !== null) entry.path = path
+      if (channels.length) entry.channels = [...channels]
+      slice.watched.push(entry)
+      return channels.length
+        ? `watching ${labelStr} + ${channels.join(' ')}`
+        : `watching ${labelStr}`
+    }
+    if (!channels.length) return `already watching ${labelStr}`
+    const localEntries = this.pluginConfig<CommitsPluginConfig>(local)?.watched ?? []
+    const localEntry = localEntries.find(e => matchesEntry(e, repo, branch, path))
+    if (!localEntry) {
+      return trackedRefusal(labelStr, 'add channels')
+    }
+    const existing = new Set(localEntry.channels ?? [])
+    const added: string[] = []
+    for (const c of channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
+    if (!added.length) return `${labelStr} channels unchanged`
+    localEntry.channels = [...existing]
+    return `${labelStr} + ${added.join(' ')}`
+  }
+
+  private applyUnwatchRepo(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string, branch: string | null, path: string | null): string {
+    const labelStr = formatRepoSpec(repo, branch, path)
+    const localEntries = this.pluginConfig<CommitsPluginConfig>(local)?.watched ?? []
+    const localIdx = localEntries.findIndex(e => matchesEntry(e, repo, branch, path))
+    if (localIdx >= 0) {
+      localEntries.splice(localIdx, 1)
+      return `unwatched ${labelStr}`
+    }
+    if (this.mergedWatched(merged).some(e => matchesEntry(e, repo, branch, path))) {
+      return trackedRefusal(labelStr, 'remove')
+    }
+    return `not watching ${labelStr}`
+  }
+
+  private formatListSection(merged: OrchestratorConfig): string {
+    // Dedup by (repo, effective branch, path) across the concat-merged
+    // base+local lists — matches scrape behavior.
+    const entries = this.mergedWatched(merged)
+    const byKey = new Map<string, { repo: string; branch: string; path: string | null; channels: Set<string> }>()
+    const order: string[] = []
+    for (const e of entries) {
+      const key = entryKey(e)
+      let bucket = byKey.get(key)
+      if (!bucket) {
+        bucket = { repo: e.repo, branch: e.branch ?? DEFAULT_BRANCH, path: e.path ?? null, channels: new Set<string>() }
+        byKey.set(key, bucket)
+        order.push(key)
+      }
+      for (const c of e.channels ?? []) bucket.channels.add(c)
+    }
+    const header = `${this.name} (${byKey.size}):`
+    if (!byKey.size) return `${header}\n  (none)`
+    const lines = order.map(k => {
+      const b = byKey.get(k)!
+      const id = b.path ? `${b.repo}@${b.branch}:${b.path}` : `${b.repo}@${b.branch}`
+      const chans = b.channels.size ? ` + ${[...b.channels].join(' ')}` : ''
+      return `  ${id}${chans}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch repo <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  — watch commit feed`,
+      `  unwatch repo <owner>/<repo>[@<branch>[:<path>]]            — stop watching commit feed`,
+      `  watch list                                                — include this plugin's watched repos in the reply`,
+    ].join('\n')
+  }
 
   desiredChannels(config: OrchestratorConfig): string[] {
     const slice = this.pluginConfig<CommitsPluginConfig>(config) ?? {}

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -26,6 +26,7 @@ import type { OrchestratorConfig } from '../../config.js'
 import { assertEntryRepoMode } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
+import { trackedRefusal } from '../_shared.js'
 import { labelNames, type GhRepoIssue } from './github-api.js'
 import { GhPluginBase } from './base.js'
 
@@ -41,9 +42,6 @@ interface NewIssuesPluginConfig {
 export interface NewIssuesPluginState {
   repos: Record<string, number[]>
 }
-
-const trackedRefusal = (labelStr: string, action: string) =>
-  `${labelStr} in tracked config.json — hand-edit to ${action}`
 
 export class GitHubNewIssuesPlugin extends GhPluginBase {
   readonly name = 'github-new-issues'
@@ -168,9 +166,14 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
   // Each watched entry's repo must equal config.repo when set (single mode);
   // the type guarantees repo is present, so the multi-mode missing-repo branch
   // never fires for this plugin. Mirrors the gh-base watched check.
-  assertRepoMode(config: OrchestratorConfig): void {
-    const slice = this.pluginConfig<NewIssuesPluginConfig>(config) ?? {}
-    const topRepo = config.repo
+  //
+  // The repo-mode invariant runs only against tracked `config.json` entries
+  // — local-overlay entries (DM-driven) bypass it because the DM parser
+  // validates OWNER/REPO shape at write time, leaving the overlay
+  // parser-clean by construction.
+  assertRepoMode(base: OrchestratorConfig): void {
+    const slice = this.pluginConfig<NewIssuesPluginConfig>(base) ?? {}
+    const topRepo = base.repo
     for (const entry of slice.watched ?? []) {
       assertEntryRepoMode(this.name, `(repo=${entry.repo})`, entry.repo, topRepo)
     }

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -10,6 +10,10 @@
 // init` writes one for new projects; existing projects need an operator edit
 // (or the example.json refresh) to pick this up.
 //
+// DM grammar: claims target=`new-issues`. Operators can `watch new-issues
+// <owner>/<repo> [#chan ...]` / `unwatch new-issues <owner>/<repo>`.
+// `@branch`/`:path` are not accepted — new-issues entries are repo-only.
+//
 // State slice: `{ repos: Record<string, number[]> }` keyed by repo slug.
 // Seeding (`prev===null`) and first-observation of a new repo entry
 // (`prev.repos[repo]===undefined`) both capture the current open set without
@@ -17,6 +21,7 @@
 // forward in state (matches commits-plugin) so remove-then-readd doesn't
 // replay history. Closed issues that re-open will re-announce only if pruned
 // from `seen` (we don't prune today; the operator can `watch <N>` for it).
+import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import { assertEntryRepoMode } from '../../config.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
@@ -37,8 +42,117 @@ export interface NewIssuesPluginState {
   repos: Record<string, number[]>
 }
 
+const trackedRefusal = (labelStr: string, action: string) =>
+  `${labelStr} in tracked config.json — hand-edit to ${action}`
+
 export class GitHubNewIssuesPlugin extends GhPluginBase {
   readonly name = 'github-new-issues'
+
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'watch-repo') {
+      if (cmd.target !== 'new-issues') return null
+      if (cmd.branch !== null || cmd.path !== null) {
+        return `error: new-issues does not support @branch or :path — try \`watch new-issues ${cmd.repo}\``
+      }
+      return this.applyWatch(merged, local, cmd.repo, cmd.channels)
+    }
+    if (cmd.kind === 'unwatch-repo') {
+      if (cmd.target !== 'new-issues') return null
+      if (cmd.branch !== null || cmd.path !== null) {
+        return `error: new-issues does not support @branch or :path — try \`unwatch new-issues ${cmd.repo}\``
+      }
+      return this.applyUnwatch(merged, local, cmd.repo)
+    }
+    return null
+  }
+
+  private localSlice(local: OrchestratorConfig): NewIssuesPluginConfig {
+    local.plugins ??= {}
+    const existing = local.plugins[this.name]
+    if (existing && typeof existing === 'object') return existing as NewIssuesPluginConfig
+    const fresh: NewIssuesPluginConfig = {}
+    local.plugins[this.name] = fresh
+    return fresh
+  }
+
+  private mergedWatched(config: OrchestratorConfig): NewIssuesWatchEntry[] {
+    return this.pluginConfig<NewIssuesPluginConfig>(config)?.watched ?? []
+  }
+
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string, channels: string[]): string {
+    const labelStr = `new-issues ${repo}`
+    const inMerged = this.mergedWatched(merged).find(e => e.repo === repo)
+    if (!inMerged) {
+      const slice = this.localSlice(local)
+      slice.watched ??= []
+      const entry: NewIssuesWatchEntry = { repo }
+      if (channels.length) entry.channels = [...channels]
+      slice.watched.push(entry)
+      return channels.length
+        ? `watching ${labelStr} + ${channels.join(' ')}`
+        : `watching ${labelStr}`
+    }
+    if (!channels.length) return `already watching ${labelStr}`
+    const localEntries = this.pluginConfig<NewIssuesPluginConfig>(local)?.watched ?? []
+    const localEntry = localEntries.find(e => e.repo === repo)
+    if (!localEntry) {
+      return trackedRefusal(labelStr, 'add channels')
+    }
+    const existing = new Set(localEntry.channels ?? [])
+    const added: string[] = []
+    for (const c of channels) if (!existing.has(c)) { existing.add(c); added.push(c) }
+    if (!added.length) return `${labelStr} channels unchanged`
+    localEntry.channels = [...existing]
+    return `${labelStr} + ${added.join(' ')}`
+  }
+
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string): string {
+    const labelStr = `new-issues ${repo}`
+    const localEntries = this.pluginConfig<NewIssuesPluginConfig>(local)?.watched ?? []
+    const localIdx = localEntries.findIndex(e => e.repo === repo)
+    if (localIdx >= 0) {
+      localEntries.splice(localIdx, 1)
+      return `unwatched ${labelStr}`
+    }
+    if (this.mergedWatched(merged).some(e => e.repo === repo)) {
+      return trackedRefusal(labelStr, 'remove')
+    }
+    return `not watching ${labelStr}`
+  }
+
+  private formatListSection(merged: OrchestratorConfig): string {
+    const entries = this.mergedWatched(merged)
+    const byRepo = new Map<string, Set<string>>()
+    const order: string[] = []
+    for (const e of entries) {
+      let chans = byRepo.get(e.repo)
+      if (!chans) {
+        chans = new Set<string>()
+        byRepo.set(e.repo, chans)
+        order.push(e.repo)
+      }
+      for (const c of e.channels ?? []) chans.add(c)
+    }
+    const header = `${this.name} (${byRepo.size}):`
+    if (!byRepo.size) return `${header}\n  (none)`
+    const lines = order.map(r => {
+      const chans = byRepo.get(r)!
+      const chansStr = chans.size ? ` + ${[...chans].join(' ')}` : ''
+      return `  ${r}${chansStr}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch new-issues <owner>/<repo> [#chan ...]   — watch new-issues feed`,
+      `  unwatch new-issues <owner>/<repo>             — stop watching new-issues feed`,
+      `  watch list                                   — include this plugin's watched repos in the reply`,
+    ].join('\n')
+  }
 
   // Project channel is unioned in by the orchestrator. Explicit per-entry
   // channels are surfaced here so they join at boot.


### PR DESCRIPTION
Closes #433

## Summary

Extends the dispatcher DM grammar so operators can manage cross-repo per-PR/issue watches and whole-repo commit / new-issues feeds without hand-editing `config.json`. Migrates all four github plugins onto the new grammar.

## New shapes

```
watch [<target>] <N> [<owner>/<repo>] [#chan ...]              # per-N + cross-repo
unwatch [<target>] <N> [<owner>/<repo>]
watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  # whole-repo
unwatch <target> <owner>/<repo>[@<branch>[:<path>]]
```

| `<target>` | plugin | grammar |
|---|---|---|
| (none) | github-issues | `watch <N> [<owner>/<repo>] [#chan ...]` |
| `pr` | github-prs | `watch pr <N> [<owner>/<repo>] [#chan ...]` |
| `repo` | github-commits | `watch repo <owner>/<repo>[@<branch>[:<path>]] [#chan ...]` |
| `new-issues` | github-new-issues | `watch new-issues <owner>/<repo> [#chan ...]` |

Disambiguation is shape-driven: repo positional contains `/`, channels start with `#`, numbers are all digits. Branch separator is `@` to mirror the github-commits state key (`<repo>@<branch>:<path>`) so a daemon.log line copy-pastes into a DM.

## Repo-mode invariant — tracked-strict, local-loose

Per pressure-test from `@AlexSc` via lead-pm: the single-vs-multi-repo check now runs **only** against tracked `config.json` entries. Local-overlay entries (DM-driven, parser-validated) bypass it — they may pin any repo. A single-repo dispatcher can `watch pr 5 OtherOrg/r` without losing the typo guard on tracked entries. Rationale documented at the `Plugin.assertRepoMode` contract, the `assertEntryRepoMode` helper, and in DISPATCHER.md.

## Top-level help

`help` DM now prepends a dispatcher synopsis above the per-plugin help sections so the grammar is discoverable from one entry.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 659 pass, 0 fail (32 new cases covering parser shapes, cross-repo dedup, github-commits handleCommand, github-new-issues handleCommand, regression for `watch pr 5 #chan`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)