### PR TITLE
maint: bump package.json to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bump 0.6.5 → 0.7.0.

what's new since v0.6.5:
- orchestrator/dispatcher cleanup: collapsed duplication, trimmed verbose comments (~15% LOC reduction)
- shared fs lock primitives: `src/fs-lock.ts` + `bin/_lock-lib.sh`
- consolidated tmux buffer-chain: `bin/roost-tmux-inject`
- inverted DM parsing: plugins claim grammar via `parseCommand` + `grammarPriority`
- restored daemon.log specificity for plugin-claimed DM commands