### PR TITLE
feat(learnings): split learnings by audience (worker/reviewer/lead-pm/apm)

### DIFF
--- a/.claude/learnings/apm.md
+++ b/.claude/learnings/apm.md
@@ -1,0 +1,15 @@
+# APM Learnings
+
+Patterns extracted from postmortems. Loaded by the associate-pm agent at startup.
+
+## 2026-05-19: Always spawn with bare model aliases, never full ids (from #422)
+
+Use bare aliases (`opus`, `sonnet`, `haiku`) — full ids (`claude-opus-4-5` etc.) pin the session to that exact dated variant instead of tracking the latest version at spawn time. The APM was filling `<model>` placeholders in its templates with full ids and silently shipping work on stale models. Stick to aliases unless the lead explicitly asked for a pinned version (rollback test, regression repro, A/B). The wrapper now warns when `--model` looks like a full id — heed it. Next escalation if a warning is cited as ignored: hard error + `--pin-version` opt-in.
+
+## 2026-05-20: Filing a followup: check if it's service-of-future-milestone work before defaulting to current (from #458)
+
+When filing a followup issue, ask whether the work is primarily in service of a future milestone before defaulting to the current one. If the followup's value lands in a later wave (e.g., a boot-time priority-tie warning is most useful when the Linear plugin lands in 0.8.0, not during a 0.7.0 cleanup pass), file it in that future milestone. The concrete test: "when does this followup's primary consumer arrive?"
+
+## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
+
+Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.

--- a/.claude/learnings/lead-pm.md
+++ b/.claude/learnings/lead-pm.md
@@ -1,0 +1,43 @@
+# Lead-PM Learnings
+
+Patterns extracted from postmortems. Loaded by the lead-pm agent at startup.
+
+## 2026-05-19: Use goal-framed deep review for artifact-shaped PRs (from #410)
+
+For issues whose deliverable is a durable artifact (prompt change, new dance, written convention), follow the diff-level reviewer with a second `--effort max` pass framed against the project's three goals: minimize rework, maximize flexibility, maximize quality. The default reviewer underweights structural gaps in design-shaped PRs. Cheap insurance against a load-bearing artifact shipping with a flaw.
+
+## 2026-05-19: Always spawn with bare model aliases, never full ids (from #422)
+
+Use bare aliases (`opus`, `sonnet`, `haiku`) — full ids (`claude-opus-4-5` etc.) pin the session to that exact dated variant instead of tracking the latest version at spawn time. The APM was filling `<model>` placeholders in its templates with full ids and silently shipping work on stale models. Stick to aliases unless the lead explicitly asked for a pinned version (rollback test, regression repro, A/B). The wrapper now warns when `--model` looks like a full id — heed it. Next escalation if a warning is cited as ignored: hard error + `--pin-version` opt-in.
+
+## 2026-05-19: Three repeats of a bug class in one milestone triggers escalation to worker-driven design (from #450)
+
+Three repeats of a bug class in one milestone is the escalation signal — flip from lead-rolled-in fix to worker-driven design with review. Recurrence count, not severity, is what triggers the flip. Cheap fixes on operator-facing surfaces (config files, tracked templates, docs) rarely stay cheap; the cost compounds across every future operator.
+
+## 2026-05-20: Verify external-system behavior empirically before flipping ready (from #449)
+
+When a PR's core logic depends on external system behavior — API field shape, platform feature firing, third-party side effect — unit tests of mocked responses prove your code handles the shape; they don't prove the shape exists in the wild. Verify empirically before lead-review.
+
+Concrete: PR #462 routed cross-repo closure events. 666 mocked tests passed, but nobody had confirmed GitHub's `closingIssuesReferences` actually populates for cross-repo refs. A 15-min throwaway PR + GraphQL query confirmed both same-org and cross-org variants populate.
+
+Gate this in the lead's pre-review pressure-test, not the worker's plan. Question: "what external-system fact is this code load-bearing on, and have we observed it?"
+
+Different from §#410 (artifact-shape): that's about durable artifacts (prompts, conventions). This is about behavior shapes (does the API actually do X). Same load-bearing-assumption muscle.
+
+## 2026-05-20: Run survey/audit issues before paired specific cleanup issues (from #457)
+
+When a milestone pairs a survey/audit issue with specific cleanup issues, run the survey first. It either obsoletes the specifics (saving the work) or confirms them with concrete data — running specifics-first risks doing work the survey would have re-scoped.
+
+Concrete: #457 (orchestrator rereview) paired with #473 (lock primitives) and #475 (tmux buffer-chain). Running the survey first confirmed both specifics were still valid and gave a concrete LOC baseline; running specifics-first would have risked work the survey then re-scoped.
+
+## 2026-05-20: Filing a followup: check if it's service-of-future-milestone work before defaulting to current (from #458)
+
+When filing a followup issue, ask whether the work is primarily in service of a future milestone before defaulting to the current one. If the followup's value lands in a later wave (e.g., a boot-time priority-tie warning is most useful when the Linear plugin lands in 0.8.0, not during a 0.7.0 cleanup pass), file it in that future milestone. The concrete test: "when does this followup's primary consumer arrive?"
+
+## 2026-05-21: "Describes output, not mechanism" gap means the research hasn't happened yet (from #424)
+
+When an issue's body describes the output (add X to file Y) but not how the underlying primitive works, the deliverable is research — probe + document, not mechanical config. Size opus. The "describes output, not mechanism" gap is the research that hasn't happened yet.
+
+## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
+
+Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.

