### PR TITLE
fix(dispatcher): restore log specificity for plugin-claimed DM commands

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -69,7 +69,7 @@ When two plugins want overlapping shapes (e.g. a linear plugin claiming bare `wa
 
 ### Migration from pre-0.7.0
 
-Plugins that used to receive every `Command` via `handleCommand` (the central parser model) need to add a `parseCommand` to claim what they want. `handleCommand` now only fires for `list`, `help`, and the plugin's own claimed commands. There are no built-in `watch`/`unwatch`/`watch-repo`/`unwatch-repo` Command kinds anymore; the dispatcher wraps claimed payloads as `{kind:'plugin', plugin:<name>, cmd:<your shape>}`.
+Plugins that used to receive every `Command` via `handleCommand` (the central parser model) need to add a `parseCommand` to claim what they want. `handleCommand` now only fires for `list`, `help`, and the plugin's own claimed commands. There are no built-in `watch`/`unwatch`/`watch-repo`/`unwatch-repo` Command kinds anymore; the dispatcher wraps claimed payloads as `{kind:'plugin', plugin:<name>, cmd:<your shape>, raw:<original DM line>}`. `raw` is dispatcher-injected for logging — plugin authors don't set it, but test code constructing synthetic `plugin` Commands must include it.
 
 ## Register on load
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -133,12 +133,13 @@ describe('parseCommand (central — global verbs)', () => {
 })
 
 describe('parseCommand (plugin claims)', () => {
-  it('routes claims to the matching plugin', () => {
+  it('routes claims to the matching plugin and preserves raw line', () => {
     const issues = new StubPlugin('issues', null)
     const prs = new StubPlugin('prs', 'pr')
     const cmd = parseCommand('watch pr 10', [issues, prs], {}) as Extract<Command, { kind: 'plugin' }>
     expect(cmd.kind).toBe('plugin')
     expect(cmd.plugin).toBe('prs')
+    expect(cmd.raw).toBe('watch pr 10')
   })
 
   it('honors grammarPriority (higher wins on overlap)', () => {
@@ -386,6 +387,17 @@ describe('handleDm — routing', () => {
     expect(irc.dms[0].text).toBe('watching 5\n\nalready watching 5')
     const overlay = await loadLocalOverlay(dir)
     expect((overlay.plugins?.['listish'] as { watched: number[] }).watched).toEqual([5])
+  })
+
+  it('write-path log includes plugin name and raw line for plugin commands', async () => {
+    await writeConfig(dir, { project: 'roost', plugins: {} })
+    const issues = new StubPlugin('issues', null)
+    const { deps, irc } = makeDeps(dir, [issues])
+    await handleDm(deps, { sender: 'roost-lead-pm', text: 'watch 7' })
+    const logLine = irc.logs.find(l => l.includes('cmd=plugin'))
+    expect(logLine).toBeDefined()
+    expect(logLine).toContain('plugin=issues')
+    expect(logLine).toContain('"watch 7"')
   })
 
   it('empty-body DMs are ignored silently', async () => {

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -14,8 +14,10 @@ import { splitCommands } from './plugins/grammar.js'
 
 // `plugin` carries an opaque cmd payload — the plugin that produced it is the
 // only one that handles it. `list` / `help` broadcast to every plugin.
+// `raw` on `plugin` is the original DM line, injected by the dispatcher at
+// parse time so daemon.log entries show what the operator actually typed.
 export type Command =
-  | { kind: 'plugin'; plugin: string; cmd: unknown }
+  | { kind: 'plugin'; plugin: string; cmd: unknown; raw: string }
   | { kind: 'list' }
   | { kind: 'help' }
   | { kind: 'unknown'; raw: string; error: string }
@@ -81,7 +83,7 @@ export function parseCommand(line: string, plugins: Plugin[], config: Orchestrat
       const result = p.parseCommand?.(line)
       if (result == null) continue
       if (result.kind === 'error') return { kind: 'unknown', raw: line, error: result.message }
-      return { kind: 'plugin', plugin: p.name, cmd: result.cmd }
+      return { kind: 'plugin', plugin: p.name, cmd: result.cmd, raw: line }
     }
     const names = plugins.map(p => p.name).sort().join(', ') || '(none)'
     return { kind: 'unknown', raw: line, error: `no plugin handles \`${line}\` — enabled plugins: ${names}` }
