### PR TITLE
feat(learnings): support paths: frontmatter on rule files

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -218,21 +218,26 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    ```
    printf '## Postmortem\n\n%s' "$postmortem_text" | gh issue comment <I> --repo <owner>/<repo> --body-file -
    ```
-3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <slug>)` — `<slug>` becomes the rule filename. If no extractable insight, skip this step silently.
+3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <slug>)`. The `<slug>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<slug>.md` filename. If no extractable insight, skip this step silently.
 4. **Iterate with the lead.** Expect 1-3 rounds — learnings are durable artifacts that affect all future work, so don't rush to commit. Parse intent loosely (same pattern as the ack-before-action affirmatives):
    - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested path scope if any
    - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested path scope if any
    - Affirmative with explicit scope (e.g., "file paths=src/orchestrator/** topic=orchestrator", optionally combined with `with: <text>`) → commit using the lead's `paths` and `topic`, overriding any suggestion
+   - Affirmative dropping the suggestion (e.g., "file unscoped", "file without scope") → commit verbatim to `project-learnings.md`, ignoring any APM-suggested `paths`/`topic`
    - Clear negative (e.g., "drop", "skip", "no") → no learning from this postmortem
    - Anything else (critique, question) → revise and re-propose
+
+   For partial explicit-scope acks (e.g., `paths=` without `topic=`, or a typo like `path=`): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
 5. When filing a learning:
    - **Unscoped** (no `paths:`): append the formatted block to `.claude/rules/project-learnings.md`.
    - **Path-scoped** (lead ratified a `paths:` glob and `topic` slug): write to `.claude/rules/<slug>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line; if the new entry needs a different glob, flag it in `#<project>-leads` before writing.
    - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
-   - Commit and push:
+   - Commit and push (use the appropriate filename for the scope):
      ```
      mkdir -p .claude/rules
-     git add .claude/rules/<file>.md
+     git add .claude/rules/project-learnings.md   # unscoped
+     # or
+     git add .claude/rules/<slug>.md              # path-scoped
      git commit -m "add learning from #<I>"
      git push origin main
      ```
@@ -283,6 +288,8 @@ Patterns extracted from postmortems. Loads when files matching `<glob>` are read
 
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
+
+`<slug>` is the lowercase filename token; `<Slug>` is its title-cased rendering for the heading (e.g., `orchestrator-lock` → `Orchestrator Lock`).
 
 Subsequent entries in the same scoped file just append a new `## YYYY-MM-DD: ...` block under the existing header — the frontmatter stays at the top.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -218,18 +218,21 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    ```
    printf '## Postmortem\n\n%s' "$postmortem_text" | gh issue comment <I> --repo <owner>/<repo> --body-file -
    ```
-3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If no extractable insight, skip this step silently.
+3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <slug>)` — `<slug>` becomes the rule filename. If no extractable insight, skip this step silently.
 4. **Iterate with the lead.** Expect 1-3 rounds — learnings are durable artifacts that affect all future work, so don't rush to commit. Parse intent loosely (same pattern as the ack-before-action affirmatives):
-   - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim
-   - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version
+   - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested path scope if any
+   - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested path scope if any
+   - Affirmative with explicit scope (e.g., "file paths=src/orchestrator/** topic=orchestrator", optionally combined with `with: <text>`) → commit using the lead's `paths` and `topic`, overriding any suggestion
    - Clear negative (e.g., "drop", "skip", "no") → no learning from this postmortem
    - Anything else (critique, question) → revise and re-propose
 5. When filing a learning:
-   - Write the formatted learning block to `.claude/rules/project-learnings.md` using Edit/Write. If the file or directory doesn't exist, create them. Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
+   - **Unscoped** (no `paths:`): append the formatted block to `.claude/rules/project-learnings.md`.
+   - **Path-scoped** (lead ratified a `paths:` glob and `topic` slug): write to `.claude/rules/<slug>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line; if the new entry needs a different glob, flag it in `#<project>-leads` before writing.
+   - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
    - Commit and push:
      ```
      mkdir -p .claude/rules
-     git add .claude/rules/project-learnings.md
+     git add .claude/rules/<file>.md
      git commit -m "add learning from #<I>"
      git push origin main
      ```
@@ -250,8 +253,9 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
 - One-shot fix ("don't use `cat` in script X")
 - Vague platitude ("be careful with refactors")
 - Process theater (rules nobody will follow)
+- Over-narrow `paths:` scope (e.g. a single file like `paths: src/foo.ts`) — the rule loads only when that exact file is Read, and a learning the reader can't reach is dead history. Aim for a directory- or module-shaped glob the rule actually applies to.
 
