### PR TITLE
feat(dispatcher): boot-time priority-tie warning for overlapping plugin grammar

### DIFF
--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -88,11 +88,11 @@ describe('buildPlugins', () => {
 // ---- warnPriorityTies -------------------------------------------------------
 
 // Minimal stub — no registry, no factory. Tests exercise warnPriorityTies directly.
-function makePlugin(name: string, claims: string[], grammarPriority?: number): Plugin {
+function makePlugin(name: string, grammarPriority?: number): Plugin {
   return {
     name,
     grammarPriority,
-    parseCommand: (line: string) => claims.includes(line) ? { kind: 'ok', cmd: {} } : null,
+    parseCommand: () => null,
     desiredChannels: () => [],
     runTick: async (): Promise<PluginTickResult> => ({ state: null, taggedEvents: [], channels: [] }),
   }
@@ -113,22 +113,13 @@ describe('warnPriorityTies', () => {
     expect(logs).toHaveLength(0)
   })
 
-  it('no warning when same-priority plugins claim different lines', () => {
+  it('warns when two parseable plugins share the same priority (regardless of what they claim)', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'])
-    const b = makePlugin('b', ['watch org/repo'])
-    warnPriorityTies([a, b], {}, msg => logs.push(msg))
-    expect(logs).toHaveLength(0)
-  })
-
-  it('warns when two plugins both claim the same probe line at the same priority', () => {
-    const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'])
-    const b = makePlugin('b', ['watch 1'])
+    const a = makePlugin('a')
+    const b = makePlugin('b')
     warnPriorityTies([a, b], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(1)
     expect(logs[0]).toContain('"a"')
-    expect(logs[0]).toContain('"watch 1"')
     expect(logs[0]).toContain('"b" shadowed')
     expect(logs[0]).toContain('plugin_priorities.a')
     expect(logs[0]).toContain('plugin_priorities.b')
@@ -136,43 +127,38 @@ describe('warnPriorityTies', () => {
 
   it('no warning when priorities differ', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'], 10)
-    const b = makePlugin('b', ['watch 1'], 0)
+    const a = makePlugin('a', 10)
+    const b = makePlugin('b', 0)
     warnPriorityTies([a, b], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(0)
   })
 
   it('plugin_priorities override resolves a tie', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'])
-    const b = makePlugin('b', ['watch 1'])
+    const a = makePlugin('a')
+    const b = makePlugin('b')
     const config: OrchestratorConfig = { plugin_priorities: { a: 5 } }
     warnPriorityTies([a, b], config, msg => logs.push(msg))
     expect(logs).toHaveLength(0)
   })
 
-  it('warns once per conflicting pair even when multiple probe lines tie', () => {
+  it('warns once per pair', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1', 'watch org/repo'])
-    const b = makePlugin('b', ['watch 1', 'watch org/repo'])
-    warnPriorityTies([a, b], {}, msg => logs.push(msg))
+    warnPriorityTies([makePlugin('a'), makePlugin('b')], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(1)
   })
 
   it('warns for each conflicting pair independently', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'])
-    const b = makePlugin('b', ['watch 1'])
-    const c = makePlugin('c', ['watch 1'])
-    warnPriorityTies([a, b, c], {}, msg => logs.push(msg))
+    warnPriorityTies([makePlugin('a'), makePlugin('b'), makePlugin('c')], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(3)
   })
 
   it('only pairs where both have parseCommand are checked', () => {
     const logs: string[] = []
-    const a = makePlugin('a', ['watch 1'])
+    const a = makePlugin('a')
     const plain = makePlainPlugin('plain')
-    const b = makePlugin('b', ['watch 1'])
+    const b = makePlugin('b')
     warnPriorityTies([a, plain, b], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(1)
     expect(logs[0]).toContain('"a"')

--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -128,8 +128,8 @@ describe('warnPriorityTies', () => {
     warnPriorityTies([a, b], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(1)
     expect(logs[0]).toContain('"a"')
-    expect(logs[0]).toContain('"b"')
     expect(logs[0]).toContain('"watch 1"')
+    expect(logs[0]).toContain('"b" shadowed')
     expect(logs[0]).toContain('plugin_priorities.a')
     expect(logs[0]).toContain('plugin_priorities.b')
   })
@@ -166,12 +166,6 @@ describe('warnPriorityTies', () => {
     const c = makePlugin('c', ['watch 1'])
     warnPriorityTies([a, b, c], {}, msg => logs.push(msg))
     expect(logs).toHaveLength(3)
-  })
-
-  it('no warning for empty plugin list', () => {
-    const logs: string[] = []
-    warnPriorityTies([], {}, msg => logs.push(msg))
-    expect(logs).toHaveLength(0)
   })
 
   it('only pairs where both have parseCommand are checked', () => {

--- a/src/orchestrator/__tests__/build-plugins.test.ts
+++ b/src/orchestrator/__tests__/build-plugins.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test'
-import { buildPlugins } from '../build-plugins.js'
+import { buildPlugins, warnPriorityTies } from '../build-plugins.js'
 import type { OrchestratorConfig } from '../config.js'
+import type { Plugin, PluginTickResult } from '../plugin.js'
 import '../registry.js'
 
 const NOOP_LOG = () => {}
@@ -81,5 +82,106 @@ describe('buildPlugins', () => {
     }
     const names = buildPlugins(cfg, '#proj-leads', NOOP_LOG).map(p => p.name)
     expect(names).toEqual(['github-prs'])
+  })
+})
+
+// ---- warnPriorityTies -------------------------------------------------------
+
+// Minimal stub — no registry, no factory. Tests exercise warnPriorityTies directly.
+function makePlugin(name: string, claims: string[], grammarPriority?: number): Plugin {
+  return {
+    name,
+    grammarPriority,
+    parseCommand: (line: string) => claims.includes(line) ? { kind: 'ok', cmd: {} } : null,
+    desiredChannels: () => [],
+    runTick: async (): Promise<PluginTickResult> => ({ state: null, taggedEvents: [], channels: [] }),
+  }
+}
+
+function makePlainPlugin(name: string): Plugin {
+  return {
+    name,
+    desiredChannels: () => [],
+    runTick: async (): Promise<PluginTickResult> => ({ state: null, taggedEvents: [], channels: [] }),
+  }
+}
+
+describe('warnPriorityTies', () => {
+  it('no warning when no plugins have parseCommand', () => {
+    const logs: string[] = []
+    warnPriorityTies([makePlainPlugin('a'), makePlainPlugin('b')], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(0)
+  })
+
+  it('no warning when same-priority plugins claim different lines', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'])
+    const b = makePlugin('b', ['watch org/repo'])
+    warnPriorityTies([a, b], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(0)
+  })
+
+  it('warns when two plugins both claim the same probe line at the same priority', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'])
+    const b = makePlugin('b', ['watch 1'])
+    warnPriorityTies([a, b], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toContain('"a"')
+    expect(logs[0]).toContain('"b"')
+    expect(logs[0]).toContain('"watch 1"')
+    expect(logs[0]).toContain('plugin_priorities.a')
+    expect(logs[0]).toContain('plugin_priorities.b')
+  })
+
+  it('no warning when priorities differ', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'], 10)
+    const b = makePlugin('b', ['watch 1'], 0)
+    warnPriorityTies([a, b], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(0)
+  })
+
+  it('plugin_priorities override resolves a tie', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'])
+    const b = makePlugin('b', ['watch 1'])
+    const config: OrchestratorConfig = { plugin_priorities: { a: 5 } }
+    warnPriorityTies([a, b], config, msg => logs.push(msg))
+    expect(logs).toHaveLength(0)
+  })
+
+  it('warns once per conflicting pair even when multiple probe lines tie', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1', 'watch org/repo'])
+    const b = makePlugin('b', ['watch 1', 'watch org/repo'])
+    warnPriorityTies([a, b], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(1)
+  })
+
+  it('warns for each conflicting pair independently', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'])
+    const b = makePlugin('b', ['watch 1'])
+    const c = makePlugin('c', ['watch 1'])
+    warnPriorityTies([a, b, c], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(3)
+  })
+
+  it('no warning for empty plugin list', () => {
+    const logs: string[] = []
+    warnPriorityTies([], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(0)
+  })
+
+  it('only pairs where both have parseCommand are checked', () => {
+    const logs: string[] = []
+    const a = makePlugin('a', ['watch 1'])
+    const plain = makePlainPlugin('plain')
+    const b = makePlugin('b', ['watch 1'])
+    warnPriorityTies([a, plain, b], {}, msg => logs.push(msg))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toContain('"a"')
+    expect(logs[0]).toContain('"b"')
   })
 })

--- a/src/orchestrator/__tests__/plugin.test.ts
+++ b/src/orchestrator/__tests__/plugin.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
 import {
   BasePlugin,
+  priorityOf,
+  type Plugin,
   type PluginTickResult,
   type TaggedEvent,
   registerPlugin,
@@ -167,6 +169,34 @@ describe('registry + plugin-owned events + per-plugin config (end-to-end)', () =
     await import('../registry.js')
     expect(getPluginFactory('github-prs')!('#x', () => {}).name).toBe('github-prs')
     expect(getPluginFactory('github-issues')!('#x', () => {}).name).toBe('github-issues')
+  })
+})
+
+describe('priorityOf', () => {
+  const base: Plugin = {
+    name: 'p',
+    desiredChannels: () => [],
+    runTick: async (): Promise<PluginTickResult> => ({ state: null, taggedEvents: [], channels: [] }),
+  }
+
+  it('returns 0 when no grammarPriority and no override', () => {
+    expect(priorityOf(base, {})).toBe(0)
+  })
+
+  it('returns grammarPriority when set and no override', () => {
+    expect(priorityOf({ ...base, grammarPriority: 5 }, {})).toBe(5)
+  })
+
+  it('config.plugin_priorities override replaces grammarPriority outright', () => {
+    expect(priorityOf({ ...base, grammarPriority: 5 }, { plugin_priorities: { p: 99 } })).toBe(99)
+  })
+
+  it('override of 0 wins over a non-zero grammarPriority (no max/sum)', () => {
+    expect(priorityOf({ ...base, grammarPriority: 10 }, { plugin_priorities: { p: 0 } })).toBe(0)
+  })
+
+  it('throws when plugin is falsy', () => {
+    expect(() => priorityOf(null as unknown as Plugin, {})).toThrow('priorityOf: plugin is required')
   })
 })
 

--- a/src/orchestrator/build-plugins.ts
+++ b/src/orchestrator/build-plugins.ts
@@ -3,21 +3,14 @@
 import type { OrchestratorConfig } from './config.js'
 import { getPluginFactory, priorityOf, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
 
-// Representative lines covering the two bare-grammar shapes defined by
-// tryClaimPerN / tryClaimPerRepo in plugins/grammar.ts. Keyword-prefixed
-// plugins (e.g. `watch pr 1`) only claim lines starting with their keyword,
-// so they can't tie on these probes unless two plugins share a keyword.
-// Extend this set when grammar.ts gains a new bare-grammar shape.
-const PROBE_LINES = ['watch 1', 'watch org/repo']
-
-type ParseablePlugin = Plugin & { parseCommand: NonNullable<Plugin['parseCommand']> }
-
-function isParseable(p: Plugin): p is ParseablePlugin {
+function isParseable(p: Plugin): p is Plugin & { parseCommand: NonNullable<Plugin['parseCommand']> } {
   return typeof p.parseCommand === 'function'
 }
 
-// Warn once per conflicting pair: same effective priority AND both claim the
-// same probe line. Points operators at `plugin_priorities` in config.json.
+// Warn for every pair of configured plugins where both implement parseCommand
+// and share the same effective priority. The dispatcher resolves ties by
+// config order, silently shadowing the later plugin. Points operators at
+// plugin_priorities in config.json.
 export function warnPriorityTies(plugins: Plugin[], config: OrchestratorConfig, log: PluginLogger): void {
   const parseable = plugins.filter(isParseable)
   for (let i = 0; i < parseable.length; i++) {
@@ -26,16 +19,11 @@ export function warnPriorityTies(plugins: Plugin[], config: OrchestratorConfig, 
       const b = parseable[j]
       const pri = priorityOf(a, config)
       if (pri !== priorityOf(b, config)) continue
-      for (const probe of PROBE_LINES) {
-        if (a.parseCommand(probe)?.kind === 'ok' && b.parseCommand(probe)?.kind === 'ok') {
-          log(
-            `[priority-tie] "${a.name}" and "${b.name}" both claim "${probe}" at priority ${pri};` +
-            ` "${b.name}" shadowed by config order.` +
-            ` set plugin_priorities.${a.name} or plugin_priorities.${b.name} in config.json to resolve.\n`
-          )
-          break
-        }
-      }
+      log(
+        `[priority-tie] "${a.name}" and "${b.name}" both define parseCommand at priority ${pri};` +
+        ` "${b.name}" shadowed by config order if their grammars overlap.` +
+        ` set plugin_priorities.${a.name} or plugin_priorities.${b.name} in config.json to resolve.\n`
+      )
     }
   }
 }

--- a/src/orchestrator/build-plugins.ts
+++ b/src/orchestrator/build-plugins.ts
@@ -3,10 +3,44 @@
 import type { OrchestratorConfig } from './config.js'
 import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
 
+// Representative lines covering the two bare-grammar shapes. Keyword-prefixed
+// plugins (e.g. `watch pr 1`) only claim lines that start with their keyword,
+// so they can't tie on these probes unless two plugins share a keyword.
+// Extend this set if a future plugin introduces a new bare-grammar shape.
+const PROBE_LINES = ['watch 1', 'watch org/repo']
+
+function effectivePriority(plugin: Plugin, config: OrchestratorConfig): number {
+  return config.plugin_priorities?.[plugin.name] ?? plugin.grammarPriority ?? 0
+}
+
+// Warn once per conflicting pair: same effective priority AND both claim the
+// same probe line. Points operators at `plugin_priorities` in config.json.
+export function warnPriorityTies(plugins: Plugin[], config: OrchestratorConfig, log: PluginLogger): void {
+  const parseable = plugins.filter(p => typeof p.parseCommand === 'function')
+  for (let i = 0; i < parseable.length; i++) {
+    for (let j = i + 1; j < parseable.length; j++) {
+      const a = parseable[i]
+      const b = parseable[j]
+      const pri = effectivePriority(a, config)
+      if (pri !== effectivePriority(b, config)) continue
+      for (const probe of PROBE_LINES) {
+        if (a.parseCommand!(probe)?.kind === 'ok' && b.parseCommand!(probe)?.kind === 'ok') {
+          log(
+            `[priority-tie] "${a.name}" and "${b.name}" both claim "${probe}" at priority ${pri};` +
+            ` "${b.name}" shadowed by config order.` +
+            ` set plugin_priorities.${a.name} or plugin_priorities.${b.name} in config.json to resolve.\n`
+          )
+          break
+        }
+      }
+    }
+  }
+}
+
 // Order follows `Object.keys` insertion order so emission order is predictable.
 export function buildPlugins(config: OrchestratorConfig, defaultChannel: string, log: PluginLogger): Plugin[] {
   const names = Object.keys(config.plugins ?? {})
-  return names.map(name => {
+  const plugins = names.map(name => {
     const factory = getPluginFactory(name)
     if (!factory) {
       const available = registeredPluginNames().sort().join(', ') || '(none)'
@@ -14,4 +48,6 @@ export function buildPlugins(config: OrchestratorConfig, defaultChannel: string,
     }
     return factory(defaultChannel, log)
   })
+  warnPriorityTies(plugins, config, log)
+  return plugins
 }

--- a/src/orchestrator/build-plugins.ts
+++ b/src/orchestrator/build-plugins.ts
@@ -1,30 +1,33 @@
 // Plugin instantiation. A plugin not listed in `config.plugins` is not built —
 // no default-on. New projects pick up shipped plugins via `bin/roost init`.
 import type { OrchestratorConfig } from './config.js'
-import { getPluginFactory, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
+import { getPluginFactory, priorityOf, registeredPluginNames, type Plugin, type PluginLogger } from './plugin.js'
 
-// Representative lines covering the two bare-grammar shapes. Keyword-prefixed
-// plugins (e.g. `watch pr 1`) only claim lines that start with their keyword,
+// Representative lines covering the two bare-grammar shapes defined by
+// tryClaimPerN / tryClaimPerRepo in plugins/grammar.ts. Keyword-prefixed
+// plugins (e.g. `watch pr 1`) only claim lines starting with their keyword,
 // so they can't tie on these probes unless two plugins share a keyword.
-// Extend this set if a future plugin introduces a new bare-grammar shape.
+// Extend this set when grammar.ts gains a new bare-grammar shape.
 const PROBE_LINES = ['watch 1', 'watch org/repo']
 
-function effectivePriority(plugin: Plugin, config: OrchestratorConfig): number {
-  return config.plugin_priorities?.[plugin.name] ?? plugin.grammarPriority ?? 0
+type ParseablePlugin = Plugin & { parseCommand: NonNullable<Plugin['parseCommand']> }
+
+function isParseable(p: Plugin): p is ParseablePlugin {
+  return typeof p.parseCommand === 'function'
 }
 
 // Warn once per conflicting pair: same effective priority AND both claim the
 // same probe line. Points operators at `plugin_priorities` in config.json.
 export function warnPriorityTies(plugins: Plugin[], config: OrchestratorConfig, log: PluginLogger): void {
-  const parseable = plugins.filter(p => typeof p.parseCommand === 'function')
+  const parseable = plugins.filter(isParseable)
   for (let i = 0; i < parseable.length; i++) {
     for (let j = i + 1; j < parseable.length; j++) {
       const a = parseable[i]
       const b = parseable[j]
-      const pri = effectivePriority(a, config)
-      if (pri !== effectivePriority(b, config)) continue
+      const pri = priorityOf(a, config)
+      if (pri !== priorityOf(b, config)) continue
       for (const probe of PROBE_LINES) {
-        if (a.parseCommand!(probe)?.kind === 'ok' && b.parseCommand!(probe)?.kind === 'ok') {
+        if (a.parseCommand(probe)?.kind === 'ok' && b.parseCommand(probe)?.kind === 'ok') {
           log(
             `[priority-tie] "${a.name}" and "${b.name}" both claim "${probe}" at priority ${pri};` +
             ` "${b.name}" shadowed by config order.` +

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -9,7 +9,7 @@
 
 import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
-import { assertRepoModeAll, type Plugin } from './plugin.js'
+import { assertRepoModeAll, priorityOf, type Plugin } from './plugin.js'
 import { splitCommands } from './plugins/grammar.js'
 
 // `plugin` carries an opaque cmd payload — the plugin that produced it is the
@@ -47,10 +47,8 @@ const RESERVED_TARGETS = new Set(['watch', 'unwatch', 'help'])
 // `config.plugins` Object.keys order). Operator overrides via
 // `config.plugin_priorities[name]` replace the static value outright.
 function priorityOrder(plugins: Plugin[], config: OrchestratorConfig): Plugin[] {
-  const overrides = config.plugin_priorities ?? {}
-  const pri = (p: Plugin) => overrides[p.name] ?? p.grammarPriority ?? 0
   return [...plugins]
-    .map((p, idx) => ({ p, idx, pri: pri(p) }))
+    .map((p, idx) => ({ p, idx, pri: priorityOf(p, config) }))
     .sort((a, b) => b.pri - a.pri || a.idx - b.idx)
     .map(x => x.p)
 }

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -154,3 +154,12 @@ export function registeredPluginNames(): string[] {
 export function assertRepoModeAll(plugins: Plugin[], base: OrchestratorConfig): void {
   for (const p of plugins) p.assertRepoMode?.(base)
 }
+
+// Effective grammar priority for a plugin: operator override > static hint > 0.
+// Operator override (`config.plugin_priorities[name]`) replaces the static value
+// outright — no max/sum. Used by both the tie-warning check and the DM parser
+// so they agree on ordering.
+export function priorityOf(plugin: Plugin, config: OrchestratorConfig): number {
+  if (!plugin) throw new Error('priorityOf: plugin is required')
+  return config.plugin_priorities?.[plugin.name] ?? plugin.grammarPriority ?? 0
+}


### PR DESCRIPTION
Closes #486

adds `warnPriorityTies()` to `build-plugins.ts`, called at the end of `buildPlugins`. probes each same-priority plugin pair against `'watch 1'` and `'watch org/repo'` (the two bare-grammar shapes); warns once per pair with the exact config path needed to resolve.

probe set is hardcoded to the two bare-grammar shapes. if a future plugin introduces a new bare-grammar shape, add that shape to `PROBE_LINES` in `build-plugins.ts`.

no built-in plugins tie today — warning fires only when a new plugin overlaps a bare-grammar shape at the same priority. load-bearing when the linear plugin lands in 0.8.0 if it claims bare `watch <N>` (currently it uses keyword target=`linear`, so no tie).

702 tests pass.