### PR TITLE
feat(orchestrator): invert DM parsing into plugins; add grammarPriority

### DIFF
--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -157,8 +157,13 @@ SIGTERM, waits up to 30s (`STOP_TIMEOUT=<seconds>` overrides). No SIGKILL escala
 ## DM grammar
 
 The dispatcher accepts a small grammar via DM from nicks in
-`irc.command_senders` (defaults to lead-pm + APM). Plugins claim target
-keywords; the parser is target-agnostic.
+`irc.command_senders` (defaults to lead-pm + APM). Plugins own their watch/
+unwatch shapes — the dispatcher only parses `help` / `watch list` centrally
+and hands every other line to plugins in `grammarPriority` order. Operators
+override the priority via `config.plugin_priorities: {<name>: <number>}`
+(higher wins, replaces the plugin's static value). See `docs/PLUGINS.md` for
+the plugin-author view; the canonical seam contract is the `Plugin.parseCommand`
+JSDoc.
 
 ```
 watch [<target>] <N> [<owner>/<repo>] [#chan ...]      # github-prs, github-issues

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -32,9 +32,44 @@ import {
 | `name` | Slot key for both slices. Must match the string passed to `registerPlugin`. |
 | `desiredChannels(config)` | Channels to join at boot. The orchestrator adds the project channel. |
 | `runTick(config, prevState)` | Returns `{ state, taggedEvents, channels }`. `prevState === null` on a seed tick. `channels` is the post-scrape set. |
-| `handleCommand?(config, cmd)` | Optional. Returns a reply when this plugin owns the command, `null` otherwise. Return `"error: ..."` on failure. Don't throw. |
+| `parseCommand?(line)` | Optional. Claim a single watch/unwatch DM line. See "DM grammar" below. |
+| `grammarPriority?` | Optional. Higher = parsed first when two plugins overlap. Default 0. Operator override: `config.plugin_priorities[name]` replaces this outright. |
+| `handleCommand?(merged, local, cmd)` | Optional. Receives `list`/`help` broadcasts + any command this plugin's own `parseCommand` claimed. Returns a reply or `null`. Return `"error: ..."` on failure. Don't throw. |
 
 The dispatcher writes each `TaggedEvent` to every channel in `event.channels`. Event kind strings are yours.
+
+## DM grammar
+
+The dispatcher knows only two global verbs (`help`, `watch list`) and an allowlist. Everything else — `watch <N>`, `watch pr 5`, `watch repo org/r@main`, your own `watch deploy …` — is parsed by the plugin that claims the shape. The canonical semantics live on `Plugin.parseCommand` in `src/orchestrator/plugin.ts` (defer with `null`, claim with `{kind:'ok',cmd}`, fail with `{kind:'error',message}`).
+
+Shared parser helpers cover the two shipped shapes:
+
+```ts
+import { tryClaimPerN, tryClaimPerRepo } from 'roost/plugin'
+
+class MyPlugin extends BasePlugin {
+  readonly name = 'acme-deploy'
+  parseCommand(line: string) {
+    // Claims `watch deploy <N>` / `unwatch deploy <N>`.
+    return tryClaimPerN('deploy', line)
+  }
+  handleCommand(merged, local, cmd) {
+    if (cmd.kind === 'list') return `${this.name}: …`
+    if (cmd.kind === 'help') return `${this.name}: …`
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as { verb: 'watch'|'unwatch'; number: number; repo: string|null; channels: string[] }
+      // …
+    }
+    return null
+  }
+}
+```
+
+When two plugins want overlapping shapes (e.g. a linear plugin claiming bare `watch <N>` alongside `github-issues`), pick a `grammarPriority` (higher wins) or let the operator set `config.plugin_priorities`. Once a plugin returns `{kind:'error'}`, no other plugin gets a second crack at that line — the producing plugin's parser is the authority on its shape.
+
+### Migration from pre-0.7.0
+
+Plugins that used to receive every `Command` via `handleCommand` (the central parser model) need to add a `parseCommand` to claim what they want. `handleCommand` now only fires for `list`, `help`, and the plugin's own claimed commands. There are no built-in `watch`/`unwatch`/`watch-repo`/`unwatch-repo` Command kinds anymore; the dispatcher wraps claimed payloads as `{kind:'plugin', plugin:<name>, cmd:<your shape>}`.
 
 ## Register on load
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -12,7 +12,7 @@ import {
   type HandlerDeps,
 } from '../dispatcher-dm-handler.js'
 import { loadConfig, loadConfigBase, loadLocalOverlay, writeConfig, type OrchestratorConfig } from '../config.js'
-import type { Plugin, PluginTickResult } from '../plugin.js'
+import type { ParseResult, Plugin, PluginTickResult } from '../plugin.js'
 
 let dir: string
 
@@ -34,219 +34,162 @@ describe('splitCommands', () => {
   })
 })
 
-describe('parseCommand', () => {
-  it('parses bare watch as target=null', () => {
-    expect(parseCommand('watch 5')).toEqual({ kind: 'watch', target: null, number: 5, repo: null, channels: [] })
-  })
-
-  it('parses watch with channels', () => {
-    expect(parseCommand('watch 5 #foo #bar')).toEqual({
-      kind: 'watch', target: null, number: 5, repo: null, channels: ['#foo', '#bar'],
+// A minimal Plugin that claims a target keyword via a per-N parser. Records
+// every handleCommand call so tests can assert routing precisely.
+class StubPlugin implements Plugin {
+  readonly name: string
+  readonly grammarPriority?: number
+  readonly handled: Array<{ cmd: Command; mergedSnapshot: OrchestratorConfig; localSnapshot: OrchestratorConfig }> = []
+  constructor(
+    name: string,
+    private readonly target: string | null,
+    private readonly behavior?: (cmd: Command, merged: OrchestratorConfig, local: OrchestratorConfig) => string | null,
+    grammarPriority?: number,
+  ) {
+    this.name = name
+    this.grammarPriority = grammarPriority
+  }
+  desiredChannels(): string[] { return [] }
+  async runTick(): Promise<PluginTickResult> {
+    return { state: null, taggedEvents: [], channels: [] }
+  }
+  parseCommand(line: string): ParseResult | null {
+    const tokens = line.split(/\s+/).filter(Boolean)
+    const verb = tokens[0]?.toLowerCase()
+    if (verb !== 'watch' && verb !== 'unwatch') return null
+    let i = 1
+    if (this.target !== null) {
+      if (tokens[i]?.toLowerCase() !== this.target) return null
+      i++
+    } else if (tokens[i] !== undefined && !/^\d+$/.test(tokens[i])) {
+      return null
+    }
+    const numTok = tokens[i]
+    if (numTok === undefined || !/^\d+$/.test(numTok)) return null
+    const number = parseInt(numTok, 10)
+    const channels = tokens.slice(i + 1).filter(t => t.startsWith('#'))
+    if (tokens.slice(i + 1).some(t => !t.startsWith('#'))) {
+      return { kind: 'error', message: 'channels must match channel sigil' }
+    }
+    return { kind: 'ok', cmd: { verb, number, channels } }
+  }
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    this.handled.push({
+      cmd,
+      mergedSnapshot: JSON.parse(JSON.stringify(merged)) as OrchestratorConfig,
+      localSnapshot: JSON.parse(JSON.stringify(local)) as OrchestratorConfig,
     })
-  })
+    if (this.behavior) return this.behavior(cmd, merged, local)
+    if (cmd.kind === 'list') return `${this.name}: list-section`
+    if (cmd.kind === 'help') return `${this.name}: help-section`
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as { verb: 'watch' | 'unwatch'; number: number }
+      if (c.verb === 'watch') {
+        local.plugins ??= {}
+        local.plugins[this.name] = { watched: c.number }
+        return `${this.name}: watched ${c.number}`
+      }
+      return `${this.name}: unwatched ${c.number}`
+    }
+    return null
+  }
+}
 
-  it('parses unwatch with target=null', () => {
-    expect(parseCommand('unwatch 5')).toEqual({ kind: 'unwatch', target: null, number: 5, repo: null })
-  })
-
-  it('parses target keyword from any non-numeric first token', () => {
-    expect(parseCommand('watch pr 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] })
-    expect(parseCommand('watch linear 99')).toEqual({ kind: 'watch', target: 'linear', number: 99, repo: null, channels: [] })
-    expect(parseCommand('unwatch pr 10')).toEqual({ kind: 'unwatch', target: 'pr', number: 10, repo: null })
-  })
-
-  it('lowercases the target keyword', () => {
-    expect(parseCommand('watch PR 10')).toEqual({ kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] })
+describe('parseCommand (central — global verbs)', () => {
+  it('parses help', () => {
+    expect(parseCommand('help', [], {})).toEqual({ kind: 'help' })
   })
 
   it('parses watch list', () => {
-    expect(parseCommand('watch list')).toEqual({ kind: 'list' })
-  })
-
-  it('parses help', () => {
-    expect(parseCommand('help')).toEqual({ kind: 'help' })
+    expect(parseCommand('watch list', [], {})).toEqual({ kind: 'list' })
   })
 
   it('is case-insensitive on verbs', () => {
-    expect(parseCommand('WATCH 5')).toEqual({ kind: 'watch', target: null, number: 5, repo: null, channels: [] })
-    expect(parseCommand('Help')).toEqual({ kind: 'help' })
-  })
-
-  it('rejects bareword channel arguments', () => {
-    const cmd = parseCommand('watch 5 foo') as Extract<Command, { kind: 'unknown' }>
-    expect(cmd.kind).toBe('unknown')
-    expect(cmd.error).toMatch(/channels must match/)
-  })
-
-  it('rejects malformed channel arguments', () => {
-    for (const bad of ['#', '##foo']) {
-      const cmd = parseCommand(`watch 5 ${bad}`) as Extract<Command, { kind: 'unknown' }>
-      expect(cmd.kind).toBe('unknown')
-      expect(cmd.error).toMatch(/channels must match/)
-    }
+    expect(parseCommand('Help', [], {})).toEqual({ kind: 'help' })
   })
 
   it('rejects trailing tokens after `watch list`', () => {
-    const cmd = parseCommand('watch list foo') as Extract<Command, { kind: 'unknown' }>
+    const cmd = parseCommand('watch list foo', [], {}) as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
     expect(cmd.error).toMatch(/watch list takes no arguments/)
   })
 
   it('rejects trailing tokens after `help`', () => {
-    const cmd = parseCommand('help me') as Extract<Command, { kind: 'unknown' }>
+    const cmd = parseCommand('help me', [], {}) as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
     expect(cmd.error).toMatch(/help takes no arguments/)
   })
 
-  it('rejects a reserved verb in the target slot', () => {
-    // `watch unwatch 5` is almost certainly a typo, not "target=unwatch";
-    // surface the reserved-verb collision rather than silently routing.
-    const cmd = parseCommand('watch unwatch 5') as Extract<Command, { kind: 'unknown' }>
+  it('rejects a reserved verb in the target slot before consulting plugins', () => {
+    const cmd = parseCommand('watch unwatch 5', [new StubPlugin('issues', null)], {}) as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
     expect(cmd.error).toMatch(/reserved verb/)
   })
 
-  it('rejects non-positive integers', () => {
-    expect(parseCommand('watch foo bar').kind).toBe('unknown')
-    expect(parseCommand('watch 5.5').kind).toBe('unknown')
-    expect(parseCommand('watch -1').kind).toBe('unknown')
-  })
-
-  it('rejects unwatch with channel args', () => {
-    const cmd = parseCommand('unwatch 5 #x') as Extract<Command, { kind: 'unknown' }>
-    expect(cmd.kind).toBe('unknown')
-    expect(cmd.error).toMatch(/no channel arguments/)
-  })
-
-  it('rejects unknown verb', () => {
-    const cmd = parseCommand('foo bar') as Extract<Command, { kind: 'unknown' }>
+  it('rejects an unknown top-level verb', () => {
+    const cmd = parseCommand('foo bar', [], {}) as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
     expect(cmd.error).toMatch(/unknown command/)
   })
 
-  it('requires a number or repo-shape spec for watch/unwatch', () => {
-    expect(parseCommand('watch').kind).toBe('unknown')
-    expect(parseCommand('watch pr').kind).toBe('unknown')
+  it('surfaces "no plugin handles" when no plugin claims', () => {
+    const cmd = parseCommand('watch linear 99', [new StubPlugin('issues', null)], {}) as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/no plugin handles `watch linear 99`/)
+    expect(cmd.error).toMatch(/enabled plugins: issues/)
+  })
+})
+
+describe('parseCommand (plugin claims)', () => {
+  it('routes claims to the matching plugin', () => {
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const cmd = parseCommand('watch pr 10', [issues, prs], {}) as Extract<Command, { kind: 'plugin' }>
+    expect(cmd.kind).toBe('plugin')
+    expect(cmd.plugin).toBe('prs')
   })
 
-  describe('repo positional on per-N grammar', () => {
-    // Regression for the load-bearing disambiguation: `#chan` after a number
-    // must NOT be misread as a repo positional. Channel sigil is `#`; repo
-    // positional requires `/`. Keep this paired with the `org/repo #chan`
-    // case below — both shapes are the entire reason the repo positional is
-    // safe to add unannotated.
-    it('does NOT grab a #channel as a repo positional', () => {
-      expect(parseCommand('watch pr 5 #chan')).toEqual({
-        kind: 'watch', target: 'pr', number: 5, repo: null, channels: ['#chan'],
-      })
-    })
-
-    it('parses bare <owner>/<repo> after the number', () => {
-      expect(parseCommand('watch pr 5 org/repo')).toEqual({
-        kind: 'watch', target: 'pr', number: 5, repo: 'org/repo', channels: [],
-      })
-    })
-
-    it('parses <owner>/<repo> before channels', () => {
-      expect(parseCommand('watch pr 5 org/repo #chan #other')).toEqual({
-        kind: 'watch', target: 'pr', number: 5, repo: 'org/repo', channels: ['#chan', '#other'],
-      })
-    })
-
-    it('attaches repo to unwatch', () => {
-      expect(parseCommand('unwatch pr 5 org/repo')).toEqual({
-        kind: 'unwatch', target: 'pr', number: 5, repo: 'org/repo',
-      })
-    })
-
-    it('accepts repo without a target keyword', () => {
-      expect(parseCommand('watch 5 org/repo #chan')).toEqual({
-        kind: 'watch', target: null, number: 5, repo: 'org/repo', channels: ['#chan'],
-      })
-    })
-
-    it('only one repo positional allowed; second token is treated as a (malformed) channel', () => {
-      const cmd = parseCommand('watch pr 5 org/a org/b') as Extract<Command, { kind: 'unknown' }>
-      expect(cmd.kind).toBe('unknown')
-      expect(cmd.error).toMatch(/channels must match/)
-    })
-
-    it('rejects a channel before the repo positional (positional must precede channels)', () => {
-      // `#chan` in the repo slot is a #-prefixed token that doesn't match
-      // OWNER_REPO_RE; it falls through to channels and the trailing
-      // `org/r` then fails CHANNEL_RE. Locks in the "repo before channels"
-      // ordering so a future loosening doesn't accidentally accept both.
-      const cmd = parseCommand('watch pr 5 #chan org/r') as Extract<Command, { kind: 'unknown' }>
-      expect(cmd.kind).toBe('unknown')
-      expect(cmd.error).toMatch(/channels must match/)
-    })
-
-    it('rejects unwatch with a trailing channel even when a repo positional is present', () => {
-      // Without repo: `unwatch pr 5 #x` already errors. The repo positional
-      // mustn't carve a loophole that lets channels sneak in.
-      const cmd = parseCommand('unwatch pr 5 org/r #x') as Extract<Command, { kind: 'unknown' }>
-      expect(cmd.kind).toBe('unknown')
-      expect(cmd.error).toMatch(/no channel arguments/)
-    })
+  it('honors grammarPriority (higher wins on overlap)', () => {
+    const lo = new StubPlugin('lo', 'pr', undefined, 0)
+    const hi = new StubPlugin('hi', 'pr', undefined, 10)
+    const cmd = parseCommand('watch pr 5', [lo, hi], {}) as Extract<Command, { kind: 'plugin' }>
+    expect(cmd.plugin).toBe('hi')
   })
 
