### PR TITLE
debounce PreCompact inject via atomic mkdir lock

### DIFF
--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -23,6 +23,12 @@ set -u
 # summary it produces (not verbatim retention).
 DIRECTIVE='retain: agent role and IRC nick; channels currently joined; in-flight GitHub issue and PR numbers and the state of each (worker spawned, draft, reviewed, merged), each worker'"'"'s nick (<project>-worker-<issue-number>), and each reviewer'"'"'s nick (<project>-reviewer-<PR-number>); recently-completed issues (post-merge, pre-cleanup) with their worker and reviewer nicks; recent decisions, design pivots, and blockers from the project leads channel; pending work the agent committed to or is waiting on'
 
+# Debounce TTL in minutes. Must be > observed max compact duration (~1m48s)
+# to prevent re-inject while a prior /compact is still running. Trade-off:
+# if the agent dies mid-compact, PostCompact never fires and the stale lock
+# delays the next legit compact by up to this many minutes.
+LOCK_TTL_MIN=3
+
 log() { echo "roost-compact-hook: $*" >&2; }
 
 input="$(cat)"
@@ -74,6 +80,27 @@ if [ "$trigger" = "auto" ] && [ -n "$nick" ]; then
     session_name="roost-${nick}"
   fi
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_name" 2>/dev/null; then
+    # Debounce: if a prior inject is still in flight, return block without
+    # re-injecting. Uses mkdir as an atomic lock — mkdir is POSIX-atomic, so
+    # two concurrent invocations can't both claim the lock.
+    if [ -n "${ROOST_DATA_DIR:-}" ]; then
+      lock_dir="${ROOST_DATA_DIR}/compact-inject.lock.d"
+      if [ -d "$lock_dir" ]; then
+        if [ -n "$(find "$lock_dir" -maxdepth 0 -mmin -${LOCK_TTL_MIN} -type d 2>/dev/null)" ]; then
+          log "auto-trigger: inject in flight (lock fresh), debouncing"
+          printf '%s\n' '{"decision":"block","reason":"roost: compact inject in flight, debouncing re-inject"}'
+          exit 0
+        fi
+        # Stale lock — prior session likely died before PostCompact fired.
+        rm -rf "$lock_dir" 2>/dev/null || true
+      fi
+      if ! mkdir "$lock_dir" 2>/dev/null; then
+        # Race: a concurrent invocation just claimed the lock.
+        log "auto-trigger: lock claimed by concurrent invocation, debouncing"
+        printf '%s\n' '{"decision":"block","reason":"roost: compact inject in flight, debouncing re-inject"}'
+        exit 0
+      fi
+    fi
     # Background subshell: claude code reads our {"decision":"block"} on
     # stdout and unwinds its own auto-compact state machine; we want our
     # send-keys to land after that settles, not race it. 150ms is the

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -100,6 +100,7 @@ if [ "$trigger" = "auto" ] && [ -n "$nick" ]; then
         printf '%s\n' '{"decision":"block","reason":"roost: compact inject in flight, debouncing re-inject"}'
         exit 0
       fi
+      log "auto-trigger: lock claimed, injecting /compact"
     fi
     # Background subshell: claude code reads our {"decision":"block"} on
     # stdout and unwinds its own auto-compact state machine; we want our

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -24,4 +24,6 @@ if kill -USR2 "$pid" 2>/dev/null; then
 else
   echo "roost-post-compact-hook: kill -USR2 $pid failed (no such process?)" >&2
 fi
+rm -rf "${ROOST_DATA_DIR}/compact-inject.lock.d" 2>/dev/null || true
+echo "roost-post-compact-hook: cleared compact-inject.lock.d" >&2
 exit 0

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -7,6 +7,12 @@ if [ -z "$ROOST_DATA_DIR" ]; then
   echo "roost-post-compact-hook: ROOST_DATA_DIR not set, skipping" >&2
   exit 0
 fi
