### PR TITLE
maint: extract roost-tmux-inject buffer-chain helper

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -1080,11 +1080,7 @@ cmd_send() {
     echo "no tmux session named '${session_name}'" >&2
     exit 4
   fi
-  local buf="roost-send-${nick}-$$"
-  printf '%s' "${message}" | tmux load-buffer -b "${buf}" -
-  tmux paste-buffer -t "${session_name}" -b "${buf}" -p
-  tmux send-keys -t "${session_name}" Enter
-  tmux delete-buffer -b "${buf}" 2>/dev/null || true
+  printf '%s' "${message}" | "${ROOST_DIR}/bin/roost-tmux-inject" "${session_name}" "roost-send-${nick}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -106,20 +106,8 @@ if [ "$trigger" = "auto" ] && [ -n "$nick" ]; then
     # stdout and unwinds its own auto-compact state machine; we want our
     # send-keys to land after that settles, not race it. 150ms is the
     # smallest sleep that consistently avoids partial /compact buffers
-    # under load. Buffer name uses $$ (this hook process's pid — distinct
-    # per invocation; a subshell inherits its parent's $$ in POSIX sh) to
-    # avoid collisions across concurrent compacts. The load-buffer /
-    # paste-buffer -p / send-keys Enter / delete-buffer sequence mirrors
-    # `cmd_send` in bin/roost — keep them in sync if either grows e.g.
-    # better multi-line handling.
-    (
-      sleep 0.15
-      buf="roost-compact-${nick}-$$"
-      printf '/compact %s' "$DIRECTIVE" | tmux load-buffer -b "$buf" -
-      tmux paste-buffer -t "$session_name" -b "$buf" -p
-      tmux send-keys -t "$session_name" Enter
-      tmux delete-buffer -b "$buf" 2>/dev/null || true
-    ) &
+    # under load.
+    (sleep 0.15; printf '/compact %s' "$DIRECTIVE" | "$(dirname "$0")/roost-tmux-inject" "$session_name" "roost-compact-${nick}") &
     log "auto-trigger intercepted; queued /compact <directive> for $session_name"
     printf '%s\n' '{"decision":"block","reason":"roost: redirecting auto-compact to manual /compact with custom_instructions"}'
     exit 0

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -40,7 +40,6 @@ else
   esac
 fi
 # Inject channel-membership verification directive if the tmux session is reachable.
-# Buffer name uses $$ to avoid collisions if two PostCompact hooks overlap.
 nick="${ROOST_IRC_NICK:-}"
 if [ -n "$nick" ]; then
   session_file="${ROOST_DATA_DIR}/session-name.txt"
@@ -50,16 +49,9 @@ if [ -n "$nick" ]; then
     session_name="roost-${nick}"
   fi
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_name" 2>/dev/null; then
-    (
-      # Small buffer for the SIGUSR2-triggered MCP replay to start delivering
-      # before the directive fires — agent should see backfilled context first.
-      sleep 0.15
-      buf="roost-post-compact-${nick}-$$"
-      printf '%s' "$DIRECTIVE" | tmux load-buffer -b "$buf" -
-      tmux paste-buffer -t "$session_name" -b "$buf" -p
-      tmux send-keys -t "$session_name" Enter
-      tmux delete-buffer -b "$buf" 2>/dev/null || true
-    ) &
+    # Small buffer for the SIGUSR2-triggered MCP replay to start delivering
+    # before the directive fires — agent should see backfilled context first.
+    (sleep 0.15; printf '%s' "$DIRECTIVE" | "$(dirname "$0")/roost-tmux-inject" "$session_name" "roost-post-compact-${nick}") &
     echo "roost-post-compact-hook: queued channel-verify directive for $session_name" >&2
   fi
 fi

--- a/bin/roost-tmux-inject
+++ b/bin/roost-tmux-inject
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Inject stdin text into a tmux pane via the load-buffer/paste-buffer/send-keys/delete-buffer chain.
 # Usage: printf 'text' | roost-tmux-inject <session> <buf-name-prefix>
+: "${1:?roost-tmux-inject: session name required}" "${2:?roost-tmux-inject: buf-name-prefix required}"
 buf="${2}-$$"
 tmux load-buffer -b "$buf" -
 tmux paste-buffer -t "$1" -b "$buf" -p

--- a/bin/roost-tmux-inject
+++ b/bin/roost-tmux-inject
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Inject stdin text into a tmux pane via the load-buffer/paste-buffer/send-keys/delete-buffer chain.
+# Usage: printf 'text' | roost-tmux-inject <session> <buf-name-prefix>
+buf="${2}-$$"
+tmux load-buffer -b "$buf" -
+tmux paste-buffer -t "$1" -b "$buf" -p
+tmux send-keys -t "$1" Enter
+tmux delete-buffer -b "$buf" 2>/dev/null || true


### PR DESCRIPTION
Closes #475

Extracts the repeated load-buffer/paste-buffer/send-keys/delete-buffer chain into `bin/roost-tmux-inject`. Three callers had near-identical copies; one even carried a "keep in sync with cmd_send" comment.

**Interface:** `printf 'text' | roost-tmux-inject <session> <buf-prefix>` — appends `-$$` to the prefix for per-invocation uniqueness.

**Sleep wrapper** stays at each hook callsite — the 150ms delay is hook-specific semantics (let Claude Code unwind before send-keys lands / let MCP replay start), not part of the chain.

**Tests:** existing `test/compact-hook_test.sh` passes unchanged — mock tmux is on PATH and `roost-tmux-inject` inherits it. shellcheck auto-discovers the new script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)