### PR TITLE
feat: standardize lock primitives into library helpers

### DIFF
--- a/bin/_lock-lib.sh
+++ b/bin/_lock-lib.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+# _lock-lib.sh — source this; do not execute directly.
+#
+# Sentinel lock primitives (mkdir-based). For the full two-flavor rationale
+# (sentinel vs data-bearing O_EXCL) see src/fs-lock.ts.
+#
+# acquire_dir_lock <dir>       — atomic mkdir; 0 on win, non-zero on EEXIST
+# release_dir_lock <dir>       — rm -rf the dir; idempotent
+# dir_lock_fresh <dir> <ttl>  — true if dir is younger than <ttl> minutes
+
+acquire_dir_lock() {
+  mkdir "$1" 2>/dev/null
+}
+
+release_dir_lock() {
+  rm -rf "$1" 2>/dev/null || true
+}
+
+# Returns 0 (true) if the lock dir exists and its mtime is within the last
+# <ttl_minutes> minutes. Returns 1 if stale or absent.
+dir_lock_fresh() {
+  [ -n "$(find "$1" -maxdepth 0 -mmin -"$2" -type d 2>/dev/null)" ]
+}

--- a/bin/_lock-lib.sh
+++ b/bin/_lock-lib.sh
@@ -12,6 +12,10 @@ acquire_dir_lock() {
   mkdir "$1" 2>/dev/null
 }
 
+# Uses rm -rf for robustness. Sentinel lock dirs must stay empty — nothing
+# should ever write into them. If something does, rm -rf silently removes it
+# rather than surfacing the invariant break; add explicit checks at the call
+# site if you need that guard.
 release_dir_lock() {
   rm -rf "$1" 2>/dev/null || true
 }

--- a/bin/roost-compact-hook
+++ b/bin/roost-compact-hook
@@ -16,6 +16,8 @@
 # hook failure must not block compaction (the {"decision":"block"} we DO
 # emit in case 1 is the explicit signal).
 set -u
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/_lock-lib.sh"
 
 # Generic compaction directive for the roost agent set. One place to edit
 # if we ever tune it. Single-line, semicolon-separated — passed as the
@@ -80,21 +82,19 @@ if [ "$trigger" = "auto" ] && [ -n "$nick" ]; then
     session_name="roost-${nick}"
   fi
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_name" 2>/dev/null; then
-    # Debounce: if a prior inject is still in flight, return block without
-    # re-injecting. Uses mkdir as an atomic lock — mkdir is POSIX-atomic, so
-    # two concurrent invocations can't both claim the lock.
+    # Debounce: if a prior inject is still in flight, block without re-injecting.
     if [ -n "${ROOST_DATA_DIR:-}" ]; then
       lock_dir="${ROOST_DATA_DIR}/compact-inject.lock.d"
       if [ -d "$lock_dir" ]; then
-        if [ -n "$(find "$lock_dir" -maxdepth 0 -mmin -${LOCK_TTL_MIN} -type d 2>/dev/null)" ]; then
+        if dir_lock_fresh "$lock_dir" "$LOCK_TTL_MIN"; then
           log "auto-trigger: inject in flight (lock fresh), debouncing"
           printf '%s\n' '{"decision":"block","reason":"roost: compact inject in flight, debouncing re-inject"}'
           exit 0
         fi
         # Stale lock — prior session likely died before PostCompact fired.
-        rm -rf "$lock_dir" 2>/dev/null || true
+        release_dir_lock "$lock_dir"
       fi
-      if ! mkdir "$lock_dir" 2>/dev/null; then
+      if ! acquire_dir_lock "$lock_dir"; then
         # Race: a concurrent invocation just claimed the lock.
         log "auto-trigger: lock claimed by concurrent invocation, debouncing"
         printf '%s\n' '{"decision":"block","reason":"roost: compact inject in flight, debouncing re-inject"}'

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -11,16 +11,16 @@
 # so the agent knows what to compare against.
 DIRECTIVE='call channel_list to confirm your channel membership matches the "channels currently joined" section of the compact summary; rejoin any that are missing'
 
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/_lock-lib.sh"
+
 if [ -z "$ROOST_DATA_DIR" ]; then
   echo "roost-post-compact-hook: ROOST_DATA_DIR not set, skipping" >&2
   exit 0
 fi
 # Clear the debounce lock regardless of SIGUSR2 path success — lock cleanup
 # is independent of whether the MCP pid is present or reachable.