--- a/.claude/learnings/worker.md
+++ b/.claude/learnings/worker.md
@@ -1,0 +1,33 @@
+# Worker Learnings
+
+Patterns extracted from postmortems. Loaded by the worker prompt at startup.
+
+## 2026-05-19: When fixing an asymmetry, scan adjacent files for the same pattern (from #419)
+
+When a fix adds the missing half of a pair (unpaired call, missing step, unmatched keyword), scan all touched-or-adjacent files for the same pattern before closing scope. Rolling symmetric fixes into one PR is cheap; a separate follow-up issue is not.
+
+## 2026-05-19: When removing a guard, audit tests that passed because of it (from #415)
+
+When you delete a guard (error check, validation, early-return), scan tests for ones that asserted the guard's error. Those tests will still pass if the new code triggers a different error — assert the new error verbatim, not just "some error."
+
+## 2026-05-19: Restate approved naming/ordering decisions verbatim in the plan (from #434)
+
+When the lead has approved a specific naming or ordering decision in chat (e.g. `<project>-<slug>-worker-<N>` rather than just "slug-aware nick"), restate the exact string in your plan back to the lead. Paraphrasing loses load-bearing detail and pushes the mismatch out to human review instead of catching it in plan review.
+
+## 2026-05-19: Frame "could go either way" design calls as explicit questions, not defended picks (from #433)
+
+When a worker hits a design call mid-plan with two plausible answers, surface it to the lead as an explicit question with the trade-offs spelled out. Don't pick one and defend it. A defended choice typically resurfaces as a rework round in human review; a framed question gets resolved cheaply at plan stage. The asymmetry of conviction is the lever — workers convey "I see two options" rather than "I chose option A," and the lead negotiates before code lands.
+
+## 2026-05-20: Add arg validation when extracting N inline copies into one shared helper (from #475)
+
+When extracting N inline copies into one shared helper, add arg validation to the new helper even if the originals had none. The helper is now load-bearing across all callers, and a silent failure in one caller becomes everyone's problem.
+
+## 2026-05-20: When migrating call sites to a new helper, scan within-function retry branches (from #473)
+
+When migrating N call sites to a new helper, scan each migrated function for *every* invocation of the old primitive — including within-function retry/fallback branches that weren't the initial migration target. The #473 worker migrated `writeDispatcherPid`'s initial `wx` attempt to `exclusiveCreate` but left the function's stale-retry path on raw `writeFile(wx)`. Distinct from §#419 (adjacent files): same file, same function, different code branch. Migration is incomplete until every callsite of the old primitive within migrated scope uses the new helper.
+
+## 2026-05-20: When you see N copies of the same intervention accumulating, debounce at the producer (from #470)
+
+When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.
+
+Concrete: PreCompact fired 4× during one milestone, each invocation queued another /compact in tmux; none drained because each new IRC message triggered another auto-compact. Fix was atomic mkdir lock at injection; PR #471.

--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -1,26 +1,12 @@
 # Project Learnings
 
-Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions.
+Cross-cutting patterns extracted from postmortems — entries here span 3+ roles. Auto-loaded into every Claude Code session in this repo.
 
-## 2026-05-19: Use goal-framed deep review for artifact-shaped PRs (from #410)
-
-For issues whose deliverable is a durable artifact (prompt change, new dance, written convention), follow the diff-level reviewer with a second `--effort max` pass framed against the project's three goals: minimize rework, maximize flexibility, maximize quality. The default reviewer underweights structural gaps in design-shaped PRs. Cheap insurance against a load-bearing artifact shipping with a flaw.
-
-## 2026-05-19: When fixing an asymmetry, scan adjacent files for the same pattern (from #419)
-
-When a fix adds the missing half of a pair (unpaired call, missing step, unmatched keyword), scan all touched-or-adjacent files for the same pattern before closing scope. Rolling symmetric fixes into one PR is cheap; a separate follow-up issue is not.
+Role-specific learnings live in `.claude/learnings/<role>.md` and are loaded by the role's prompt at startup. See `agents/associate-pm.md` historian dance for the audience-routing rules.
 
 ## 2026-05-19: Canonicalize wording verbatim when an invariant lives in 3+ surfaces (from #422)
 
 When the same invariant lives in 3+ surfaces (operator help, agent prompts, learnings, etc.), pick one canonical sentence and copy it verbatim across all places. Paraphrasing looks fine at first but drifts on the next edit — and a future reader can't tell which copy is right. For ≤2 places, the duplication tax exceeds the drift risk; phrase each in context.
-
-## 2026-05-19: Always spawn with bare model aliases, never full ids (from #422)
-
-Use bare aliases (`opus`, `sonnet`, `haiku`) — full ids (`claude-opus-4-5` etc.) pin the session to that exact dated variant instead of tracking the latest version at spawn time. The APM was filling `<model>` placeholders in its templates with full ids and silently shipping work on stale models. Stick to aliases unless the lead explicitly asked for a pinned version (rollback test, regression repro, A/B). The wrapper now warns when `--model` looks like a full id — heed it. Next escalation if a warning is cited as ignored: hard error + `--pin-version` opt-in.
-
-## 2026-05-19: When removing a guard, audit tests that passed because of it (from #415)
-
-When you delete a guard (error check, validation, early-return), scan tests for ones that asserted the guard's error. Those tests will still pass if the new code triggers a different error — assert the new error verbatim, not just "some error."
 
 ## 2026-05-19: Write docs in IRC-conversational voice from the first draft (from #255)
 
@@ -28,64 +14,10 @@ Prose in this project needs one idea per sentence. Skip em-dashes. Don't use jar
 
 Self-check: read the sentence aloud. If it has more than one connector, split it.
 
-## 2026-05-19: Restate approved naming/ordering decisions verbatim in the plan (from #434)
-
-When the lead has approved a specific naming or ordering decision in chat (e.g. `<project>-<slug>-worker-<N>` rather than just "slug-aware nick"), restate the exact string in your plan back to the lead. Paraphrasing loses load-bearing detail and pushes the mismatch out to human review instead of catching it in plan review.
-
-## 2026-05-19: Three repeats of a bug class in one milestone triggers escalation to worker-driven design (from #450)
-
-Three repeats of a bug class in one milestone is the escalation signal — flip from lead-rolled-in fix to worker-driven design with review. Recurrence count, not severity, is what triggers the flip. Cheap fixes on operator-facing surfaces (config files, tracked templates, docs) rarely stay cheap; the cost compounds across every future operator.
-
-## 2026-05-19: Frame "could go either way" design calls as explicit questions, not defended picks (from #433)
-
-When a worker hits a design call mid-plan with two plausible answers, surface it to the lead as an explicit question with the trade-offs spelled out. Don't pick one and defend it. A defended choice typically resurfaces as a rework round in human review; a framed question gets resolved cheaply at plan stage. The asymmetry of conviction is the lever — workers convey "I see two options" rather than "I chose option A," and the lead negotiates before code lands.
-
 ## 2026-05-19: When fixing a prompt failure mode, audit whether the trigger is narrower than the right fix (from #448)
 
 Adding a behavior rule to agent prompts to address a specific failure? Audit whether the failure mode is narrower than the rule needs to be. The #448 trigger was "inline PR thread comment" but the right fix covers all GitHub PR reply surfaces — inline diff threads, top-level review summaries, and PR conversation comments. Phrasing the rule against the trigger example leaves adjacent failure modes unpatched. Generalize at first draft; the reviewer agent will catch over-narrowing, but it's cheaper to think one level up while writing.
 