-  describe('repo-shape grammar (watch/unwatch <target> <owner>/<repo>[@branch[:path]])', () => {
-    it('parses bare <owner>/<repo>', () => {
-      expect(parseCommand('watch repo org/r')).toEqual({
-        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: [],
-      })
-    })
+  it('config.plugin_priorities overrides static grammarPriority outright', () => {
+    const a = new StubPlugin('a', 'pr', undefined, 10)
+    const b = new StubPlugin('b', 'pr', undefined, 0)
+    // Static order would pick a (10>0). Override flips it.
+    const cmd = parseCommand('watch pr 5', [a, b], { plugin_priorities: { a: 0, b: 100 } }) as Extract<Command, { kind: 'plugin' }>
+    expect(cmd.plugin).toBe('b')
+  })
 
-    it('parses @branch', () => {
-      expect(parseCommand('watch repo org/r@develop')).toEqual({
-        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: null, channels: [],
-      })
-    })
-
-    it('parses :path without branch', () => {
-      expect(parseCommand('watch repo org/r:Formula/x.rb')).toEqual({
-        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: 'Formula/x.rb', channels: [],
-      })
-    })
-
-    it('parses @branch:path', () => {
-      expect(parseCommand('watch repo org/r@develop:Formula/x.rb #chan')).toEqual({
-        kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb', channels: ['#chan'],
-      })
-    })
-
-    it('parses unwatch-repo with the same shape', () => {
-      expect(parseCommand('unwatch repo org/r@develop:Formula/x.rb')).toEqual({
-        kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb',
-      })
-    })
-
-    it('accepts non-`repo` target (new-issues style)', () => {
-      expect(parseCommand('watch new-issues org/r #chan')).toEqual({
-        kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
-      })
-    })
-
-    it('accepts target=null repo-shape (no plugin will claim it but parser is generic)', () => {
-      expect(parseCommand('watch org/r')).toEqual({
-        kind: 'watch-repo', target: null, repo: 'org/r', branch: null, path: null, channels: [],
-      })
-    })
-
-    it('rejects unwatch-repo with channel args', () => {
-      const cmd = parseCommand('unwatch repo org/r #x') as Extract<Command, { kind: 'unknown' }>
-      expect(cmd.kind).toBe('unknown')
-      expect(cmd.error).toMatch(/no channel arguments/)
-    })
+  it('plugin error claims terminate iteration (no second crack at the same line)', () => {
+    // First plugin in priority order claims-with-error; second plugin would
+    // succeed if it got the chance — it must not.
+    class ErrPlugin implements Plugin {
+      readonly name = 'first'
+      readonly grammarPriority = 100
+      desiredChannels(): string[] { return [] }
+      async runTick(): Promise<PluginTickResult> { return { state: null, taggedEvents: [], channels: [] } }
+      parseCommand(): ParseResult { return { kind: 'error', message: 'first-plugin malformed' } }
+      handleCommand(): string | null { return null }
+    }
+    const second = new StubPlugin('second', null)
+    const cmd = parseCommand('watch 5', [new ErrPlugin(), second], {}) as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toBe('first-plugin malformed')
   })
 })
 
 describe('parseCommands', () => {
   it('parses multi-line input', () => {
-    expect(parseCommands('watch 5; unwatch pr 10')).toEqual([
-      { kind: 'watch', target: null, number: 5, repo: null, channels: [] },
-      { kind: 'unwatch', target: 'pr', number: 10, repo: null },
-    ])
+    const issues = new StubPlugin('issues', null)
+    const prs = new StubPlugin('prs', 'pr')
+    const cmds = parseCommands('watch 5; unwatch pr 10', [issues, prs], {})
+    expect(cmds).toHaveLength(2)
+    expect(cmds[0]).toMatchObject({ kind: 'plugin', plugin: 'issues' })
+    expect(cmds[1]).toMatchObject({ kind: 'plugin', plugin: 'prs' })
   })
 })
 
