### PR TITLE
inject channel-verify directive from PostCompact hook

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -773,13 +773,12 @@ cmd_spawn() {
     prompt_file="${ROOST_DATA_DIR}/prompt.txt"
     printf '%s' "${prompt_text}" > "${prompt_file}"
   fi
-  if [ "${steer_compact}" -eq 1 ]; then
-    # Tell the PreCompact hook which tmux session to inject into. Without
-    # this the hook would have to guess from ROOST_IRC_NICK + the default
-    # ${SESSION_PREFIX}${nick} convention — and would silently miss when
-    # the operator passed -s/--session NAME with a non-default name.
-    printf '%s' "${session_name}" > "${ROOST_DATA_DIR}/session-name.txt"
-  fi
+  # Tell compact hooks which tmux session to inject into. Without this they
+  # would have to guess from ROOST_IRC_NICK + the ${SESSION_PREFIX}${nick}
+  # convention — and would silently miss when the operator passes -s/--session
+  # NAME with a non-default name. Written unconditionally: PostCompact is
+  # always wired and reads this file too.
+  printf '%s' "${session_name}" > "${ROOST_DATA_DIR}/session-name.txt"
   # Per-session roost-settings.json. Written before the tmux/ircd preflight
   # so test seams can read it on preflight failure. PostCompact + SessionStart
   # matcher=compact are always wired; PreCompact is opt-in via --steer-compact;

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -5,6 +5,12 @@
 #
 # Wired by bin/roost at spawn time via roost-settings.json. Never exits
 # non-zero — a hook failure must not block compaction.
+
+# Directive injected into the agent's tmux pane after compaction. One place
+# to edit — references PreCompact's "channels currently joined" retain hint
+# so the agent knows what to compare against.
+DIRECTIVE='call channel_list to confirm your channel membership matches the "channels currently joined" section of the compact summary; rejoin any that are missing'
+
 if [ -z "$ROOST_DATA_DIR" ]; then
   echo "roost-post-compact-hook: ROOST_DATA_DIR not set, skipping" >&2
   exit 0
@@ -45,10 +51,11 @@ if [ -n "$nick" ]; then
   fi
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_name" 2>/dev/null; then
     (
+      # Small buffer for the SIGUSR2-triggered MCP replay to start delivering
+      # before the directive fires — agent should see backfilled context first.
       sleep 0.15
       buf="roost-post-compact-${nick}-$$"
-      printf 'call channel_list to confirm your channel membership matches the compact summary; rejoin any that are missing' \
-        | tmux load-buffer -b "$buf" -
+      printf '%s' "$DIRECTIVE" | tmux load-buffer -b "$buf" -
       tmux paste-buffer -t "$session_name" -b "$buf" -p
       tmux send-keys -t "$session_name" Enter
       tmux delete-buffer -b "$buf" 2>/dev/null || true

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -1,5 +1,7 @@
 #!/bin/sh
-# PostCompact hook — signal MCP to replay missed messages (SIGUSR2).
+# PostCompact hook — two jobs after compaction returns:
+# 1. signal MCP to replay missed messages (SIGUSR2)
+# 2. inject a channel-membership verification directive into the tmux pane
 #
 # Wired by bin/roost at spawn time via roost-settings.json. Never exits
 # non-zero — a hook failure must not block compaction.
@@ -15,19 +17,43 @@ if [ -d "${ROOST_DATA_DIR}/compact-inject.lock.d" ]; then
 fi
 pid_file="$ROOST_DATA_DIR/mcp.pid"
 if [ ! -f "$pid_file" ]; then
-  echo "roost-post-compact-hook: $pid_file not found, skipping" >&2
-  exit 0
-fi
-pid=$(cat "$pid_file")
-case "$pid" in
-  ''|*[!0-9]*)
-    echo "roost-post-compact-hook: malformed pid in $pid_file: '$pid', skipping" >&2
-    exit 0
-    ;;
-esac
-if kill -USR2 "$pid" 2>/dev/null; then
-  echo "roost-post-compact-hook: sent SIGUSR2 to MCP pid $pid" >&2
+  echo "roost-post-compact-hook: $pid_file not found, skipping SIGUSR2" >&2
 else
-  echo "roost-post-compact-hook: kill -USR2 $pid failed (no such process?)" >&2
+  pid=$(cat "$pid_file")
+  case "$pid" in
+    ''|*[!0-9]*)
+      echo "roost-post-compact-hook: malformed pid in $pid_file: '$pid', skipping SIGUSR2" >&2
+      ;;
+    *)
+      if kill -USR2 "$pid" 2>/dev/null; then
+        echo "roost-post-compact-hook: sent SIGUSR2 to MCP pid $pid" >&2
+      else
+        echo "roost-post-compact-hook: kill -USR2 $pid failed (no such process?)" >&2
+      fi
+      ;;
+  esac
+fi
+# Inject channel-membership verification directive if the tmux session is reachable.
+# Buffer name uses $$ to avoid collisions if two PostCompact hooks overlap.
+nick="${ROOST_IRC_NICK:-}"
+if [ -n "$nick" ]; then
+  session_file="${ROOST_DATA_DIR}/session-name.txt"
+  if [ -s "$session_file" ]; then
+    session_name="$(cat "$session_file")"
+  else
+    session_name="roost-${nick}"
+  fi
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_name" 2>/dev/null; then
+    (
+      sleep 0.15
+      buf="roost-post-compact-${nick}-$$"
+      printf 'call channel_list to confirm your channel membership matches the compact summary; rejoin any that are missing' \
+        | tmux load-buffer -b "$buf" -
+      tmux paste-buffer -t "$session_name" -b "$buf" -p
+      tmux send-keys -t "$session_name" Enter
+      tmux delete-buffer -b "$buf" 2>/dev/null || true
+    ) &
+    echo "roost-post-compact-hook: queued channel-verify directive for $session_name" >&2
+  fi
 fi
 exit 0

