### PR TITLE
maint: bump version to 0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump package.json 0.6.4 → 0.6.5 for the v0.6.5 release.

Since v0.6.4:
- Multi-repo orchestrator support: cross-repo PR closure routing (#449/#462), github-new-issues plugin (#464), config.json/config.local.json split (#450/#452)
- Nick/channel disambiguation with `<project>-<slug>-` prefix support (#434/#433)
- PreCompact hook debounce via atomic mkdir lock — fixes 24+ stacked inject loop (#470/#471)
- PostCompact hook: channel-verify directive inject after compaction (#472/#474)
- APM/lead-pm spawn help text improvements (#447/#448/#465)