@@ -280,39 +223,6 @@ interface FakeIrc {
   dms: Array<{ nick: string; text: string }>
   errors: string[]
   logs: string[]
-}
-
-// A minimal Plugin that claims a target keyword. Records every call so
-// tests can assert routing precisely without depending on slice schemas.
-class StubPlugin implements Plugin {
-  readonly name: string
-  readonly handled: Array<{ cmd: Command; mergedSnapshot: OrchestratorConfig; localSnapshot: OrchestratorConfig }> = []
-  constructor(name: string, private readonly target: string | null, private readonly behavior?: (cmd: Command, merged: OrchestratorConfig, local: OrchestratorConfig) => string | null) {
-    this.name = name
-  }
-  desiredChannels(): string[] { return [] }
-  async runTick(): Promise<PluginTickResult> {
-    return { state: null, taggedEvents: [], channels: [] }
-  }
-  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
-    this.handled.push({
-      cmd,
-      mergedSnapshot: JSON.parse(JSON.stringify(merged)) as OrchestratorConfig,
-      localSnapshot: JSON.parse(JSON.stringify(local)) as OrchestratorConfig,
-    })
-    if (this.behavior) return this.behavior(cmd, merged, local)
-    if (cmd.kind === 'list') return `${this.name}: list-section`
-    if (cmd.kind === 'help') return `${this.name}: help-section`
-    if (cmd.kind === 'watch' && cmd.target === this.target) {
-      local.plugins ??= {}
-      local.plugins[this.name] = { watched: cmd.number }
-      return `${this.name}: watched ${cmd.number}`
-    }
-    if (cmd.kind === 'unwatch' && cmd.target === this.target) {
-      return `${this.name}: unwatched ${cmd.number}`
-    }
-    return null
-  }
 }
 
 function makeDeps(stateDir: string, plugins: Plugin[] = []): { deps: HandlerDeps; irc: FakeIrc } {
@@ -356,15 +266,14 @@ describe('handleDm — routing', () => {
     expect(issues.handled).toHaveLength(1)
   })
 
-  it('routes target=null commands only to the matching plugin', async () => {
+  it('routes a bare watch only to the matching plugin', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
     const issues = new StubPlugin('issues', null)
     const prs = new StubPlugin('prs', 'pr')
     const { deps, irc } = makeDeps(dir, [issues, prs])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 5' })
-    // Both plugins are invoked, only issues claims it.
     expect(issues.handled).toHaveLength(1)
-    expect(prs.handled).toHaveLength(1)
+    expect(prs.handled).toHaveLength(0)
     expect(irc.dms[0].text).toBe('issues: watched 5')
   })
 
@@ -375,6 +284,7 @@ describe('handleDm — routing', () => {
     const { deps, irc } = makeDeps(dir, [issues, prs])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch pr 10' })
     expect(irc.dms[0].text).toBe('prs: watched 10')
+    expect(issues.handled).toHaveLength(0)
   })
 
   it('broadcasts `watch list` to every plugin and joins replies with \\n\\n', async () => {
@@ -387,7 +297,7 @@ describe('handleDm — routing', () => {
     expect(irc.dms[0].text).toBe('issues: list-section\n\nprs: list-section')
   })
 
-  it('broadcasts `help` to every plugin and joins with \\n\\n, prepending the dispatcher synopsis', async () => {
+  it('broadcasts `help` and prepends the dispatcher synopsis', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
     const issues = new StubPlugin('issues', null)
     const prs = new StubPlugin('prs', 'pr')
@@ -397,30 +307,14 @@ describe('handleDm — routing', () => {
     expect(irc.dms[0].text).toContain('issues: help-section\n\nprs: help-section')
   })
 
-  it('surfaces "no plugin handles" when no plugin claims a target', async () => {
+  it('surfaces "no plugin handles" with the raw line + enabled plugins', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
     const issues = new StubPlugin('issues', null)
     const { deps, irc } = makeDeps(dir, [issues])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch linear 99' })
     expect(irc.dms).toHaveLength(1)
-    expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear <N>/)
+    expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear 99`/)
     expect(irc.dms[0].text).toMatch(/enabled plugins: issues/)
-  })
-
-  it('surfaces "no plugin handles" with the repo positional in the grammar shape', async () => {
-    await writeConfig(dir, { project: 'roost', plugins: {} })
-    const issues = new StubPlugin('issues', null)
-    const { deps, irc } = makeDeps(dir, [issues])
-    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch linear 99 org/r' })
-    expect(irc.dms[0].text).toMatch(/no plugin handles `watch linear <N> <owner>\/<repo>/)
-  })
-
-  it('surfaces "no plugin handles" for a watch-repo when no plugin claims it', async () => {
-    await writeConfig(dir, { project: 'roost', plugins: {} })
-    const issues = new StubPlugin('issues', null)
-    const { deps, irc } = makeDeps(dir, [issues])
-    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch repo org/r' })
-    expect(irc.dms[0].text).toMatch(/no plugin handles `watch repo <owner>\/<repo>/)
   })
 
   it('any parse error aborts the batch — no plugin called', async () => {
@@ -470,23 +364,29 @@ describe('handleDm — routing', () => {
 
   it('re-merges base+local before each cmd so in-batch dedup sees prior writes', async () => {
     await writeConfig(dir, { project: 'roost', plugins: {} })
-    // A plugin that appends a number to its local watched list and refuses
-    // duplicates against the merged view — mimicking GhBase semantics.
     class ListishPlugin implements Plugin {
       readonly name = 'listish'
       desiredChannels(): string[] { return [] }
       async runTick(): Promise<PluginTickResult> {
         return { state: null, taggedEvents: [], channels: [] }
       }
+      parseCommand(line: string): ParseResult | null {
+        const tokens = line.split(/\s+/).filter(Boolean)
+        if (tokens[0]?.toLowerCase() !== 'watch') return null
+        const numTok = tokens[1]
+        if (!numTok || !/^\d+$/.test(numTok)) return null
+        return { kind: 'ok', cmd: { number: parseInt(numTok, 10) } }
+      }
       handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
-        if (cmd.kind !== 'watch' || cmd.target !== null) return null
+        if (cmd.kind !== 'plugin' || cmd.plugin !== 'listish') return null
+        const c = cmd.cmd as { number: number }
         const mergedWatched = (merged.plugins?.['listish'] as { watched?: number[] } | undefined)?.watched ?? []
-        if (mergedWatched.includes(cmd.number)) return `already watching ${cmd.number}`
+        if (mergedWatched.includes(c.number)) return `already watching ${c.number}`
         local.plugins ??= {}
         const slice = (local.plugins['listish'] as { watched?: number[] } | undefined) ?? {}
-        slice.watched = [...(slice.watched ?? []), cmd.number]
+        slice.watched = [...(slice.watched ?? []), c.number]
         local.plugins['listish'] = slice
-        return `watching ${cmd.number}`
+        return `watching ${c.number}`
       }
     }
     const { deps, irc } = makeDeps(dir, [new ListishPlugin()])
@@ -552,11 +452,8 @@ describe('handleDm — routing', () => {
   })
 
   it('pure-read batches do not call mutateConfig (snapshot path)', async () => {
-    // Seed a watched entry. After `watch list`, config on disk is unchanged
-    // — proves we didn't re-serialize via mutateConfig.
     await writeConfig(dir, { project: 'roost', repo: 'org/r', plugins: { issues: { watched: [{ number: 99 }] } } })
     const { mtimeMs: before } = await Bun.file(join(dir, 'config.json')).stat()
-    // Small delay so a write would show a different mtime.
     await new Promise(r => setTimeout(r, 20))
     const { deps, irc } = makeDeps(dir, [new StubPlugin('issues', null)])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch list' })

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -7,7 +7,6 @@ import {
   parseCommand,
   parseCommands,
   resolveAllowlist,
-  splitCommands,
   type Command,
   type HandlerDeps,
 } from '../dispatcher-dm-handler.js'
@@ -25,14 +24,7 @@ afterEach(async () => {
 })
 
 // ---- Parser ----------------------------------------------------------------
-
-describe('splitCommands', () => {
-  it('splits on newlines, semicolons, commas; trims; drops empties', () => {
-    expect(splitCommands('watch 5\n watch 6 ; watch 7, ,\nhelp')).toEqual([
-      'watch 5', 'watch 6', 'watch 7', 'help',
-    ])
-  })
-})
+// splitCommands is covered in plugins/__tests__/grammar.test.ts (canonical home).
 
 // A minimal Plugin that claims a target keyword via a per-N parser. Records
 // every handleCommand call so tests can assert routing precisely.

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -34,6 +34,11 @@ export interface OrchestratorConfig {
   // `registerPlugin` at top level. Relative paths resolve against the config
   // directory. See docs/PLUGINS.md.
   plugin_paths?: string[]
+  // Operator override for grammar-claim ordering — higher wins. Replaces the
+  // plugin's static `grammarPriority` outright (no max/sum). Used when two
+  // plugins overlap on a shape (e.g. a 3rd-party plugin claiming `watch <N>`
+  // alongside `github-issues`). See `Plugin.parseCommand`.
+  plugin_priorities?: Record<string, number>
 }
 
 export interface OrchestratorState {
@@ -106,6 +111,7 @@ export function mergeConfigs(base: OrchestratorConfig, local: OrchestratorConfig
   if (local.repo !== undefined) result.repo = local.repo
   if (local.agent_logins !== undefined) result.agent_logins = local.agent_logins
   if (local.plugin_paths !== undefined) result.plugin_paths = local.plugin_paths
+  if (local.plugin_priorities !== undefined) result.plugin_priorities = local.plugin_priorities
   if (base.irc !== undefined || local.irc !== undefined) {
     result.irc = { ...base.irc, ...local.irc }
   }

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -10,6 +10,7 @@
 import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
 import { assertRepoModeAll, type Plugin } from './plugin.js'
+import { splitCommands } from './plugins/grammar.js'
 
 // `plugin` carries an opaque cmd payload — the plugin that produced it is the
 // only one that handles it. `list` / `help` broadcast to every plugin.
@@ -38,14 +39,6 @@ export interface HandlerDeps {
 const RESERVED_TARGETS = new Set(['watch', 'unwatch', 'help'])
 
 // ---- Parser ----------------------------------------------------------------
-
-// Split a body into command lines. Newlines, semicolons, and commas separate.
-export function splitCommands(text: string): string[] {
-  return text
-    .split(/[\n;,]+/)
-    .map(s => s.trim())
-    .filter(Boolean)
-}
 
 // Sort plugins for parse-claim iteration: higher grammarPriority first, ties
 // resolved by the original `plugins` array order (which mirrors

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -1,6 +1,7 @@
-// Dispatcher DM handler. Parses a small command grammar and routes commands
-// to plugins via `Plugin.handleCommand`. The parser knows only verbs and a
-// free-form target keyword; slice schemas + reply phrasing belong to plugins.
+// Dispatcher DM handler. Parses two global verbs (`help`, `watch list`) and
+// hands every other line to plugins in `grammarPriority` order — first
+// non-null claim wins. The dispatcher carries the claimed payload back to the
+// same plugin's `handleCommand` unchanged; the central code never inspects it.
 //
 // Per DM: allowlist-check → parse → run each cmd inside one mutateConfig pass
 // → coalesce replies into one DM. Never throws — parse failures abort with a
@@ -10,19 +11,19 @@ import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfi
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
 import { assertRepoModeAll, type Plugin } from './plugin.js'
 
+// `plugin` carries an opaque cmd payload — the plugin that produced it is the
+// only one that handles it. `list` / `help` broadcast to every plugin.
 export type Command =
-  | { kind: 'watch'; target: string | null; number: number; repo: string | null; channels: string[] }
-  | { kind: 'unwatch'; target: string | null; number: number; repo: string | null }
-  | { kind: 'watch-repo'; target: string | null; repo: string; branch: string | null; path: string | null; channels: string[] }
-  | { kind: 'unwatch-repo'; target: string | null; repo: string; branch: string | null; path: string | null }
+  | { kind: 'plugin'; plugin: string; cmd: unknown }
   | { kind: 'list' }
   | { kind: 'help' }
   | { kind: 'unknown'; raw: string; error: string }
 
 export interface HandlerDeps {
   stateDir: string
-  // The enabled plugin set. Iterated for handleCommand routing. Built
-  // once at daemon boot — plugins are stateless w.r.t. command handling.
+  // The enabled plugin set. Iterated for parseCommand and handleCommand
+  // routing. Built once at daemon boot — plugins are stateless w.r.t.
+  // command handling.
   plugins: Plugin[]
   // Pure I/O — only the bits we need from RoostIrcClient.
   dm: (nick: string, text: string) => void
@@ -30,19 +31,11 @@ export interface HandlerDeps {
   log: (line: string) => void
 }
 
-const CHANNEL_RE = /^#[^\s,#]+$/
-
-// Bare `<owner>/<repo>` — the optional repo positional after a number in the
-// per-N grammar. Disambiguated from channels (start with `#`) and numbers
-// (all digits) purely on shape.
-const OWNER_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
-
-// Full repo-shape spec for the whole-repo grammar — `org/r[@branch[:path]]`.
-// Mirrors github-commits' state key so daemon.log lines copy-paste into a DM.
-const REPO_SPEC_RE = /^([A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*)(?:@([^:@\s]+))?(?::([^\s]+))?$/
-
-// Reserved verbs — plugins can't shadow these as targets.
-const VERBS = new Set(['watch', 'unwatch', 'help'])
+// Reserved verbs — operators occasionally typo `watch unwatch 5`. Surfacing
+// "reserved verb" beats the generic "no plugin handles" because plugins'
+// parsers defer on this shape (their target doesn't match) — without this
+// pre-check the error would lose information.
+const RESERVED_TARGETS = new Set(['watch', 'unwatch', 'help'])
 
 // ---- Parser ----------------------------------------------------------------
 
@@ -54,8 +47,24 @@ export function splitCommands(text: string): string[] {
     .filter(Boolean)
 }
 
-// Returns `unknown` rather than throwing so the handler can DM a hint and continue.
-export function parseCommand(line: string): Command {
+// Sort plugins for parse-claim iteration: higher grammarPriority first, ties
+// resolved by the original `plugins` array order (which mirrors
+// `config.plugins` Object.keys order). Operator overrides via
+// `config.plugin_priorities[name]` replace the static value outright.
+function priorityOrder(plugins: Plugin[], config: OrchestratorConfig): Plugin[] {
+  const overrides = config.plugin_priorities ?? {}
+  const pri = (p: Plugin) => overrides[p.name] ?? p.grammarPriority ?? 0
+  return [...plugins]
+    .map((p, idx) => ({ p, idx, pri: pri(p) }))
+    .sort((a, b) => b.pri - a.pri || a.idx - b.idx)
+    .map(x => x.p)
+}
+
+// Parse a single line. Global verbs (`help`, `watch list`) stay central;
+// everything else is offered to plugins in priority order. The first plugin
+// to return a non-null result wins — `{kind:'error'}` aborts (no other
+// plugin gets a second crack at the same shape; see `Plugin.parseCommand`).
+export function parseCommand(line: string, plugins: Plugin[], config: OrchestratorConfig): Command {
   const tokens = line.split(/\s+/).filter(Boolean)
   if (tokens.length === 0) return { kind: 'unknown', raw: line, error: 'empty command' }
   const verb = tokens[0].toLowerCase()
@@ -70,87 +79,26 @@ export function parseCommand(line: string): Command {
     return { kind: 'list' }
   }
 
-  if (verb === 'watch') return parseWatchOrUnwatch(line, 'watch', tokens.slice(1))
-  if (verb === 'unwatch') return parseWatchOrUnwatch(line, 'unwatch', tokens.slice(1))
+  if (verb === 'watch' || verb === 'unwatch') {
+    const second = tokens[1]?.toLowerCase()
+    if (second !== undefined && RESERVED_TARGETS.has(second)) {
+      return { kind: 'unknown', raw: line, error: `${verb}: "${tokens[1]}" is a reserved verb, not a target` }
+    }
+    for (const p of priorityOrder(plugins, config)) {
+      const result = p.parseCommand?.(line)
+      if (result == null) continue
+      if (result.kind === 'error') return { kind: 'unknown', raw: line, error: result.message }
+      return { kind: 'plugin', plugin: p.name, cmd: result.cmd }
+    }
+    const names = plugins.map(p => p.name).sort().join(', ') || '(none)'
+    return { kind: 'unknown', raw: line, error: `no plugin handles \`${line}\` — enabled plugins: ${names}` }
+  }
 
   return { kind: 'unknown', raw: line, error: `unknown command: ${tokens[0]}` }
 }
 
-// Two shapes after the verb:
-//   per-N : `[target] <num> [<owner>/<repo>] [#chan ...]`
-//   repo  : `[target] <owner>/<repo>[@<branch>[:<path>]] [#chan ...]`
-// `target` is whatever non-numeric, non-repo-shape keyword precedes the spec;
-// plugins claim what they own. The spec token shape selects per-N vs repo emission.
-function parseWatchOrUnwatch(raw: string, verb: 'watch' | 'unwatch', rest: string[]): Command {
-  let target: string | null = null
-  let i = 0
-  const first = rest[0]
-  if (first !== undefined && !/^\d+$/.test(first) && !REPO_SPEC_RE.test(first)) {
-    if (VERBS.has(first.toLowerCase())) {
-      return { kind: 'unknown', raw, error: `${verb}: "${first}" is a reserved verb, not a target` }
-    }
-    target = first.toLowerCase()
-    i = 1
-  }
-
-  const specTok = rest[i]
-  if (specTok === undefined) {
-    return { kind: 'unknown', raw, error: `${verb} requires an issue/PR number or <owner>/<repo> spec` }
-  }
-
-  // Repo-shape: `owner/repo[@branch][:path]`. Picked when the token contains a `/`.
-  const repoMatch = specTok.match(REPO_SPEC_RE)
-  if (repoMatch) {
-    const repo = repoMatch[1]
-    const branch = repoMatch[2] ?? null
-    const path = repoMatch[3] ?? null
-    const channels = rest.slice(i + 1)
-    if (verb === 'unwatch') {
-      if (channels.length) {
-        return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
-      }
-      return { kind: 'unwatch-repo', target, repo, branch, path }
-    }
-    for (const c of channels) {
-      if (!CHANNEL_RE.test(c)) {
-        return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
-      }
-    }
-    return { kind: 'watch-repo', target, repo, branch, path, channels }
-  }
-
-  // Number-shape spec.
-  const number = parseInt(specTok, 10)
-  if (number <= 0 || String(number) !== specTok) {
-    return { kind: 'unknown', raw, error: `${verb}: "${specTok}" is not a positive integer or <owner>/<repo> spec` }
-  }
-  i += 1
-
-  // Optional repo positional after the number — `@branch`/`:path` not allowed here.
-  let repo: string | null = null
-  if (rest[i] !== undefined && OWNER_REPO_RE.test(rest[i])) {
-    repo = rest[i]
-    i += 1
-  }
-
-  const channels = rest.slice(i)
-  if (verb === 'unwatch') {
-    if (channels.length) {
-      return { kind: 'unknown', raw, error: 'unwatch takes no channel arguments' }
-    }
-    return { kind: 'unwatch', target, number, repo }
-  }
-
-  for (const c of channels) {
-    if (!CHANNEL_RE.test(c)) {
-      return { kind: 'unknown', raw, error: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
-    }
-  }
-  return { kind: 'watch', target, number, repo, channels }
-}
-
-export function parseCommands(text: string): Command[] {
-  return splitCommands(text).map(parseCommand)
+export function parseCommands(text: string, plugins: Plugin[], config: OrchestratorConfig): Command[] {
+  return splitCommands(text).map(line => parseCommand(line, plugins, config))
 }
 
 // ---- Allowlist -------------------------------------------------------------
@@ -171,29 +119,12 @@ export function resolveAllowlist(config: OrchestratorConfig, log?: (line: string
 
 // ---- Routing ---------------------------------------------------------------
 
-// Synopsis of the user's input shape — used only in the "no plugin handles..." reply.
-function describeCommand(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'watch-repo' | 'unwatch-repo' }>): string {
-  const target = cmd.target ? `${cmd.target} ` : ''
-  if (cmd.kind === 'watch-repo') return `watch ${target}<owner>/<repo>[@<branch>[:<path>]] [#chan ...]`
-  if (cmd.kind === 'unwatch-repo') return `unwatch ${target}<owner>/<repo>[@<branch>[:<path>]]`
-  const repoSlot = cmd.repo != null ? ' <owner>/<repo>' : ''
-  return cmd.kind === 'watch'
-    ? `watch ${target}<N>${repoSlot} [#chan ...]`
-    : `unwatch ${target}<N>${repoSlot}`
-}
-
-// watch/unwatch match exactly one plugin; list/help broadcast and join with `\n\n`.
-
 const HELP_SYNOPSIS = [
   'dispatcher DM grammar (one per line, or `;`/`,`-separated):',
-  '  watch [<target>] <N> [<owner>/<repo>] [#chan ...]',
-  '  unwatch [<target>] <N> [<owner>/<repo>]',
-  '  watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]',
-  '  unwatch <target> <owner>/<repo>[@<branch>[:<path>]]',
   '  watch list                 — every plugin\'s active entries',
   '  help                       — this synopsis + per-plugin commands',
   '',
-  '<target> is plugin-claimed (`pr`, `repo`, `new-issues`, …). per-plugin help:',
+  'plugins claim their own watch/unwatch shapes; per-plugin grammar:',
 ].join('\n')
 
 async function routeOne(
@@ -203,20 +134,23 @@ async function routeOne(
   plugins: Plugin[],
 ): Promise<string | null> {
   if (cmd.kind === 'unknown') return `error: ${cmd.error}`
-  const replies: string[] = []
-  for (const p of plugins) {
-    const reply = await p.handleCommand?.(merged, local, cmd)
-    if (reply !== null && reply !== undefined) replies.push(reply)
-  }
-  // help leads with the dispatcher synopsis; per-plugin sections trail.
-  if (cmd.kind === 'help') return [HELP_SYNOPSIS, ...replies].join('\n\n')
-  if (replies.length === 0) return null
-  return replies.join(cmd.kind === 'list' ? '\n\n' : '\n')
-}
 
-function unmatchedReply(cmd: Extract<Command, { kind: 'watch' | 'unwatch' | 'watch-repo' | 'unwatch-repo' }>, plugins: Plugin[]): string {
-  const names = plugins.map(p => p.name).sort().join(', ') || '(none)'
-  return `error: no plugin handles \`${describeCommand(cmd)}\` — enabled plugins: ${names}`
+  // list/help broadcast — every plugin contributes its own section.
+  if (cmd.kind === 'list' || cmd.kind === 'help') {
+    const replies: string[] = []
+    for (const p of plugins) {
+      const reply = await p.handleCommand?.(merged, local, cmd)
+      if (reply !== null && reply !== undefined) replies.push(reply)
+    }
+    if (cmd.kind === 'help') return [HELP_SYNOPSIS, ...replies].join('\n\n')
+    return replies.join('\n\n')
+  }
+
+  // Plugin-claimed: route back to the exact plugin that parsed it.
+  const owner = plugins.find(p => p.name === cmd.plugin)
+  if (!owner) return `error: plugin ${cmd.plugin} not registered (parse-time claim, runtime miss)`
+  const reply = await owner.handleCommand?.(merged, local, cmd)
+  return reply ?? null
 }
 
 // ---- Handler entry point ---------------------------------------------------
@@ -252,7 +186,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
     return
   }
 
-  const cmds = parseCommands(body)
+  const cmds = parseCommands(body, deps.plugins, snapshot)
   if (cmds.length === 0) return
 
   // Any parse failure aborts the batch — a typo shouldn't half-commit.
@@ -301,11 +235,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
         const merged = mergeConfigs(base, local)
         try {
           const reply = await routeOne(merged, local, cmd, deps.plugins)
-          if (reply !== null) {
-            replies.push(reply)
-          } else if (cmd.kind === 'watch' || cmd.kind === 'unwatch' || cmd.kind === 'watch-repo' || cmd.kind === 'unwatch-repo') {
-            replies.push(unmatchedReply(cmd, deps.plugins))
-          }
+          if (reply !== null) replies.push(reply)
         } catch (e) {
           deps.log(`dispatcher-dm-handler: handler threw on ${cmd.kind} from ${dm.sender}: ${e}`)
           deps.postProjectError(`[dispatcher_error] handleCommand(${cmd.kind}): ${e}`)
@@ -323,11 +253,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   if (writeFailed) return
   for (const cmd of cmds) {
     const parts = [`cmd=${cmd.kind}`]
-    if ('target' in cmd) parts.push(`target=${cmd.target ?? '(default)'}`)
-    if ('number' in cmd) parts.push(`n=${cmd.number}`)
-    if ('repo' in cmd && cmd.repo) parts.push(`repo=${cmd.repo}`)
-    if ('branch' in cmd && cmd.branch) parts.push(`branch=${cmd.branch}`)
-    if ('path' in cmd && cmd.path) parts.push(`path=${cmd.path}`)
+    if (cmd.kind === 'plugin') parts.push(`plugin=${cmd.plugin}`)
     deps.log(`dispatcher-dm-handler: ${dm.sender} ${parts.join(' ')}`)
   }
   deps.dm(dm.sender, replies.join('\n\n'))

--- a/src/orchestrator/plugin-api.ts
+++ b/src/orchestrator/plugin-api.ts
@@ -4,6 +4,7 @@
 export {
   BasePlugin,
   registerPlugin,
+  type ParseResult,
   type Plugin,
   type PluginConfig,
   type PluginFactory,
@@ -14,3 +15,11 @@ export {
 } from './plugin.js'
 
 export type { Command } from './dispatcher-dm-handler.js'
+
+export {
+  tryClaimPerN,
+  tryClaimPerRepo,
+  type PerNCommand,
+  type PerRepoCommand,
+  type Verb,
+} from './plugins/grammar.js'

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -28,6 +28,13 @@ export interface PluginTickResult {
   channels: string[]
 }
 
+// Result of a plugin's `parseCommand`. The cmd payload is plugin-owned and
+// opaque to the dispatcher — it's threaded back to the same plugin's
+// `handleCommand` unchanged.
+export type ParseResult =
+  | { kind: 'ok'; cmd: unknown }
+  | { kind: 'error'; message: string }
+
 export interface Plugin {
   readonly name: string
   // Config-only channel view at boot, before first tick. Excludes the project
@@ -36,11 +43,31 @@ export interface Plugin {
   // Per tick: next state slice, tagged events, and the live channel set
   // (post-scrape, including dynamic discoveries). `prevState === null` signals seed.
   runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult>
+  // Try to claim a single watch/unwatch DM line. The dispatcher iterates
+  // plugins in `grammarPriority` order (higher first; ties → `config.plugins`
+  // Object.keys order) and takes the first non-null result:
+  //   - `null`        — not my shape; try the next plugin.
+  //   - `{kind:'ok'}` — claimed cleanly; cmd is threaded back to this plugin's
+  //                     handleCommand on a `{kind:'plugin'}` Command.
+  //   - `{kind:'error'}` — claimed-but-malformed; the dispatcher surfaces the
+  //                     message and aborts iteration. NO other plugin gets a
+  //                     second crack at the same line. The plugin's own parser
+  //                     is the authority on its shape: silently re-routing a
+  //                     malformed claim would let a typo land in a different
+  //                     plugin's slice.
+  // `help` and `watch list` are parsed centrally and broadcast to every
+  // plugin's handleCommand — parseCommand is only consulted for the rest.
+  parseCommand?(line: string): ParseResult | null
+  // Static grammar-priority hint. Operator override via
+  // `config.plugin_priorities[name]` replaces this value outright (no max/sum).
+  // Default 0.
+  readonly grammarPriority?: number
   // Optional DM handler. `merged` is the live view; `local` is the gitignored
   // overlay the plugin mutates (config.json is read-only from the dispatcher).
   // Returns the reply when handled, null when not ours. MUST NOT throw —
   // deterministic failures come back as `"error: ..."`. `list`/`help` broadcast
-  // to every plugin; replies join with `\n\n`.
+  // to every plugin; replies join with `\n\n`. Plugin-claimed commands arrive
+  // as `{kind:'plugin', plugin:this.name, cmd:<your parsed shape>}`.
   handleCommand?(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null | Promise<string | null>
   // Optional repo-mode check for plugins that own a `watched`/`repo` shape.
   // Throws on violation. Called after every config load.

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -30,9 +30,11 @@ export interface PluginTickResult {
 
 // Result of a plugin's `parseCommand`. The cmd payload is plugin-owned and
 // opaque to the dispatcher — it's threaded back to the same plugin's
-// `handleCommand` unchanged.
-export type ParseResult =
-  | { kind: 'ok'; cmd: unknown }
+// `handleCommand` unchanged. Parameterized so helpers (`tryClaimPerN`,
+// `tryClaimPerRepo`) can advertise their concrete shape; the dispatcher
+// surface stays `ParseResult<unknown>` because cmd payloads vary per plugin.
+export type ParseResult<T = unknown> =
+  | { kind: 'ok'; cmd: T }
   | { kind: 'error'; message: string }
 
 export interface Plugin {

--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { tryClaimPerN, tryClaimPerRepo, splitCommands, tokenizeVerbLine } from '../grammar.js'
+import { tryClaimPerN, tryClaimPerRepo, splitCommands } from '../grammar.js'
 
 // ---- splitCommands --------------------------------------------------------
 
@@ -11,18 +11,8 @@ describe('splitCommands', () => {
   })
 })
 
-// ---- tokenizeVerbLine -----------------------------------------------------
-
-describe('tokenizeVerbLine', () => {
-  it('returns null for non-watch/unwatch verbs', () => {
-    expect(tokenizeVerbLine('help')).toBeNull()
-    expect(tokenizeVerbLine('foo bar')).toBeNull()
-    expect(tokenizeVerbLine('')).toBeNull()
-  })
-  it('lowercases verb and slices tokens', () => {
-    expect(tokenizeVerbLine('WATCH pr 5')).toEqual({ verb: 'watch', tokens: ['pr', '5'] })
-  })
-})
+// tokenizeVerbLine is a grammar.ts internal — exercised end-to-end via the
+// tryClaim* helpers below. No standalone test.
 
 // ---- tryClaimPerN (target=null — bare watch <N>) --------------------------
 
@@ -60,7 +50,7 @@ describe('tryClaimPerN — bare (target=null)', () => {
 
   it('errors on missing number after the verb', () => {
     const r = tryClaimPerN(null, 'watch')
-    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number' })
+    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number or <owner>/<repo> spec' })
   })
 
   it('defers on a first token that\'s neither a digit-string, repo-shape, nor channel', () => {
@@ -153,7 +143,7 @@ describe('tryClaimPerN — target=pr', () => {
 
   it('errors when target matches but number is missing', () => {
     const r = tryClaimPerN('pr', 'watch pr')
-    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number' })
+    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number or <owner>/<repo> spec' })
   })
 
   it('claims `watch pr 10 org/r #chan`', () => {

--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'bun:test'
+import { tryClaimPerN, tryClaimPerRepo, splitCommands, tokenizeVerbLine } from '../grammar.js'
+
+// ---- splitCommands --------------------------------------------------------
+
+describe('splitCommands', () => {
+  it('splits on newlines, semicolons, commas; trims; drops empties', () => {
+    expect(splitCommands('watch 5\n watch 6 ; watch 7, ,\nhelp')).toEqual([
+      'watch 5', 'watch 6', 'watch 7', 'help',
+    ])
+  })
+})
+
+// ---- tokenizeVerbLine -----------------------------------------------------
+
+describe('tokenizeVerbLine', () => {
+  it('returns null for non-watch/unwatch verbs', () => {
+    expect(tokenizeVerbLine('help')).toBeNull()
+    expect(tokenizeVerbLine('foo bar')).toBeNull()
+    expect(tokenizeVerbLine('')).toBeNull()
+  })
+  it('lowercases verb and slices tokens', () => {
+    expect(tokenizeVerbLine('WATCH pr 5')).toEqual({ verb: 'watch', tokens: ['pr', '5'] })
+  })
+})
+
+// ---- tryClaimPerN (target=null — bare watch <N>) --------------------------
+
+describe('tryClaimPerN — bare (target=null)', () => {
+  it('claims `watch 5`', () => {
+    expect(tryClaimPerN(null, 'watch 5')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 5, repo: null, channels: [] },
+    })
+  })
+
+  it('claims with channels', () => {
+    expect(tryClaimPerN(null, 'watch 5 #foo #bar')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 5, repo: null, channels: ['#foo', '#bar'] },
+    })
+  })
+
+  it('claims `unwatch 5`', () => {
+    expect(tryClaimPerN(null, 'unwatch 5')).toEqual({
+      kind: 'ok', cmd: { verb: 'unwatch', number: 5, repo: null, channels: [] },
+    })
+  })
+
+  it('defers on a leading target keyword (some other plugin claims `pr`)', () => {
+    expect(tryClaimPerN(null, 'watch pr 10')).toBeNull()
+    expect(tryClaimPerN(null, 'unwatch pr 10')).toBeNull()
+  })
+
+  it('defers on a leading reserved verb (typo handler upstream)', () => {
+    expect(tryClaimPerN(null, 'watch unwatch 5')).toBeNull()
+  })
+
+  it('defers when the spec token is repo-shape (per-repo plugin claims)', () => {
+    expect(tryClaimPerN(null, 'watch org/r')).toBeNull()
+  })
+
+  it('errors on missing number after the verb', () => {
+    const r = tryClaimPerN(null, 'watch')
+    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number' })
+  })
+
+  it('defers on a first token that\'s neither a digit-string, repo-shape, nor channel', () => {
+    // `watch foo` / `watch -1` / `watch 5.5` could all be "some other plugin's
+    // target=… with missing args" from the bare claimer's perspective. Defer
+    // and let the dispatcher surface "no plugin handles" if nothing claims it.
+    expect(tryClaimPerN(null, 'watch foo')).toBeNull()
+    expect(tryClaimPerN(null, 'watch -1')).toBeNull()
+    expect(tryClaimPerN(null, 'watch 5.5')).toBeNull()
+  })
+
+  it('errors on a digit-shaped but non-positive integer', () => {
+    expect(tryClaimPerN(null, 'watch 0')?.kind).toBe('error')
+  })
+
+  it('claims repo positional after the number', () => {
+    expect(tryClaimPerN(null, 'watch 5 org/repo')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 5, repo: 'org/repo', channels: [] },
+    })
+  })
+
+  it('claims repo + channels', () => {
+    expect(tryClaimPerN(null, 'watch 5 org/repo #chan')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 5, repo: 'org/repo', channels: ['#chan'] },
+    })
+  })
+
+  it('does NOT mis-grab a #channel as the repo positional', () => {
+    expect(tryClaimPerN(null, 'watch 5 #chan')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 5, repo: null, channels: ['#chan'] },
+    })
+  })
+
+  it('rejects unwatch with channel args', () => {
+    expect(tryClaimPerN(null, 'unwatch 5 #x')).toEqual({
+      kind: 'error', message: 'unwatch takes no channel arguments',
+    })
+  })
+
+  it('rejects malformed channels', () => {
+    for (const bad of ['#', '##foo']) {
+      const r = tryClaimPerN(null, `watch 5 ${bad}`)
+      expect(r?.kind).toBe('error')
+      expect((r as { kind: 'error'; message: string }).message).toMatch(/channels must match/)
+    }
+  })
+
+  it('rejects bareword channel arguments', () => {
+    const r = tryClaimPerN(null, 'watch 5 foo')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/channels must match/)
+  })
+
+  it('only one repo positional; a second is treated as malformed channel', () => {
+    const r = tryClaimPerN(null, 'watch 5 org/a org/b')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/channels must match/)
+  })
+
+  it('rejects unwatch with a trailing channel after the repo positional', () => {
+    const r = tryClaimPerN(null, 'unwatch 5 org/r #x')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/no channel arguments/)
+  })
+})
+
+// ---- tryClaimPerN (target='pr') -------------------------------------------
+
+describe('tryClaimPerN — target=pr', () => {
+  it('claims `watch pr 10`', () => {
+    expect(tryClaimPerN('pr', 'watch pr 10')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 10, repo: null, channels: [] },
+    })
+  })
+
+  it('defers on bare `watch 10` (bare claimer\'s shape)', () => {
+    expect(tryClaimPerN('pr', 'watch 10')).toBeNull()
+  })
+
+  it('defers on a different target', () => {
+    expect(tryClaimPerN('pr', 'watch repo org/r')).toBeNull()
+    expect(tryClaimPerN('pr', 'watch new-issues org/r')).toBeNull()
+  })
+
+  it('lowercases the target token', () => {
+    expect(tryClaimPerN('pr', 'watch PR 10')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 10, repo: null, channels: [] },
+    })
+  })
+
+  it('errors when target matches but number is missing', () => {
+    const r = tryClaimPerN('pr', 'watch pr')
+    expect(r).toEqual({ kind: 'error', message: 'watch requires an issue/PR number' })
+  })
+
+  it('claims `watch pr 10 org/r #chan`', () => {
+    expect(tryClaimPerN('pr', 'watch pr 10 org/r #chan')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', number: 10, repo: 'org/r', channels: ['#chan'] },
+    })
+  })
+})
+
+// ---- tryClaimPerRepo (target='repo') --------------------------------------
+
+describe('tryClaimPerRepo — target=repo', () => {
+  it('claims bare `watch repo org/r`', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo org/r')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: null, path: null, channels: [] },
+    })
+  })
+
+  it('claims @branch', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo org/r@develop')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: 'develop', path: null, channels: [] },
+    })
+  })
+
+  it('claims :path without branch', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo org/r:Formula/x.rb')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: null, path: 'Formula/x.rb', channels: [] },
+    })
+  })
+
+  it('claims @branch:path + channels', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo org/r@develop:Formula/x.rb #chan')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb', channels: ['#chan'] },
+    })
+  })
+
+  it('claims `unwatch repo org/r@develop:Formula/x.rb`', () => {
+    expect(tryClaimPerRepo('repo', 'unwatch repo org/r@develop:Formula/x.rb')).toEqual({
+      kind: 'ok', cmd: { verb: 'unwatch', repo: 'org/r', branch: 'develop', path: 'Formula/x.rb', channels: [] },
+    })
+  })
+
+  it('defers on a different target', () => {
+    expect(tryClaimPerRepo('repo', 'watch new-issues org/r')).toBeNull()
+  })
+
+  it('defers when spec is a number (per-N plugin claims)', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo 5')).toBeNull()
+  })
+
+  it('errors when target matches but spec is missing', () => {
+    expect(tryClaimPerRepo('repo', 'watch repo')).toEqual({
+      kind: 'error', message: 'watch requires an <owner>/<repo> spec',
+    })
+  })
+
+  it('errors on a malformed repo spec', () => {
+    const r = tryClaimPerRepo('repo', 'watch repo notavalidspec!')
+    expect(r?.kind).toBe('error')
+  })
+
+  it('rejects unwatch with channel args', () => {
+    expect(tryClaimPerRepo('repo', 'unwatch repo org/r #x')).toEqual({
+      kind: 'error', message: 'unwatch takes no channel arguments',
+    })
+  })
+})
+
+// ---- tryClaimPerRepo (target='new-issues') --------------------------------
+
+describe('tryClaimPerRepo — target=new-issues', () => {
+  it('claims `watch new-issues org/r #chan`', () => {
+    expect(tryClaimPerRepo('new-issues', 'watch new-issues org/r #chan')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: null, path: null, channels: ['#chan'] },
+    })
+  })
+})
+
+// ---- tryClaimPerRepo (target=null) ---------------------------------------
+
+describe('tryClaimPerRepo — bare (target=null)', () => {
+  it('claims bare `watch org/r` (a generic per-repo plugin can opt in)', () => {
+    expect(tryClaimPerRepo(null, 'watch org/r')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', repo: 'org/r', branch: null, path: null, channels: [] },
+    })
+  })
+
+  it('defers on `watch pr org/r` (target keyword), `watch 5` (number)', () => {
+    expect(tryClaimPerRepo(null, 'watch pr org/r')).toBeNull()
+    expect(tryClaimPerRepo(null, 'watch 5')).toBeNull()
+  })
+})

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -588,7 +588,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     expect(merged.plugins?.['github-issues']).toBeUndefined()
   })
 