-## 2026-05-20: Verify external-system behavior empirically before flipping ready (from #449)
-
-When a PR's core logic depends on external system behavior — API field shape, platform feature firing, third-party side effect — unit tests of mocked responses prove your code handles the shape; they don't prove the shape exists in the wild. Verify empirically before lead-review.
-
-Concrete: PR #462 routed cross-repo closure events. 666 mocked tests passed, but nobody had confirmed GitHub's `closingIssuesReferences` actually populates for cross-repo refs. A 15-min throwaway PR + GraphQL query confirmed both same-org and cross-org variants populate.
-
-Gate this in the lead's pre-review pressure-test, not the worker's plan. Question: "what external-system fact is this code load-bearing on, and have we observed it?"
-
-Different from §#410 (artifact-shape): that's about durable artifacts (prompts, conventions). This is about behavior shapes (does the API actually do X). Same load-bearing-assumption muscle.
-
-## 2026-05-20: Run survey/audit issues before paired specific cleanup issues (from #457)
-
-When a milestone pairs a survey/audit issue with specific cleanup issues, run the survey first. It either obsoletes the specifics (saving the work) or confirms them with concrete data — running specifics-first risks doing work the survey would have re-scoped.
-
-Concrete: #457 (orchestrator rereview) paired with #473 (lock primitives) and #475 (tmux buffer-chain). Running the survey first confirmed both specifics were still valid and gave a concrete LOC baseline; running specifics-first would have risked work the survey then re-scoped.
-
-## 2026-05-20: Add arg validation when extracting N inline copies into one shared helper (from #475)
-
-When extracting N inline copies into one shared helper, add arg validation to the new helper even if the originals had none. The helper is now load-bearing across all callers, and a silent failure in one caller becomes everyone's problem.
-
-## 2026-05-20: When migrating call sites to a new helper, scan within-function retry branches (from #473)
-
-When migrating N call sites to a new helper, scan each migrated function for *every* invocation of the old primitive — including within-function retry/fallback branches that weren't the initial migration target. The #473 worker migrated `writeDispatcherPid`'s initial `wx` attempt to `exclusiveCreate` but left the function's stale-retry path on raw `writeFile(wx)`. Distinct from §#419 (adjacent files): same file, same function, different code branch. Migration is incomplete until every callsite of the old primitive within migrated scope uses the new helper.
-
-## 2026-05-20: Filing a followup: check if it's service-of-future-milestone work before defaulting to current (from #458)
-
-When filing a followup issue, ask whether the work is primarily in service of a future milestone before defaulting to the current one. If the followup's value lands in a later wave (e.g., a boot-time priority-tie warning is most useful when the Linear plugin lands in 0.8.0, not during a 0.7.0 cleanup pass), file it in that future milestone. The concrete test: "when does this followup's primary consumer arrive?"
-
-## 2026-05-20: When you see N copies of the same intervention accumulating, debounce at the producer (from #470)
-
-When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.
-
-Concrete: PreCompact fired 4× during one milestone, each invocation queued another /compact in tmux; none drained because each new IRC message triggered another auto-compact. Fix was atomic mkdir lock at injection; PR #471.
-
-## 2026-05-21: "Describes output, not mechanism" gap means the research hasn't happened yet (from #424)
-
-When an issue's body describes the output (add X to file Y) but not how the underlying primitive works, the deliverable is research — probe + document, not mechanical config. Size opus. The "describes output, not mechanism" gap is the research that hasn't happened yet.
-
 ## 2026-05-21: Treat reviewer "narrower than the failure mode" as a blocker, not a fyi (from #486)
 
 Treat reviewer "fyi: this is narrower than the failure mode" as a blocker on the current PR, not a fyi to defer. §#448 covered this for prompts; same logic for code/test checks. Asymmetry: widening at plan/review costs a paragraph; shipping narrow costs a re-cycle (worker respawn, push, re-CI, re-review). The reviewer's narrowness flag is the signal, whether the artifact is a prompt rule or a code check.