-Learning file shape (`.claude/rules/project-learnings.md`):
+Unscoped learning file shape (`.claude/rules/project-learnings.md`):
 
 ```markdown
 # Project Learnings
@@ -262,6 +266,25 @@ Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions.
 
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
+
+Path-scoped learning file shape (`.claude/rules/<slug>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
+
+```markdown
+---
+paths:
+  - <glob>
+---
+
+# <Slug> Learnings
+
+Patterns extracted from postmortems. Loads when files matching `<glob>` are read.
+
+## YYYY-MM-DD: <one-line lesson> (from #<I>)
+
+<2-3 sentences: what happened, why it matters, what to do differently>
+```
+
+Subsequent entries in the same scoped file just append a new `## YYYY-MM-DD: ...` block under the existing header — the frontmatter stays at the top.
 
 Learnings are sparse — not every postmortem yields one.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -218,7 +218,7 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    ```
    printf '## Postmortem\n\n%s' "$postmortem_text" | gh issue comment <I> --repo <owner>/<repo> --body-file -
    ```
-3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <slug>)`. The `<slug>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<slug>.md` filename. If no extractable insight, skip this step silently.
+3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <topic>)`. The `<topic>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<topic>.md` filename. If no extractable insight, skip this step silently.
 4. **Iterate with the lead.** Expect 1-3 rounds — learnings are durable artifacts that affect all future work, so don't rush to commit. Parse intent loosely (same pattern as the ack-before-action affirmatives):
    - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested path scope if any
    - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested path scope if any
@@ -230,14 +230,14 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    For partial explicit-scope acks (e.g., `paths=` without `topic=`, or a typo like `path=`): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
 5. When filing a learning:
    - **Unscoped** (no `paths:`): append the formatted block to `.claude/rules/project-learnings.md`.
-   - **Path-scoped** (lead ratified a `paths:` glob and `topic` slug): write to `.claude/rules/<slug>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line; if the new entry needs a different glob, flag it in `#<project>-leads` before writing.
+   - **Path-scoped** (lead ratified a `paths:` glob and a `topic`): write to `.claude/rules/<topic>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line. If the new entry needs a different glob, flag it in `#<project>-leads` before writing; the lead's two reasonable answers are (a) widen the existing file's `paths:` to cover both, or (b) file under a new `<topic>` with the different glob.
    - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
    - Commit and push (use the appropriate filename for the scope):
      ```
      mkdir -p .claude/rules
      git add .claude/rules/project-learnings.md   # unscoped
      # or
-     git add .claude/rules/<slug>.md              # path-scoped
+     git add .claude/rules/<topic>.md             # path-scoped
      git commit -m "add learning from #<I>"
      git push origin main
      ```
