### PR TITLE
fix(prs-plugin): route cross-repo PR closures to linked issue's own slug

### DIFF
--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -91,6 +91,29 @@ mode and is required per entry in multi-repo mode. `channels` adds
 destinations on top of the auto-routed issue channel (PR events also route
 to each linked issue's channel, slugged the same way in multi-repo mode).
 
+### Cross-repo PR closures
+
+`closingIssuesReferences` can cross repos — a PR in repo A may close an
+issue in repo B. The slug for each linked-issue channel is derived from
+the linked issue's own repo, not the PR's repo:
+
+- **Multi-repo mode:** PR `org/a#25` closing `org/b#14` routes events to
+  `#<project>-b-issue-14`. If `org/b` is also watched, the PR-side and
+  issue-side events converge in the same channel.
+- **Single-repo mode (`config.repo` set), same-repo linked issue:**
+  routes to bare `#<project>-issue-<N>` as before.
+- **Single-repo mode, cross-repo linked issue:** the foreign-repo issue
+  is dropped from routing (no synthesized slug in single-mode) and the
+  dispatcher emits one stderr line per drop with the remediation: add the
+  foreign repo to `config.json` or switch to multi-repo mode. The drop
+  warning is debounced per `head_oid` — it re-fires when the PR force-pushes
+  and the closing references are re-resolved.
+  
+  Operator-visible signal in this case is **dual**: the IRC channel still
+  shows `now watching PR ...` (because `gh` did return a linked issue,
+  just not one we can address), but stderr carries the drop notice.
+  Read stderr when in doubt.
+
 A plugin not listed under `plugins` is not instantiated — there is no top-level
 fallback. The first-party set shipped in this repo is `github-prs`,
 `github-issues`, `github-new-issues`, `github-commits`. External plugins are

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -5,9 +5,10 @@ import { promisify } from 'node:util'
 
 const execFileP = promisify(execFile)
 
-// Schema version 3: GitHub plugin split into Prs/Issues; each owns its
-// own state slice. Schema bumps trigger a one-time re-seed via loadState().
-export const SCHEMA_VERSION = 3
+// Schema version 4: PrSnap.linked_issues carries per-issue repo (was bare
+// number[]); cross-repo PR closures route to the linked issue's own repo
+// slug. Schema bumps trigger a one-time re-seed via loadState().
+export const SCHEMA_VERSION = 4
 
 export interface WatchedEntry {
   repo?: string

--- a/src/orchestrator/plugins/github/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/diff.test.ts
@@ -194,14 +194,14 @@ describe('diffPr — pr_no_linked_issues', () => {
 
   it('does not emit pr_no_linked_issues when linked_issues is non-empty', () => {
     const prev: PrSnap = { ...basePrSnap({ linked_issues: [] }) }
-    const cur = basePrSnap({ linked_issues: [42] })
+    const cur = basePrSnap({ linked_issues: [{ repo: 'org/repo', number: 42 }] })
     const events = diffPr(prev, cur)
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
   })
 
   it('warns again after linked_issues cleared ([N] → [] transition)', () => {
     // prev had linked issues so warned_no_linked was reset to false
-    const prev: PrSnap = { ...basePrSnap({ linked_issues: [42], warned_no_linked: false }) }
+    const prev: PrSnap = { ...basePrSnap({ linked_issues: [{ repo: 'org/repo', number: 42 }], warned_no_linked: false }) }
     const cur = basePrSnap({ linked_issues: [] })
     const events = diffPr(prev, cur)
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(true)
@@ -226,7 +226,7 @@ describe('computePrEvents — pr_no_linked_issues', () => {
   })
 
   it('does not emit pr_no_linked_issues and clears flag for new PR with linked issues', () => {
-    const snap = basePrSnap({ linked_issues: [5] })
+    const snap = basePrSnap({ linked_issues: [{ repo: 'org/repo', number: 5 }] })
     const { events, nextWarnedNoLinked } = computePrEvents(snap, null, new Set())
     expect(events.some(e => e.kind === 'pr_no_linked_issues')).toBe(false)
     expect(nextWarnedNoLinked).toBe(false)

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -34,11 +34,11 @@ describe('GitHubPrsPlugin.runTick', () => {
       repo: 'org/repo', pr: 25, url: 'https://example.com/p/25',
       author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
       comment_id: 1, comment_url: 'https://example.com/c/1',
-      linked_issues: [14],
+      linked_issues: [{ repo: 'org/repo', number: 14 }],
     } as OrchestratorEvent
 
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
-      snap: fakePrSnap({ linked_issues: [14] }),
+      snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 14 }] }),
       events: [commentEv],
     })
     try {
@@ -61,7 +61,7 @@ describe('GitHubPrsPlugin.runTick', () => {
 
   it('persists scraped PR state under its own slice', async () => {
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
-      snap: fakePrSnap({ linked_issues: [7] }), events: [],
+      snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 7 }] }), events: [],
     })
     try {
       const cfg: OrchestratorConfig = {
@@ -74,7 +74,7 @@ describe('GitHubPrsPlugin.runTick', () => {
       }
       const result = await new GitHubPrsPlugin('#proj').runTick(cfg, null)
       const state = result.state as { prs: Record<string, PrSnap> }
-      expect(state.prs['org/repo#25']?.linked_issues).toEqual([7])
+      expect(state.prs['org/repo#25']?.linked_issues).toEqual([{ repo: 'org/repo', number: 7 }])
       expect(result.channels).toContain('#proj-issue-7')
     } finally { spy.mockRestore() }
   })
@@ -119,10 +119,10 @@ describe('GitHubPrsPlugin.runTick', () => {
   it('emits now-watching to project channel when pr_added_to_watch has linked issues', async () => {
     const seedEv: OrchestratorEvent = {
       kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
-      linked_issues: [7, 14],
+      linked_issues: [{ repo: 'org/repo', number: 7 }, { repo: 'org/repo', number: 14 }],
     } as OrchestratorEvent
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
-      snap: fakePrSnap({ linked_issues: [7, 14] }), events: [seedEv],
+      snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 7 }, { repo: 'org/repo', number: 14 }] }), events: [seedEv],
     })
     try {
       const cfg: OrchestratorConfig = {
@@ -142,10 +142,10 @@ describe('GitHubPrsPlugin.runTick', () => {
   it('includes entry channels in now-watching routing list', async () => {
     const seedEv: OrchestratorEvent = {
       kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
-      linked_issues: [7],
+      linked_issues: [{ repo: 'org/repo', number: 7 }],
     } as OrchestratorEvent
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
-      snap: fakePrSnap({ linked_issues: [7] }), events: [seedEv],
+      snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 7 }] }), events: [seedEv],
     })
     try {
       const cfg: OrchestratorConfig = {
@@ -296,10 +296,10 @@ describe('multi-repo runTick — slug-aware channel routing', () => {
       repo: 'org/foo', pr: 25, url: 'u',
       author: 'a', body: 'x', body_preview: 'x', is_worker_reply: false,
       comment_id: 1, comment_url: 'cu',
-      linked_issues: [14],
+      linked_issues: [{ repo: 'org/foo', number: 14 }],
     } as OrchestratorEvent
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
-      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [14] }),
+      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [{ repo: 'org/foo', number: 14 }] }),
       events: [commentEv],
     })
     try {
@@ -352,6 +352,123 @@ describe('multi-repo runTick — slug-aware channel routing', () => {
       const result = await new GitHubIssuesPlugin('#proj').runTick(cfg, { issues: {} })
       expect(result.taggedEvents).toHaveLength(1)
       expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-50'])
+    } finally { spy.mockRestore() }
+  })
+})
+
+describe('GitHubPrsPlugin.runTick — cross-repo linked issues', () => {
+  it('multi-mode: PR in repoA closing issue in repoB routes to repoB slug', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/foo', pr: 25, url: 'u',
+      author: 'a', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'cu',
+      linked_issues: [{ repo: 'org/bar', number: 14 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [{ repo: 'org/bar', number: 14 }] }),
+      events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'github-prs': { watched: [{ number: 25, repo: 'org/foo' }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-bar-issue-14'])
+      expect(result.channels).toContain('#proj-bar-issue-14')
+    } finally { spy.mockRestore() }
+  })
+
+  it('multi-mode: PR with mixed same-repo + cross-repo linked issues routes to both slugged channels', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/foo', pr: 25, url: 'u',
+      author: 'a', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'cu',
+      linked_issues: [{ repo: 'org/bar', number: 14 }, { repo: 'org/foo', number: 7 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [{ repo: 'org/bar', number: 14 }, { repo: 'org/foo', number: 7 }] }),
+      events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'github-prs': { watched: [{ number: 25, repo: 'org/foo' }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#proj-bar-issue-14', '#proj-foo-issue-7'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('single-mode: foreign-repo linked issue is dropped from routing and logged to stderr', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/main', pr: 25, url: 'u',
+      author: 'a', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'cu',
+      linked_issues: [{ repo: 'org/other', number: 14 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', number: 25, linked_issues: [{ repo: 'org/other', number: 14 }] }),
+      events: [commentEv],
+    })
+    const logs: string[] = []
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/main',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj', (m) => { logs.push(m) }).runTick(cfg, { prs: {} })
+      // Foreign repo dropped → falls back to the PR's own issue channel.
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+      // The cross-repo channel must not appear in the desired-channel set.
+      expect(result.channels).not.toContain('#proj-issue-14')
+      // Operator-visible stderr warning naming both sides + the remediation.
+      const dropWarn = logs.find(l => l.includes('cross-repo closure not routed'))
+      expect(dropWarn).toContain('org/main#25')
+      expect(dropWarn).toContain('org/other#14')
+      expect(dropWarn).toContain('add org/other to config')
+    } finally { spy.mockRestore() }
+  })
+
+  it('single-mode: same-repo linked issue retained, foreign one dropped (mixed case)', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/main', pr: 25, url: 'u',
+      author: 'a', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'cu',
+      linked_issues: [{ repo: 'org/main', number: 7 }, { repo: 'org/other', number: 14 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', linked_issues: [{ repo: 'org/main', number: 7 }, { repo: 'org/other', number: 14 }] }),
+      events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/main',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      // Same-repo issue routes normally; cross-repo dropped.
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-7'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('multi-mode: snap.linked_issues populates the dispatcher channel set for cross-repo issues', async () => {
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [{ repo: 'org/bar', number: 14 }] }),
+      events: [],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'github-prs': { watched: [{ number: 25, repo: 'org/foo' }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.channels).toContain('#proj-bar-issue-14')
     } finally { spy.mockRestore() }
   })
 })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -471,6 +471,82 @@ describe('GitHubPrsPlugin.runTick — cross-repo linked issues', () => {
       expect(result.channels).toContain('#proj-bar-issue-14')
     } finally { spy.mockRestore() }
   })