-  it('ignores `watch pr` (returns null)', () => {
+  it('ignores cmds routed to a different plugin', () => {
     const local: OrchestratorConfig = {}
     const out = issues().handleCommand!(singleRepo(), local, watchCmd('github-prs', 5, null, []))
     expect(out).toBeNull()
@@ -760,7 +760,7 @@ describe('GhBase.handleCommand — prs plugin (target=pr)', () => {
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
-  it('ignores bare watch (returns null)', () => {
+  it('ignores cmds routed to a different plugin', () => {
     const out = prs().handleCommand!({ repo: 'org/r' }, {}, watchCmd('github-issues', 10, null, []))
     expect(out).toBeNull()
   })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -6,10 +6,26 @@ import { GitHubCommitsPlugin } from '../commits-plugin.js'
 import { GhPluginBase } from '../base.js'
 import { RATE_LIMIT_WINDOW_MS } from '../github-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import type { Command } from '../../../dispatcher-dm-handler.js'
 import type { PrSnap, IssueSnap } from '../types.js'
 import { GhScraper } from '../scraper.js'
 import type { OrchestratorEvent } from '../diff.js'
 import { stubRateLimit } from './gh-test-helpers.js'
+
+// Test helpers — wrap the plugin-owned shapes in the dispatcher's
+// `{kind:'plugin'}` envelope so test call sites stay readable.
+function watchCmd(plugin: string, number: number, repo: string | null, channels: string[]): Command {
+  return { kind: 'plugin', plugin, cmd: { verb: 'watch', number, repo, channels } }
+}
+function unwatchCmd(plugin: string, number: number, repo: string | null): Command {
+  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', number, repo, channels: [] } }
+}
+function watchRepoCmd(plugin: string, repo: string, branch: string | null, path: string | null, channels: string[]): Command {
+  return { kind: 'plugin', plugin, cmd: { verb: 'watch', repo, branch, path, channels } }
+}
+function unwatchRepoCmd(plugin: string, repo: string, branch: string | null, path: string | null): Command {
+  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', repo, branch, path, channels: [] } }
+}
 
 function fakePrSnap(overrides: Partial<PrSnap> = {}): PrSnap {
   return {
@@ -566,7 +582,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('claims bare watch (target=null) and writes to local', () => {
     const merged: OrchestratorConfig = singleRepo()
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: [] })
+    const out = issues().handleCommand!(merged, local, watchCmd('github-issues', 5, null, []))
     expect(out).toMatch(/watching issue #5/)
     expect((local.plugins?.['github-issues'] as { watched: unknown[] }).watched).toEqual([{ number: 5 }])
     expect(merged.plugins?.['github-issues']).toBeUndefined()
@@ -574,7 +590,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
 
   it('ignores `watch pr` (returns null)', () => {
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(singleRepo(), local, { kind: 'watch', target: 'pr', number: 5, repo: null, channels: [] })
+    const out = issues().handleCommand!(singleRepo(), local, watchCmd('github-prs', 5, null, []))
     expect(out).toBeNull()
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -582,7 +598,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('is idempotent on duplicate watch (entry visible via merged)', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: [] })
+    const out = issues().handleCommand!(merged, local, watchCmd('github-issues', 5, null, []))
     expect(out).toMatch(/already watching/)
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -591,7 +607,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     const slice = { watched: [{ number: 5, channels: ['#a'] }] }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
     const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
-    issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#a', '#b'] })
+    issues().handleCommand!(merged, local, watchCmd('github-issues', 5, null, ['#a', '#b']))
     const entry = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0]
     expect(entry.channels).toEqual(['#a', '#b'])
   })
@@ -599,7 +615,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
   it('refuses to add channels to a tracked-only entry', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#x'] })
+    const out = issues().handleCommand!(merged, local, watchCmd('github-issues', 5, null, ['#x']))
     expect(out).toBe('issue #5 in tracked config.json — hand-edit to add channels')
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
@@ -609,7 +625,7 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
     const slice = { watched: [{ number: 5, channels: before }] }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': slice } })
     const local: OrchestratorConfig = { plugins: { 'github-issues': slice } }
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 5, repo: null, channels: ['#a', '#b'] })
+    const out = issues().handleCommand!(merged, local, watchCmd('github-issues', 5, null, ['#a', '#b']))
     expect(out).toMatch(/channels unchanged/)
     const after = (local.plugins!['github-issues'] as { watched: { channels: string[] }[] }).watched[0].channels
     expect(after).toBe(before)
@@ -620,19 +636,19 @@ describe('GhBase.handleCommand — issues plugin (target=null)', () => {
       plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } },
     }
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }, { number: 6 }] } } })
-    issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5, repo: null })
+    issues().handleCommand!(merged, local, unwatchCmd('github-issues', 5, null))
     expect((local.plugins!['github-issues'] as { watched: { number: number }[] }).watched).toEqual([{ number: 6 }])
   })
 
   it('refuses to unwatch a tracked-only entry', () => {
     const merged: OrchestratorConfig = singleRepo({ plugins: { 'github-issues': { watched: [{ number: 5 }] } } })
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'unwatch', target: null, number: 5, repo: null })
+    const out = issues().handleCommand!(merged, local, unwatchCmd('github-issues', 5, null))
     expect(out).toBe('issue #5 in tracked config.json — hand-edit to remove')
   })
 
   it('reports not-watching on unwatch of unknown entry', () => {
-    const out = issues().handleCommand!(singleRepo(), {}, { kind: 'unwatch', target: null, number: 5, repo: null })
+    const out = issues().handleCommand!(singleRepo(), {}, unwatchCmd('github-issues', 5, null))
     expect(out).toMatch(/not watching/)
   })
 
