### PR TITLE
maint: add cross-project learning (don't tag humans until agents resolve all outstanding issues)

### DIFF
--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -72,6 +72,12 @@ When migrating N call sites to a new helper, scan each migrated function for *ev
 
 When filing a followup issue, ask whether the work is primarily in service of a future milestone before defaulting to the current one. If the followup's value lands in a later wave (e.g., a boot-time priority-tie warning is most useful when the Linear plugin lands in 0.8.0, not during a 0.7.0 cleanup pass), file it in that future milestone. The concrete test: "when does this followup's primary consumer arrive?"
 
+## 2026-05-20: Don't tag humans until agents have resolved all outstanding issues (from cross-project scratcher)
+
+Agents resolve all outstanding issues first; humans only get tagged when the team has nothing left to improve. In the ready-for-review dance: worker drafts PR, reviewer posts findings, worker addresses them, CI goes green, lead pressure-tests — only then does the lead explicitly signal "mark ready + add human." No auto-fire on worker-ready+CI-green. The concrete cost of premature tagging: human review time spent on issues the agent team would have caught.
+
+Attribution: alex, cross-project learning from scratcher milestone.
+
 ## 2026-05-20: When you see N copies of the same intervention accumulating, debounce at the producer (from #470)
 
 When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.

--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -74,7 +74,7 @@ When filing a followup issue, ask whether the work is primarily in service of a 
 
 ## 2026-05-20: Don't tag humans until agents have resolved all outstanding issues (from cross-project scratcher)
 
-Agents resolve all outstanding issues first; humans only get tagged when the team has nothing left to improve. In the ready-for-review dance: worker drafts PR, reviewer posts findings, worker addresses them, CI goes green, lead pressure-tests — only then does the lead explicitly signal "mark ready + add human." No auto-fire on worker-ready+CI-green. The concrete cost of premature tagging: human review time spent on issues the agent team would have caught.
+Agents resolve all outstanding issues first; humans only get tagged when the team has nothing left to improve. The APM does not tag a human reviewer — marking a PR ready, adding a reviewer, or re-requesting review — until the lead explicitly signals go. In the ready-for-review dance: worker drafts PR, reviewer posts findings, worker addresses them, CI goes green, lead pressure-tests — only then does the lead signal go. The concrete cost of premature tagging: human review time spent on issues the agent team would have caught.
 
 Attribution: alex, cross-project learning from scratcher milestone.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -43,7 +43,6 @@ Your IRC nick is `<project>-apm`. On boot:
 Some triggers are unambiguous — proceed directly without acking the lead first:
 
 - **Reviewer spawn** — worker posts a draft PR with a valid closing reference; model is always opus.
-- **Mark-ready + re-request review** — worker signals "ready to flip" AND dispatcher confirms CI green (both conditions deterministic).
 - **Follow-up filing** — lead provides title-shape + source context (e.g., "from PR #N") + milestone; APM drafts body and files.
 - **Unwatch/cleanup steps** — mechanical teardown that follows an already-confirmed merge.
 - **Watch self-authored PR** — lead explicitly says "watch PR #N and add human"; model is irrelevant (no reviewer-agent), action is unambiguous.
@@ -51,6 +50,7 @@ Some triggers are unambiguous — proceed directly without acking the lead first
 Everything else requires ack-before-action:
 
 - **Worker spawn** — model choice and branch name must be confirmed (or be unambiguous from the lead's message).
+- **Mark-ready + re-request review** — The APM does not tag a human reviewer — marking a PR ready, adding a reviewer, or re-requesting review — until the lead explicitly signals go.
 - **Merge itself** — destructive and irreversible.
 - **Multi-issue/PR actions** — any single action touching more than one issue or PR.
 - **Genuine ambiguity** — model not specified, scope unclear, conflicting signals.
@@ -147,11 +147,13 @@ The reviewer shuts itself down after posting. You don't follow up.
 
 ### Ready-for-review dance
 
-Trigger: BOTH the worker reports addressing reviewer findings (e.g., posts "pushed", "addressed", "ready to flip" in the issue channel) AND the dispatcher reports CI passed on the new commit. Wait for whichever comes second.
+Trigger: lead explicitly signals go (e.g., "mark it ready", "flip it", "go") after the worker has addressed all outstanding findings and CI is green. Do NOT fire on worker-ready + CI-green alone — wait for the lead's explicit signal.
 
-This dance also covers re-requesting review after a human leaves CHANGES_REQUESTED or COMMENT and the worker pushes a fix.
+This dance also covers re-requesting review after a human leaves CHANGES_REQUESTED or COMMENT and the worker pushes a fix. Same rule: wait for the lead's explicit go before re-requesting.
 
-When both conditions are met, proceed without ack:
+The APM does not tag a human reviewer — marking a PR ready, adding a reviewer, or re-requesting review — until the lead explicitly signals go.
+
+On lead go:
 - `gh pr ready <N> --repo <owner>/<repo>` (no-op if already ready, that's fine).
 - `gh pr edit <N> --repo <owner>/<repo> --add-reviewer <gh-login>`.
 - Post in `#<project>-issue-<N>`: `PR #<N> marked ready, <gh-login> added for review`.

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -82,7 +82,7 @@ When the human leaves PR comments, reply on the PR, not in IRC. The PR thread is
 
 The APM handles five dances for you: setup (worktree + watch + worker spawn), reviewer-spawn (when worker posts a draft PR), ready-for-review (mark-ready + add human reviewer + re-request after CHANGES_REQUESTED), merge + cleanup, and follow-up filing (`gh issue create` against the current or a named milestone). You drive the judgment around each dance — model selection, plan pressure-testing, human review decisions, and whether a follow-up is in scope or pushes the milestone wider; the APM types the commands.
 
-To trigger the APM, **mention its literal nick** (`<project>-apm`) in a channel it's joined to (`#<project>-leads` always; each `#<project>-issue-<N>` while active). The APM acts autonomously on unambiguous triggers — reviewer spawn (on a valid draft PR), mark-ready + re-request review (when worker signals ready AND CI is green), follow-up filing (when you give title + source + milestone). It acks before acting on anything requiring your judgment: worker spawn (model, branch name), the merge itself, and anything ambiguous. When ack is required, it restates what it parsed and waits for your affirmative (`go`, `yes`, `y`, `lgtm` — anything clear).
+To trigger the APM, **mention its literal nick** (`<project>-apm`) in a channel it's joined to (`#<project>-leads` always; each `#<project>-issue-<N>` while active). The APM acts autonomously on unambiguous triggers — reviewer spawn (on a valid draft PR), follow-up filing (when you give title + source + milestone). It acks before acting on anything requiring your judgment: worker spawn (model, branch name), marking a PR ready or adding/re-requesting a human reviewer, the merge itself, and anything ambiguous. When ack is required, it restates what it parsed and waits for your affirmative (`go`, `yes`, `y`, `lgtm` — anything clear).
 
 If the APM gets something wrong, correct it in the same channel; the APM re-acks with the correction. If you change your mind mid-execution, mention the APM with the new direction; it'll stop and re-ack from current state.
 
@@ -112,11 +112,11 @@ For each issue:
 
 6. **The reviewer shuts itself down after posting** — no action needed.
 
-7. **When the worker says "ready to flip" AND CI is green**, the APM marks the PR ready and adds `<gh-login>` automatically — no ack needed (both conditions are deterministic). The same dance covers re-requesting review after the human leaves CHANGES_REQUESTED or COMMENT and the worker pushes a fix. Workers do NOT mark the PR ready themselves.
+7. **When the worker says "ready to flip" AND CI is green**, signal the APM to mark the PR ready and add `<gh-login>`. The APM does not tag a human reviewer — marking a PR ready, adding a reviewer, or re-requesting review — until the lead explicitly signals go. Workers do NOT mark the PR ready themselves.
 
-   Once ready, the PR stays in ready state throughout the human review loop — do NOT convert back to draft, regardless of feedback. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits; the APM handles re-request. Three outcomes from the human:
+   Once ready, the PR stays in ready state throughout the human review loop — do NOT convert back to draft, regardless of feedback. GitHub does not auto-rerequest a CHANGES_REQUESTED reviewer after new commits; mention the APM to re-request when the worker pushes a fix. Three outcomes from the human:
    - **APPROVE**: proceed to step 8.
-   - **COMMENT** or **CHANGES_REQUESTED**: equivalent. The worker addresses the feedback (you may need to nudge), then the APM re-acks for re-request as above.
+   - **COMMENT** or **CHANGES_REQUESTED**: equivalent. The worker addresses the feedback (you may need to nudge), then signal the APM to re-request review.
 
 8. **On human approval**, the APM acks in `#<project>-leads`: `PR #<N> approved + CI green, ready to merge and clean up?` (with any reviewer nitpicks surfaced for your call). Confirm with an affirmative. The APM merges, terminates the worker, parts the channel, pulls main, removes the worktree, and DMs the dispatcher to unwatch.
 


### PR DESCRIPTION
add cross-project learning from scratcher: agents resolve all outstanding issues before tagging humans. changes the ready-for-review posture from auto-fire to explicit lead go.

🤖 Generated with Claude Code