### PR TITLE
feat(linear-new-issues): per-team new-issue feed

### DIFF
--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { tryClaimPerN, tryClaimPerRepo, tryClaimPerLinearId, splitCommands } from '../grammar.js'
+import { tryClaimPerN, tryClaimPerRepo, tryClaimPerLinearId, tryClaimPerLinearTeam, splitCommands } from '../grammar.js'
 
 // ---- splitCommands --------------------------------------------------------
 
@@ -310,5 +310,72 @@ describe('tryClaimPerLinearId', () => {
     const r = tryClaimPerLinearId('watch linear C-758 notachannel')
     expect(r?.kind).toBe('error')
     expect((r as { kind: 'error'; message: string }).message).toMatch(/channels must match/)
+  })
+})
+
+// ---- tryClaimPerLinearTeam ------------------------------------------------
+
+describe('tryClaimPerLinearTeam — target=linear-team', () => {
+  it('claims `watch linear-team C`', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', channels: [] },
+    })
+  })
+
+  it('claims multi-letter team key', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team MAR')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', team: 'MAR', channels: [] },
+    })
+  })
+
+  it('claims with channels', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C #triage #leads')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', channels: ['#triage', '#leads'] },
+    })
+  })
+
+  it('claims `unwatch linear-team C`', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'unwatch linear-team C')).toEqual({
+      kind: 'ok', cmd: { verb: 'unwatch', team: 'C', channels: [] },
+    })
+  })
+
+  it('errors on lowercase team key', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team c')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toContain('"c"')
+    expect((r as { kind: 'error'; message: string }).message).toContain('uppercase')
+  })
+
+  it('errors on mixed-case team key', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team Car')
+    expect(r?.kind).toBe('error')
+  })
+
+  it('errors on missing team after target', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toContain('team key')
+  })
+
+  it('errors on unwatch with trailing channel', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'unwatch linear-team C #foo')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toContain('no channel arguments')
+  })
+
+  it('errors on malformed channel', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team C notachannel')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toContain('channels must match')
+  })
+
+  it('defers when target keyword is absent', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch C')).toBeNull()
+    expect(tryClaimPerLinearTeam('linear-team', 'watch new-issues org/repo')).toBeNull()
+  })
+
+  it('defers on non-watch/unwatch verbs', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'help linear-team C')).toBeNull()
   })
 })

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -192,6 +192,53 @@ export function tryClaimPerLinearId(line: string): ParseResult<PerLinearIdComman
   return { kind: 'ok', cmd: { verb, identifier, channels } }
 }
 
+export interface PerLinearTeamCommand {
+  verb: Verb
+  team: string
+  channels: string[]
+}
+
+// Try to claim a per-Linear-team line for `target`. Returns:
+//   - `null` if the line isn't watch/unwatch, or doesn't lead with this target.
+//   - `{kind:'ok',cmd}` on a clean claim.
+//   - `{kind:'error',msg}` when the line claimed this plugin's target but the
+//     body fails validation (bad team key, malformed channel, etc.). Unlike
+//     `tryClaimPerN`/`tryClaimPerRepo`, there is no shape-based defer — `linear-team`
+//     is an unambiguous keyword; no other plugin claims it.
+export function tryClaimPerLinearTeam(target: string, line: string): ParseResult<PerLinearTeamCommand> | null {
+  const parsed = tokenizeVerbLine(line)
+  if (!parsed) return null
+  const { verb, tokens } = parsed
+  const targetMatch = matchTarget(target, tokens)
+  if (targetMatch === null) return null
+  const rest = tokens.slice(targetMatch)
+
+  const specTok = rest[0]
+  if (specTok === undefined) {
+    return { kind: 'error', message: `${verb} requires a team key (e.g. C, MAR)` }
+  }
+
+  const TEAM_RE = /^[A-Z]+$/
+  if (!TEAM_RE.test(specTok)) {
+    return {
+      kind: 'error',
+      message: `${verb}: "${specTok}" is not a valid team key — must be uppercase letters only (e.g. C, MAR)`,
+    }
+  }
+
+  const channels = rest.slice(1)
+  if (verb === 'unwatch') {
+    if (channels.length) return { kind: 'error', message: 'unwatch takes no channel arguments' }
+    return { kind: 'ok', cmd: { verb, team: specTok, channels: [] } }
+  }
+  for (const c of channels) {
+    if (!CHANNEL_RE.test(c)) {
+      return { kind: 'error', message: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
+    }
+  }
+  return { kind: 'ok', cmd: { verb, team: specTok, channels } }
+}
+
 // Returns the index of the first non-target token in `tokens`, or null when
 // `target` is set but doesn't appear at position 0. `target=null` means the
 // plugin claims bare verbs; we still reject a leading reserved verb so

--- a/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn, beforeAll, afterAll } from 'bun:test'
 import { LinearNewIssuesPlugin, type LinearNewIssuesPluginState, formatNewLinearIssue } from '../new-issues-plugin.js'
 import { LinearClient, type LinearIssueNode } from '../linear-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import { RATE_LIMIT_WINDOW_MS } from '../../_rate-limit.js'
 
 const noopLog = () => {}
 
