### PR TITLE
add learning from #486

### DIFF
--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -77,3 +77,7 @@ When filing a followup issue, ask whether the work is primarily in service of a 
 When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.
 
 Concrete: PreCompact fired 4× during one milestone, each invocation queued another /compact in tmux; none drained because each new IRC message triggered another auto-compact. Fix was atomic mkdir lock at injection; PR #471.
+
+## 2026-05-21: "Describes output, not mechanism" gap means the research hasn't happened yet (from #424)
+
+When an issue's body describes the output (add X to file Y) but not how the underlying primitive works, the deliverable is research — probe + document, not mechanical config. Size opus. The "describes output, not mechanism" gap is the research that hasn't happened yet.

--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -81,3 +81,7 @@ Concrete: PreCompact fired 4× during one milestone, each invocation queued anot
 ## 2026-05-21: "Describes output, not mechanism" gap means the research hasn't happened yet (from #424)
 
 When an issue's body describes the output (add X to file Y) but not how the underlying primitive works, the deliverable is research — probe + document, not mechanical config. Size opus. The "describes output, not mechanism" gap is the research that hasn't happened yet.
+
+## 2026-05-21: Treat reviewer "narrower than the failure mode" as a blocker, not a fyi (from #486)
+
+Treat reviewer "fyi: this is narrower than the failure mode" as a blocker on the current PR, not a fyi to defer. §#448 covered this for prompts; same logic for code/test checks. Asymmetry: widening at plan/review costs a paragraph; shipping narrow costs a re-cycle (worker respawn, push, re-CI, re-review). The reviewer's narrowness flag is the signal, whether the artifact is a prompt rule or a code check.


### PR DESCRIPTION
from #486 postmortem: treat reviewer narrowness fyi as a blocker, extends §#448 to code/test checks.