### PR TITLE
feat(prompts): worker last-look gate + reviewer fit-specific requirement

### DIFF
--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -37,16 +37,13 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 4. **Pass (B): diff-level review.** Run /simplify against the changed code on the current branch ($3). Then sweep for: code reuse, quality, efficiency, dead code, premature abstraction, style smells, test gaps.
 
-5. **Last-look gate before posting.** Before you write the comment:
-   - If you haven't pulled up the consumer-side reads step 2 calls for, don't post — do them now. A pass (B)-only review without consumer-side reads is the failure mode this step exists to catch.
-   - **Name one specific structural property you verified in Pass (A): fit check** (your *fit-specific*) — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location. If you can't name one, redo Pass (A); your fit check was a glance, not a check.
-   - If your findings list is short (only `nit`s and `fyi`s, or fewer than ~3 total), ask yourself whether Pass (A) was worked or skimped; if skimped, redo it. A clean review without a verified fit-specific is suspect — short findings lists are more often a tired reviewer than a clean PR.
+5. **Last-look before posting** — how you put the team's best foot forward for the lead and human reviewer. Before you write the comment, **name one specific structural property you verified in Pass (A): fit check** (your *fit-specific*) — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location.
 
 6. **Post findings as a single comment on PR #$1**, prefixed `[$6]`. Tag each finding with severity (`blocker` / `nit` / `fyi`) and confidence. Be terse per finding — IRC tone — but report coverage, not a curated subset. Group fit-check findings (pass A) before diff-level findings (pass B) so the reader can scan structurally.
 
 7. Do NOT make edits — review only.
 
-8. Once posted, report 'review complete' in $7 with a one-line headline that **must include the Pass (A) fit-specific from step 5** — e.g. "12 findings, 0 blocker, fit-check: consumer X still wired correctly after Y refactor" or "5 findings, 1 blocker, fit-check: no duplicated invariant between A and B". A headline without a concrete fit-specific (e.g. "12 findings, looks good") is a self-detected gate failure — loop back to step 5. Then shut yourself down: `roost shutdown $6`. Don't poll, don't follow up, don't comment on fixups.
+8. Once posted, report 'review complete' in $7 with a one-line headline that includes the Pass (A) fit-specific from step 5 — e.g. "12 findings, 0 blocker, fit-check: consumer X still wired correctly after Y refactor" or "5 findings, 1 blocker, fit-check: no duplicated invariant between A and B". Then shut yourself down: `roost shutdown $6`. Don't poll, don't follow up, don't comment on fixups.
 
 ## What NOT to flag
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -38,7 +38,7 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 4. **Pass (B): diff-level review.** Run /simplify against the changed code on the current branch ($3). Then sweep for: code reuse, quality, efficiency, dead code, premature abstraction, style smells, test gaps.
 
 5. **Last-look gate before posting.** Before you write the comment:
-   - If you haven't pulled up the consumer-side files step 2 mandates, don't post — do them now. A pass (B)-only review without consumer-side reads is the failure mode this step exists to catch.
+   - If you haven't pulled up the consumer-side reads step 2 calls for, don't post — do them now. A pass (B)-only review without consumer-side reads is the failure mode this step exists to catch.
    - **Name one specific structural property you verified in Pass (A): fit check** (your *fit-specific*) — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location. If you can't name one, redo Pass (A); your fit check was a glance, not a check.
    - If your findings list is short (only `nit`s and `fyi`s, or fewer than ~3 total), ask yourself whether Pass (A) was worked or skimped; if skimped, redo it. A clean review without a verified fit-specific is suspect — short findings lists are more often a tired reviewer than a clean PR.
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -39,8 +39,8 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 5. **Last-look gate before posting.** Before you write the comment:
    - If you haven't pulled up the consumer-side files step 2 mandates, don't post — do them now. A pass (B)-only review without consumer-side reads is the failure mode this step exists to catch.