-if [ -d "${ROOST_DATA_DIR}/compact-inject.lock.d" ]; then
-  rm -rf "${ROOST_DATA_DIR}/compact-inject.lock.d" 2>/dev/null || true
-  echo "roost-post-compact-hook: cleared compact-inject.lock.d" >&2
-fi
+release_dir_lock "${ROOST_DATA_DIR}/compact-inject.lock.d"
 pid_file="$ROOST_DATA_DIR/mcp.pid"
 if [ ! -f "$pid_file" ]; then
   echo "roost-post-compact-hook: $pid_file not found, skipping SIGUSR2" >&2

--- a/bin/roost-post-compact-hook
+++ b/bin/roost-post-compact-hook
@@ -20,7 +20,9 @@ if [ -z "$ROOST_DATA_DIR" ]; then
 fi
 # Clear the debounce lock regardless of SIGUSR2 path success — lock cleanup
 # is independent of whether the MCP pid is present or reachable.
-release_dir_lock "${ROOST_DATA_DIR}/compact-inject.lock.d"
+_lock_dir="${ROOST_DATA_DIR}/compact-inject.lock.d"
+[ -d "$_lock_dir" ] && echo "roost-post-compact-hook: cleared compact-inject.lock.d" >&2
+release_dir_lock "$_lock_dir"
 pid_file="$ROOST_DATA_DIR/mcp.pid"
 if [ ! -f "$pid_file" ]; then
   echo "roost-post-compact-hook: $pid_file not found, skipping SIGUSR2" >&2

--- a/bin/start-dispatcher
+++ b/bin/start-dispatcher
@@ -37,6 +37,8 @@ LOCK_DIR="$CONFIG_DIR/.dispatcher.start.lock"
 
 # shellcheck disable=SC1091
 source "$DIR/_dispatcher-pid-lib.sh"
+# shellcheck disable=SC1091
+source "$DIR/_lock-lib.sh"
 
 mkdir -p "$CONFIG_DIR"
 
