### PR TITLE
document --ask-irc/--ask-target in lead/APM spawn surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,6 +176,8 @@ instance from durable artifacts. Sequence:
 ```bash
 roost spawn productops-simplifyrewards \
   -c '#leads-simplifyrewards,#issue-718,#issue-721,#issue-693' \
+  --steer-compact --cache-ttl 1h \
+  --ask-irc '#leads-simplifyrewards' --ask-target <answerer> \
   --prompt-file /tmp/handoff-2026-04-28.md
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,7 +177,7 @@ instance from durable artifacts. Sequence:
 roost spawn productops-simplifyrewards \
   -c '#leads-simplifyrewards,#issue-718,#issue-721,#issue-693' \
   --steer-compact --cache-ttl 1h \
-  --ask-irc '#leads-simplifyrewards' --ask-target <answerer> \
+  --ask-irc '#leads-simplifyrewards' --ask-target <your-nick> \
   --prompt-file /tmp/handoff-2026-04-28.md
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The PreCompact hook (`bin/roost-compact-hook`) is opt-in via `--steer-compact` a
 
 ## Agent class heuristic
 
-The role→flag heuristic for `--cache-ttl` and `--steer-compact` lives in the "Agent class guidance" block of `bin/roost`'s `spawn --help` output — that's the canonical source. Agent prompts (`agents/lead-pm.md`, `agents/associate-pm.md`), the roost skill, and `docs/LEARNINGS.md` §9 all point at it. Edit the `bin/roost` block if the trade-offs shift; the pointers don't need to move. Shipped artifacts (agent prompts, the skill) deliberately don't carry "edit here" instructions — they install into projects that aren't roost, where operators don't own the heuristic.
+The role→flag heuristic for `--cache-ttl`, `--steer-compact`, and `--ask-irc` lives in the "Agent class guidance" block of `bin/roost`'s `spawn --help` output — that's the canonical source. Agent prompts (`agents/lead-pm.md`, `agents/associate-pm.md`), the roost skill, and `docs/LEARNINGS.md` §9 all point at it. Edit the `bin/roost` block if the trade-offs shift; the pointers don't need to move. Shipped artifacts (agent prompts, the skill) deliberately don't carry "edit here" instructions — they install into projects that aren't roost, where operators don't own the heuristic.
 
 ## Comments
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ roost spawn myproject-lead-pm \
   --agent lead-pm \
   --channels '#myproject-leads' \
   --steer-compact --cache-ttl 1h \
+  --ask-irc '#myproject-leads' --ask-target <your-nick> \
   --prompt 'milestone=<milestone> human=<your-nick> gh-login=<your-gh-login>'
 ```
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -54,7 +54,8 @@ Spawn the associate-pm (APM). It owns the rote setup/teardown — starting the d
 ```bash
 roost spawn <project>-apm --agent associate-pm --cache-ttl 1h --steer-compact --channels '#<project>-leads' \
   --prompt 'human=<human> gh-login=<gh-login>' \
-  --perm-irc --perm-target <project>-lead-pm
+  --perm-irc --perm-target <project>-lead-pm \
+  --ask-irc '#<project>-leads' --ask-target <project>-lead-pm
 ```
 
 Pass the same `<human>` / `<gh-login>` values you parsed from your own initial prompt. If the prompt is missing them the APM will ask in `#<project>-leads` as a one-shot rescue.

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -62,7 +62,7 @@ Pass the same `<human>` / `<gh-login>` values you parsed from your own initial p
 
 (`roost spawn` errors out if you pass `--model` alongside `--agent`; see `roost spawn --help`.) On boot the APM will start the dispatcher daemon if it isn't already running, then post a hello in `#<project>-leads`. If the hello doesn't arrive within a minute, check the APM session.
 
-See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — what to pass with `--cache-ttl` and `--steer-compact` for each agent class.
+See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — what to pass with `--cache-ttl`, `--steer-compact`, and `--ask-irc` for each agent class.
 
 ## Working In Channels
 

--- a/bin/roost
+++ b/bin/roost
@@ -184,16 +184,22 @@ Options:
                              Use for --chrome, --system-prompt, etc.
 
 Agent class guidance:
-  Pick --cache-ttl and --steer-compact by session lifetime and cache
-  reuse. 1h cache writes cost 2x the 5m rate, so reach for 1h only when
+  Pick --cache-ttl, --steer-compact, and --ask-irc by session lifetime,
+  cache reuse, and whether AskUserQuestion calls should route via IRC.
+  1h cache writes cost 2x the 5m rate, so reach for 1h only when
   the session genuinely idles past 5 minutes. --steer-compact preserves
   runtime state across auto-compact; long-running agents need it,
   short-lived ones don't (auto-compact rarely fires in their lifetime).
+  --ask-irc routes AskUserQuestion calls to a channel instead of blocking
+  the terminal; pair with --ask-target (the nick whose replies count).
 
   PM agents (lead-pm, associate-pm) — long-running, idle through review
   loops and message-relay timescales that blow past 5m; runtime state
-  would be lost across a directive-less auto-compact:
-    --steer-compact --cache-ttl 1h
+  would be lost across a directive-less auto-compact; AskUserQuestion
+  should route via IRC so a blocked question surfaces in the leads channel
+  instead of freezing the terminal:
+    --steer-compact --cache-ttl 1h \
+    --ask-irc '#<project>-leads' --ask-target <answerer>
   Workers — multi-turn through reviewer + human review cycles that
   routinely exceed 5 minutes, so \`--cache-ttl 1h\`. But short-lived
   enough that auto-compact rarely fires, so no \`--steer-compact\`:

--- a/bin/roost
+++ b/bin/roost
@@ -125,10 +125,11 @@ Options:
                              mode. Lifecycle = MCP lifecycle.
   --perm-target NICK         Operator nick to DM for permission prompts.
                              Required when --perm-irc is set.
-  --ask-irc CHANNEL          Proxy AskUserQuestion calls over IRC. Posts
-                             questions to CHANNEL and waits for a reply from
-                             --ask-target (or --perm-target). Enables permbot
-                             if not already started by --perm-irc.
+  --ask-irc CHANNEL          Routes AskUserQuestion calls to a channel
+                             instead of blocking the terminal; pair with
+                             --ask-target (the nick whose replies count).
+                             Enables permbot if not already started by
+                             --perm-irc.
   --ask-target NICK          Nick whose replies count for AskUserQuestion.
                              Defaults to --perm-target when both are set.
                              Required when --ask-irc is set without --perm-target.

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -33,7 +33,8 @@ roost spawn <nick> [-c CHANS] [-m MODEL] [-s SESSION] [--mcp-config PATH] \
                    [--cwd PATH] [--prompt PROMPT] \
                    [--permission-mode MODE] [--cache-ttl 5m|1h] \
                    [--steer-compact] \
-                   [--perm-irc --perm-target NICK]
+                   [--perm-irc --perm-target NICK] \
+                   [--ask-irc CHANNEL --ask-target NICK]
 roost shutdown <nick>
 roost list
 roost attach <nick>
@@ -122,6 +123,23 @@ cat "$dir/permbot.log"
 ```
 
 The data dir is also printed by `roost spawn` as "data dir: ...".
+
+## AskUserQuestion routing (--ask-irc)
+
+Routes AskUserQuestion calls to a channel instead of blocking the terminal; pair with --ask-target (the nick whose replies count).
+
+```bash
+# Lead-pm routes questions to the leads channel (human answers):
+roost spawn myproject-lead-pm --agent lead-pm \
+  --ask-irc '#myproject-leads' --ask-target <your-nick>
+
+# APM routes questions to the leads channel (lead-pm answers):
+roost spawn myproject-apm --agent associate-pm \
+  --ask-irc '#myproject-leads' --ask-target myproject-lead-pm
+```
+
+`--ask-target` defaults to `--perm-target` when both are set. See
+`roost spawn --help` ("Agent class guidance") for the full role→flag heuristic.
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #465

Flags existed but weren't mentioned where operators look when spawning lead-pm or APM. Two real-world blocking incidents traced to this gap.

5 surfaces updated (doc-only, no code):
- `bin/roost` "Agent class guidance": expand intro to cover `--ask-irc`; add flag to PM-agent recommended set with context on why
- `agents/lead-pm.md` Getting-started: add `--ask-irc`/`--ask-target` to APM spawn command
- `skills/roost/SKILL.md`: add flag to command synopsis; new AskUserQuestion routing section with examples
- `README.md`: add `--ask-irc`/`--ask-target` to quickstart lead-pm spawn
- `ARCHITECTURE.md`: add `--steer-compact`/`--cache-ttl`/`--ask-irc` to PM-class respawn example (§#419 scan hit)

Per §#422: canonical explanation sentence used verbatim in `bin/roost` guidance block and `SKILL.md` section.