@@ -684,7 +700,7 @@ describe('GhBase.handleCommand — multi-repo mode (bare watch only)', () => {
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
       merged,
       local,
-      { kind: 'watch', target: null, number: 5, repo: null, channels: [] },
+      watchCmd('github-issues', 5, null, []),
     )
     expect(out).toMatch(/multi-repo mode/)
     expect(out).toMatch(/<owner>\/<repo>/)
@@ -702,7 +718,7 @@ describe('GhBase.handleCommand — multi-repo mode (bare watch only)', () => {
     const out = new GitHubIssuesPlugin('#proj').handleCommand!(
       merged,
       local,
-      { kind: 'unwatch', target: null, number: 5, repo: null },
+      unwatchCmd('github-issues', 5, null),
     )
     expect(out).toMatch(/multi-repo mode/)
     expect((local.plugins!['github-issues'] as { watched: unknown[] }).watched).toHaveLength(1)
@@ -713,7 +729,7 @@ describe('GhBase.handleCommand — multi-repo mode (bare watch only)', () => {
     const out = new GitHubPrsPlugin('#proj').handleCommand!(
       merged,
       {},
-      { kind: 'watch', target: 'pr', number: 10, repo: null, channels: [] },
+      watchCmd('github-prs', 10, null, []),
     )
     expect(out).toMatch(/multi-repo mode/)
   })
@@ -724,7 +740,7 @@ describe('GhBase.handleCommand — multi-repo mode (bare watch only)', () => {
     const out = new GitHubPrsPlugin('#proj').handleCommand!(
       merged,
       local,
-      { kind: 'watch', target: 'pr', number: 10, repo: 'org/a', channels: [] },
+      watchCmd('github-prs', 10, 'org/a', []),
     )
     expect(out).toMatch(/watching pr org\/a#10/)
     expect((local.plugins!['github-prs'] as { watched: { number: number; repo: string }[] }).watched)
@@ -738,14 +754,14 @@ describe('GhBase.handleCommand — prs plugin (target=pr)', () => {
   it('claims `watch pr` (target=pr) and writes to local', () => {
     const merged: OrchestratorConfig = { repo: 'org/r' }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: null, channels: ['#x'] })
+    const out = prs().handleCommand!(merged, local, watchCmd('github-prs', 10, null, ['#x']))
     expect(out).toMatch(/watching pr #10 \+ #x/)
     expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, channels: ['#x'] }] })
     expect(local.plugins?.['github-issues']).toBeUndefined()
   })
 
   it('ignores bare watch (returns null)', () => {
-    const out = prs().handleCommand!({ repo: 'org/r' }, {}, { kind: 'watch', target: null, number: 10, repo: null, channels: [] })
+    const out = prs().handleCommand!({ repo: 'org/r' }, {}, watchCmd('github-issues', 10, null, []))
     expect(out).toBeNull()
   })
 
@@ -764,7 +780,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
   it('creates a cross-repo entry, displays repo prefix, pins repo on the stored entry', () => {
     const merged: OrchestratorConfig = { repo: 'org/main' }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    const out = prs().handleCommand!(merged, local, watchCmd('github-prs', 10, 'org/other', []))
     expect(out).toBe('watching pr org/other#10')
     expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, repo: 'org/other' }] })
   })