-   - **Name one specific structural property you verified in Pass (A): fit check** — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location. If you can't name one, redo Pass (A); your fit check was a glance, not a check.
-   - If your findings list is short (only `nit`s and `fyi`s, or fewer than ~3 total), specifically ask whether Pass (A) was worked or skimped. A clean review without a verified fit-specific is suspect — short findings lists are more often a tired reviewer than a clean PR.
+   - **Name one specific structural property you verified in Pass (A): fit check** (your *fit-specific*) — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location. If you can't name one, redo Pass (A); your fit check was a glance, not a check.
+   - If your findings list is short (only `nit`s and `fyi`s, or fewer than ~3 total), ask yourself whether Pass (A) was worked or skimped; if skimped, redo it. A clean review without a verified fit-specific is suspect — short findings lists are more often a tired reviewer than a clean PR.
 
 6. **Post findings as a single comment on PR #$1**, prefixed `[$6]`. Tag each finding with severity (`blocker` / `nit` / `fyi`) and confidence. Be terse per finding — IRC tone — but report coverage, not a curated subset. Group fit-check findings (pass A) before diff-level findings (pass B) so the reader can scan structurally.
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -37,11 +37,16 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 4. **Pass (B): diff-level review.** Run /simplify against the changed code on the current branch ($3). Then sweep for: code reuse, quality, efficiency, dead code, premature abstraction, style smells, test gaps.
 
-5. **Post findings as a single comment on PR #$1**, prefixed `[$6]`. Tag each finding with severity (`blocker` / `nit` / `fyi`) and confidence. Be terse per finding — IRC tone — but report coverage, not a curated subset. Group fit-check findings (pass A) before diff-level findings (pass B) so the reader can scan structurally.
+5. **Last-look gate before posting.** Before you write the comment:
+   - If you haven't pulled up the consumer-side files step 2 mandates, don't post — do them now. A pass (B)-only review without consumer-side reads is the failure mode this step exists to catch.
+   - **Name one specific structural property you verified in Pass (A): fit check** — a consumer wire-up that still holds, an invariant that lives in exactly one place, a comment that still describes current behavior, a path that's actually exercised. Not "looks reasonable" or "fits the codebase" — a concrete property at a named location. If you can't name one, redo Pass (A); your fit check was a glance, not a check.
+   - If your findings list is short (only `nit`s and `fyi`s, or fewer than ~3 total), specifically ask whether Pass (A) was worked or skimped. A clean review without a verified fit-specific is suspect — short findings lists are more often a tired reviewer than a clean PR.
 
-6. Do NOT make edits — review only.
+6. **Post findings as a single comment on PR #$1**, prefixed `[$6]`. Tag each finding with severity (`blocker` / `nit` / `fyi`) and confidence. Be terse per finding — IRC tone — but report coverage, not a curated subset. Group fit-check findings (pass A) before diff-level findings (pass B) so the reader can scan structurally.
 
-7. Once posted, report 'review complete' in $7 with a one-line headline (e.g. "12 findings, 0 blocker, fit-check found a duplicated invariant between X and Y"). Then shut yourself down: `roost shutdown $6`. Don't poll, don't follow up, don't comment on fixups.
+7. Do NOT make edits — review only.
+
+8. Once posted, report 'review complete' in $7 with a one-line headline that **must include the Pass (A) fit-specific from step 5** — e.g. "12 findings, 0 blocker, fit-check: consumer X still wired correctly after Y refactor" or "5 findings, 1 blocker, fit-check: no duplicated invariant between A and B". A headline without a concrete fit-specific (e.g. "12 findings, looks good") is a self-detected gate failure — loop back to step 5. Then shut yourself down: `roost shutdown $6`. Don't poll, don't follow up, don't comment on fixups.
 
 ## What NOT to flag
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -53,7 +53,7 @@ Before you signal "ready to flip" — both after the reviewer round and after ea
 4. If the answer in (3) is something you haven't actually verified is solid, fix it now — don't signal ready.
 5. Signal ready with a structural summary line *and* a `highest-risk specific: <file:section or function or invariant>` line. A platitude there ("highest-risk specific: correctness", "the new code") is a self-detected gate failure — loop back to (3) and pick a real one.
 
-The gate is yours to fail loudly. Lead-pm and the human will read your `highest-risk specific:` line and check whether the PR actually addresses that risk — a vague answer is more visible than a missing one.
+The `highest-risk specific:` line lives in the issue channel and the PR — it's a visible commitment, not a checkbox. Anyone reviewing the PR (lead, human, future you on a follow-up) can spot a platitude, and a vague answer is more visible than a missing one. The gate is yours to fail loudly.
 
 ## Commits
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -45,15 +45,15 @@ Batch multiple changes-requested items into one push so you don't ping the lead 
 
 ## Last-look gate
 