+
+  it('multi-mode: pr_added_to_watch cross-repo routes the now-watching list through the linked-issue slug', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'pr_added_to_watch', repo: 'org/foo', pr: 25, url: 'u', title: 't',
+      linked_issues: [{ repo: 'org/bar', number: 14 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/foo', linked_issues: [{ repo: 'org/bar', number: 14 }] }),
+      events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'github-prs': { watched: [{ number: 25, repo: 'org/foo' }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'now watching PR org/foo#25 — routing events to #proj-bar-issue-14',
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('single-mode: stderr drop warning debounced by head_oid (no re-warn across same-head ticks)', async () => {
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', number: 25, head_oid: 'sha-A', linked_issues: [{ repo: 'org/other', number: 14 }] }),
+      events: [],
+    })
+    const logs: string[] = []
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/main',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const plugin = new GitHubPrsPlugin('#proj', (m) => { logs.push(m) })
+      // First tick: drops are new → one warning.
+      const r1 = await plugin.runTick(cfg, { prs: {} })
+      // Second tick with prev state: same head_oid → no re-warn.
+      await plugin.runTick(cfg, r1.state)
+      // Third tick: still same head_oid → still no re-warn.
+      await plugin.runTick(cfg, r1.state)
+      const drops = logs.filter(l => l.includes('cross-repo closure not routed'))
+      expect(drops).toHaveLength(1)
+    } finally { spy.mockRestore() }
+  })
+
+  it('single-mode: drop warning re-fires when head_oid changes (force-push alters closures)', async () => {
+    const logs: string[] = []
+    const plugin = new GitHubPrsPlugin('#proj', (m) => { logs.push(m) })
+    const cfg: OrchestratorConfig = {
+      project: 'proj', repo: 'org/main',
+      plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+    }
+    // Tick 1: head sha-A.
+    const spy1 = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', number: 25, head_oid: 'sha-A', linked_issues: [{ repo: 'org/other', number: 14 }] }),
+      events: [],
+    })
+    let prevState: unknown
+    try {
+      const r1 = await plugin.runTick(cfg, { prs: {} })
+      prevState = r1.state
+    } finally { spy1.mockRestore() }
+    // Tick 2: head sha-B (force-push), same dropped link.
+    const spy2 = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', number: 25, head_oid: 'sha-B', linked_issues: [{ repo: 'org/other', number: 14 }] }),
+      events: [],
+    })
+    try {
+      await plugin.runTick(cfg, prevState)
+    } finally { spy2.mockRestore() }
+    const drops = logs.filter(l => l.includes('cross-repo closure not routed'))
+    expect(drops).toHaveLength(2)
+  })
 })
 
 describe('GhBase.handleCommand — issues plugin (target=null)', () => {

--- a/src/orchestrator/plugins/github/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/scraper.test.ts
@@ -56,10 +56,10 @@ describe('computePrEvents — new watch entry (prevSnap = null)', () => {
   })
 
   it('includes linked_issues in seed event when present', () => {
-    const snap = basePrInternal({ linked_issues: [5, 6] })
+    const snap = basePrInternal({ linked_issues: [{ repo: 'org/repo', number: 5 }, { repo: 'org/repo', number: 6 }] })
     const { events } = computePrEvents(snap, null, new Set())
-    const ev = events.find(e => e.kind === 'pr_added_to_watch') as { linked_issues?: number[] } | undefined
-    expect(ev?.linked_issues).toEqual([5, 6])
+    const ev = events.find(e => e.kind === 'pr_added_to_watch') as { linked_issues?: Array<{ repo: string; number: number }> } | undefined
+    expect(ev?.linked_issues).toEqual([{ repo: 'org/repo', number: 5 }, { repo: 'org/repo', number: 6 }])
   })
 
   it('emits pr_has_existing_comments when review comments exist', () => {

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -1,4 +1,4 @@
-import type { PrSnap, IssueSnap } from './types.js'
+import type { PrSnap, IssueSnap, LinkedIssue } from './types.js'
 import type { PrSnapInternal, IssueSnapInternal } from './scraper.js'
 import type { GhComment, GhReview } from './github-api.js'
 
@@ -11,7 +11,7 @@ export interface BaseEvent {
   issue?: number
   url?: string
   title?: string
-  linked_issues?: number[]
+  linked_issues?: LinkedIssue[]
 }
 
 export interface LabelEvent extends BaseEvent {
@@ -129,7 +129,7 @@ export function formatCommentEvent(
     issue?: number
     url: string
     agentLogins?: Set<string>
-    linkedIssues?: number[]
+    linkedIssues?: LinkedIssue[]
   }
 ): CommentEvent {
   const author = c.user?.login

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -364,13 +364,17 @@ export class GhClient {
     return (await this.api(`repos/${repo}/pulls/${number}/reviews?per_page=100`, true) ?? []) as GhReview[]
   }
 
-  async fetchPrLinkedIssues(repo: string, number: number): Promise<number[]> {
+  // Returns `{repo, number}` per linked issue — `closingIssuesReferences` can
+  // cross repos (a PR in repo A closing an issue in repo B), so the repo is
+  // load-bearing for downstream channel routing. Sorted by `(repo, number)`
+  // for deterministic order.
+  async fetchPrLinkedIssues(repo: string, number: number): Promise<Array<{ repo: string; number: number }>> {
     const [owner, name] = repo.split('/', 2)
     const query = (
       'query($owner:String!,$name:String!,$number:Int!){' +
       'repository(owner:$owner,name:$name){' +
       'pullRequest(number:$number){' +
-      'closingIssuesReferences(first:25){nodes{number}}}}}'
+      'closingIssuesReferences(first:25){nodes{number,repository{nameWithOwner}}}}}}'
     )
     const result = await this.graphql(query, { owner, name, number })
     if (!result) return []
@@ -378,11 +382,11 @@ export class GhClient {
     const nodes = (
       ((r.data as Record<string, unknown> | undefined)?.repository as Record<string, unknown> | undefined)
         ?.pullRequest as Record<string, unknown> | undefined
-    )?.closingIssuesReferences as { nodes?: Array<{ number?: number }> } | undefined
+    )?.closingIssuesReferences as { nodes?: Array<{ number?: number; repository?: { nameWithOwner?: string } }> } | undefined
     return (nodes?.nodes ?? [])
-      .filter(n => n.number != null)
-      .map(n => n.number as number)
-      .sort((a, b) => a - b)
+      .filter(n => n.number != null && n.repository?.nameWithOwner)
+      .map(n => ({ repo: n.repository!.nameWithOwner as string, number: n.number as number }))
+      .sort((a, b) => a.repo === b.repo ? a.number - b.number : a.repo.localeCompare(b.repo))
   }
 
   async fetchIssue(repo: string, number: number): Promise<GhIssue> {

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -1,12 +1,12 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
-import { channelSlug, defaultProject, issueChannel, resolveProjectChannel } from '../../naming.js'
-import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
+import { channelSlug, defaultProject, isMultiRepo, issueChannel, resolveProjectChannel } from '../../naming.js'
+import type { PluginLogger, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
-import type { PrSnap, PrPluginState } from './types.js'
+import type { LinkedIssue, PrSnap, PrPluginState } from './types.js'
 
 export class GitHubPrsPlugin extends GhBase {
   readonly name = 'github-prs'
@@ -17,24 +17,62 @@ export class GitHubPrsPlugin extends GhBase {
     return this.entryChannels(config, this.watched(config))
   }
 
-  // Auto-detected channels for a PR event: linked-issue channels, project
-  // channel for no-linked-issues warnings, or PR's own issue channel as fallback.
-  // `slug` is the multi-repo slug (undefined in single-repo mode). Linked issues
-  // are assumed to live in the same repo as the PR — cross-repo closures
-  // (gh's `closingIssuesReferences` supports them) would route to a wrong-slug
-  // channel; flagged as a known footgun.
+  // Partition linked issues into those routable in the current mode (same-repo
+  // in single-mode; everything in multi-mode) and those dropped (foreign-repo
+  // in single-mode). Returning both halves lets the caller emit a stderr
+  // warning for drops without re-running the partition.
+  private static partitionLinked(
+    config: OrchestratorConfig,
+    prRepo: string,
+    linked: LinkedIssue[],
+  ): { routable: LinkedIssue[]; dropped: LinkedIssue[] } {
+    if (isMultiRepo(config)) return { routable: linked, dropped: [] }
+    const routable: LinkedIssue[] = []
+    const dropped: LinkedIssue[] = []
+    for (const li of linked) {
+      if (li.repo === prRepo) routable.push(li)
+      else dropped.push(li)
+    }
+    return { routable, dropped }
+  }
+
+  // Auto-detected channels for a PR event: linked-issue channels (slugged per
+  // each linked issue's own repo — closures can cross repos), project channel
+  // for no-linked-issues warnings, or PR's own issue channel as fallback.
+  // In single-repo mode, cross-repo linked issues are dropped here (the
+  // caller has already logged a stderr warning for them).
   private static prEventChannels(
+    config: OrchestratorConfig,
     project: string,
     event: OrchestratorEvent,
     projectChannel: string,
-    slug: string | undefined,
+    prRepo: string,
   ): string[] {
     if (event.pr == null) return []
     if (event.kind === 'pr_no_linked_issues') return [projectChannel]
     const linked = event.linked_issues ?? []
-    return linked.length
-      ? linked.map(n => issueChannel(project, n, slug))
-      : [issueChannel(project, event.pr, slug)]
+    const { routable } = GitHubPrsPlugin.partitionLinked(config, prRepo, linked)
+    if (routable.length) {
+      return routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo)))
+    }
+    return [issueChannel(project, event.pr, channelSlug(config, prRepo))]
+  }
+
+  // Emit a stderr warning for each cross-repo linked issue dropped in
+  // single-repo mode. Operator-visible (the dispatcher log) without IRC noise.
+  private static logDroppedLinked(
+    log: PluginLogger,
+    prRepo: string,
+    prNumber: number,
+    dropped: LinkedIssue[],
+  ): void {
+    for (const li of dropped) {
+      log(
+        `[github-prs] PR ${prRepo}#${prNumber} closes ${li.repo}#${li.number} ` +
+        `but dispatcher is single-mode on ${prRepo}; cross-repo closure not routed. ` +
+        `add ${li.repo} to config or switch to multi-repo mode.\n`
+      )
+    }
   }
 
   async runTick(
@@ -66,7 +104,10 @@ export class GitHubPrsPlugin extends GhBase {
     const taggedEvents: TaggedEvent[] = []
     for (const { key, snap, events, entryChannels } of scraped) {
       curState.prs[key] = snap
-      const slug = channelSlug(config, snap.repo)
+      // Log dropped cross-repo links once per scrape (not per event) — the
+      // surfacing is operator-facing, not per-IRC-message.
+      const { dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
+      GitHubPrsPlugin.logDroppedLinked(this.log, snap.repo, snap.number, dropped)
       for (const event of events) {
         if (event.kind === 'pr_added_to_watch') {
           const linked = event.linked_issues ?? []
@@ -74,7 +115,7 @@ export class GitHubPrsPlugin extends GhBase {
           // with the clearer "events won't be routed" message on the same tick.
           if (linked.length) {
             const routingChannels = this.resolveChannels(
-              GitHubPrsPlugin.prEventChannels(project, event, projectChannel, slug),
+              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo),
               entryChannels
             ).filter(ch => ch !== projectChannel)
             taggedEvents.push({
@@ -86,19 +127,20 @@ export class GitHubPrsPlugin extends GhBase {
         }
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(project, event, projectChannel, slug), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo), entryChannels),
           payload: formatPayload(event),
         })
       }
     }
 
     // Comprehensive channel set: static (config) + dynamic (linked-issues
-    // discovered during scrape). Slug each linked-issue channel against the
-    // PR's own repo — same-repo assumption as prEventChannels.
+    // discovered during scrape). Slug each linked-issue channel against its
+    // *own* repo — `closingIssuesReferences` crosses repos, so the PR's slug
+    // is not the right answer.
     const channels = new Set<string>(this.desiredChannels(config))
     for (const snap of Object.values(curState.prs)) {
-      const slug = channelSlug(config, snap.repo)
-      for (const n of snap.linked_issues ?? []) channels.add(issueChannel(project, n, slug))
+      const { routable } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
+      for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
     }
 
     taggedEvents.push(...await this.observeRateLimit(projectChannel))

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -19,8 +19,8 @@ export class GitHubPrsPlugin extends GhBase {
 
   // Partition linked issues into those routable in the current mode (same-repo
   // in single-mode; everything in multi-mode) and those dropped (foreign-repo
-  // in single-mode). Returning both halves lets the caller emit a stderr
-  // warning for drops without re-running the partition.
+  // in single-mode). Called once per scraped PR per tick — the result is
+  // threaded through every routing decision so the partition stays cheap.
   private static partitionLinked(
     config: OrchestratorConfig,
     prRepo: string,
@@ -39,19 +39,17 @@ export class GitHubPrsPlugin extends GhBase {
   // Auto-detected channels for a PR event: linked-issue channels (slugged per
   // each linked issue's own repo — closures can cross repos), project channel
   // for no-linked-issues warnings, or PR's own issue channel as fallback.
-  // In single-repo mode, cross-repo linked issues are dropped here (the
-  // caller has already logged a stderr warning for them).
+  // `routable` is pre-computed by `partitionLinked` once per scrape.
   private static prEventChannels(
     config: OrchestratorConfig,
     project: string,
     event: OrchestratorEvent,
     projectChannel: string,
     prRepo: string,
+    routable: LinkedIssue[],
   ): string[] {
     if (event.pr == null) return []
     if (event.kind === 'pr_no_linked_issues') return [projectChannel]
-    const linked = event.linked_issues ?? []
-    const { routable } = GitHubPrsPlugin.partitionLinked(config, prRepo, linked)
     if (routable.length) {
       return routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo)))
     }
@@ -102,12 +100,28 @@ export class GitHubPrsPlugin extends GhBase {
 
     const curState: PrPluginState = { prs: {} }
     const taggedEvents: TaggedEvent[] = []
+    // Comprehensive channel set: static (config) + dynamic (linked-issues
+    // discovered during scrape). Slug each linked-issue channel against its
+    // *own* repo — `closingIssuesReferences` crosses repos, so the PR's slug
+    // is not the right answer.
+    const channels = new Set<string>(this.desiredChannels(config))
     for (const { key, snap, events, entryChannels } of scraped) {
       curState.prs[key] = snap
-      // Log dropped cross-repo links once per scrape (not per event) — the
-      // surfacing is operator-facing, not per-IRC-message.
-      const { dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
-      GitHubPrsPlugin.logDroppedLinked(this.log, snap.repo, snap.number, dropped)
+      // Partition once per scrape — both halves are reused: `routable` for
+      // every event's channel-resolution + the dispatcher channel set,
+      // `dropped` for the stderr warning.
+      const { routable, dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
+      for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+      // Debounced cross-repo drop warning: emit at most once per head_oid.
+      // `closingIssuesReferences` is re-fetched on head_oid change (see
+      // scraper.ts), so a force-push that alters closures re-triggers.
+      const prevWarnedOid = prev?.prs[key]?.warned_drops_for_oid ?? null
+      if (dropped.length) {
+        if (prevWarnedOid !== snap.head_oid) {
+          GitHubPrsPlugin.logDroppedLinked(this.log, snap.repo, snap.number, dropped)
+        }
+        snap.warned_drops_for_oid = snap.head_oid
+      }
       for (const event of events) {
         if (event.kind === 'pr_added_to_watch') {
           const linked = event.linked_issues ?? []
@@ -115,7 +129,7 @@ export class GitHubPrsPlugin extends GhBase {
           // with the clearer "events won't be routed" message on the same tick.
           if (linked.length) {
             const routingChannels = this.resolveChannels(
-              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo),
+              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable),
               entryChannels
             ).filter(ch => ch !== projectChannel)
             taggedEvents.push({
@@ -127,20 +141,10 @@ export class GitHubPrsPlugin extends GhBase {
         }
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable), entryChannels),
           payload: formatPayload(event),
         })
       }
-    }
-
-    // Comprehensive channel set: static (config) + dynamic (linked-issues
-    // discovered during scrape). Slug each linked-issue channel against its
-    // *own* repo — `closingIssuesReferences` crosses repos, so the PR's slug
-    // is not the right answer.
-    const channels = new Set<string>(this.desiredChannels(config))
-    for (const snap of Object.values(curState.prs)) {
-      const { routable } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
-      for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
     }
 
     taggedEvents.push(...await this.observeRateLimit(projectChannel))

--- a/src/orchestrator/plugins/github/types.ts
+++ b/src/orchestrator/plugins/github/types.ts
@@ -27,6 +27,11 @@ export interface PrSnap {
   // Absent in old snapshots (pre-upgrade) — !undefined is true, so upgrade
   // path warns on first tick without any special handling.
   warned_no_linked?: boolean
+  // Mute key for cross-repo drop stderr warnings: the head_oid we last
+  // warned about. Mirrors `warned_no_linked` but keyed on head_oid because
+  // closing references are re-fetched on head_oid change (see scraper.ts),
+  // so a force-push that changes closures should re-trigger the warning.
+  warned_drops_for_oid?: string | null
 }
 
 export interface IssueSnap {

--- a/src/orchestrator/plugins/github/types.ts
+++ b/src/orchestrator/plugins/github/types.ts
@@ -1,3 +1,11 @@
+// A linked issue closure — `closingIssuesReferences` can cross repos, so each
+// entry carries its own repo. Routing slugs the channel per linked issue's
+// repo, not the PR's repo.
+export interface LinkedIssue {
+  repo: string
+  number: number
+}
+
 export interface PrSnap {
   repo: string
   number: number
@@ -10,7 +18,7 @@ export interface PrSnap {
   state: string | null
   labels: string[]
   ci_state: string | null
-  linked_issues: number[]
+  linked_issues: LinkedIssue[]
   seen_review_comment_ids: number[]
   seen_conversation_comment_ids: number[]
   seen_review_ids: number[]


### PR DESCRIPTION
Closes #449

## Summary

- `closingIssuesReferences` can cross repos. PR in repo A closing issue in repo B was routing to `#<project>-<slugA>-issue-N` (multi-mode) or colliding with home-repo issue N (single-mode).
- Track linked issues as `{repo, number}` end-to-end; slug each linked-issue channel against its own repo.
- Single-mode: foreign-repo linked issues are dropped from routing and logged to stderr with the remediation. No IRC noise.
- Schema bump 3→4 forces a one-time re-seed.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 666 pass / 0 fail
- [x] new tests cover: multi-mode cross-repo routing, multi-mode mixed (same+cross), single-mode foreign drop + stderr warning, single-mode mixed, channel-set discovery for cross-repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)