@@ -76,10 +78,9 @@ spawn_daemon() {
 }
 
 acquire_lock_and_run() {
-  # `mkdir` is POSIX-atomic — winner gets the lock, losers see EEXIST.
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
+  if acquire_dir_lock "$LOCK_DIR"; then
     # shellcheck disable=SC2064
-    trap "rmdir '$LOCK_DIR' 2>/dev/null || true" EXIT
+    trap "release_dir_lock '$LOCK_DIR'" EXIT
     if pid_file_is_live; then
       report_running
       return 0
@@ -117,7 +118,7 @@ fi
 # Stale lock recovery: no PID file appeared and no live dispatcher. The lock
 # holder crashed before writing. Forcibly clear the lock and retry once.
 echo "start-dispatcher: stale lock at $LOCK_DIR, recovering" >&2
-rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+release_dir_lock "$LOCK_DIR"
 if acquire_lock_and_run; then
   exit 0
 fi

--- a/src/fs-lock.ts
+++ b/src/fs-lock.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs'
+import { writeFile, readFile } from 'node:fs/promises'
+
+// Atomic exclusive-create primitives for two lock flavors used in this project:
+//
+// Sentinel locks (mkdir-based, shell-only) — the lock has no content; existence
+// == "held". Used when you just need mutual exclusion with no data to store.
+// See bin/_lock-lib.sh for the shell API; it points here for the full rationale.
+//
+// Data-bearing locks (O_EXCL writeFile, this module) — the lock file carries
+// content (a PID record, a session ID). O_EXCL / `wx` makes the create atomic:
+// exactly one writer wins; all others see EEXIST.
+//
+// Neither flavor uses advisory file locking (flock/lockf) — those require
+// persistent open fds and break across process restarts. Sentinel and O_EXCL
+// are both crash-safe: the file either exists or it doesn't, independent of
+// who holds a fd.
+
+export type ExclusiveCreateResult = { created: true } | { created: false; existing: string }
+
+// Atomic exclusive create. Returns { created: true } if this caller created the
+// file, { created: false, existing } if the file already existed (EEXIST).
+// Does not mkdir the parent dir — caller is responsible. Does not retry or
+// remove stale files — callers handle domain semantics (liveness checks, etc).
+// Throws on any error other than EEXIST.
+export async function exclusiveCreate(
+  path: string,
+  content: string,
+  options?: { mode?: number },
+): Promise<ExclusiveCreateResult> {
+  try {
+    await writeFile(path, content, { flag: 'wx', mode: options?.mode })
+    return { created: true }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e
+    const existing = await readFile(path, 'utf8')
+    return { created: false, existing }
+  }
+}
+
+// Sync variant for callers that can't await (e.g. MCP startup in irc-server.ts).
+export function exclusiveCreateSync(
+  path: string,
+  content: string,
+  options?: { mode?: number },
+): ExclusiveCreateResult {
+  try {
+    fs.writeFileSync(path, content, { flag: 'wx', mode: options?.mode })
+    return { created: true }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e
+    const existing = fs.readFileSync(path, 'utf8')
+    return { created: false, existing }
+  }
+}

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -2,6 +2,7 @@ import { mkdir, rename, unlink, writeFile, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import { exclusiveCreate } from '../fs-lock.js'
 
 const execFileP = promisify(execFile)
 
@@ -262,8 +263,7 @@ export async function readDispatcherPid(stateDir: string): Promise<DispatcherPid
   return info
 }
 
-// O_EXCL via `wx` — node:fs/promises rather than Bun.write because the latter
-// has no exclusive-create flag. Stale file (no live owner) → unlink and retry once.
+// Stale file (no live owner) → unlink and retry once.
 export async function writeDispatcherPid(stateDir: string): Promise<DispatcherPidInfo> {
   await mkdir(stateDir, { recursive: true })
   const path = join(stateDir, DISPATCHER_PID_FILE)
@@ -273,17 +273,15 @@ export async function writeDispatcherPid(stateDir: string): Promise<DispatcherPi
     cmdline: [process.execPath, ...process.argv.slice(1)].join(' '),
   }
   const payload = JSON.stringify(info) + '\n'
-  try {
-    await writeFile(path, payload, { flag: 'wx' })
-    return info
-  } catch {
+  const result = await exclusiveCreate(path, payload)
+  if (!result.created) {
     const existing = await readDispatcherPid(stateDir)
     if (existing) throw new Error(`dispatcher already running (pid ${existing.pid})`)
     // Stale file with no live owner — remove and try once more.
     try { await unlink(path) } catch { /* race with another cleaner */ }
     await writeFile(path, payload, { flag: 'wx' })
-    return info
   }
+  return info
 }
 
 export async function removeDispatcherPid(stateDir: string): Promise<void> {

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename, unlink, writeFile, readFile } from 'node:fs/promises'
+import { mkdir, rename, unlink, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
@@ -279,7 +279,12 @@ export async function writeDispatcherPid(stateDir: string): Promise<DispatcherPi
     if (existing) throw new Error(`dispatcher already running (pid ${existing.pid})`)
     // Stale file with no live owner — remove and try once more.
     try { await unlink(path) } catch { /* race with another cleaner */ }
-    await writeFile(path, payload, { flag: 'wx' })
+    const retry = await exclusiveCreate(path, payload)
+    if (!retry.created) {
+      // Lost retry race — a concurrent dispatcher just claimed this dir.
+      const winner = await readDispatcherPid(stateDir)
+      if (winner) throw new Error(`dispatcher already running (pid ${winner.pid})`)
+    }
   }
   return info
 }

--- a/src/owner-gate.ts
+++ b/src/owner-gate.ts
@@ -8,6 +8,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { exclusiveCreateSync } from './fs-lock.js'
 
 export type Ownership = 'owner' | 'passive'
 
@@ -25,14 +26,9 @@ const FILE = 'owner.session'
 // dirs via `roost spawn`, so this is a known edge, not a recurring bug.
 export function claimOwnership(dataDir: string, sessionId: string): Ownership {
   const p = path.join(dataDir, FILE)
-  try {
-    fs.writeFileSync(p, sessionId, { flag: 'wx', mode: 0o600 })
-    return 'owner'
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e
-    const existing = fs.readFileSync(p, 'utf8').trim()
-    return existing === sessionId ? 'owner' : 'passive'
-  }
+  const result = exclusiveCreateSync(p, sessionId, { mode: 0o600 })
+  if (result.created) return 'owner'
+  return result.existing.trim() === sessionId ? 'owner' : 'passive'
 }
 
 // Read-only check — used by the permission-prompt hook. Returns 'no-gate'