-Before you signal "ready to flip" — both after the reviewer round and after each human-review round — run this gate. It exists so the agent team resolves what it can resolve before the human sees the PR; a human-review round spent on a finding you'd have caught on a re-read is the failure mode.
+Before you signal "ready to flip" — both after the reviewer round and after each human-review round — run this gate. It's how the team puts its best foot forward for the lead and human reviewer: re-read with fresh eyes, name the riskiest piece in plain language, hand leadership a concrete starting point for their review.
 
 1. Re-read the full diff end-to-end. Not just the files you touched this push — the whole PR.
 2. Re-read the reviewer's findings, including the `nit`s and the ones you argued past. For each one you didn't address, ask whether your reason still holds after the re-read — sometimes a nit dismissed on its own reads as structural once the diff is whole again.
-3. Answer concretely: **name one specific file/section/function/invariant in this PR that, if you'd skimped on it, would surface as a finding in human review.** Not "correctness" or "the new logic" — a real location. If nothing comes to mind, the gate failed open; re-read until something does.
+3. Answer concretely: **name one specific file/section/function/invariant in this PR that, if you'd skimped on it, would surface as a finding in human review.** Not "correctness" or "the new logic" — a real location.
 4. If the answer in (3) is something you haven't actually verified is solid, fix it now — don't signal ready.
-5. Signal ready with a structural summary line *and* a `highest-risk specific: <file:section or function or invariant>` line. A platitude there ("highest-risk specific: correctness", "the new code") is a self-detected gate failure — loop back to (3) and pick a real one.
+5. Signal ready with a structural summary line *and* a `highest-risk specific: <file:section or function or invariant>` line.
 
-The `highest-risk specific:` line lives in the issue channel — a visible commitment at the moment you signal ready, not a checkbox. Anyone in the channel at that moment (lead, human, reviewer if still attached) can spot a platitude, and a vague answer is more visible than a missing one. The gate is yours to fail loudly.
+The `highest-risk specific:` line is a concrete commitment the lead and human can engage with at the moment you signal ready. It lives in the issue channel where lead, human, and reviewer (if still attached) read it together.
 
 ## Commits
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -36,7 +36,7 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 PRs start as draft and go through a reviewer pass *before* anyone flips them ready.
 
 1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
-2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then run the **last-look gate** (below) before signaling ready. When the gate clears, signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback", and append a `highest-risk specific:` line as the gate requires. APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
+2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then run the **last-look gate** (below) before signaling ready. When the gate clears, signal in the channel — structural summary plus the `highest-risk specific:` line the gate requires. Use a structural summary like "tightened X validation, dropped Y helper", not "addressed reviewer feedback". APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
 3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal, last-look gate — and APM re-requests review.
 
    When the human leaves PR comments, reply on the PR, not in IRC.
@@ -53,7 +53,7 @@ Before you signal "ready to flip" — both after the reviewer round and after ea
 4. If the answer in (3) is something you haven't actually verified is solid, fix it now — don't signal ready.
 5. Signal ready with a structural summary line *and* a `highest-risk specific: <file:section or function or invariant>` line. A platitude there ("highest-risk specific: correctness", "the new code") is a self-detected gate failure — loop back to (3) and pick a real one.
 
-The `highest-risk specific:` line lives in the issue channel and the PR — it's a visible commitment, not a checkbox. Anyone reviewing the PR (lead, human, future you on a follow-up) can spot a platitude, and a vague answer is more visible than a missing one. The gate is yours to fail loudly.
+The `highest-risk specific:` line lives in the issue channel — a visible commitment at the moment you signal ready, not a checkbox. Anyone in the channel at that moment (lead, human, reviewer if still attached) can spot a platitude, and a vague answer is more visible than a missing one. The gate is yours to fail loudly.
 
 ## Commits
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -36,12 +36,24 @@ Ask in the channel before any destructive or shared-state action: force-push, br
 PRs start as draft and go through a reviewer pass *before* anyone flips them ready.
 
 1. **After your initial draft push:** post the PR link in the channel and stop. Lead-pm spawns a reviewer (opus) against the draft. Do not say "ready to flip" — there's no flip yet.