@@ -157,7 +158,7 @@ describe('LinearNewIssuesPlugin.runTick', () => {
     expect(result.taggedEvents).toHaveLength(0)
   })
 
-  it('orders announcements by identifier', async () => {
+  it('orders announcements by issue number (numeric, not lex — C-5 before C-11 before C-20)', async () => {
     const spy = stubFetch([issue('C-20'), issue('C-5'), issue('C-11')])
     try {
       const { plugin } = makePlugin()
@@ -165,7 +166,7 @@ describe('LinearNewIssuesPlugin.runTick', () => {
       const identifiers = result.taggedEvents.map(e =>
         ((e.payload as { kind: 'oneline'; text: string }).text.match(/new linear issue (\S+):/)?.[1])
       )
-      expect(identifiers).toEqual(['C-11', 'C-20', 'C-5'])
+      expect(identifiers).toEqual(['C-5', 'C-11', 'C-20'])
     } finally { spy.mockRestore() }
   })
 
@@ -288,5 +289,78 @@ describe('formatNewLinearIssue', () => {
   it('handles null labels gracefully', () => {
     const text = formatNewLinearIssue(issue('C-1', { labels: null }))
     expect(text).not.toContain('[')
+  })
+})
+
+describe('LinearNewIssuesPlugin.observeLinearRateLimit — warning emission', () => {
+  it('emits a warning event to the project channel when rolling rate predicts exhaustion before reset', async () => {
+    const { plugin, client } = makePlugin()
+    const rlSpy = spyOn(client, 'getLastRateLimit').mockReturnValue({
+      remaining: 100,
+      limit: 2500,
+      resetAt: Math.floor((Date.now() + 60 * 60_000) / 1000),
+    })
+    // Seed history: 2500 remaining 160s ago (> half-window threshold).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [
+      { remaining: 2500, ts: Date.now() - 160_000 },
+    ]
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    try {
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      const warnings = result.taggedEvents.filter(e =>
+        (e.payload as { text?: string }).text?.includes('rate limit warning')
+      )
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]?.channels).toEqual(['#proj-leads'])
+      expect((warnings[0]?.payload as { text: string }).text).toContain('Linear')
+    } finally {
+      rlSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('no warning on cold-start (no history)', async () => {
+    const { plugin, client } = makePlugin()
+    const rlSpy = spyOn(client, 'getLastRateLimit').mockReturnValue({
+      remaining: 100,
+      limit: 2500,
+      resetAt: Math.floor((Date.now() + 60 * 60_000) / 1000),
+    })
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    try {
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      const warnings = result.taggedEvents.filter(e =>
+        (e.payload as { text?: string }).text?.includes('rate limit warning')
+      )
+      expect(warnings).toHaveLength(0)
+    } finally {
+      rlSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('prunes stale history — no warning after a long gap', async () => {
+    const { plugin, client } = makePlugin()
+    const rlSpy = spyOn(client, 'getLastRateLimit').mockReturnValue({
+      remaining: 100,
+      limit: 2500,
+      resetAt: Math.floor((Date.now() + 60 * 60_000) / 1000),
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [
+      { remaining: 2500, ts: Date.now() - RATE_LIMIT_WINDOW_MS - 10_000 },
+    ]
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    try {
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      const warnings = result.taggedEvents.filter(e =>
+        (e.payload as { text?: string }).text?.includes('rate limit warning')
+      )
+      expect(warnings).toHaveLength(0)
+    } finally {
+      rlSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
   })
 })

--- a/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, spyOn, beforeAll, afterAll } from 'bun:test'
+import { LinearNewIssuesPlugin, type LinearNewIssuesPluginState, formatNewLinearIssue } from '../new-issues-plugin.js'
+import { LinearClient, type LinearIssueNode } from '../linear-api.js'
+import type { OrchestratorConfig } from '../../../config.js'
+
+const noopLog = () => {}
+
+function issue(identifier: string, overrides: Partial<LinearIssueNode> = {}): LinearIssueNode {
+  const [team, num] = identifier.split('-')
+  return {
+    id: `uuid-${identifier}`,
+    identifier,
+    title: `Issue ${team}-${num}`,
+    labels: null,
+    url: `https://linear.app/test/issue/${identifier.toLowerCase()}/issue-${team}-${num}`,
+    ...overrides,
+  }
+}
+
+function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    project: 'proj',
+    plugins: { 'linear-new-issues': { watched: [{ team: 'C' }] } },
+    ...overrides,
+  }
+}
+
+// Create a plugin with a fake client (avoids reading LINEAR_API_KEY from env).
+function makePlugin(channel = '#proj-leads'): { plugin: LinearNewIssuesPlugin; client: LinearClient } {
+  const client = new LinearClient('lin_api_fake_test', noopLog)
+  const plugin = new LinearNewIssuesPlugin(channel, noopLog, client)
+  return { plugin, client }
+}
+
+// Stub fetchTeamOpenIssues on the prototype so all instances in a test get the mock.
+function stubFetch(response: LinearIssueNode[]) {
+  return spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue(response)
+}
+
+// Suppress the rate-limit observe path — `getLastRateLimit` returns null, no events.
+function stubRateLimit() {
+  let spy: { mockRestore(): void }
+  beforeAll(() => {
+    spy = spyOn(LinearClient.prototype, 'getLastRateLimit').mockReturnValue(null)
+  })
+  afterAll(() => { spy.mockRestore() })
+}
+
+function prevState(identifiers: string[], team = 'C'): LinearNewIssuesPluginState {
+  return { teams: { [team]: [...identifiers].sort() } }
+}
+
+describe('LinearNewIssuesPlugin.runTick', () => {
+  stubRateLimit()
+
+  it('seeds without emitting on first run (prev === null)', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2'), issue('C-3')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), null)
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as LinearNewIssuesPluginState).teams['C']).toEqual(['C-1', 'C-2', 'C-3'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits a oneline announcement for issues new since last tick', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2'), issue('C-3')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState(['C-1']))
+      expect(result.taggedEvents).toHaveLength(2)
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: `new linear issue C-2: Issue C-2 — https://linear.app/test/issue/c-2/issue-C-2`,
+      })
+      expect(result.taggedEvents[1]?.payload).toEqual({
+        kind: 'oneline',
+        text: `new linear issue C-3: Issue C-3 — https://linear.app/test/issue/c-3/issue-C-3`,
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes announcements to the project channel by default', async () => {
+    const spy = stubFetch([issue('C-5')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('honors entry.channels override when set', async () => {
+    const spy = stubFetch([issue('C-5')])
+    try {
+      const { plugin } = makePlugin()
+      const config = baseConfig({ plugins: { 'linear-new-issues': { watched: [{ team: 'C', channels: ['#triage', '#leads'] }] } } })
+      const result = await plugin.runTick(config, prevState([]))
+      expect(result.taggedEvents[0]?.channels).toEqual(['#triage', '#leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits a defensive per-event channel copy — sibling mutation does not leak', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      result.taggedEvents[0]?.channels.push('#tampered')
+      expect(result.taggedEvents[1]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('includes labels in the announcement when present', async () => {
+    const spy = stubFetch([issue('C-7', { labels: { nodes: [{ name: 'bug' }, { name: 'Tooling' }] } })])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('[bug, Tooling]')
+    } finally { spy.mockRestore() }
+  })
+
+  it('accumulates seen identifiers across ticks', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState(['C-5']))
+      expect((result.state as LinearNewIssuesPluginState).teams['C']).toEqual(['C-1', 'C-2', 'C-5'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('does not re-announce issues already in seen', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState(['C-1', 'C-2']))
+      expect(result.taggedEvents).toHaveLength(0)
+    } finally { spy.mockRestore() }
+  })
+
+  it('no-ops when watched list is empty', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-new-issues': { watched: [] } },
+    }
+    const { plugin } = makePlugin()
+    const result = await plugin.runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
+  })
+
+  it('no-ops when watched is absent', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-new-issues': {} },
+    }
+    const { plugin } = makePlugin()
+    const result = await plugin.runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
+  })
+
+  it('orders announcements by identifier', async () => {
+    const spy = stubFetch([issue('C-20'), issue('C-5'), issue('C-11')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      const identifiers = result.taggedEvents.map(e =>
+        ((e.payload as { kind: 'oneline'; text: string }).text.match(/new linear issue (\S+):/)?.[1])
+      )
+      expect(identifiers).toEqual(['C-11', 'C-20', 'C-5'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('desiredChannels returns empty when no entry has channels', () => {
+    const { plugin } = makePlugin()
+    expect(plugin.desiredChannels(baseConfig())).toEqual([])
+  })
+
+  it('desiredChannels unions channels across all watched entries', () => {
+    const { plugin } = makePlugin()
+    const config = baseConfig({
+      plugins: {
+        'linear-new-issues': {
+          watched: [
+            { team: 'C', channels: ['#triage'] },
+            { team: 'MAR', channels: ['#triage', '#leads'] },
+          ],
+        },
+      },
+    })
+    expect(plugin.desiredChannels(config)).toEqual(['#triage', '#leads'])
+  })
+
+  it('polls each watched team independently', async () => {
+    const calls: string[] = []
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (team: string) => {
+      calls.push(team)
+      return team === 'C' ? [issue('C-1')] : [issue('MAR-2')]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'linear-new-issues': {
+            watched: [{ team: 'C' }, { team: 'MAR' }],
+          },
+        },
+      }
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(config, { teams: { C: [], MAR: [] } })
+      expect(calls).toEqual(['C', 'MAR'])
+      expect(result.taggedEvents).toHaveLength(2)
+      expect((result.taggedEvents[0]?.payload as { text: string }).text).toContain('C-1')
+      expect((result.taggedEvents[1]?.payload as { text: string }).text).toContain('MAR-2')
+    } finally { spy.mockRestore() }
+  })
+
+  it('seeds a new team entry without emitting when added to an existing config', async () => {
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (team: string) => {
+      return team === 'C' ? [issue('C-1')] : [issue('MAR-10'), issue('MAR-11')]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'linear-new-issues': {
+            watched: [{ team: 'C' }, { team: 'MAR' }],
+          },
+        },
+      }
+      const { plugin } = makePlugin()
+      // prev state only has C — MAR is brand new
+      const result = await plugin.runTick(config, { teams: { C: [] } })
+      const texts = result.taggedEvents.map(e => (e.payload as { text: string }).text)
+      expect(texts.every(t => t.includes('C-1'))).toBe(true)
+      expect(texts.some(t => t.includes('MAR'))).toBe(false)
+      expect((result.state as LinearNewIssuesPluginState).teams['MAR']).toEqual(['MAR-10', 'MAR-11'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('carries forward removed-entry state — remove-then-readd does not replay history', async () => {
+    const spy = stubFetch([issue('C-5')])
+    try {
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(
+        baseConfig(),
+        { teams: { C: [], GONE: ['GONE-10', 'GONE-11'] } },
+      )
+      const state = result.state as LinearNewIssuesPluginState
+      expect(state.teams['GONE']).toEqual(['GONE-10', 'GONE-11'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('treats old non-teams state shape as null and re-seeds', async () => {
+    const spy = stubFetch([issue('C-1'), issue('C-2')])
+    try {
+      const { plugin } = makePlugin()
+      const oldState = { seen_identifiers: ['C-1', 'C-2', 'C-3'] }
+      const result = await plugin.runTick(baseConfig(), oldState)
+      // Re-seeded: no events emitted
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as LinearNewIssuesPluginState).teams['C']).toEqual(['C-1', 'C-2'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('logs and continues when fetchTeamOpenIssues throws', async () => {
+    const logs: string[] = []
+    const errClient = new LinearClient('lin_api_fake_test', (msg) => { logs.push(msg) })
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockRejectedValue(new Error('network error'))
+    try {
+      const plugin = new LinearNewIssuesPlugin('#proj-leads', (msg) => { logs.push(msg) }, errClient)
+      const result = await plugin.runTick(baseConfig(), prevState([]))
+      expect(result.taggedEvents).toHaveLength(0)
+      expect(logs.some(l => l.includes('network error'))).toBe(true)
+    } finally { spy.mockRestore() }
+  })
+})
+
+describe('formatNewLinearIssue', () => {
+  it('formats without labels', () => {
+    const text = formatNewLinearIssue(issue('C-758'))
+    expect(text).toBe('new linear issue C-758: Issue C-758 — https://linear.app/test/issue/c-758/issue-C-758')
+  })
+
+  it('formats with labels', () => {
+    const text = formatNewLinearIssue(issue('C-758', { labels: { nodes: [{ name: 'carrot' }, { name: 'Tooling' }] } }))
+    expect(text).toContain('[carrot, Tooling]')
+  })
+
+  it('handles null labels gracefully', () => {
+    const text = formatNewLinearIssue(issue('C-1', { labels: null }))
+    expect(text).not.toContain('[')
+  })
+})

--- a/src/orchestrator/plugins/linear/linear-api.ts
+++ b/src/orchestrator/plugins/linear/linear-api.ts
@@ -282,6 +282,32 @@ export async function spawnLinear(
   throw new LinearError(`spawnLinear: loop exited without result for ${cmd}`)
 }
 
+// ---- New-issues shape -----------------------------------------------------
+
+export interface LinearIssueNode {
+  id: string           // UUID
+  identifier: string   // "C-758"
+  title: string | null
+  labels: { nodes: Array<{ name: string }> } | null
+  url: string | null
+}
+
+function isLabelsShape(v: unknown): v is { nodes: Array<{ name: string }> } {
+  if (v == null || typeof v !== 'object') return false
+  const nodes = (v as Record<string, unknown>).nodes
+  return Array.isArray(nodes)
+}
+
+const TEAM_OPEN_ISSUES_QUERY = `query($teamKey: String!) {
+  teams(filter: { key: { eq: $teamKey } }) {
+    nodes {
+      issues(filter: { state: { type: { nin: ["completed", "canceled"] } } }) {
+        nodes { id identifier title labels { nodes { name } } url }
+      }
+    }
+  }
+}`
+
 // ---- Probe shape ----------------------------------------------------------
 
 export interface LinearProbeResult {
@@ -343,6 +369,28 @@ export class LinearClient {
       )
     }
     return result.body.data
+  }
+
+  // Fetch open (not completed, not canceled) issues for a team identified by key
+  // (e.g. "C", "MAR"). Returns an empty array when the team key is not found —
+  // caller is responsible for logging the missing-team warning.
+  async fetchTeamOpenIssues(teamKey: string): Promise<LinearIssueNode[]> {
+    const data = (await this.graphql(TEAM_OPEN_ISSUES_QUERY, { teamKey })) as {
+      teams?: { nodes?: Array<{ issues?: { nodes?: unknown[] } }> }
+    } | undefined | null
+    const teamNode = data?.teams?.nodes?.[0]
+    if (!teamNode) return []
+    const nodes = teamNode.issues?.nodes ?? []
+    return nodes
+      .filter((n): n is Record<string, unknown> => n != null && typeof n === 'object')
+      .map(n => ({
+        id: typeof n.id === 'string' ? n.id : '',
+        identifier: typeof n.identifier === 'string' ? n.identifier : '',
+        title: typeof n.title === 'string' ? n.title : null,
+        labels: isLabelsShape(n.labels) ? n.labels : null,
+        url: typeof n.url === 'string' ? n.url : null,
+      }))
+      .filter(n => n.id && n.identifier)
   }
 
   // Boot probe: confirms auth + identifies the workspace and teams. Throws

--- a/src/orchestrator/plugins/linear/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/new-issues-plugin.ts
@@ -1,0 +1,229 @@
+// Per-team new-issue triage feed for Linear. Polls watched teams for open
+// issues and announces the first time a given Linear ID is observed.
+//
+// DM grammar: claims target=`linear-team` — `watch linear-team <TEAM>
+// [#chan ...]`. Team key must match `^[A-Z]+$`.
+//
+// State slice: `{ teams: Record<string, string[]> }`. Seeding (`prev===null`)
+// and first-observation of a new team entry both capture without emitting.
+// Removed entries are carried forward so remove-then-readd doesn't replay.
+import type { Command } from '../../dispatcher-dm-handler.js'
+import type { OrchestratorConfig } from '../../config.js'
+import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
+import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
+import { resolveProjectChannel } from '../../naming.js'
+import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS } from '../_rate-limit.js'
+import { tryClaimPerLinearTeam, type PerLinearTeamCommand } from '../grammar.js'
+import { LinearClient, type LinearIssueNode } from './linear-api.js'
+
+export interface LinearNewIssuesWatchEntry {
+  team: string
+  channels?: string[]
+}
+
+interface LinearNewIssuesPluginConfig {
+  watched?: LinearNewIssuesWatchEntry[]
+}
+
+export interface LinearNewIssuesPluginState {
+  teams: Record<string, string[]>
+}
+
+export class LinearNewIssuesPlugin extends BasePlugin {
+  readonly name = 'linear-new-issues'
+
+  private readonly log: PluginLogger
+  private readonly client: LinearClient
+  private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
+
+  private static _warnedAt: number | null = null
+  private static readonly WARN_COOLDOWN_MS = 10 * 60_000
+
+  constructor(
+    defaultChannel: string,
+    log: PluginLogger = defaultPluginLogger,
+    client?: LinearClient,
+  ) {
+    super(defaultChannel)
+    this.log = log
+    this.client = client ?? LinearClient.fromEnv(log)
+  }
+
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerLinearTeam('linear-team', line)
+  }
+
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerLinearTeamCommand
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.team, c.channels)
+      return this.applyUnwatch(merged, local, c.team)
+    }
+    return null
+  }
+
+  private mergedWatched(config: OrchestratorConfig): LinearNewIssuesWatchEntry[] {
+    return this.pluginConfig<LinearNewIssuesPluginConfig>(config)?.watched ?? []
+  }
+
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, team: string, channels: string[]): string {
+    const labelStr = `linear-team ${team}`
+    const match = (e: LinearNewIssuesWatchEntry) => e.team === team
+    if (!this.mergedWatched(merged).some(match)) {
+      const slice = this.localSlice<LinearNewIssuesPluginConfig>(local)
+      slice.watched ??= []
+      const entry: LinearNewIssuesWatchEntry = { team }
+      if (channels.length) entry.channels = [...channels]
+      slice.watched.push(entry)
+      return channels.length ? `watching ${labelStr} + ${channels.join(' ')}` : `watching ${labelStr}`
+    }
+    const localEntry = (this.pluginConfig<LinearNewIssuesPluginConfig>(local)?.watched ?? []).find(match)
+    if (!localEntry) return channels.length ? trackedRefusal(labelStr, 'add channels') : `already watching ${labelStr}`
+    return addChannelsToEntry(localEntry, channels, labelStr)
+  }
+
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, team: string): string {
+    return applyUnwatchEntry<LinearNewIssuesWatchEntry>(
+      this.mergedWatched(merged),
+      this.pluginConfig<LinearNewIssuesPluginConfig>(local)?.watched ?? [],
+      e => e.team === team,
+      `linear-team ${team}`,
+    )
+  }
+
+  private formatListSection(merged: OrchestratorConfig): string {
+    const entries = this.mergedWatched(merged)
+    const byTeam = new Map<string, Set<string>>()
+    const order: string[] = []
+    for (const e of entries) {
+      let chans = byTeam.get(e.team)
+      if (!chans) {
+        chans = new Set<string>()
+        byTeam.set(e.team, chans)
+        order.push(e.team)
+      }
+      for (const c of e.channels ?? []) chans.add(c)
+    }
+    const header = `${this.name} (${byTeam.size}):`
+    if (!byTeam.size) return `${header}\n  (none)`
+    const lines = order.map(t => {
+      const chans = byTeam.get(t)!
+      const chansStr = chans.size ? ` + ${[...chans].join(' ')}` : ''
+      return `  ${t}${chansStr}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch linear-team <TEAM> [#chan ...]   — watch new-issues feed for TEAM`,
+      `  unwatch linear-team <TEAM>             — stop watching new-issues feed`,
+      `  watch list                             — include this plugin's watched teams in the reply`,
+    ].join('\n')
+  }
+
+  desiredChannels(config: OrchestratorConfig): string[] {
+    const slice = this.pluginConfig<LinearNewIssuesPluginConfig>(config) ?? {}
+    const chans = new Set<string>()
+    for (const entry of slice.watched ?? []) {
+      for (const c of entry.channels ?? []) chans.add(c)
+    }
+    return [...chans]
+  }
+
+  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
+    const slice = this.pluginConfig<LinearNewIssuesPluginConfig>(config) ?? {}
+    const watchEntries = slice.watched ?? []
+    if (!watchEntries.length) return { state: prevState ?? { teams: {} }, taggedEvents: [], channels: [] }
+
+    // Re-seed cleanly from older shapes (no `teams` key).
+    const prev = (prevState != null && typeof prevState === 'object' && 'teams' in prevState)
+      ? prevState as LinearNewIssuesPluginState
+      : null
+
+    const taggedEvents: TaggedEvent[] = []
+    const nextTeams: Record<string, string[]> = prev ? { ...prev.teams } : {}
+
+    for (const entry of watchEntries) {
+      const { team, channels } = entry
+      const announcementChannels = channels?.length
+        ? [...channels]
+        : [resolveProjectChannel(config)]
+
+      let issues: LinearIssueNode[]
+      try {
+        issues = await this.client.fetchTeamOpenIssues(team)
+      } catch (e) {
+        this.log(`linear-new-issues: error fetching team ${team}: ${e instanceof Error ? e.message : String(e)}\n`)
+        continue
+      }
+
+      if (!issues.length && !(prev?.teams[team])) {
+        // Team not found on first observation — log and skip but don't block other teams.
+        this.log(`linear-new-issues: team ${team} not found or has no open issues; entry kept in config\n`)
+      }
+
+      // First observation of this team (or full re-seed): capture without emitting.
+      const isFirstForTeam = prev === null || prev.teams[team] === undefined
+      const seen = new Set<string>(prev?.teams[team] ?? [])
+
+      if (!isFirstForTeam) {
+        const newIssues = issues
+          .filter(i => !seen.has(i.identifier))
+          .sort((a, b) => a.identifier.localeCompare(b.identifier))
+        for (const issue of newIssues) {
+          taggedEvents.push({
+            channels: [...announcementChannels],
+            payload: { kind: 'oneline', text: formatNewLinearIssue(issue) },
+          })
+        }
+      }
+
+      for (const i of issues) seen.add(i.identifier)
+      nextTeams[team] = [...seen].sort()
+    }
+
+    taggedEvents.push(...this.observeLinearRateLimit(resolveProjectChannel(config)))
+    const state: LinearNewIssuesPluginState = { teams: nextTeams }
+    return { state, taggedEvents, channels: [] }
+  }
+
+  private observeLinearRateLimit(projectChannel: string): TaggedEvent[] {
+    const info = this.client.getLastRateLimit()
+    if (!info) return []
+
+    const now = Date.now()
+    const cutoff = now - RATE_LIMIT_WINDOW_MS
+    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
+
+    const prev = this._rateLimitHistory.length > 0
+      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
+      : null
+    const delta = prev != null ? prev.remaining - info.remaining : null
+    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
+    const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
+    this.log(`[ratelimit] linear remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
+
+    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now, 'Linear')
+    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
+    if (!warning) return []
+
+    const cooldownElapsed = LinearNewIssuesPlugin._warnedAt == null || now - LinearNewIssuesPlugin._warnedAt > LinearNewIssuesPlugin.WARN_COOLDOWN_MS
+    if (!cooldownElapsed) return []
+
+    LinearNewIssuesPlugin._warnedAt = now
+    return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
+  }
+}
+
+export function formatNewLinearIssue(issue: LinearIssueNode): string {
+  const title = issue.title ?? ''
+  const labelNames = (issue.labels?.nodes ?? []).map(l => l.name).filter(Boolean)
+  const labelStr = labelNames.length ? ` [${labelNames.join(', ')}]` : ''
+  const url = issue.url ?? ''
+  return `new linear issue ${issue.identifier}: ${title}${labelStr} — ${url}`
+}

--- a/src/orchestrator/plugins/linear/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/new-issues-plugin.ts
@@ -174,7 +174,7 @@ export class LinearNewIssuesPlugin extends BasePlugin {
       if (!isFirstForTeam) {
         const newIssues = issues
           .filter(i => !seen.has(i.identifier))
-          .sort((a, b) => a.identifier.localeCompare(b.identifier))
+          .sort((a, b) => linearIdNum(a.identifier) - linearIdNum(b.identifier))
         for (const issue of newIssues) {
           taggedEvents.push({
             channels: [...announcementChannels],
@@ -184,7 +184,7 @@ export class LinearNewIssuesPlugin extends BasePlugin {
       }
 
       for (const i of issues) seen.add(i.identifier)
-      nextTeams[team] = [...seen].sort()
+      nextTeams[team] = [...seen].sort((a, b) => linearIdNum(a) - linearIdNum(b))
     }
 
     taggedEvents.push(...this.observeLinearRateLimit(resolveProjectChannel(config)))
@@ -218,6 +218,13 @@ export class LinearNewIssuesPlugin extends BasePlugin {
     LinearNewIssuesPlugin._warnedAt = now
     return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
   }
+}
+
+// Numeric sort key from `<TEAM>-<N>` identifier — splits on the last dash and
+// parses the tail as int. Keeps numeric announcement order matching github-new-issues.
+function linearIdNum(identifier: string): number {
+  const dash = identifier.lastIndexOf('-')
+  return dash >= 0 ? parseInt(identifier.slice(dash + 1), 10) || 0 : 0
 }
 
 export function formatNewLinearIssue(issue: LinearIssueNode): string {

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -6,9 +6,11 @@ import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
 import { GitHubNewIssuesPlugin } from './plugins/github/new-issues-plugin.js'
 import { GitHubCommitsPlugin } from './plugins/github/commits-plugin.js'
 import { LinearIssuesPlugin } from './plugins/linear/issues-plugin.js'
+import { LinearNewIssuesPlugin } from './plugins/linear/new-issues-plugin.js'
 
 registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
 registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))
 registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log))
 registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log))
 registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log))
+registerPlugin('linear-new-issues', (defaultChannel, log) => new LinearNewIssuesPlugin(defaultChannel, log))


### PR DESCRIPTION
Closes #494

Per-team new-issue triage feed for Linear. Mirrors `github-new-issues`.

## What ships

- `tryClaimPerLinearTeam` grammar helper — spec `^[A-Z]+$`, rejects lowercase with a fixit message
- `LinearClient.fetchTeamOpenIssues` — queries by team key via `teams(filter: { key: { eq } })`, filters `nin: ["completed","canceled"]`
- `LinearNewIssuesPlugin` — state `{ teams: Record<string, string[]> }`, first-observation capture without emit, carry-forward on unwatch, rate-limit observe via `getLastRateLimit` + `computeRateLimitWarning`
- Registered as `linear-new-issues` in registry.ts
- 69 new tests (grammar + plugin), 768 total passing, lint clean

## Design calls

`team(id:)` takes UUID not key — using `teams(filter: { key: { eq: $teamKey } })` instead, which is the documented key-based lookup.

DI for `LinearClient` in the constructor (`client?: LinearClient`) so tests skip env-var reads without prototype-spy gymnastics.

[roost-worker-494]