--- a/test/compact-hook_test.sh
+++ b/test/compact-hook_test.sh
@@ -277,6 +277,42 @@ else
 fi
 teardown_tmpdir
 
+# -- Test 12: PostCompact inject fires even when mcp.pid is missing -----------
+# Proves the tmux inject path is decoupled from the SIGUSR2 path.
+
+setup_tmpdir
+# no mcp.pid written — SIGUSR2 skipped but inject should still fire
+env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$POST_HOOK" >/dev/null 2>/dev/null
+sleep 0.5
+
+if [ -s "$TRACE" ] \
+    && grep -q "load-buffer" "$TRACE" \
+    && grep -qF 'channel_list' "$TRACE"; then
+  ok "post-compact: inject fires independently of mcp.pid"
+else
+  fail "post-compact: inject fires independently of mcp.pid" "trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
+# -- Test 13: ROOST_IRC_NICK unset → no tmux call ----------------------------
+
+setup_tmpdir
+perl -e '$SIG{USR2} = sub { exit 0 }; sleep 5' &
+victim_pid=$!
+sleep 0.1
+echo "$victim_pid" > "$TDIR/mcp.pid"
+env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" "$POST_HOOK" >/dev/null 2>/dev/null
+sleep 0.5
+kill "$victim_pid" 2>/dev/null || true
+wait 2>/dev/null || true
+
+if ! grep -q "load-buffer" "$TRACE" 2>/dev/null; then
+  ok "post-compact: ROOST_IRC_NICK unset → no tmux inject"
+else
+  fail "post-compact: ROOST_IRC_NICK unset → no tmux inject" "trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/test/compact-hook_test.sh
+++ b/test/compact-hook_test.sh
@@ -249,6 +249,34 @@ else
 fi
 teardown_tmpdir
 
+# -- Test 11: PostCompact injects channel-verify directive via tmux ------------
+# When ROOST_IRC_NICK is set and tmux session is live, the hook should
+# background a load-buffer/paste-buffer/send-keys chain carrying the
+# channel_list verification directive.
+
+setup_tmpdir
+perl -e '$SIG{USR2} = sub { exit 0 }; sleep 5' &
+victim_pid=$!
+sleep 0.1
+echo "$victim_pid" > "$TDIR/mcp.pid"
+env -i PATH="$MOCK:$PATH" ROOST_DATA_DIR="$TDIR" ROOST_IRC_NICK="testnick" "$POST_HOOK" >/dev/null 2>/dev/null
+sleep 0.5
+kill "$victim_pid" 2>/dev/null || true
+wait 2>/dev/null || true
+
+if [ -s "$TRACE" ] \
+    && grep -q "has-session" "$TRACE" \
+    && grep -q "load-buffer" "$TRACE" \
+    && grep -q "paste-buffer" "$TRACE" \
+    && grep -q "send-keys.*Enter" "$TRACE" \
+    && grep -qF 'channel_list' "$TRACE" \
+    && grep -qF 'rejoin' "$TRACE"; then
+  ok "post-compact: channel-verify directive injected via tmux"
+else
+  fail "post-compact: channel-verify directive injected via tmux" "trace=$(cat "$TRACE" 2>/dev/null)"
+fi
+teardown_tmpdir
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -361,8 +361,9 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
-# -- Test 20: no --steer-compact → no PreCompact entry, no session-name.txt --
+# -- Test 20: no --steer-compact → no PreCompact entry; session-name.txt written
 # Default behavior: claude code's native auto-compact runs unmodified.
+# session-name.txt is written unconditionally (PostCompact reads it too).
 
 setup
 out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
@@ -371,10 +372,10 @@ if [ -n "$data_dir" ] \
     && [ -f "$data_dir/roost-settings.json" ] \
     && ! grep -qF '"PreCompact"' "$data_dir/roost-settings.json" \
     && ! grep -qF 'roost-compact-hook' "$data_dir/roost-settings.json" \
-    && [ ! -f "$data_dir/session-name.txt" ]; then
-  ok "no flag: PreCompact omitted from settings, no session-name.txt"
+    && [ -f "$data_dir/session-name.txt" ]; then
+  ok "no flag: PreCompact omitted from settings, session-name.txt written"
 else
-  fail "no flag: PreCompact omitted from settings, no session-name.txt" "data_dir=$data_dir settings=$(cat "$data_dir/roost-settings.json" 2>/dev/null)"
+  fail "no flag: PreCompact omitted from settings, session-name.txt written" "data_dir=$data_dir settings=$(cat "$data_dir/roost-settings.json" 2>/dev/null)"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown


### PR DESCRIPTION
Closes #472

Extends `bin/roost-post-compact-hook` with a tmux inject step that fires after compaction. Same load-buffer/paste-buffer/send-keys pattern as PreCompact. Directive:

> call channel_list to confirm your channel membership matches the compact summary; rejoin any that are missing

The pid-file early-exits are restructured into if/else blocks so the tmux inject runs independently of SIGUSR2 success (they're orthogonal operations).

Adds test 11 to `compact-hook_test.sh` covering the new inject path. All 12 tests pass; shellcheck + lint + typecheck clean.