### PR TITLE
mock observeRateLimit in gh plugin tests to eliminate rate-limit flake

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/commits-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/commits-plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn } from 'bun:test'
 import { GitHubCommitsPlugin, type CommitsPluginState } from '../commits-plugin.js'
 import { GhClient, type GhCommit } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import { stubRateLimit } from './gh-test-helpers.js'
 
 function commit(sha: string, subject: string): GhCommit {
   return {
@@ -33,6 +34,8 @@ function onelineText(payload: { kind: 'oneline'; text: string } | unknown): stri
 }
 
 describe('GitHubCommitsPlugin.runTick', () => {
+  stubRateLimit()
+
   it('seeds without emitting on first run and records the head sha per entry', async () => {
     const spy = stubFetch(() => [commit('aaa1111', 'bump 1'), commit('bbb2222', 'bump 0')])
     try {

--- a/src/orchestrator/plugins/github/__tests__/gh-test-helpers.ts
+++ b/src/orchestrator/plugins/github/__tests__/gh-test-helpers.ts
@@ -1,0 +1,15 @@
+import { beforeAll, afterAll, spyOn } from 'bun:test'
+import { GhPluginBase } from '../base.js'
+
+// Call inside a describe block to suppress the real `gh api /rate_limit`
+// subprocess that observeRateLimit fires at the end of every runTick.
+// Affects: commits-plugin.test.ts, new-issues-plugin.test.ts,
+//          the runTick describe blocks in plugin.test.ts.
+export function stubRateLimit(): void {
+  let spy: { mockRestore(): void }
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spy = spyOn(GhPluginBase.prototype as any, 'observeRateLimit').mockResolvedValue([])
+  })
+  afterAll(() => { spy.mockRestore() })
+}

--- a/src/orchestrator/plugins/github/__tests__/gh-test-helpers.ts
+++ b/src/orchestrator/plugins/github/__tests__/gh-test-helpers.ts
@@ -3,8 +3,6 @@ import { GhPluginBase } from '../base.js'
 
 // Call inside a describe block to suppress the real `gh api /rate_limit`
 // subprocess that observeRateLimit fires at the end of every runTick.
-// Affects: commits-plugin.test.ts, new-issues-plugin.test.ts,
-//          the runTick describe blocks in plugin.test.ts.
 export function stubRateLimit(): void {
   let spy: { mockRestore(): void }
   beforeAll(() => {

--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn } from 'bun:test'
 import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
 import { GhClient, type GhRepoIssue } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import { stubRateLimit } from './gh-test-helpers.js'
 
 function issue(n: number, overrides: Partial<GhRepoIssue> = {}): GhRepoIssue {
   return {
@@ -34,6 +35,8 @@ function prevState(numbers: number[], repo = 'org/repo'): NewIssuesPluginState {
 }
 
 describe('GitHubNewIssuesPlugin.runTick', () => {
+  stubRateLimit()
+
   it('seeds without emitting on first run (prev === null)', async () => {
     const spy = stubFetch([issue(1), issue(2), issue(3)])
     try {

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -9,6 +9,7 @@ import type { OrchestratorConfig } from '../../../config.js'
 import type { PrSnap, IssueSnap } from '../types.js'
 import { GhScraper } from '../scraper.js'
 import type { OrchestratorEvent } from '../diff.js'
+import { stubRateLimit } from './gh-test-helpers.js'
 
 function fakePrSnap(overrides: Partial<PrSnap> = {}): PrSnap {
   return {
@@ -28,6 +29,8 @@ function fakeIssueSnap(overrides: Partial<IssueSnap> = {}): IssueSnap {
 }
 
 describe('GitHubPrsPlugin.runTick', () => {
+  stubRateLimit()
+
   it('routes a PR comment to linked-issue channels unioned with entry channels', async () => {
     const commentEv: OrchestratorEvent = {
       kind: 'pr_review_comment',
@@ -163,6 +166,8 @@ describe('GitHubPrsPlugin.runTick', () => {
 })
 
 describe('GitHubIssuesPlugin.runTick', () => {
+  stubRateLimit()
+
   it('emits now-watching to project channel on issue_added_to_watch', async () => {
     const seedEv: OrchestratorEvent = {
       kind: 'issue_added_to_watch', repo: 'org/repo', issue: 50, url: 'u', title: 't',
@@ -290,6 +295,8 @@ describe('desiredChannels', () => {
 })
 
 describe('multi-repo runTick — slug-aware channel routing', () => {
+  stubRateLimit()
+
   it('PR event routes to the slugged linked-issue channel', async () => {
     const commentEv: OrchestratorEvent = {
       kind: 'pr_review_comment',


### PR DESCRIPTION
Closes #447

three test files were calling the real `gh api /rate_limit` subprocess at the end of every `runTick`. on slow CI this hit the per-test timeout.

extracted a shared `stubRateLimit()` helper to `gh-test-helpers.ts` that spies on `GhPluginBase.prototype.observeRateLimit` → `[]` for the duration of each affected describe block. the `observeRateLimit` integration and pruning describe blocks in `plugin.test.ts` are untouched — they supply their own `_fetch` or own spy.

109 tests pass, lint and typecheck clean.