### PR TITLE
prompt: PR thread replies belong on the PR, not in IRC

### DIFF
--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -75,7 +75,7 @@ You do not need to restate anything that the human or dispatcher says in the cha
 
 If you comment on GitHub, prefix your comment with your name [<project>-lead-pm]
 
-When the human leaves inline PR thread comments, reply on the PR thread, not in IRC. IRC is for team coordination; the PR thread is the durable record.
+When the human leaves PR comments, reply on the PR, not in IRC. The PR thread is the durable record; coordinate any followup in #<project>-leads.
 
 ## Working with the APM
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -75,6 +75,8 @@ You do not need to restate anything that the human or dispatcher says in the cha
 
 If you comment on GitHub, prefix your comment with your name [<project>-lead-pm]
 
+When the human leaves inline PR thread comments, reply on the PR thread, not in IRC. IRC is for team coordination; the PR thread is the durable record.
+
 ## Working with the APM
 
 The APM handles five dances for you: setup (worktree + watch + worker spawn), reviewer-spawn (when worker posts a draft PR), ready-for-review (mark-ready + add human reviewer + re-request after CHANGES_REQUESTED), merge + cleanup, and follow-up filing (`gh issue create` against the current or a named milestone). You drive the judgment around each dance — model selection, plan pressure-testing, human review decisions, and whether a follow-up is in scope or pushes the milestone wider; the APM types the commands.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -37,7 +37,9 @@ PRs start as draft and go through a reviewer pass *before* anyone flips them rea
 
 1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
 2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback". APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
-3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review. When the human leaves inline PR thread comments, reply on the PR thread, not in IRC.
+3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review.
+
+   When the human leaves PR comments, reply on the PR, not in IRC.
 
 Batch multiple changes-requested items into one push so you don't ping the lead after each individual fix; inside that push, the commits still split by theme.
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -37,7 +37,7 @@ PRs start as draft and go through a reviewer pass *before* anyone flips them rea
 
 1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
 2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback". APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
-3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review.
+3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review. When the human leaves inline PR thread comments, reply on the PR thread, not in IRC.
 
 Batch multiple changes-requested items into one push so you don't ping the lead after each individual fix; inside that push, the commits still split by theme.
 


### PR DESCRIPTION
Closes #448

lead-pm replied to alex's inline PR comments in IRC (#roost-issue-441) instead of on the PR thread. the prompts were silent on this.

two targeted additions:
- `agents/lead-pm.md` (Working In Channels): 2 sentences — reply to inline PR thread comments on the PR, not IRC
- `prompts/worker.md` (Human review loop step 3): 1 sentence — same rule

reviewer.md and associate-pm.md skipped: reviewer posts one comment then exits, APM doesn't do PR review conversation.

§#422 check: 2 surfaces → phrase each in context, no verbatim canonicalization needed.
§#419 check: grepped agents/ + prompts/ for "PR thread", "PR comment", "PR review comment" — one hit (lead-pm.md, the section being edited). no third surface.