@@ -772,7 +788,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
   it('explicit repo that matches config.repo is equivalent to bare — no entry.repo, no prefix', () => {
     const merged: OrchestratorConfig = { repo: 'org/main' }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/main', channels: [] })
+    const out = prs().handleCommand!(merged, local, watchCmd('github-prs', 10, 'org/main', []))
     expect(out).toBe('watching pr #10')
     expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10 }] })
   })
@@ -783,7 +799,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
       plugins: { 'github-prs': { watched: [{ number: 10 }] } },
     }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    const out = prs().handleCommand!(merged, local, watchCmd('github-prs', 10, 'org/other', []))
     expect(out).toBe('watching pr org/other#10')
     expect(local.plugins?.['github-prs']).toEqual({ watched: [{ number: 10, repo: 'org/other' }] })
   })
@@ -791,7 +807,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
   it('idempotent on duplicate cross-repo watch', () => {
     const slice = { watched: [{ number: 10, repo: 'org/other' }] }
     const merged: OrchestratorConfig = { repo: 'org/main', plugins: { 'github-prs': slice } }
-    const out = prs().handleCommand!(merged, { plugins: { 'github-prs': slice } }, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: [] })
+    const out = prs().handleCommand!(merged, { plugins: { 'github-prs': slice } }, watchCmd('github-prs', 10, 'org/other', []))
     expect(out).toBe('already watching pr org/other#10')
   })
 
@@ -801,7 +817,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
       plugins: { 'github-prs': { watched: [{ number: 10, repo: 'org/other' }] } },
     }
     const local: OrchestratorConfig = {}
-    const out = prs().handleCommand!(merged, local, { kind: 'watch', target: 'pr', number: 10, repo: 'org/other', channels: ['#x'] })
+    const out = prs().handleCommand!(merged, local, watchCmd('github-prs', 10, 'org/other', ['#x']))
     expect(out).toBe('pr org/other#10 in tracked config.json — hand-edit to add channels')
   })
 
@@ -813,7 +829,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
       repo: 'org/main',
       plugins: { 'github-prs': { watched: [{ number: 10, repo: 'org/other' }, { number: 10 }] } },
     }
-    const out = prs().handleCommand!(merged, local, { kind: 'unwatch', target: 'pr', number: 10, repo: 'org/other' })
+    const out = prs().handleCommand!(merged, local, unwatchCmd('github-prs', 10, 'org/other'))
     expect(out).toBe('unwatched pr org/other#10')
     expect((local.plugins!['github-prs'] as { watched: unknown[] }).watched).toEqual([{ number: 10 }])
   })