--- a/test/fs-lock.test.ts
+++ b/test/fs-lock.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { statSync } from 'node:fs'
+import { exclusiveCreate, exclusiveCreateSync } from '../src/fs-lock.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'fs-lock-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('exclusiveCreate', () => {
+  it('creates the file and returns created:true when absent', async () => {
+    const p = join(dir, 'test.lock')
+    const result = await exclusiveCreate(p, 'hello')
+    expect(result.created).toBe(true)
+  })
+
+  it('returns created:false with existing content on EEXIST', async () => {
+    const p = join(dir, 'test.lock')
+    await exclusiveCreate(p, 'first')
+    const result = await exclusiveCreate(p, 'second')
+    expect(result.created).toBe(false)
+    if (!result.created) expect(result.existing).toBe('first')
+  })
+
+  it('does not overwrite the file on EEXIST', async () => {
+    const p = join(dir, 'test.lock')
+    await exclusiveCreate(p, 'original')
+    await exclusiveCreate(p, 'intruder')
+    const second = await exclusiveCreate(p, 'check')
+    expect(second.created).toBe(false)
+    if (!second.created) expect(second.existing).toBe('original')
+  })
+
+  it('applies the mode option', async () => {
+    const p = join(dir, 'test.lock')
+    await exclusiveCreate(p, 'x', { mode: 0o600 })
+    const mode = statSync(p).mode & 0o777
+    // Mask with 0o600 — umask may restrict further but won't add bits.
+    expect(mode & ~0o600).toBe(0)
+  })
+
+  it('throws on non-EEXIST errors (parent dir absent)', async () => {
+    const p = join(dir, 'nonexistent', 'test.lock')
+    await expect(exclusiveCreate(p, 'x')).rejects.toThrow()
+  })
+})
+
+describe('exclusiveCreateSync', () => {
+  it('creates the file and returns created:true when absent', () => {
+    const p = join(dir, 'test.lock')
+    const result = exclusiveCreateSync(p, 'hello')
+    expect(result.created).toBe(true)
+  })
+
+  it('returns created:false with existing content on EEXIST', () => {
+    const p = join(dir, 'test.lock')
+    exclusiveCreateSync(p, 'first')
+    const result = exclusiveCreateSync(p, 'second')
+    expect(result.created).toBe(false)
+    if (!result.created) expect(result.existing).toBe('first')
+  })
+
+  it('does not overwrite the file on EEXIST', () => {
+    const p = join(dir, 'test.lock')
+    exclusiveCreateSync(p, 'original')
+    exclusiveCreateSync(p, 'intruder')
+    const second = exclusiveCreateSync(p, 'check')
+    expect(second.created).toBe(false)
+    if (!second.created) expect(second.existing).toBe('original')
+  })
+
+  it('applies the mode option', () => {
+    const p = join(dir, 'test.lock')
+    exclusiveCreateSync(p, 'x', { mode: 0o600 })
+    const mode = statSync(p).mode & 0o777
+    expect(mode & ~0o600).toBe(0)
+  })
+
+  it('throws on non-EEXIST errors (parent dir absent)', () => {
+    const p = join(dir, 'nonexistent', 'test.lock')
+    expect(() => exclusiveCreateSync(p, 'x')).toThrow()
+  })
+})


### PR DESCRIPTION
Closes #473

Two new helpers, one per language, covering all four lock sites.

**Why two APIs instead of one:** the four sites split cleanly by language — shell scripts can't import TypeScript. Collapsing into a single cross-language abstraction would be over-engineered. "Single helper API" means one per language, not four ad-hoc patterns.

## TypeScript: `src/fs-lock.ts`

`exclusiveCreate` / `exclusiveCreateSync` — wraps O_EXCL `writeFile(wx)` / `writeFileSync(wx)`. Returns `{ created: true } | { created: false; existing: string }`. Callers retain domain semantics. Module-level JSDoc explains the sentinel vs data-bearing split (canonical home per §#422).

Sites migrated:
- `src/orchestrator/config.ts:writeDispatcherPid` — initial wx attempt via `exclusiveCreate`; liveness check + stale-unlink-retry stays in place
- `src/owner-gate.ts:claimOwnership` — 3 lines now instead of try/catch block

## Shell: `bin/_lock-lib.sh`

`acquire_dir_lock` / `release_dir_lock` / `dir_lock_fresh` — wraps `mkdir` / `rm -rf` / `find -mmin`. Header points to `src/fs-lock.ts` for rationale. POSIX sh compatible; shellcheck-clean.

Sites migrated:
- `bin/start-dispatcher` — `acquire_dir_lock` / `release_dir_lock` at the startup mutex
- `bin/roost-compact-hook` — replaces inline mkdir/find/rm with the three functions
- `bin/roost-post-compact-hook` — `release_dir_lock` for lock-clear step

## Tests

`test/fs-lock.test.ts` — 10 tests covering create/EEXIST/mode/error paths for both sync and async. All existing shell tests pass unchanged.