@@ -272,7 +272,7 @@ Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions.
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-Path-scoped learning file shape (`.claude/rules/<slug>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
+Path-scoped learning file shape (`.claude/rules/<topic>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
 
 ```markdown
 ---
@@ -280,20 +280,22 @@ paths:
   - <glob>
 ---
 
-# <Slug> Learnings
+# <Topic> Learnings
 
-Patterns extracted from postmortems. Loads when files matching `<glob>` are read.
+Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions when files matching `<glob>` are read.
 
 ## YYYY-MM-DD: <one-line lesson> (from #<I>)
 
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-`<slug>` is the lowercase filename token; `<Slug>` is its title-cased rendering for the heading (e.g., `orchestrator-lock` → `Orchestrator Lock`).
+`<topic>` is the lowercase filename token; `<Topic>` is its title-cased rendering for the heading (e.g., `orchestrator-lock` → `Orchestrator Lock`).
 
 Subsequent entries in the same scoped file just append a new `## YYYY-MM-DD: ...` block under the existing header — the frontmatter stays at the top.
 
 Learnings are sparse — not every postmortem yields one.
+
+Note: a learning filed mid-milestone only reaches the *next* worker/reviewer session. Claude Code discovers `.claude/rules/*.md` at session start, and subagents inherit the parent's snapshot from spawn time — so in-flight workers still run with the rule set from before your commit existed. The next session to spawn picks it up.
 
 ### Milestone teardown dance
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -129,7 +129,7 @@ For each issue:
    - Did you push back mid-flight? Would you do the same next time?
    - Does this pattern apply to future issues, or was it one-shot?
 
-   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria and the file/drop/critique vocabulary. Filed learnings go to `.claude/rules/*.md` and auto-load into future worker/reviewer sessions — cross-cutting in `project-learnings.md`, path-narrow in per-topic files with `paths:` frontmatter. See APM doc historian dance for the iteration vocab and file shapes.
+   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria, the file/drop/critique vocabulary, and file shapes. Filed learnings go to `.claude/rules/*.md` and auto-load into future worker/reviewer sessions. Cross-cutting learnings live in `project-learnings.md`; path-narrow ones live in per-topic files with `paths:` frontmatter.
 
 10. **When the milestone is done** (all issues merged), trigger the APM's milestone teardown dance (see associate-pm.md) by mentioning it: `<project>-apm milestone done, stand down`. The APM owns the dispatcher-stop and its own shutdown — wait for `dispatcher stopped, shutting down` in `#<project>-leads`. If no confirmation arrives within ~30s (APM crashed mid-teardown), call `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"` yourself. Then: `roost shutdown <project>-lead-pm`.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -129,7 +129,7 @@ For each issue:
    - Did you push back mid-flight? Would you do the same next time?
    - Does this pattern apply to future issues, or was it one-shot?
 
-   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria and the file/drop/critique vocabulary. Filed learnings go to `.claude/rules/project-learnings.md` and auto-load into future worker/reviewer sessions.
+   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria and the file/drop/critique vocabulary. Filed learnings go to `.claude/rules/*.md` and auto-load into future worker/reviewer sessions — cross-cutting in `project-learnings.md`, path-narrow in per-topic files with `paths:` frontmatter. See APM doc historian dance for the iteration vocab and file shapes.
 
 10. **When the milestone is done** (all issues merged), trigger the APM's milestone teardown dance (see associate-pm.md) by mentioning it: `<project>-apm milestone done, stand down`. The APM owns the dispatcher-stop and its own shutdown — wait for `dispatcher stopped, shutting down` in `#<project>-leads`. If no confirmation arrives within ~30s (APM crashed mid-teardown), call `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"` yourself. Then: `roost shutdown <project>-lead-pm`.
 


### PR DESCRIPTION
Closes #424

## Summary

- Teach the historian dance to file path-narrow learnings into a per-topic rule file (`.claude/rules/<topic>.md`) with `paths:` frontmatter, so the lesson only loads when matching files are Read. Cross-cutting default (append to `project-learnings.md`) is unchanged.
- New iteration variants: `file paths=<glob> topic=<topic> [with: <text>]` for explicit scope, `file unscoped` to drop the APM's suggestion.
- Added single-file-paths warning to anti-examples (over-narrow scope = dead history) and a path-scoped file template with the repo-relative resolution rule called out inline. `<topic>` placeholder (lowercase filename) is split from `<Topic>` (title-cased heading); slug hygiene rule (lowercase, hyphen-separated, single word-ish) named in step 3.
- `lead-pm.md` step 9 pointer acknowledges both file shapes; canonical detail stays in APM doc.
- Documented the operational meta-fact in the dance: a learning filed mid-milestone only reaches the *next* worker/reviewer session (Claude Code rule discovery is one-shot at session start; subagents inherit the parent's snapshot).

## Empirical verification (per learnings §#449)

Doc-read says `paths:` gates loading. Verified against the live harness before code landed.

Setup: 3 probe rules at `.claude/rules/__probe-{alpha,beta,control}.md` (`paths: src/**/*.ts`, `paths: bin/**`, no frontmatter). 3 fresh general-purpose subagents spawned in parallel, each Reading a different target file.

| Read target | alpha (src/**/*.ts) | beta (bin/**) | control (unscoped) |
|---|---|---|---|
| `src/irc-server.ts` | SEEN | NOT | NOT |
| `bin/roost` | NOT | SEEN | NOT |
| `package.json` | NOT | NOT | NOT |

Mechanism: harness injects rule body as `<system-reminder>` block with literal prefix `Contents of <abs-path>:` immediately after the matching tool result. Globs are repo-relative (a Read with an absolute path was correctly resolved against repo root).

The verification also surfaced the subagent-snapshot meta-fact (control probe didn't auto-load into subagents because it was born after parent-session-start). That finding is now folded into the dance doc instead of being deferred.

Probe files deleted before commit.

## Test plan

- [ ] APM proposal with `(suggested paths: <glob>; topic: <topic>)` parses correctly
- [ ] `file paths=<glob> topic=<topic>` iteration variant overrides any suggestion
- [ ] `file unscoped` iteration variant drops a suggestion and writes to `project-learnings.md`
- [ ] Partial explicit-scope ack (e.g., `paths=` without `topic=`) triggers re-ack instead of silent fill-from-suggestion
- [ ] New `.claude/rules/<topic>.md` file created with valid frontmatter when path-scoped
- [ ] Existing path-scoped file appended (header preserved, no frontmatter duplication)
- [ ] Glob conflict on append prompts the lead's two-option resolution path
- [ ] Lead's `file as-is` still defaults to unscoped `project-learnings.md` when no suggestion was made
- [ ] Filed scoped learning auto-loads only on matching Read in a future session

🤖 Generated with [Claude Code](https://claude.com/claude-code)