-2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback". APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
-3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal — and APM re-requests review.
+2. **After reviewer findings post:** address them in logical commits — group by theme (see Commits below), split when themes diverge. Push, then run the **last-look gate** (below) before signaling ready. When the gate clears, signal in the channel naming what *structurally* changed ("tightened X validation, dropped Y helper"), not "addressed reviewer feedback", and append a `highest-risk specific:` line as the gate requires. APM marks the PR ready and adds the human reviewer at that point — not you. Never call `gh pr ready` yourself.
+3. **Human review loop:** the PR stays ready throughout — no draft/ready toggling. If the human leaves changes-requested or comment feedback, address it the same way — logical commits, structural signal, last-look gate — and APM re-requests review.
 
    When the human leaves PR comments, reply on the PR, not in IRC.
 
 Batch multiple changes-requested items into one push so you don't ping the lead after each individual fix; inside that push, the commits still split by theme.
+
+## Last-look gate
+
+Before you signal "ready to flip" — both after the reviewer round and after each human-review round — run this gate. It exists so the agent team resolves what it can resolve before the human sees the PR; a human-review round spent on a finding you'd have caught on a re-read is the failure mode.
+
+1. Re-read the full diff end-to-end. Not just the files you touched this push — the whole PR.
+2. Re-read the reviewer's findings, including the `nit`s and the ones you argued past. For each one you didn't address, ask whether your reason still holds after the re-read — sometimes a nit dismissed on its own reads as structural once the diff is whole again.
+3. Answer concretely: **name one specific file/section/function/invariant in this PR that, if you'd skimped on it, would surface as a finding in human review.** Not "correctness" or "the new logic" — a real location. If nothing comes to mind, the gate failed open; re-read until something does.
+4. If the answer in (3) is something you haven't actually verified is solid, fix it now — don't signal ready.
+5. Signal ready with a structural summary line *and* a `highest-risk specific: <file:section or function or invariant>` line. A platitude there ("highest-risk specific: correctness", "the new code") is a self-detected gate failure — loop back to (3) and pick a real one.
+
+The gate is yours to fail loudly. Lead-pm and the human will read your `highest-risk specific:` line and check whether the PR actually addresses that risk — a vague answer is more visible than a missing one.
 
 ## Commits
 


### PR DESCRIPTION
Closes #496

Replaces the dropped lead/APM-layer "explicit-go" requirement from PR #491 with a gate at the worker/reviewer layer. Both agents must produce a concrete artifact — not a checkbox — before signaling ready.

## Worker last-look gate

Between "addressed reviewer findings + pushed" and "ready to flip", the worker:
- Re-reads the full diff.
- Re-engages with the reviewer's nits and dismissed findings.
- Names one concrete file/section/function/invariant as `highest-risk specific:` in the ready signal.

A platitude (`highest-risk specific: correctness`) is a self-detected gate failure — the worker loops back.

## Reviewer fit-specific requirement

Between Pass (B): diff-level review and posting findings, the reviewer:
- Confirms consumer-side reads were done.
- Names one concrete structural property verified in Pass (A): fit check.
- Carries that fit-specific into the "review complete" headline.

A headline like "12 findings, looks good" is a self-detected gate failure.

## Why this shape

PR #491 codified the gate at the lead/APM layer (explicit "go" before the APM flips ready). That was rejected — the right lever is the worker and reviewer doing their best work *before* the PR reaches the human. This PR pushes the gate up one layer, into the agents producing the work.

Output-forcing is the design lever: "name a concrete X" produces a visible artifact; "ask yourself if it's your best work" produces a vibe.

## Notes for review

- This is an artifact-shaped PR (prompt change). Per §#410, after the diff-level reviewer passes, a second `--effort max` goal-framed pass should run before lead pressure-test concludes.
- The associate-pm and lead-pm prompts deliberately stay unchanged. The `highest-risk specific:` line surfaces naturally in the channel; the lead's existing pressure-test step picks it up on a normal read. Adding mention-detection there would re-create the #491 shape (lead/APM enforcement) the issue is moving away from.

🤖 Generated with Claude Code