-
-## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
-
-Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .claude/*
 !.claude/commands/
 !.claude/rules/
+!.claude/learnings/
 
 # Orchestrator runtime state (config.json is tracked)
 .orchestrator/state.json

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -22,6 +22,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 
 Your IRC nick is `<project>-apm`. On boot:
 
+0. **Role learnings** — read `.claude/learnings/apm.md` if it exists. Missing file is fine — no APM-specific learnings filed yet.
 1. Parse your initial prompt for `key=value` tokens (both required):
    ```
    human=<irc-nick> gh-login=<github-login>
@@ -218,24 +219,32 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    ```
    printf '## Postmortem\n\n%s' "$postmortem_text" | gh issue comment <I> --repo <owner>/<repo> --body-file -
    ```
-3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. If the lesson is clearly narrow to a code area (subsystem, test surface, single tool), append a scope suggestion on the same line: `(suggested paths: <glob>; topic: <topic>)`. The `<topic>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<topic>.md` filename. If no extractable insight, skip this step silently.
+3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. Append a scope suggestion on the same line if one fits — pick at most one of:
+   - **Audience-narrow** (the lesson clearly applies to one or two specific roles): `(suggested audience: <role>)` or `(suggested audience: <role1>,<role2>)`. Valid roles: `worker`, `reviewer`, `lead-pm`, `apm`. Comma-separated for multi-audience.
+   - **Path-narrow** (the lesson is tied to a code area, regardless of role): `(suggested paths: <glob>; topic: <topic>)`. The `<topic>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<topic>.md` filename.
+
+   Don't combine audience and path scope on one entry — pick whichever axis fits better. If no extractable insight, skip this step silently.
 4. **Iterate with the lead.** Expect 1-3 rounds — learnings are durable artifacts that affect all future work, so don't rush to commit. Parse intent loosely (same pattern as the ack-before-action affirmatives):
-   - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested path scope if any
-   - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested path scope if any
-   - Affirmative with explicit scope (e.g., "file paths=src/orchestrator/** topic=orchestrator", optionally combined with `with: <text>`) → commit using the lead's `paths` and `topic`, overriding any suggestion
-   - Affirmative dropping the suggestion (e.g., "file unscoped", "file without scope") → commit verbatim to `project-learnings.md`, ignoring any APM-suggested `paths`/`topic`
+   - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested scope (audience or path) if any
+   - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested scope if any
+   - Affirmative with explicit audience scope (e.g., "file audience=worker", "file audience=lead-pm,apm", optionally combined with `with: <text>`) → commit role-scoped using the lead's audience list, overriding any suggestion
+   - Affirmative with explicit path scope (e.g., "file paths=src/orchestrator/** topic=orchestrator", optionally combined with `with: <text>`) → commit using the lead's `paths` and `topic`, overriding any suggestion
+   - Affirmative dropping the suggestion (e.g., "file unscoped", "file without scope") → commit verbatim to `project-learnings.md`, ignoring any APM-suggested scope
    - Clear negative (e.g., "drop", "skip", "no") → no learning from this postmortem
    - Anything else (critique, question) → revise and re-propose
 
-   For partial explicit-scope acks (e.g., `paths=` without `topic=`, or a typo like `path=`): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
+   For partial explicit-scope acks (e.g., `paths=` without `topic=`, a typo like `path=` or `audience` with an unknown role): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
 5. When filing a learning:
-   - **Unscoped** (no `paths:`): append the formatted block to `.claude/rules/project-learnings.md`.
+   - **Unscoped** (cross-cutting, 3+ roles): append the formatted block to `.claude/rules/project-learnings.md`. This file auto-loads in every Claude Code session in the repo.
+   - **Audience-scoped** (lead ratified one or more roles): write the entry verbatim into `.claude/learnings/<role>.md` for *each* named role. For multi-audience entries, the duplication is canonical per §#422 (verbatim across all named role files). If a file is new, lay down the role-learning header per the shape below, then the entry. If it already exists, append the new entry under the existing header.
    - **Path-scoped** (lead ratified a `paths:` glob and a `topic`): write to `.claude/rules/<topic>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line. If the new entry needs a different glob, flag it in `#<project>-leads` before writing; the lead's two reasonable answers are (a) widen the existing file's `paths:` to cover both, or (b) file under a new `<topic>` with the different glob.
    - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
-   - Commit and push (use the appropriate filename for the scope):
+   - Commit and push (use the appropriate filename(s) for the scope):
      ```
-     mkdir -p .claude/rules
+     mkdir -p .claude/rules .claude/learnings
      git add .claude/rules/project-learnings.md   # unscoped
+     # or
+     git add .claude/learnings/<role>.md          # audience-scoped (one git add per named role)
      # or
      git add .claude/rules/<topic>.md             # path-scoped
      git commit -m "add learning from #<I>"
@@ -259,18 +268,33 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
 - Vague platitude ("be careful with refactors")
 - Process theater (rules nobody will follow)
 - Over-narrow `paths:` scope (e.g. a single file like `paths: src/foo.ts`) — the rule loads only when that exact file is Read, and a learning the reader can't reach is dead history. Aim for a directory- or module-shaped glob the rule actually applies to.
+- Over-narrow audience scope (filing under one role when the lesson plausibly hits 3+) — entries that genuinely cross-cut belong in `project-learnings.md`. Reserve role files for lessons whose audience is unambiguously narrow.
 
-Unscoped learning file shape (`.claude/rules/project-learnings.md`):
+Unscoped learning file shape (`.claude/rules/project-learnings.md`) — cross-cutting (3+ roles), auto-loads in every Claude Code session in the repo:
 
 ```markdown
 # Project Learnings
 
-Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions.
+Cross-cutting patterns extracted from postmortems — entries here span 3+ roles. Auto-loaded into every Claude Code session in this repo.
 
 ## YYYY-MM-DD: <one-line lesson> (from #<I>)
 
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
+
+Audience-scoped learning file shape (`.claude/learnings/<role>.md`) — files under `.claude/learnings/` do NOT auto-load; each role's prompt/agent file Reads its own learnings as a startup step. Valid `<role>` values: `worker`, `reviewer`, `lead-pm`, `apm`:
+
+```markdown
+# <Role> Learnings
+
+Patterns extracted from postmortems. Loaded by the <role> prompt at startup.
+
+## YYYY-MM-DD: <one-line lesson> (from #<I>)
+
+<2-3 sentences: what happened, why it matters, what to do differently>
+```
+
+`<Role>` in the heading is title-cased (`worker` → `Worker`, `lead-pm` → `Lead-PM`, `apm` → `APM`).
 
 Path-scoped learning file shape (`.claude/rules/<topic>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
 
@@ -282,7 +306,7 @@ paths:
 
 # <Topic> Learnings
 
-Patterns extracted from postmortems. Auto-loaded into worker/reviewer sessions when files matching `<glob>` are read.
+Patterns extracted from postmortems. Loaded when files matching `<glob>` are read.
 
 ## YYYY-MM-DD: <one-line lesson> (from #<I>)
 
@@ -295,7 +319,7 @@ Subsequent entries in the same scoped file just append a new `## YYYY-MM-DD: ...
 
 Learnings are sparse — not every postmortem yields one.
 
-Note: a learning filed mid-milestone only reaches the *next* worker/reviewer session. Claude Code discovers `.claude/rules/*.md` at session start, and subagents inherit the parent's snapshot from spawn time — so in-flight workers still run with the rule set from before your commit existed. The next session to spawn picks it up.
+Note: a learning filed mid-milestone only reaches the *next* session that loads it. `.claude/rules/*.md` are discovered at session start; `.claude/learnings/<role>.md` are read by the role prompt at startup. Subagents inherit the parent's snapshot from spawn time — so in-flight workers still run with the rule set from before your commit existed. The next session to spawn picks it up.
 
 ### Milestone teardown dance
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -73,7 +73,7 @@ The `--cache-ttl` and `--steer-compact` choices baked into the spawn templates b
 
 ### Setup dance
 
-Trigger: lead mentions you with intent like "let's do #290 with opus, and #291" or "kick off 42".
+Trigger: lead mentions you with intent like "let's do #<N> with opus, and #<M>" or "kick off <N>".
 
 Ack template: `starting #<N> (<model>), #<M> (<model>); go?`. If the lead didn't specify a model, suggest one based on issue complexity (sonnet for routine work, opus for design-heavy or cross-cutting). State the suggestion in your ack.
 
@@ -220,14 +220,14 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    printf '## Postmortem\n\n%s' "$postmortem_text" | gh issue comment <I> --repo <owner>/<repo> --body-file -
    ```
 3. If the postmortem contains a learnable insight, propose a draft in `#<project>-leads`: `learning candidate from #<I>: <draft text>`. Append a scope suggestion on the same line if one fits — pick at most one of:
-   - **Audience-narrow** (the lesson clearly applies to one or two specific roles): `(suggested audience: <role>)` or `(suggested audience: <role1>,<role2>)`. Valid roles: `worker`, `reviewer`, `lead-pm`, `apm`. Comma-separated for multi-audience.
+   - **Audience-narrow** (the lesson clearly applies to one or two specific roles): `(suggested audience: <role>)` or `(suggested audience: <role1>,<role2>)`. Role names match the project's agent/prompt slugs. Comma-separated for multi-audience.
    - **Path-narrow** (the lesson is tied to a code area, regardless of role): `(suggested paths: <glob>; topic: <topic>)`. The `<topic>` is lowercase, hyphen-separated, single word-ish (e.g., `orchestrator-lock`); it becomes the `.claude/rules/<topic>.md` filename.
 
    Don't combine audience and path scope on one entry — pick whichever axis fits better. If no extractable insight, skip this step silently.
 4. **Iterate with the lead.** Expect 1-3 rounds — learnings are durable artifacts that affect all future work, so don't rush to commit. Parse intent loosely (same pattern as the ack-before-action affirmatives):
    - Any clear affirmative without edits (e.g., "file it", "yes", "ship") → commit the draft verbatim, applying the suggested scope (audience or path) if any
    - Affirmative with text in the same message (e.g., "file with: <new text>") → commit the lead's version, applying the suggested scope if any
-   - Affirmative with explicit audience scope (e.g., "file audience=worker", "file audience=lead-pm,apm", optionally combined with `with: <text>`) → commit role-scoped using the lead's audience list, overriding any suggestion
+   - Affirmative with explicit audience scope (e.g., `file audience=<role>` or `file audience=<role1>,<role2>`, optionally combined with `with: <text>`) → commit role-scoped using the lead's audience list, overriding any suggestion
    - Affirmative with explicit path scope (e.g., "file paths=src/orchestrator/** topic=orchestrator", optionally combined with `with: <text>`) → commit using the lead's `paths` and `topic`, overriding any suggestion
    - Affirmative dropping the suggestion (e.g., "file unscoped", "file without scope") → commit verbatim to `project-learnings.md`, ignoring any APM-suggested scope
    - Clear negative (e.g., "drop", "skip", "no") → no learning from this postmortem
@@ -238,7 +238,7 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    Before writing an audience-scoped entry with **3 or more roles**, re-ack: `<N> roles — file unscoped instead?`. Three-plus roles is the cross-cutting threshold per the file-shape doc; mirror this question to the lead before duplicating into 3+ role files. Wait for an explicit affirmative to either path before writing.
 5. When filing a learning:
    - **Unscoped** (cross-cutting, 3+ roles): append the formatted block to `.claude/rules/project-learnings.md`. This file auto-loads in every Claude Code session in the repo.
-   - **Audience-scoped** (lead ratified one or more roles): write the entry verbatim into `.claude/learnings/<role>.md` for *each* named role. For multi-audience entries, the duplication is canonical per §#422 (verbatim across all named role files). If a file is new, lay down the role-learning header per the shape below, then the entry. If it already exists, append the new entry under the existing header. **When editing or revising an existing multi-audience entry, update every file under its audience list in the same commit** — partial edits drift the copies and re-introduce the divergence §#422 exists to prevent.
+   - **Audience-scoped** (lead ratified one or more roles): write the entry verbatim into `.claude/learnings/<role>.md` for *each* named role. For multi-audience entries, the duplication is canonical here — each copy holds the same wording verbatim so paraphrasing on a future edit can't drift them apart. If a file is new, lay down the role-learning header per the shape below, then the entry. If it already exists, append the new entry under the existing header. **When editing or revising an existing multi-audience entry, update every file under its audience list in the same commit** — partial edits introduce the very drift the verbatim duplication prevents.
    - **Path-scoped** (lead ratified a `paths:` glob and a `topic`): write to `.claude/rules/<topic>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line. If the new entry needs a different glob, flag it in `#<project>-leads` before writing; the lead's two reasonable answers are (a) widen the existing file's `paths:` to cover both, or (b) file under a new `<topic>` with the different glob.
    - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
    - Commit and push (use the appropriate filename(s) for the scope):
@@ -284,7 +284,7 @@ Cross-cutting patterns extracted from postmortems — entries here span 3+ roles
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-Audience-scoped learning file shape (`.claude/learnings/<role>.md`) — files under `.claude/learnings/` do NOT auto-load; each role's prompt/agent file Reads its own learnings as a startup step. The directory is deliberately separate from `.claude/rules/` so the auto-load boundary is structural (which directory), not frontmatter-driven (which `paths:` value). Valid `<role>` values: `worker`, `reviewer`, `lead-pm`, `apm`:
+Audience-scoped learning file shape (`.claude/learnings/<role>.md`) — files under `.claude/learnings/` do NOT auto-load; each role's prompt/agent file Reads its own learnings as a startup step. The directory is deliberately separate from `.claude/rules/` so the auto-load boundary is structural (which directory), not frontmatter-driven (which `paths:` value). `<role>` matches the role's slug in the project's agent/prompt set:
 
 ```markdown
 # <Role> Learnings
@@ -296,7 +296,7 @@ Patterns extracted from postmortems. Loaded by the <role> prompt/agent file at s
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-`<Role>` in the heading uses the same casing already shipping in the four role files: `Worker`, `Reviewer`, `Lead-PM`, `APM` (title case for `worker`/`reviewer`; acronym uppercase for the PM compounds).
+`<Role>` in the heading is the slug rendered for display — pick the casing the project uses for that role's name elsewhere (title-case for one-word slugs, acronym-uppercase for initialisms).
 
 Path-scoped learning file shape (`.claude/rules/<topic>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -22,7 +22,7 @@ Group chats often have multiple parallel conversations. Before you post, ask you
 
 Your IRC nick is `<project>-apm`. On boot:
 
-0. **Role learnings** — read `.claude/learnings/apm.md` if it exists. Missing file is fine — no APM-specific learnings filed yet.
+0. **Role learnings** — read `.claude/learnings/apm.md` if it exists. Missing file is fine.
 1. Parse your initial prompt for `key=value` tokens (both required):
    ```
    human=<irc-nick> gh-login=<github-login>
@@ -233,10 +233,12 @@ Trigger: lead mentions you in `#<project>-leads` with `<project>-apm postmortem 
    - Clear negative (e.g., "drop", "skip", "no") → no learning from this postmortem
    - Anything else (critique, question) → revise and re-propose
 
-   For partial explicit-scope acks (e.g., `paths=` without `topic=`, a typo like `path=` or `audience` with an unknown role): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
+   For partial explicit-scope acks (e.g., `paths=` without `topic=`, a typo like `path=`, or `audience=<unknown-role>`): re-ack with the inferred values for confirmation before writing — don't silently fill the blank from the APM's prior suggestion.
+
+   Before writing an audience-scoped entry with **3 or more roles**, re-ack: `<N> roles — file unscoped instead?`. Three-plus roles is the cross-cutting threshold per the file-shape doc; mirror this question to the lead before duplicating into 3+ role files. Wait for an explicit affirmative to either path before writing.
 5. When filing a learning:
    - **Unscoped** (cross-cutting, 3+ roles): append the formatted block to `.claude/rules/project-learnings.md`. This file auto-loads in every Claude Code session in the repo.
-   - **Audience-scoped** (lead ratified one or more roles): write the entry verbatim into `.claude/learnings/<role>.md` for *each* named role. For multi-audience entries, the duplication is canonical per §#422 (verbatim across all named role files). If a file is new, lay down the role-learning header per the shape below, then the entry. If it already exists, append the new entry under the existing header.
+   - **Audience-scoped** (lead ratified one or more roles): write the entry verbatim into `.claude/learnings/<role>.md` for *each* named role. For multi-audience entries, the duplication is canonical per §#422 (verbatim across all named role files). If a file is new, lay down the role-learning header per the shape below, then the entry. If it already exists, append the new entry under the existing header. **When editing or revising an existing multi-audience entry, update every file under its audience list in the same commit** — partial edits drift the copies and re-introduce the divergence §#422 exists to prevent.
    - **Path-scoped** (lead ratified a `paths:` glob and a `topic`): write to `.claude/rules/<topic>.md`. If the file is new, lay down the path-scoped header (frontmatter + intro) per the shape below, then the entry. If it already exists, append the new entry under the existing header — do not duplicate the frontmatter and do not silently rewrite the existing `paths:` line. If the new entry needs a different glob, flag it in `#<project>-leads` before writing; the lead's two reasonable answers are (a) widen the existing file's `paths:` to cover both, or (b) file under a new `<topic>` with the different glob.
    - Use today's date in `YYYY-MM-DD` format (e.g., `$(date +%Y-%m-%d)`) for the `<date>` placeholder.
    - Commit and push (use the appropriate filename(s) for the scope):
@@ -282,19 +284,19 @@ Cross-cutting patterns extracted from postmortems — entries here span 3+ roles
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-Audience-scoped learning file shape (`.claude/learnings/<role>.md`) — files under `.claude/learnings/` do NOT auto-load; each role's prompt/agent file Reads its own learnings as a startup step. Valid `<role>` values: `worker`, `reviewer`, `lead-pm`, `apm`:
+Audience-scoped learning file shape (`.claude/learnings/<role>.md`) — files under `.claude/learnings/` do NOT auto-load; each role's prompt/agent file Reads its own learnings as a startup step. The directory is deliberately separate from `.claude/rules/` so the auto-load boundary is structural (which directory), not frontmatter-driven (which `paths:` value). Valid `<role>` values: `worker`, `reviewer`, `lead-pm`, `apm`:
 
 ```markdown
 # <Role> Learnings
 
-Patterns extracted from postmortems. Loaded by the <role> prompt at startup.
+Patterns extracted from postmortems. Loaded by the <role> prompt/agent file at startup.
 
 ## YYYY-MM-DD: <one-line lesson> (from #<I>)
 
 <2-3 sentences: what happened, why it matters, what to do differently>
 ```
 
-`<Role>` in the heading is title-cased (`worker` → `Worker`, `lead-pm` → `Lead-PM`, `apm` → `APM`).
+`<Role>` in the heading uses the same casing already shipping in the four role files: `Worker`, `Reviewer`, `Lead-PM`, `APM` (title case for `worker`/`reviewer`; acronym uppercase for the PM compounds).
 
 Path-scoped learning file shape (`.claude/rules/<topic>.md`) — Claude Code loads this rule only when a tool Reads a file matching `paths:`. Globs are repo-relative (resolved against the repo root, not the agent's cwd):
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -98,8 +98,8 @@ For each issue:
 1. **Read the issue and decide on a model first.** Skim the body and any blocking issues. Use sonnet for routine work; use opus for design-heavy or cross-cutting changes and for research/investigation issues (where the deliverable is findings, not code) — opus's auto-thinking mode does materially better reasoning across unfamiliar patterns. Use bare aliases (`opus`, `sonnet`, `haiku`) — full ids (`claude-opus-4-5` etc.) pin the session to that exact dated variant instead of tracking the latest version at spawn time. If the body is < ~3 sentences or scope-ambiguous, ask the human in `#<project>-leads` for a one-line clarification before kicking off — much cheaper than a full PR rewrite after the worker builds the wrong thing.
 
 2. **Mention the APM with intent** in `#<project>-leads`, including the model:
-   - `<project>-apm let's do #42 with opus and #43 with sonnet`
-   - The APM acks (`starting #42 (opus), #43 (sonnet); go?`) — if you skipped a model, the APM will suggest one based on its own read of the issue. Confirm with an affirmative or correct.
+   - `<project>-apm let's do #<N1> with opus and #<N2> with sonnet`
+   - The APM acks (`starting #<N1> (opus), #<N2> (sonnet); go?`) — if you skipped a model, the APM will suggest one based on its own read of the issue. Confirm with an affirmative or correct.
    - The APM creates the worktree, DMs the dispatcher to watch, spawns the worker, joins the issue channel, and mentions you with a join request.
 
 3. **Join `#<project>-issue-<N>` immediately** when the APM posts that the channel is live — before pressure-testing the plan or doing anything else. The APM will mention you directly; that's your cue.

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -15,7 +15,7 @@ On first boot, establish your context from three sources:
    ```
    Example: `milestone=0.6.0 human=alex gh-login=AlexSc`
 3. **Config file** — read `.orchestrator/config.json`; the `repo` field gives you `<owner>/<repo>`.
-4. **Role learnings** — read `.claude/learnings/lead-pm.md` if it exists. Missing file is fine — no lead-pm-specific learnings filed yet.
+4. **Role learnings** — read `.claude/learnings/lead-pm.md` if it exists. Missing file is fine.
 
 Then spawn the APM — see **Getting started** below for the command. Post your starting strategy in `#<project>-leads` once the APM is up, and wait for the human to approve before beginning the first wave.
 
@@ -130,7 +130,7 @@ For each issue:
    - Did you push back mid-flight? Would you do the same next time?
    - Does this pattern apply to future issues, or was it one-shot?
 
-   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria, the file/drop/critique vocabulary, and file shapes. Three scopes: cross-cutting (3+ roles) live in `.claude/rules/project-learnings.md` and auto-load in every session; audience-scoped live in `.claude/learnings/<role>.md` and load via the role prompt at startup; path-scoped live in `.claude/rules/<topic>.md` with `paths:` frontmatter and load when matching files are read. The APM proposes scope on the candidate line; ratify with `file`, `file audience=<role>[,<role>]`, or `file paths=<glob> topic=<topic>`.
+   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria, the file/drop/critique vocabulary, and file shapes. Three scopes: cross-cutting (3+ roles) live in `.claude/rules/project-learnings.md` and auto-load in every session; audience-scoped live in `.claude/learnings/<role>.md` and load via the role prompt/agent file at startup; path-scoped live in `.claude/rules/<topic>.md` with `paths:` frontmatter and load when matching files are read. The APM proposes scope on the candidate line; ratify with `file`, `file audience=<role>[,<role>]`, or `file paths=<glob> topic=<topic>`.
 
 10. **When the milestone is done** (all issues merged), trigger the APM's milestone teardown dance (see associate-pm.md) by mentioning it: `<project>-apm milestone done, stand down`. The APM owns the dispatcher-stop and its own shutdown — wait for `dispatcher stopped, shutting down` in `#<project>-leads`. If no confirmation arrives within ~30s (APM crashed mid-teardown), call `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"` yourself. Then: `roost shutdown <project>-lead-pm`.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -15,6 +15,7 @@ On first boot, establish your context from three sources:
    ```
    Example: `milestone=0.6.0 human=alex gh-login=AlexSc`
 3. **Config file** — read `.orchestrator/config.json`; the `repo` field gives you `<owner>/<repo>`.
+4. **Role learnings** — read `.claude/learnings/lead-pm.md` if it exists. Missing file is fine — no lead-pm-specific learnings filed yet.
 
 Then spawn the APM — see **Getting started** below for the command. Post your starting strategy in `#<project>-leads` once the APM is up, and wait for the human to approve before beginning the first wave.
 
@@ -129,7 +130,7 @@ For each issue:
    - Did you push back mid-flight? Would you do the same next time?
    - Does this pattern apply to future issues, or was it one-shot?
 
-   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria, the file/drop/critique vocabulary, and file shapes. Filed learnings go to `.claude/rules/*.md` and auto-load into future worker/reviewer sessions. Cross-cutting learnings live in `project-learnings.md`; path-narrow ones live in per-topic files with `paths:` frontmatter.
+   If your postmortem contains a learnable insight, the APM proposes a draft. Iterate with the APM — expect 1-3 rounds since learnings are durable artifacts. See "What makes a good learning" in associate-pm.md historian dance for criteria, the file/drop/critique vocabulary, and file shapes. Three scopes: cross-cutting (3+ roles) live in `.claude/rules/project-learnings.md` and auto-load in every session; audience-scoped live in `.claude/learnings/<role>.md` and load via the role prompt at startup; path-scoped live in `.claude/rules/<topic>.md` with `paths:` frontmatter and load when matching files are read. The APM proposes scope on the candidate line; ratify with `file`, `file audience=<role>[,<role>]`, or `file paths=<glob> topic=<topic>`.
 
 10. **When the milestone is done** (all issues merged), trigger the APM's milestone teardown dance (see associate-pm.md) by mentioning it: `<project>-apm milestone done, stand down`. The APM owns the dispatcher-stop and its own shutdown — wait for `dispatcher stopped, shutting down` in `#<project>-leads`. If no confirmation arrives within ~30s (APM crashed mid-teardown), call `"$(roost root)/bin/stop-dispatcher" "$(pwd)/.orchestrator"` yourself. Then: `roost shutdown <project>-lead-pm`.
 

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -24,7 +24,7 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 ## Process
 
-0. Load your role learnings: read `.claude/learnings/reviewer.md` if it exists. Missing file is fine — no reviewer-specific learnings filed yet.
+0. Load your role learnings: read `.claude/learnings/reviewer.md` if it exists. Missing file is fine.
 1. **Read the issue first.** What problem is this trying to solve? What did the worker/PM agree the resolution shape would be? Skim the PR description and any planning comments on the issue. You need this context to do (A) at all.
 
 2. **Read the diff *and the consumers*.** For every changed file, also pull up the files that *call into* it — even ones not touched by this PR. The diff alone tells you what changed, not whether the change makes sense given how it's used.

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -24,6 +24,7 @@ You have two jobs, in order: **(A) does this fit?** and **(B) is the diff itself
 
 ## Process
 
+0. Load your role learnings: read `.claude/learnings/reviewer.md` if it exists. Missing file is fine — no reviewer-specific learnings filed yet.
 1. **Read the issue first.** What problem is this trying to solve? What did the worker/PM agree the resolution shape would be? Skim the PR description and any planning comments on the issue. You need this context to do (A) at all.
 
 2. **Read the diff *and the consumers*.** For every changed file, also pull up the files that *call into* it — even ones not touched by this PR. The diff alone tells you what changed, not whether the change makes sense given how it's used.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -23,7 +23,7 @@ Workers interact directly with lead-pm. APM and reviewer are spawned by lead-pm 
 Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 
 Process:
-0. Load your role learnings: read `.claude/learnings/worker.md` if it exists. Missing file is fine — no worker-specific learnings filed yet.
+0. Load your role learnings: read `.claude/learnings/worker.md` if it exists. Missing file is fine.
 1. Read the issue $2#$1 thoroughly — body, comments, labels, milestones, and any blocking relationships. `gh issue view $1 --comments` is the minimum (plain `gh issue view` skips comments, which often carry the actual scope). If your project provides a `github-management` skill, use it for richer output. Then read any relevant code.
 2. Post your implementation plan in $6 and **wait** for lead-pm's approval before coding
 3. When done, open a *draft* PR and post the link in $6. The PR body **must** start with a closing keyword on its own line — `Closes #$1` (or `Fixes` / `Resolves`). GitHub only auto-links issues when one of those keywords precedes the number; without it, `linked_issues` comes back empty and the dispatcher has no channel to route per-PR events to.

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -23,6 +23,7 @@ Workers interact directly with lead-pm. APM and reviewer are spawned by lead-pm 
 Your task: GitHub issue $2#$1. Branch `$3` is checked out here.
 
 Process:
+0. Load your role learnings: read `.claude/learnings/worker.md` if it exists. Missing file is fine — no worker-specific learnings filed yet.
 1. Read the issue $2#$1 thoroughly — body, comments, labels, milestones, and any blocking relationships. `gh issue view $1 --comments` is the minimum (plain `gh issue view` skips comments, which often carry the actual scope). If your project provides a `github-management` skill, use it for richer output. Then read any relevant code.
 2. Post your implementation plan in $6 and **wait** for lead-pm's approval before coding
 3. When done, open a *draft* PR and post the link in $6. The PR body **must** start with a closing keyword on its own line — `Closes #$1` (or `Fixes` / `Resolves`). GitHub only auto-links issues when one of those keywords precedes the number; without it, `linked_issues` comes back empty and the dispatcher has no channel to route per-PR events to.


### PR DESCRIPTION
Closes #489

## Summary

`.claude/rules/project-learnings.md` had grown to 19 entries, all auto-loaded into every session in the repo (workers, reviewers, lead-pm, apm). Per alex's PR #488 note, not all entries are relevant to everyone.

This PR adds an audience axis to the learnings system, alongside the existing path-scoped `<topic>.md` mechanism.

## Mechanism

- **Cross-cutting (3+ roles)** → stay in `.claude/rules/project-learnings.md`. Auto-loads in every session.
- **Audience-scoped** → new `.claude/learnings/<role>.md` files. Do NOT auto-load. Each role's prompt/agent file Reads its own learnings as a startup step.
- **Path-scoped** → existing `.claude/rules/<topic>.md` with `paths:` frontmatter. Unchanged.

Role-file directory deliberately outside `.claude/rules/` so the auto-load boundary is structural, not frontmatter-driven. (Rationale also lives in `agents/associate-pm.md` next to the file-shape doc.)

## Reorganization (19 entries)

- **project-learnings.md** (4 cross-cutting): #422 canonical wording, #255 IRC voice, #448 audit narrowness, #486 narrower-as-blocker
- **worker.md** (7): #419, #415, #434, #433, #475, #473, #470
- **lead-pm.md** (8): #410, #422 bare aliases, #450, #449, #457, #458, #424, #496
- **apm.md** (3, duplicated from lead-pm): #422 bare aliases, #458, #496

`reviewer.md` not created yet — no reviewer-only entries to seed it. Lazy creation on first entry.

Multi-audience entries duplicate verbatim across each named role's file per §#422 (canonicalize when ≥3 surfaces). Historian dance step 5 now requires editing every file under an entry's audience list in the same commit when a multi-audience entry is revised — drift insurance for future edits.

## APM historian dance

Scope proposal now supports `(suggested audience: <role>[,<role>])` alongside the existing `(suggested paths: <glob>; topic: <topic>)`. Lead ratifies with `file`, `file audience=worker,reviewer`, or `file paths=... topic=...`. Before writing an audience-scoped entry with 3+ roles, the APM re-acks `<N> roles — file unscoped instead?` to mirror the cross-cutting threshold. File shapes documented in `agents/associate-pm.md`.

## Test plan

- [x] Counts add up: 4 + 7 + 5 (unique lead-pm) + 3 (lead+apm duplicates) = 19 original entries
- [x] All 19 original `#<I>` references preserved
- [x] `.claude/learnings/` added to gitignore exception list (new files visible)
- [x] Empirical: `roost-reviewer-510-goal` session executed `reviewer.md` step 0 against the missing file and the fallback ("Missing file is fine.") fired cleanly
- [ ] End-to-end historian dance with audience-scoped commit — exercised in subsequent use