@@ -837,7 +853,7 @@ describe('GhBase.handleCommand — cross-repo watch/unwatch (single-repo mode)',
   it('multi-repo mode + repo arg creates a cross-repo entry (parser-clean local)', () => {
     const merged: OrchestratorConfig = { project: 'p' }
     const local: OrchestratorConfig = {}
-    const out = issues().handleCommand!(merged, local, { kind: 'watch', target: null, number: 7, repo: 'org/a', channels: [] })
+    const out = issues().handleCommand!(merged, local, watchCmd('github-issues', 7, 'org/a', []))
     expect(out).toBe('watching issue org/a#7')
     expect(local.plugins?.['github-issues']).toEqual({ watched: [{ number: 7, repo: 'org/a' }] })
   })
@@ -848,9 +864,7 @@ describe('github-commits handleCommand', () => {
 
   it('writes a watch-repo entry to local with explicit branch+path', () => {
     const local: OrchestratorConfig = {}
-    const out = commits().handleCommand!({}, local, {
-      kind: 'watch-repo', target: 'repo', repo: 'AvesAlight/homebrew-tap', branch: 'main', path: 'Formula/roost.rb', channels: [],
-    })
+    const out = commits().handleCommand!({}, local, watchRepoCmd('github-commits', 'AvesAlight/homebrew-tap', 'main', 'Formula/roost.rb', []))
     expect(out).toBe('watching repo AvesAlight/homebrew-tap@main:Formula/roost.rb')
     expect(local.plugins?.['github-commits']).toEqual({ watched: [{
       repo: 'AvesAlight/homebrew-tap', branch: 'main', path: 'Formula/roost.rb',
@@ -859,9 +873,7 @@ describe('github-commits handleCommand', () => {
 
   it('writes a watch-repo entry with implicit branch (omits entry.branch)', () => {
     const local: OrchestratorConfig = {}
-    const out = commits().handleCommand!({}, local, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
-    })
+    const out = commits().handleCommand!({}, local, watchRepoCmd('github-commits', 'org/r', null, null, ['#chan']))
     expect(out).toBe('watching repo org/r@main + #chan')
     expect(local.plugins?.['github-commits']).toEqual({ watched: [{ repo: 'org/r', channels: ['#chan'] }] })
   })
@@ -870,27 +882,21 @@ describe('github-commits handleCommand', () => {
     const slice = { watched: [{ repo: 'org/r' }] }
     const merged: OrchestratorConfig = { plugins: { 'github-commits': slice } }
     const local: OrchestratorConfig = { plugins: { 'github-commits': slice } }
-    const out = commits().handleCommand!(merged, local, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'main', path: null, channels: [],
-    })
+    const out = commits().handleCommand!(merged, local, watchRepoCmd('github-commits', 'org/r', 'main', null, []))
     expect(out).toBe('already watching repo org/r@main')
   })
 
   it('different branches are distinct entries', () => {
     const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }] } } }
     const local: OrchestratorConfig = {}
-    const out = commits().handleCommand!(merged, local, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'develop', path: null, channels: [],
-    })
+    const out = commits().handleCommand!(merged, local, watchRepoCmd('github-commits', 'org/r', 'develop', null, []))
     expect(out).toBe('watching repo org/r@develop')
     expect(local.plugins?.['github-commits']).toEqual({ watched: [{ repo: 'org/r', branch: 'develop' }] })
   })
 
   it('refuses to add channels to a tracked-only entry', () => {
     const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r', branch: 'main', path: 'x.rb' }] } } }
-    const out = commits().handleCommand!(merged, {}, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: 'main', path: 'x.rb', channels: ['#c'],
-    })
+    const out = commits().handleCommand!(merged, {}, watchRepoCmd('github-commits', 'org/r', 'main', 'x.rb', ['#c']))
     expect(out).toBe('repo org/r@main:x.rb in tracked config.json — hand-edit to add channels')
   })
 
@@ -898,9 +904,7 @@ describe('github-commits handleCommand', () => {
     const slice = { watched: [{ repo: 'org/r', channels: ['#a'] }] }
     const merged: OrchestratorConfig = { plugins: { 'github-commits': slice } }
     const local: OrchestratorConfig = { plugins: { 'github-commits': slice } }
-    const out = commits().handleCommand!(merged, local, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: ['#a', '#b'],
-    })
+    const out = commits().handleCommand!(merged, local, watchRepoCmd('github-commits', 'org/r', null, null, ['#a', '#b']))
     expect(out).toBe('repo org/r@main + #b')
     expect((local.plugins!['github-commits'] as { watched: { channels: string[] }[] }).watched[0].channels)
       .toEqual(['#a', '#b'])
@@ -909,9 +913,7 @@ describe('github-commits handleCommand', () => {
   it('removes a local entry on unwatch', () => {
     const local: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }, { repo: 'org/s' }] } } }
     const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }, { repo: 'org/s' }] } } }
-    const out = commits().handleCommand!(merged, local, {
-      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
-    })
+    const out = commits().handleCommand!(merged, local, unwatchRepoCmd('github-commits', 'org/r', null, null))
     expect(out).toBe('unwatched repo org/r@main')
     expect((local.plugins!['github-commits'] as { watched: { repo: string }[] }).watched)
       .toEqual([{ repo: 'org/s' }])