@@ -246,7 +248,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   if (writeFailed) return
   for (const cmd of cmds) {
     const parts = [`cmd=${cmd.kind}`]
-    if (cmd.kind === 'plugin') parts.push(`plugin=${cmd.plugin}`)
+    if (cmd.kind === 'plugin') parts.push(`plugin=${cmd.plugin}`, `raw=${JSON.stringify(cmd.raw)}`)
     deps.log(`dispatcher-dm-handler: ${dm.sender} ${parts.join(' ')}`)
   }
   deps.dm(dm.sender, replies.join('\n\n'))

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -187,7 +187,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
   // Any parse failure aborts the batch — a typo shouldn't half-commit.
   const unknowns = cmds.filter((c): c is Extract<Command, { kind: 'unknown' }> => c.kind === 'unknown')
   if (unknowns.length) {
-    for (const u of unknowns) deps.log(`dispatcher-dm-handler: ${dm.sender} parse: ${u.error}`)
+    for (const u of unknowns) deps.log(`dispatcher-dm-handler: ${dm.sender} parse: ${u.error} raw=${JSON.stringify(u.raw)}`)
     deps.dm(dm.sender, unknowns.map(u => `error: ${u.error}`).join('\n'))
     return
   }

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -14,17 +14,18 @@ import { stubRateLimit } from './gh-test-helpers.js'
 
 // Test helpers — wrap the plugin-owned shapes in the dispatcher's
 // `{kind:'plugin'}` envelope so test call sites stay readable.
+// `raw` is a dispatcher-injected logging field; synthetic test commands use ''.
 function watchCmd(plugin: string, number: number, repo: string | null, channels: string[]): Command {
-  return { kind: 'plugin', plugin, cmd: { verb: 'watch', number, repo, channels } }
+  return { kind: 'plugin', plugin, cmd: { verb: 'watch', number, repo, channels }, raw: '' }
 }
 function unwatchCmd(plugin: string, number: number, repo: string | null): Command {
-  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', number, repo, channels: [] } }
+  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', number, repo, channels: [] }, raw: '' }
 }
 function watchRepoCmd(plugin: string, repo: string, branch: string | null, path: string | null, channels: string[]): Command {
-  return { kind: 'plugin', plugin, cmd: { verb: 'watch', repo, branch, path, channels } }
+  return { kind: 'plugin', plugin, cmd: { verb: 'watch', repo, branch, path, channels }, raw: '' }
 }
 function unwatchRepoCmd(plugin: string, repo: string, branch: string | null, path: string | null): Command {
-  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', repo, branch, path, channels: [] } }
+  return { kind: 'plugin', plugin, cmd: { verb: 'unwatch', repo, branch, path, channels: [] }, raw: '' }
 }
 
 function fakePrSnap(overrides: Partial<PrSnap> = {}): PrSnap {


### PR DESCRIPTION
Closes #485

After the grammar inversion, daemon.log showed `cmd=plugin plugin=github-prs` instead of the specific args (`target=pr n=10 repo=org/r`). The plugin-claimed cmd payload is opaque so the dispatcher can't introspect it.

Fix: add `raw: string` to the `plugin` Command variant. The dispatcher injects the original DM line at parse time (`parseCommand` has it; plugins never touch `raw`). Log line is now:

```
dispatcher-dm-handler: <sender> cmd=plugin plugin=<name> raw="<line>"
```

`JSON.stringify` provides quote/newline-safe encoding. No Plugin interface changes — works for all plugins from day one.

Files touched: `dispatcher-dm-handler.ts` (type, parse, log), two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)