+# Clear the debounce lock regardless of SIGUSR2 path success — lock cleanup
+# is independent of whether the MCP pid is present or reachable.
+if [ -d "${ROOST_DATA_DIR}/compact-inject.lock.d" ]; then
+  rm -rf "${ROOST_DATA_DIR}/compact-inject.lock.d" 2>/dev/null || true
+  echo "roost-post-compact-hook: cleared compact-inject.lock.d" >&2
+fi
 pid_file="$ROOST_DATA_DIR/mcp.pid"
 if [ ! -f "$pid_file" ]; then
   echo "roost-post-compact-hook: $pid_file not found, skipping" >&2
@@ -24,6 +30,4 @@ if kill -USR2 "$pid" 2>/dev/null; then
 else
   echo "roost-post-compact-hook: kill -USR2 $pid failed (no such process?)" >&2
 fi
-rm -rf "${ROOST_DATA_DIR}/compact-inject.lock.d" 2>/dev/null || true
-echo "roost-post-compact-hook: cleared compact-inject.lock.d" >&2
 exit 0

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -579,6 +579,16 @@ the pass-through SIGUSR1 path inherited from the prior hook. No
 TypeScript, no env-var knobs, no polling, no fired-flag reset state
 machine.
 
+**Debounce required for long milestones (added in fix/precompact-debounce).**
+Context pressure can re-trigger PreCompact multiple times before the
+injected `/compact` drains — observed 24+ queued lines in the pane,
+agent hung. Fix: atomic mkdir lock (`${ROOST_DATA_DIR}/compact-inject.lock.d`).
+`LOCK_TTL_MIN=3` (in `bin/roost-compact-hook`) is the knob — must stay
+above observed compact duration (~1m48s). If this regresses (agent hung
+with `compact-inject.lock.d` fresh and stale), raise `LOCK_TTL_MIN`.
+Trade-off: dead sessions leave stale locks that block re-inject for up
+to TTL minutes; PostCompact normally clears them.
+
 **Operational footgun surfaced during the v3 rebase (2026-05-17):**
 GitHub stopped firing CI on this PR after the v2 push. Root cause:
 the branch became `mergeable=CONFLICTING` against main once #374/

--- a/test/compact-hook_test.sh
+++ b/test/compact-hook_test.sh
@@ -213,7 +213,22 @@ else
 fi
 teardown_tmpdir
 
-# -- Test 9: concurrent invocations — only one inject fires -------------------
+# -- Test 9: PostCompact clears lock even when mcp.pid is missing -------------
+# Lock cleanup must run regardless of the SIGUSR2 path's success.
+
+setup_tmpdir
+mkdir "$TDIR/compact-inject.lock.d"
+# no mcp.pid written — simulates MCP died between PreCompact and PostCompact
+env -i ROOST_DATA_DIR="$TDIR" "$POST_HOOK" >/dev/null 2>/dev/null
+
+if [ ! -d "$TDIR/compact-inject.lock.d" ]; then
+  ok "post-compact: lock cleared even when mcp.pid is missing"
+else
+  fail "post-compact: lock cleared even when mcp.pid is missing" "lock still exists"
+fi
+teardown_tmpdir
+
+# -- Test 10: concurrent invocations — only one inject fires ------------------
 # mkdir is POSIX-atomic: two simultaneous hook invocations can't both claim
 # the lock. Exactly one should inject; the other should debounce.
 

--- a/test/compact-hook_test.sh
+++ b/test/compact-hook_test.sh
@@ -153,6 +153,87 @@ else
 fi
 teardown_tmpdir
 