@@ -919,26 +921,18 @@ describe('github-commits handleCommand', () => {
 
   it('refuses to unwatch a tracked-only entry', () => {
     const merged: OrchestratorConfig = { plugins: { 'github-commits': { watched: [{ repo: 'org/r' }] } } }
-    const out = commits().handleCommand!(merged, {}, {
-      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
-    })
+    const out = commits().handleCommand!(merged, {}, unwatchRepoCmd('github-commits', 'org/r', null, null))
     expect(out).toBe('repo org/r@main in tracked config.json — hand-edit to remove')
   })
 
   it('reports not-watching on unknown entry', () => {
-    const out = commits().handleCommand!({}, {}, {
-      kind: 'unwatch-repo', target: 'repo', repo: 'org/r', branch: null, path: null,
-    })
+    const out = commits().handleCommand!({}, {}, unwatchRepoCmd('github-commits', 'org/r', null, null))
     expect(out).toBe('not watching repo org/r@main')
   })
 
   it('ignores commands with target!=repo', () => {
-    expect(commits().handleCommand!({}, {}, {
-      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: [],
-    })).toBeNull()
-    expect(commits().handleCommand!({}, {}, {
-      kind: 'watch', target: null, number: 5, repo: null, channels: [],
-    })).toBeNull()
+    expect(commits().handleCommand!({}, {}, watchRepoCmd('github-new-issues', 'org/r', null, null, []))).toBeNull()
+    expect(commits().handleCommand!({}, {}, watchCmd('github-issues', 5, null, []))).toBeNull()
   })
 
   it('list returns the entry list in canonical form', () => {
@@ -964,41 +958,31 @@ describe('github-new-issues handleCommand', () => {
 
   it('writes a new-issues entry to local', () => {
     const local: OrchestratorConfig = {}
-    const out = plugin().handleCommand!({}, local, {
-      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: ['#chan'],
-    })
+    const out = plugin().handleCommand!({}, local, watchRepoCmd('github-new-issues', 'org/r', null, null, ['#chan']))
     expect(out).toBe('watching new-issues org/r + #chan')
     expect(local.plugins?.['github-new-issues']).toEqual({ watched: [{ repo: 'org/r', channels: ['#chan'] }] })
   })
 
   it('rejects @branch/:path — new-issues entries are repo-only', () => {
-    const out = plugin().handleCommand!({}, {}, {
-      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: 'main', path: null, channels: [],
-    })
+    const out = plugin().handleCommand!({}, {}, watchRepoCmd('github-new-issues', 'org/r', 'main', null, []))
     expect(out).toMatch(/does not support @branch/)
   })
 
   it('idempotent on duplicate', () => {
     const slice = { watched: [{ repo: 'org/r' }] }
     const merged: OrchestratorConfig = { plugins: { 'github-new-issues': slice } }
-    const out = plugin().handleCommand!(merged, { plugins: { 'github-new-issues': slice } }, {
-      kind: 'watch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null, channels: [],
-    })
+    const out = plugin().handleCommand!(merged, { plugins: { 'github-new-issues': slice } }, watchRepoCmd('github-new-issues', 'org/r', null, null, []))
     expect(out).toBe('already watching new-issues org/r')
   })
 
   it('refuses to unwatch a tracked-only entry', () => {
     const merged: OrchestratorConfig = { plugins: { 'github-new-issues': { watched: [{ repo: 'org/r' }] } } }
-    const out = plugin().handleCommand!(merged, {}, {
-      kind: 'unwatch-repo', target: 'new-issues', repo: 'org/r', branch: null, path: null,
-    })
+    const out = plugin().handleCommand!(merged, {}, unwatchRepoCmd('github-new-issues', 'org/r', null, null))
     expect(out).toBe('new-issues org/r in tracked config.json — hand-edit to remove')
   })
 
   it('ignores target=repo (claimed by github-commits)', () => {
-    expect(plugin().handleCommand!({}, {}, {
-      kind: 'watch-repo', target: 'repo', repo: 'org/r', branch: null, path: null, channels: [],
-    })).toBeNull()
+    expect(plugin().handleCommand!({}, {}, watchRepoCmd('github-commits', 'org/r', null, null, []))).toBeNull()
   })
 })
 

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -2,8 +2,9 @@ import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { assertEntryRepoMode, resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
-import { BasePlugin, defaultPluginLogger, type PluginLogger, type TaggedEvent } from '../../plugin.js'
+import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, type TaggedEvent } from '../../plugin.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { tryClaimPerN, type PerNCommand } from '../grammar.js'
 import { GhClient, fetchRateLimit, computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from './github-api.js'
 
 // Shared base for plugins needing GhClient. GhBase extends this for watch-list
@@ -84,8 +85,9 @@ function effectiveRepo(entryRepo: string | undefined, defaultRepo: string | unde
 // Owns the `{ watched?: WatchedEntry[] }` slice convention and the
 // watch/unwatch/list/help command surface.
 export abstract class GhBase extends GhPluginBase {
-  // Target keyword for watch/unwatch — `null` = bare `watch <N>`. The parser
-  // is target-agnostic; subclasses declare what they claim.
+  // Target keyword for watch/unwatch — `null` = bare `watch <N>`. Each
+  // subclass declares what it claims; `parseCommand` below delegates to
+  // `tryClaimPerN(this.target, line)`.
   protected abstract readonly target: string | null
   // Singular noun in reply lines (e.g. "issue", "pr").
   protected abstract readonly label: string
@@ -118,16 +120,17 @@ export abstract class GhBase extends GhPluginBase {
 
   // ---- DM command handling --------------------------------------------
 
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerN(this.target, line)
+  }
+
   handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
     if (cmd.kind === 'list') return this.formatListSection(merged)
     if (cmd.kind === 'help') return this.formatHelpSection()
-    if (cmd.kind === 'watch') {
-      if (cmd.target !== this.target) return null
-      return this.applyWatch(merged, local, cmd.number, cmd.repo, cmd.channels)
-    }
-    if (cmd.kind === 'unwatch') {
-      if (cmd.target !== this.target) return null
-      return this.applyUnwatch(merged, local, cmd.number, cmd.repo)
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerNCommand
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.number, c.repo, c.channels)
+      return this.applyUnwatch(merged, local, c.number, c.repo)
     }
     return null
   }

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -15,9 +15,10 @@
 
 import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
-import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
+import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import type { GhCommit } from './github-api.js'
 import { GhPluginBase } from './base.js'
 
@@ -72,16 +73,17 @@ function formatCommit(entry: CommitWatchEntry, commit: GhCommit, sha: string): s
 export class GitHubCommitsPlugin extends GhPluginBase {
   readonly name = 'github-commits'
 
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerRepo('repo', line)
+  }
+
   handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
     if (cmd.kind === 'list') return this.formatListSection(merged)
     if (cmd.kind === 'help') return this.formatHelpSection()
-    if (cmd.kind === 'watch-repo') {
-      if (cmd.target !== 'repo') return null
-      return this.applyWatchRepo(merged, local, cmd.repo, cmd.branch, cmd.path, cmd.channels)
-    }
-    if (cmd.kind === 'unwatch-repo') {
-      if (cmd.target !== 'repo') return null
-      return this.applyUnwatchRepo(merged, local, cmd.repo, cmd.branch, cmd.path)
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerRepoCommand
+      if (c.verb === 'watch') return this.applyWatchRepo(merged, local, c.repo, c.branch, c.path, c.channels)
+      return this.applyUnwatchRepo(merged, local, c.repo, c.branch, c.path)
     }
     return null
   }

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -10,9 +10,10 @@
 import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import { assertEntryRepoMode } from '../../config.js'
-import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
+import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import { labelNames, type GhRepoIssue } from './github-api.js'
 import { GhPluginBase } from './base.js'
 
@@ -32,22 +33,21 @@ export interface NewIssuesPluginState {
 export class GitHubNewIssuesPlugin extends GhPluginBase {
   readonly name = 'github-new-issues'
 
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerRepo('new-issues', line)
+  }
+
   handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
     if (cmd.kind === 'list') return this.formatListSection(merged)
     if (cmd.kind === 'help') return this.formatHelpSection()
-    if (cmd.kind === 'watch-repo') {
-      if (cmd.target !== 'new-issues') return null
-      if (cmd.branch !== null || cmd.path !== null) {
-        return `error: new-issues does not support @branch or :path — try \`watch new-issues ${cmd.repo}\``
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerRepoCommand
+      if (c.branch !== null || c.path !== null) {
+        const verb = c.verb
+        return `error: new-issues does not support @branch or :path — try \`${verb} new-issues ${c.repo}\``
       }
-      return this.applyWatch(merged, local, cmd.repo, cmd.channels)
-    }
-    if (cmd.kind === 'unwatch-repo') {
-      if (cmd.target !== 'new-issues') return null
-      if (cmd.branch !== null || cmd.path !== null) {
-        return `error: new-issues does not support @branch or :path — try \`unwatch new-issues ${cmd.repo}\``
-      }
-      return this.applyUnwatch(merged, local, cmd.repo)
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.repo, c.channels)
+      return this.applyUnwatch(merged, local, c.repo)
     }
     return null
   }

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -3,6 +3,8 @@
 // + shape disambiguation. Plugins own which targets they claim; the dispatcher
 // stays grammar-agnostic.
 
+import type { ParseResult } from '../plugin.js'
+
 const CHANNEL_RE = /^#[^\s,#]+$/
 
 // Bare `<owner>/<repo>` — optional repo positional in the per-N grammar.
@@ -17,13 +19,6 @@ const REPO_SPEC_RE = /^([A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*)(
 const VERBS = new Set(['watch', 'unwatch', 'help'])
 
 export type Verb = 'watch' | 'unwatch'
-
-// Returned to the dispatcher. `null` = not my shape, try next plugin.
-// `error` = claimed-but-malformed; dispatcher aborts iteration (no other plugin
-// gets a second crack at a line whose shape this plugin already owned).
-export type ParseResult<T> =
-  | { kind: 'ok'; cmd: T }
-  | { kind: 'error'; message: string }
 
 export interface PerNCommand {
   verb: Verb
@@ -40,7 +35,10 @@ export interface PerRepoCommand {
   channels: string[]
 }
 
-// Split a DM body into individual command lines. Newlines, semicolons, commas separate.
+// Split a DM body into individual command lines. Newlines, semicolons, commas
+// separate. Internal — exported so `dispatcher-dm-handler.ts` can import it
+// from the same place plugins' parsers do; not re-exported via
+// `plugin-api.ts` because plugin parsers receive a single already-split line.
 export function splitCommands(text: string): string[] {
   return text
     .split(/[\n;,]+/)
@@ -48,10 +46,10 @@ export function splitCommands(text: string): string[] {
     .filter(Boolean)
 }
 
-// Tokenize a single line: lowercase verb + raw tail tokens.
-// Returns null when the line doesn't start with watch/unwatch (so plugins
-// short-circuit on lines they obviously don't own).
-export function tokenizeVerbLine(line: string): { verb: Verb; tokens: string[] } | null {
+// Tokenize a single line: lowercase verb + raw tail tokens. Returns null
+// when the line doesn't start with watch/unwatch so plugins short-circuit
+// on lines they obviously don't own. Private to this module.
+function tokenizeVerbLine(line: string): { verb: Verb; tokens: string[] } | null {
   const tokens = line.split(/\s+/).filter(Boolean)
   if (tokens.length === 0) return null
   const verb = tokens[0].toLowerCase()
@@ -76,16 +74,16 @@ export function tryClaimPerN(target: string | null, line: string): ParseResult<P
   const specTok = rest[0]
   if (specTok === undefined) {
     // Verb + target with no spec — claim the shape, fail the body.
-    return { kind: 'error', message: `${verb} requires an issue/PR number` }
+    return { kind: 'error', message: `${verb} requires an issue/PR number or <owner>/<repo> spec` }
   }
   // Repo-shape token here is not a per-N claim — a per-repo plugin owns it.
   if (REPO_SPEC_RE.test(specTok)) return null
   if (!/^\d+$/.test(specTok)) {
-    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer` }
+    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer or <owner>/<repo> spec` }
   }
   const number = parseInt(specTok, 10)
   if (number <= 0) {
-    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer` }
+    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer or <owner>/<repo> spec` }
   }
 
   let i = 1

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -1,0 +1,168 @@
+// Shared DM-grammar parsers. Each plugin's `parseCommand` picks one of these
+// helpers, passes its claimed target keyword, and the helper does tokenization
+// + shape disambiguation. Plugins own which targets they claim; the dispatcher
+// stays grammar-agnostic.
+
+const CHANNEL_RE = /^#[^\s,#]+$/
+
+// Bare `<owner>/<repo>` — optional repo positional in the per-N grammar.
+// Disambiguated from channels (start with `#`) and numbers (all digits) on shape.
+const OWNER_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+// Full repo-shape spec — `org/r[@branch[:path]]`. Mirrors github-commits'
+// state key so a daemon.log line copy-pastes into a DM.
+const REPO_SPEC_RE = /^([A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*)(?:@([^:@\s]+))?(?::([^\s]+))?$/
+
+// Reserved verbs — can't shadow as targets.
+const VERBS = new Set(['watch', 'unwatch', 'help'])
+
+export type Verb = 'watch' | 'unwatch'
+
+// Returned to the dispatcher. `null` = not my shape, try next plugin.
+// `error` = claimed-but-malformed; dispatcher aborts iteration (no other plugin
+// gets a second crack at a line whose shape this plugin already owned).
+export type ParseResult<T> =
+  | { kind: 'ok'; cmd: T }
+  | { kind: 'error'; message: string }
+
+export interface PerNCommand {
+  verb: Verb
+  number: number
+  repo: string | null
+  channels: string[]
+}
+
+export interface PerRepoCommand {
+  verb: Verb
+  repo: string
+  branch: string | null
+  path: string | null
+  channels: string[]
+}
+
+// Split a DM body into individual command lines. Newlines, semicolons, commas separate.
+export function splitCommands(text: string): string[] {
+  return text
+    .split(/[\n;,]+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+// Tokenize a single line: lowercase verb + raw tail tokens.
+// Returns null when the line doesn't start with watch/unwatch (so plugins
+// short-circuit on lines they obviously don't own).
+export function tokenizeVerbLine(line: string): { verb: Verb; tokens: string[] } | null {
+  const tokens = line.split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return null
+  const verb = tokens[0].toLowerCase()
+  if (verb !== 'watch' && verb !== 'unwatch') return null
+  return { verb, tokens: tokens.slice(1) }
+}
+
+// Try to claim a per-N line for `target` (null = bare `watch <N>`). Returns:
+//   - `null` if the line isn't watch/unwatch, or doesn't lead with this target,
+//     or the spec token shape is repo-style (-> a per-repo plugin should claim).
+//   - `{kind:'ok',cmd}` on a clean claim.
+//   - `{kind:'error',msg}` when the line claimed this plugin's target but the
+//     body fails validation (bad number, malformed channel, etc.).
+export function tryClaimPerN(target: string | null, line: string): ParseResult<PerNCommand> | null {
+  const parsed = tokenizeVerbLine(line)
+  if (!parsed) return null
+  const { verb, tokens } = parsed
+  const targetMatch = matchTarget(target, tokens)
+  if (targetMatch === null) return null
+  const rest = tokens.slice(targetMatch)
+
+  const specTok = rest[0]
+  if (specTok === undefined) {
+    // Verb + target with no spec — claim the shape, fail the body.
+    return { kind: 'error', message: `${verb} requires an issue/PR number` }
+  }
+  // Repo-shape token here is not a per-N claim — a per-repo plugin owns it.
+  if (REPO_SPEC_RE.test(specTok)) return null
+  if (!/^\d+$/.test(specTok)) {
+    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer` }
+  }
+  const number = parseInt(specTok, 10)
+  if (number <= 0) {
+    return { kind: 'error', message: `${verb}: "${specTok}" is not a positive integer` }
+  }
+
+  let i = 1
+  let repo: string | null = null
+  if (rest[i] !== undefined && OWNER_REPO_RE.test(rest[i])) {
+    repo = rest[i]
+    i += 1
+  }
+
+  const channels = rest.slice(i)
+  if (verb === 'unwatch') {
+    if (channels.length) return { kind: 'error', message: 'unwatch takes no channel arguments' }
+    return { kind: 'ok', cmd: { verb, number, repo, channels: [] } }
+  }
+  for (const c of channels) {
+    if (!CHANNEL_RE.test(c)) {
+      return { kind: 'error', message: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
+    }
+  }
+  return { kind: 'ok', cmd: { verb, number, repo, channels } }
+}
+
+// Try to claim a per-repo line for `target`. `target=null` accepts bare
+// `watch <owner>/<repo>` — generic per-repo plugins can opt in.
+export function tryClaimPerRepo(target: string | null, line: string): ParseResult<PerRepoCommand> | null {
+  const parsed = tokenizeVerbLine(line)
+  if (!parsed) return null
+  const { verb, tokens } = parsed
+  const targetMatch = matchTarget(target, tokens)
+  if (targetMatch === null) return null
+  const rest = tokens.slice(targetMatch)
+
+  const specTok = rest[0]
+  if (specTok === undefined) {
+    return { kind: 'error', message: `${verb} requires an <owner>/<repo> spec` }
+  }
+  const m = specTok.match(REPO_SPEC_RE)
+  if (!m) {
+    // Numeric spec here is not a per-repo claim — a per-N plugin owns it.
+    if (/^\d+$/.test(specTok)) return null
+    return { kind: 'error', message: `${verb}: "${specTok}" is not a valid <owner>/<repo>[@<branch>[:<path>]] spec` }
+  }
+
+  const repo = m[1]
+  const branch = m[2] ?? null
+  const path = m[3] ?? null
+  const channels = rest.slice(1)
+  if (verb === 'unwatch') {
+    if (channels.length) return { kind: 'error', message: 'unwatch takes no channel arguments' }
+    return { kind: 'ok', cmd: { verb, repo, branch, path, channels: [] } }
+  }
+  for (const c of channels) {
+    if (!CHANNEL_RE.test(c)) {
+      return { kind: 'error', message: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
+    }
+  }
+  return { kind: 'ok', cmd: { verb, repo, branch, path, channels } }
+}
+
+// Returns the index of the first non-target token in `tokens`, or null when
+// `target` is set but doesn't appear at position 0. `target=null` means the
+// plugin claims bare verbs; we still reject a leading reserved verb so
+// `watch unwatch 5` (almost certainly a typo) doesn't silently become target=unwatch.
+function matchTarget(target: string | null, tokens: string[]): number | null {
+  if (target === null) {
+    const first = tokens[0]
+    if (first === undefined) return 0
+    // A first token that's a reserved verb is a typo — not our claim, not a
+    // valid bare-target shape. Defer; the dispatcher will surface unknown.
+    if (VERBS.has(first.toLowerCase())) return null
+    // A target keyword (non-numeric, non-repo-shape, non-channel) is claimed
+    // by some other plugin — we only own bare `watch <N>` or `watch <repo>`.
+    if (!/^\d+$/.test(first) && !REPO_SPEC_RE.test(first) && !CHANNEL_RE.test(first)) {
+      return null
+    }
+    return 0
+  }
+  if (tokens[0]?.toLowerCase() !== target) return null
+  return 1
+}


### PR DESCRIPTION
Closes #458

## Summary

Inverts the DM parser so plugins claim grammar shapes themselves instead of the central handler decoding every shape into a tagged-union Command. Adds `grammarPriority` (static + operator-override) to disambiguate overlap.

In service of the upcoming Linear plugin (0.8.0), which will overlap `github-issues` on bare `watch <N>`.

## What changed

- **`Plugin.parseCommand?(line)`**: optional seam, returns `{kind:'ok',cmd}` to claim, `{kind:'error',message}` to fail (terminates iteration; no second crack from another plugin), or `null` to defer. Canonical semantics in JSDoc on the Plugin interface.
- **`Plugin.grammarPriority?: number`**: static hint (default 0). Operator override via `config.plugin_priorities[name]` replaces it outright (not max/sum) — the deployment is authoritative.
- **Central Command type slims to** `list | help | plugin | unknown`. The four `watch`/`unwatch`/`watch-repo`/`unwatch-repo` variants are gone; the dispatcher wraps claimed payloads as `{kind:'plugin', plugin:<name>, cmd:<plugin shape>}` and threads them back to the same plugin's handleCommand.
- **`src/orchestrator/plugins/grammar.ts`**: shared `tryClaimPerN(target, line)` / `tryClaimPerRepo(target, line)` helpers. Exported from `roost/plugin` for 3rd-party plugins.
- **Migrated** github-issues, github-prs, github-commits, github-new-issues to call the helpers from their own `parseCommand`.

## Breaking for external plugins

Pre-0.7 `handleCommand` received every Command kind. Now it only fires for `list`, `help`, and this plugin's own claimed commands. Plugins that used to switch on `cmd.kind === 'watch'|...` need a `parseCommand`. `docs/PLUGINS.md` has a migration note + worked example. No real-world consumers exist in this repo.

## Doc home

JSDoc on `Plugin.parseCommand` is canonical for parser semantics. PLUGINS.md walks the author through it. DISPATCHER.md is operator-facing — one line + pointer.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 695 pass, 0 fail (new `plugins/__tests__/grammar.test.ts` covers helper edge cases; dispatcher tests cover priority tie-breaks + override + error-terminate-iteration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)