+# -- Test 6: fresh lock → debounce (block returned, no tmux inject) -----------
+
+setup_tmpdir
+mkdir "$TDIR/compact-inject.lock.d"
+input='{"trigger":"auto","custom_instructions":null}'
+out="$(printf '%s' "$input" | env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$HOOK" 2>"$TDIR/err")"
+exit_code=$?
+sleep 0.5
+
+if [ "$exit_code" -eq 0 ] \
+    && echo "$out" | grep -q '"decision":"block"' \
+    && ! grep -q "load-buffer" "$TRACE" 2>/dev/null; then
+  ok "debounce: fresh lock → block without inject"
+else
+  fail "debounce: fresh lock → block without inject" "exit=$exit_code out=$out trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
+# -- Test 7: stale lock → inject fires, lock refreshed -----------------------
+# Simulate a stale lock by setting its mtime to epoch (1970-01-01).
+
+setup_tmpdir
+mkdir "$TDIR/compact-inject.lock.d"
+touch -t 197001010000.00 "$TDIR/compact-inject.lock.d"
+input='{"trigger":"auto","custom_instructions":null}'
+out="$(printf '%s' "$input" | env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$HOOK" 2>"$TDIR/err")"
+exit_code=$?
+sleep 0.5
+
+if [ "$exit_code" -eq 0 ] \
+    && echo "$out" | grep -q '"decision":"block"' \
+    && grep -q "load-buffer" "$TRACE" 2>/dev/null \
+    && [ -d "$TDIR/compact-inject.lock.d" ]; then
+  ok "debounce: stale lock → inject fires, lock re-claimed"
+else
+  fail "debounce: stale lock → inject fires, lock re-claimed" "exit=$exit_code out=$out trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
+# -- Test 8: PostCompact hook clears the lock dir -----------------------------
+
+POST_HOOK="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/bin/roost-post-compact-hook"
+
+setup_tmpdir
+mkdir "$TDIR/compact-inject.lock.d"
+perl -e '$SIG{USR2} = sub { exit 0 }; sleep 5' &
+victim_pid=$!
+sleep 0.1
+echo "$victim_pid" > "$TDIR/mcp.pid"
+env -i ROOST_DATA_DIR="$TDIR" "$POST_HOOK" >/dev/null 2>/dev/null
+kill "$victim_pid" 2>/dev/null || true
+wait 2>/dev/null || true
+
+if [ ! -d "$TDIR/compact-inject.lock.d" ]; then
+  ok "post-compact: lock dir cleared after compact"
+else
+  fail "post-compact: lock dir cleared after compact" "lock still exists"
+fi
+teardown_tmpdir
+
+# -- Test 9: concurrent invocations — only one inject fires -------------------
+# mkdir is POSIX-atomic: two simultaneous hook invocations can't both claim
+# the lock. Exactly one should inject; the other should debounce.
+
+setup_tmpdir
+input='{"trigger":"auto","custom_instructions":null}'
+printf '%s' "$input" | env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$HOOK" >/dev/null 2>/dev/null &
+pid1=$!
+printf '%s' "$input" | env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$HOOK" >/dev/null 2>/dev/null &
+pid2=$!
+wait $pid1 $pid2
+sleep 0.5
+
+inject_count=$(grep -c "load-buffer" "$TRACE" 2>/dev/null || echo 0)
+if [ "$inject_count" -eq 1 ]; then
+  ok "concurrent: exactly one inject (mkdir atomicity)"
+else
+  fail "concurrent: exactly one inject (mkdir atomicity)" "inject_count=$inject_count trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #470

`roost-compact-hook` re-injects `/compact <directive>` on every `trigger=auto` fire, and context pressure can keep triggering it while a prior inject is still queued. This stacks 24+ identical `/compact` lines in the pane and hangs the agent.

Fix: atomic mkdir lock at `${ROOST_DATA_DIR}/compact-inject.lock.d`. First auto-trigger claims it and injects; subsequent fires within 3 min return block without re-injecting. PostCompact clears the lock. TTL=3 min covers the observed ~1m48s compact duration with margin; stale locks (dead session) self-expire.

10 tests, all green — including debounce, stale-lock re-inject, PostCompact cleanup, and concurrent-invocation atomicity.