### PR TITLE
feat(plugins): add linear-issues per-issue watch plugin

### DIFF
--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -62,6 +62,13 @@ export function issueChannel(project: string, n: number, slug?: string): string 
   return slug ? `#${project}-${slug}-issue-${n}` : `#${project}-issue-${n}`
 }
 
+// Linear identifier (`<TEAM>-<N>`, uppercase team key) → per-issue channel.
+// Team segment is always emitted (Linear identifiers always lead `[A-Z]+-`),
+// which makes Linear channels uniquely shaped vs. bare github-issues channels.
+export function linearIssueChannel(project: string, identifier: string): string {
+  return `#${project}-issue-${identifier.toLowerCase()}`
+}
+
 export function leadsChannel(project: string): string {
   return `#${project}-leads`
 }

--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { tryClaimPerN, tryClaimPerRepo, splitCommands } from '../grammar.js'
+import { tryClaimPerN, tryClaimPerRepo, tryClaimPerLinearId, splitCommands } from '../grammar.js'
 
 // ---- splitCommands --------------------------------------------------------
 
@@ -234,5 +234,81 @@ describe('tryClaimPerRepo — bare (target=null)', () => {
   it('defers on `watch pr org/r` (target keyword), `watch 5` (number)', () => {
     expect(tryClaimPerRepo(null, 'watch pr org/r')).toBeNull()
     expect(tryClaimPerRepo(null, 'watch 5')).toBeNull()
+  })
+})
+
+// ---- tryClaimPerLinearId --------------------------------------------------
+
+describe('tryClaimPerLinearId', () => {
+  it('claims `watch linear C-758`', () => {
+    expect(tryClaimPerLinearId('watch linear C-758')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', identifier: 'C-758', channels: [] },
+    })
+  })
+
+  it('claims `unwatch linear C-758`', () => {
+    expect(tryClaimPerLinearId('unwatch linear C-758')).toEqual({
+      kind: 'ok', cmd: { verb: 'unwatch', identifier: 'C-758', channels: [] },
+    })
+  })
+
+  it('claims with channels', () => {
+    expect(tryClaimPerLinearId('watch linear C-758 #foo #bar')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', identifier: 'C-758', channels: ['#foo', '#bar'] },
+    })
+  })
+
+  it('accepts multi-letter team keys', () => {
+    expect(tryClaimPerLinearId('watch linear ENG-1234')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', identifier: 'ENG-1234', channels: [] },
+    })
+  })
+
+  it('lowercases the `linear` target token', () => {
+    expect(tryClaimPerLinearId('watch LINEAR C-758')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', identifier: 'C-758', channels: [] },
+    })
+  })
+
+  it('defers on non-linear targets and bare verbs', () => {
+    expect(tryClaimPerLinearId('watch 5')).toBeNull()
+    expect(tryClaimPerLinearId('watch pr 10')).toBeNull()
+    expect(tryClaimPerLinearId('watch org/r')).toBeNull()
+  })
+
+  it('defers on non-watch/unwatch lines', () => {
+    expect(tryClaimPerLinearId('help')).toBeNull()
+    expect(tryClaimPerLinearId('list')).toBeNull()
+  })
+
+  it('errors with fixit on lowercase identifier (AC: `watch linear c-758`)', () => {
+    const r = tryClaimPerLinearId('watch linear c-758')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/must be uppercase/)
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/C-758/)
+  })
+
+  it('errors on malformed identifier', () => {
+    const r = tryClaimPerLinearId('watch linear 758')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/not a Linear identifier/)
+  })
+
+  it('errors on missing identifier', () => {
+    const r = tryClaimPerLinearId('watch linear')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/requires an identifier/)
+  })
+
+  it('rejects unwatch with channel args', () => {
+    expect(tryClaimPerLinearId('unwatch linear C-758 #x')).toEqual({
+      kind: 'error', message: 'unwatch takes no channel arguments',
+    })
+  })
+
+  it('rejects malformed channels', () => {
+    const r = tryClaimPerLinearId('watch linear C-758 notachannel')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/channels must match/)
   })
 })

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -35,6 +35,18 @@ export interface PerRepoCommand {
   channels: string[]
 }
 
+export interface PerLinearIdCommand {
+  verb: Verb
+  identifier: string
+  channels: string[]
+}
+
+// Linear identifier — uppercase team key, dash, positive integer. Strict by
+// design: lowercase forms get a fixit so a typo doesn't silently land in a
+// different plugin's slice.
+const LINEAR_ID_RE = /^[A-Z]+-\d+$/
+const LINEAR_ID_CI_RE = /^[A-Za-z]+-\d+$/
+
 // Split a DM body into individual command lines. Newlines, semicolons, commas
 // separate. Internal — exported so `dispatcher-dm-handler.ts` can import it
 // from the same place plugins' parsers do; not re-exported via
@@ -141,6 +153,43 @@ export function tryClaimPerRepo(target: string | null, line: string): ParseResul
     }
   }
   return { kind: 'ok', cmd: { verb, repo, branch, path, channels } }
+}
+
+// Try to claim a per-Linear-ID line (target=`linear`, spec regex `^[A-Z]+-\d+$`). Returns:
+//   - `null` if the line isn't watch/unwatch, or doesn't lead with this target.
+//   - `{kind:'ok',cmd}` on a clean claim.
+//   - `{kind:'error',msg}` when the line claimed this plugin's target but the
+//     body fails validation (bad identifier, malformed channel, etc.).
+export function tryClaimPerLinearId(line: string): ParseResult<PerLinearIdCommand> | null {
+  const parsed = tokenizeVerbLine(line)
+  if (!parsed) return null
+  const { verb, tokens } = parsed
+  if (tokens[0]?.toLowerCase() !== 'linear') return null
+  const rest = tokens.slice(1)
+
+  const specTok = rest[0]
+  if (specTok === undefined) {
+    return { kind: 'error', message: `${verb} linear requires an identifier (e.g. C-758)` }
+  }
+  if (!LINEAR_ID_RE.test(specTok)) {
+    if (LINEAR_ID_CI_RE.test(specTok)) {
+      return { kind: 'error', message: `${verb} linear: identifier "${specTok}" must be uppercase team key (try "${specTok.toUpperCase()}")` }
+    }
+    return { kind: 'error', message: `${verb} linear: "${specTok}" is not a Linear identifier matching ${LINEAR_ID_RE.source}` }
+  }
+  const identifier = specTok
+
+  const channels = rest.slice(1)
+  if (verb === 'unwatch') {
+    if (channels.length) return { kind: 'error', message: 'unwatch takes no channel arguments' }
+    return { kind: 'ok', cmd: { verb, identifier, channels: [] } }
+  }
+  for (const c of channels) {
+    if (!CHANNEL_RE.test(c)) {
+      return { kind: 'error', message: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
+    }
+  }
+  return { kind: 'ok', cmd: { verb, identifier, channels } }
 }
 
 // Returns the index of the first non-target token in `tokens`, or null when

--- a/src/orchestrator/plugins/linear/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/diff.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'bun:test'
+import type { LinearIssueSnap } from '../types.js'
+import {
+  buildLinearSnap,
+  diffLinearIssue,
+  parseGithubPrUrl,
+  selectGithubAttachments,
+  seedLinearIssue,
+  type RawLinearIssue,
+  type RawLinearComment,
+  type LinearStateEvent,
+  type LinearLabelEvent,
+  type LinearCommentEvent,
+  type LinearThreadReplyEvent,
+  type LinearGithubPrLinkedEvent,
+  type LinearSeedEvent,
+} from '../diff.js'
+
+function baseSnap(overrides: Partial<LinearIssueSnap> = {}): LinearIssueSnap {
+  return {
+    id: 'uuid-1',
+    identifier: 'C-758',
+    title: 'Test issue',
+    url: 'https://linear.app/teakio/issue/C-758/test',
+    status: 'In Progress',
+    statusType: 'started',
+    labels: [],
+    seen_comment_ids: [],
+    seen_github_attachment_ids: [],
+    ...overrides,
+  }
+}
+
+function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
+  return {
+    id: 'uuid-1',
+    identifier: 'C-758',
+    title: 'Test issue',
+    url: 'https://linear.app/teakio/issue/C-758/test',
+    state: { type: 'started', name: 'In Progress' },
+    labels: { nodes: [] },
+    comments: { nodes: [] },
+    attachments: { nodes: [] },
+    ...overrides,
+  }
+}
+
+// ---- parseGithubPrUrl ----------------------------------------------------
+
+describe('parseGithubPrUrl (fail-closed)', () => {
+  it('matches canonical pull/<N>', () => {
+    expect(parseGithubPrUrl('https://github.com/GoCarrot/Carrot/pull/2000')).toEqual({
+      repo: 'GoCarrot/Carrot',
+      number: 2000,
+    })
+  })
+
+  it('matches pull/<N> with trailing fragment', () => {
+    expect(parseGithubPrUrl('https://github.com/Org/Repo/pull/1#discussion_r1')).toEqual({
+      repo: 'Org/Repo',
+      number: 1,
+    })
+  })
+
+  it('rejects pulls/<N> (fail-closed per lead direction)', () => {
+    expect(parseGithubPrUrl('https://github.com/Org/Repo/pulls/1')).toBeNull()
+  })
+
+  it('rejects non-github hosts', () => {
+    expect(parseGithubPrUrl('https://example.com/Org/Repo/pull/1')).toBeNull()
+  })
+
+  it('rejects nulls and unrelated URLs', () => {
+    expect(parseGithubPrUrl(null)).toBeNull()
+    expect(parseGithubPrUrl('https://github.com/Org/Repo/issues/1')).toBeNull()
+  })
+})
+
+describe('selectGithubAttachments', () => {
+  it('picks github-sourceType + parses pull URL', () => {
+    expect(selectGithubAttachments([
+      { id: 'a1', sourceType: 'github', url: 'https://github.com/GoCarrot/Carrot/pull/2000', title: null },
+      { id: 'a2', sourceType: 'figma', url: 'https://figma.com/x', title: null },
+      { id: 'a3', sourceType: 'github', url: 'https://github.com/Org/Repo/issues/1', title: null },
+    ])).toEqual([
+      { id: 'a1', pr_repo: 'GoCarrot/Carrot', pr_number: 2000, pr_url: 'https://github.com/GoCarrot/Carrot/pull/2000' },
+    ])
+  })
+})
+
+// ---- buildLinearSnap -----------------------------------------------------
+
+describe('buildLinearSnap', () => {
+  it('builds a normalized snapshot from raw GraphQL', () => {
+    const snap = buildLinearSnap(rawIssue({
+      labels: { nodes: [{ name: 'urgent' }, { name: 'bug' }] },
+      comments: { nodes: [
+        { id: 'c1', body: 'hi', user: { name: 'alice' }, parent: null },
+        { id: 'c2', body: 'reply', user: { name: 'bob' }, parent: { id: 'c1' } },
+      ] },
+      attachments: { nodes: [
+        { id: 'a1', sourceType: 'github', url: 'https://github.com/Org/Repo/pull/5', title: null },
+        { id: 'a2', sourceType: 'figma', url: 'https://figma.com/x', title: null },
+      ] },
+    }))
+    expect(snap.identifier).toBe('C-758')
+    expect(snap.labels).toEqual(['bug', 'urgent'])               // sorted
+    expect(snap.seen_comment_ids.sort()).toEqual(['c1', 'c2'])  // both top + threaded
+    expect(snap.seen_github_attachment_ids).toEqual(['a1'])      // figma excluded
+  })
+})
+
+// ---- diffLinearIssue: state changes --------------------------------------
+
+describe('diffLinearIssue — state', () => {
+  it('emits linear_state_changed on statusType transition', () => {
+    const prev = baseSnap({ statusType: 'started', status: 'In Progress' })
+    const cur = baseSnap({ statusType: 'completed', status: 'Done' })
+    const events = diffLinearIssue(prev, cur, { comments: [], githubAttachments: [] })
+    const ev = events.find(e => e.kind === 'linear_state_changed') as LinearStateEvent | undefined
+    expect(ev).toBeDefined()
+    expect(ev?.fromType).toBe('started')
+    expect(ev?.toType).toBe('completed')
+    expect(ev?.fromStatus).toBe('In Progress')
+    expect(ev?.toStatus).toBe('Done')
+  })
+
+  it('no-op when statusType is unchanged', () => {
+    const prev = baseSnap({ statusType: 'started' })
+    const cur = baseSnap({ statusType: 'started' })
+    const events = diffLinearIssue(prev, cur, { comments: [], githubAttachments: [] })
+    expect(events.find(e => e.kind === 'linear_state_changed')).toBeUndefined()
+  })
+})
+
+// ---- diffLinearIssue: labels ---------------------------------------------
+
+describe('diffLinearIssue — labels', () => {
+  it('emits +/- correctly', () => {
+    const prev = baseSnap({ labels: ['triage', 'urgent'] })
+    const cur = baseSnap({ labels: ['urgent', 'shipped'] })
+    const events = diffLinearIssue(prev, cur, { comments: [], githubAttachments: [] })
+    const ev = events.find(e => e.kind === 'linear_labels_changed') as LinearLabelEvent | undefined
+    expect(ev?.added).toEqual(['shipped'])
+    expect(ev?.removed).toEqual(['triage'])
+  })
+
+  it('no event when labels unchanged', () => {
+    const prev = baseSnap({ labels: ['a', 'b'] })
+    const cur = baseSnap({ labels: ['a', 'b'] })
+    const events = diffLinearIssue(prev, cur, { comments: [], githubAttachments: [] })
+    expect(events.find(e => e.kind === 'linear_labels_changed')).toBeUndefined()
+  })
+})
+
+// ---- diffLinearIssue: comments & thread replies --------------------------
+
+describe('diffLinearIssue — comments', () => {
+  it('emits linear_comment for top-level (parent==null)', () => {
+    const prev = baseSnap({ seen_comment_ids: [] })
+    const cur = baseSnap({ seen_comment_ids: ['c1'] })
+    const comments: RawLinearComment[] = [{ id: 'c1', body: 'hello', user: { name: 'alice' }, parent: null }]
+    const events = diffLinearIssue(prev, cur, { comments, githubAttachments: [] })
+    const ev = events.find(e => e.kind === 'linear_comment') as LinearCommentEvent | undefined
+    expect(ev).toBeDefined()
+    expect(ev?.author).toBe('alice')
+    expect(ev?.body).toBe('hello')
+    expect(ev?.comment_url).toMatch(/#comment-c1$/)
+  })
+
+  it('emits linear_thread_reply for parent != null (option a chosen)', () => {
+    const prev = baseSnap({ seen_comment_ids: ['c1'] })
+    const cur = baseSnap({ seen_comment_ids: ['c1', 'c2'] })
+    const comments: RawLinearComment[] = [
+      { id: 'c1', body: 'parent', user: { name: 'bob' }, parent: null },
+      { id: 'c2', body: 'reply', user: { name: 'alice' }, parent: { id: 'c1' } },
+    ]
+    const events = diffLinearIssue(prev, cur, { comments, githubAttachments: [] })
+    const ev = events.find(e => e.kind === 'linear_thread_reply') as LinearThreadReplyEvent | undefined
+    expect(ev).toBeDefined()
+    expect(ev?.author).toBe('alice')
+    expect(ev?.parent_author).toBe('bob')
+    expect(ev?.parent_comment_id).toBe('c1')
+    expect(ev?.parent_comment_url).toMatch(/#comment-c1$/)
+    expect(ev?.comment_url).toMatch(/#comment-c2$/)
+  })
+
+  it('thread reply carries parent_author=null when parent comment dropped from snapshot', () => {
+    // Edge: parent older than the comment window the API returned. The reply
+    // event still fires; parent_author goes null.
+    const prev = baseSnap({ seen_comment_ids: [] })
+    const cur = baseSnap({ seen_comment_ids: ['c2'] })
+    const comments: RawLinearComment[] = [
+      { id: 'c2', body: 'reply', user: { name: 'alice' }, parent: { id: 'c-missing' } },
+    ]
+    const events = diffLinearIssue(prev, cur, { comments, githubAttachments: [] })
+    const ev = events.find(e => e.kind === 'linear_thread_reply') as LinearThreadReplyEvent | undefined
+    expect(ev?.parent_author).toBeNull()
+    expect(ev?.parent_comment_url).toBeNull()
+  })
+})
+
+// ---- diffLinearIssue: github PR linked -----------------------------------
+
+describe('diffLinearIssue — github PR linked', () => {
+  it('emits linear_github_pr_linked once per new attachment id', () => {
+    const prev = baseSnap({ seen_github_attachment_ids: [] })
+    const cur = baseSnap({ seen_github_attachment_ids: ['a1'] })
+    const ctx = {
+      comments: [],
+      githubAttachments: [{ id: 'a1', pr_repo: 'GoCarrot/Carrot', pr_number: 2000, pr_url: 'https://github.com/GoCarrot/Carrot/pull/2000' }],
+    }
+    const events = diffLinearIssue(prev, cur, ctx)
+    const ev = events.find(e => e.kind === 'linear_github_pr_linked') as LinearGithubPrLinkedEvent | undefined
+    expect(ev).toBeDefined()
+    expect(ev?.pr_repo).toBe('GoCarrot/Carrot')
+    expect(ev?.pr_number).toBe(2000)
+    expect(ev?.pr_url).toBe('https://github.com/GoCarrot/Carrot/pull/2000')
+  })
+
+  it('does NOT re-fire on next tick (attachment id stays in seen set)', () => {
+    const prev = baseSnap({ seen_github_attachment_ids: ['a1'] })
+    const cur = baseSnap({ seen_github_attachment_ids: ['a1'] })
+    const events = diffLinearIssue(prev, cur, {
+      comments: [],
+      githubAttachments: [{ id: 'a1', pr_repo: 'X/Y', pr_number: 1, pr_url: 'https://github.com/X/Y/pull/1' }],
+    })
+    expect(events.find(e => e.kind === 'linear_github_pr_linked')).toBeUndefined()
+  })
+})
+
+// ---- seedLinearIssue -----------------------------------------------------
+
+describe('seedLinearIssue', () => {
+  it('emits added_to_watch with no comments', () => {
+    const events = seedLinearIssue(baseSnap())
+    expect(events.map(e => e.kind)).toEqual(['linear_issue_added_to_watch'])
+  })
+
+  it('emits has_existing_comments when backlog present', () => {
+    const events = seedLinearIssue(baseSnap({ seen_comment_ids: ['c1', 'c2', 'c3'] }))
+    const backlog = events.find(e => e.kind === 'linear_issue_has_existing_comments') as LinearSeedEvent | undefined
+    expect(backlog?.comment_count).toBe(3)
+  })
+})

--- a/src/orchestrator/plugins/linear/__tests__/format.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/format.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'bun:test'
+import { formatLinearEvent, formatLinearPayload } from '../format.js'
+import type {
+  LinearStateEvent,
+  LinearLabelEvent,
+  LinearGithubPrLinkedEvent,
+  LinearThreadReplyEvent,
+  LinearCommentEvent,
+  LinearSeedEvent,
+} from '../diff.js'
+
+const url = 'https://linear.app/teakio/issue/C-758/test'
+
+describe('formatLinearEvent — oneline shapes (issue body examples)', () => {
+  it('formats linear_state_changed', () => {
+    const ev: LinearStateEvent = {
+      kind: 'linear_state_changed',
+      identifier: 'C-758',
+      url,
+      fromType: 'started',
+      toType: 'completed',
+      fromStatus: 'In Progress',
+      toStatus: 'Done',
+    }
+    expect(formatLinearEvent(ev)).toBe(`Issue C-758 state: started → completed — ${url}`)
+  })
+
+  it('formats linear_labels_changed', () => {
+    const ev: LinearLabelEvent = {
+      kind: 'linear_labels_changed',
+      identifier: 'C-758',
+      added: ['urgent'],
+      removed: ['triage'],
+    }
+    expect(formatLinearEvent(ev)).toBe('Issue C-758 labels: +urgent -triage')
+  })
+
+  it('formats linear_github_pr_linked', () => {
+    const ev: LinearGithubPrLinkedEvent = {
+      kind: 'linear_github_pr_linked',
+      identifier: 'C-758',
+      attachment_id: 'a1',
+      pr_repo: 'GoCarrot/Carrot',
+      pr_number: 2000,
+      pr_url: 'https://github.com/GoCarrot/Carrot/pull/2000',
+    }
+    expect(formatLinearEvent(ev)).toBe(
+      'Issue C-758 PR linked: GoCarrot/Carrot#2000 — https://github.com/GoCarrot/Carrot/pull/2000'
+    )
+  })
+
+  it('formats linear_issue_disappeared (matches issue example wording)', () => {
+    const ev: LinearSeedEvent = { kind: 'linear_issue_disappeared', identifier: 'C-758' }
+    expect(formatLinearEvent(ev)).toBe(
+      'WARN Issue C-758 no longer accessible — dropping from watch. Re-watch with `watch linear C-758` if the issue is restored.'
+    )
+  })
+
+  it('formats linear_thread_reply with parent context', () => {
+    const ev: LinearThreadReplyEvent = {
+      kind: 'linear_thread_reply',
+      identifier: 'C-758',
+      comment_id: 'c2',
+      comment_url: `${url}#comment-c2`,
+      parent_comment_id: 'c1',
+      parent_author: 'bob',
+      parent_comment_url: `${url}#comment-c1`,
+      author: 'alice',
+    }
+    expect(formatLinearEvent(ev)).toBe(
+      `Issue C-758 thread reply by alice on bob's comment — ${url}#comment-c2`
+    )
+  })
+
+  it('formats linear_issue_has_existing_comments', () => {
+    const ev: LinearSeedEvent = {
+      kind: 'linear_issue_has_existing_comments',
+      identifier: 'C-758',
+      url,
+      comment_count: 3,
+    }
+    expect(formatLinearEvent(ev)).toBe(
+      `Issue C-758 BACKLOG: 3 comments existed before watch — scan manually: ${url}`
+    )
+  })
+})
+
+describe('formatLinearPayload', () => {
+  it('returns multiline shape for linear_comment', () => {
+    const ev: LinearCommentEvent = {
+      kind: 'linear_comment',
+      identifier: 'C-758',
+      url,
+      comment_id: 'c1',
+      comment_url: `${url}#comment-c1`,
+      author: 'alice',
+      body: 'looks good\nshipping',
+      body_preview: 'looks good\nshipping',
+    }
+    const payload = formatLinearPayload(ev)
+    expect(payload.kind).toBe('multiline')
+    if (payload.kind !== 'multiline') throw new Error('expected multiline')
+    expect(payload.header).toBe('Issue C-758 comment by alice:')
+    expect(payload.body).toBe('looks good\nshipping')
+    expect(payload.url).toBe(`${url}#comment-c1`)
+  })
+
+  it('returns oneline shape for non-comment events', () => {
+    const ev: LinearLabelEvent = { kind: 'linear_labels_changed', identifier: 'C-758', added: ['x'], removed: [] }
+    const payload = formatLinearPayload(ev)
+    expect(payload.kind).toBe('oneline')
+  })
+})

--- a/src/orchestrator/plugins/linear/__tests__/format.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/format.test.ts
@@ -49,10 +49,12 @@ describe('formatLinearEvent — oneline shapes (issue body examples)', () => {
     )
   })
 
-  it('formats linear_issue_disappeared (matches issue example wording)', () => {
+  it('formats linear_issue_disappeared (matches issue example wording + unwatch hint)', () => {
     const ev: LinearSeedEvent = { kind: 'linear_issue_disappeared', identifier: 'C-758' }
     expect(formatLinearEvent(ev)).toBe(
-      'WARN Issue C-758 no longer accessible — dropping from watch. Re-watch with `watch linear C-758` if the issue is restored.'
+      'WARN Issue C-758 no longer accessible — dropping from watch. ' +
+      'Re-watch with `watch linear C-758` if the issue is restored, ' +
+      'or `unwatch linear C-758` to drop the channel.'
     )
   })
 
@@ -70,6 +72,34 @@ describe('formatLinearEvent — oneline shapes (issue body examples)', () => {
     expect(formatLinearEvent(ev)).toBe(
       `Issue C-758 thread reply by alice on bob's comment — ${url}#comment-c2`
     )
+  })
+
+  it('formats linear_thread_reply with null parent_author (parent outside snapshot window)', () => {
+    const ev: LinearThreadReplyEvent = {
+      kind: 'linear_thread_reply',
+      identifier: 'C-758',
+      comment_id: 'c2',
+      comment_url: `${url}#comment-c2`,
+      parent_comment_id: 'c1',
+      parent_author: null,
+      parent_comment_url: null,
+      author: 'alice',
+    }
+    expect(formatLinearEvent(ev)).toBe(
+      `Issue C-758 thread reply by alice on ?'s comment — ${url}#comment-c2`
+    )
+  })
+
+  it('formats linear_issue_disappeared with both re-watch and unwatch hints', () => {
+    const ev: LinearSeedEvent = { kind: 'linear_issue_disappeared', identifier: 'C-758' }
+    const out = formatLinearEvent(ev)
+    expect(out).toContain('watch linear C-758')
+    expect(out).toContain('unwatch linear C-758')
+  })
+
+  it('formats linear_issue_added_to_watch via the fallback branch (defensive)', () => {
+    const ev: LinearSeedEvent = { kind: 'linear_issue_added_to_watch', identifier: 'C-758' }
+    expect(formatLinearEvent(ev)).toBe('now watching linear issue C-758')
   })
 
   it('formats linear_issue_has_existing_comments', () => {

--- a/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'bun:test'
+import { LinearIssuesPlugin, type LinearClientLike } from '../issues-plugin.js'
+import type { OrchestratorConfig } from '../../../config.js'
+import type { Command } from '../../../dispatcher-dm-handler.js'
+import type { LinearIssuePluginState, LinearIssueSnap, LinearIssueTombstone } from '../types.js'
+import { isTombstone } from '../types.js'
+import type { RawLinearIssue } from '../diff.js'
+
+// ---- Test scaffolding ----------------------------------------------------
+
+function mockClient(handler: (id: string) => RawLinearIssue | null): LinearClientLike {
+  return {
+    graphql: async (_q, vars) => {
+      const id = (vars as { id: string }).id
+      return { issue: handler(id) }
+    },
+    getLastRateLimit: () => null,
+  }
+}
+
+function plugin(client: LinearClientLike): LinearIssuesPlugin {
+  return new LinearIssuesPlugin('#proj-leads', () => {}, client)
+}
+
+function watchCmd(identifier: string, channels: string[] = []): Command {
+  return {
+    kind: 'plugin',
+    plugin: 'linear-issues',
+    cmd: { verb: 'watch', identifier, channels },
+    raw: '',
+  }
+}
+
+function unwatchCmd(identifier: string): Command {
+  return {
+    kind: 'plugin',
+    plugin: 'linear-issues',
+    cmd: { verb: 'unwatch', identifier, channels: [] },
+    raw: '',
+  }
+}
+
+function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
+  return {
+    id: 'uuid-1',
+    identifier: 'C-758',
+    title: 'A title',
+    url: 'https://linear.app/teakio/issue/C-758/a-title',
+    state: { type: 'started', name: 'In Progress' },
+    labels: { nodes: [] },
+    comments: { nodes: [] },
+    attachments: { nodes: [] },
+    ...overrides,
+  }
+}
+
+// ---- handleCommand: watch / unwatch / list / help ------------------------
+
+describe('LinearIssuesPlugin.handleCommand — watch', () => {
+  const p = () => new LinearIssuesPlugin('#proj-leads')
+
+  it('lands an entry in local overlay (AC: `watch linear C-758`)', () => {
+    const merged: OrchestratorConfig = { project: 'proj' }
+    const local: OrchestratorConfig = {}
+    const out = p().handleCommand!(merged, local, watchCmd('C-758'))
+    expect(out).toMatch(/watching linear issue C-758/)
+    expect((local.plugins?.['linear-issues'] as { watched: unknown[] }).watched).toEqual([{ identifier: 'C-758' }])
+  })
+
+  it('idempotent on duplicate watch (tracked entry visible via merged)', () => {
+    const merged: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }] } },
+    }
+    const local: OrchestratorConfig = {}
+    const out = p().handleCommand!(merged, local, watchCmd('C-758'))
+    expect(out).toMatch(/already watching/)
+    expect(local.plugins?.['linear-issues']).toBeUndefined()
+  })
+
+  it('appends channels to local entry', () => {
+    const slice = { watched: [{ identifier: 'C-758', channels: ['#a'] }] }
+    const merged: OrchestratorConfig = { project: 'proj', plugins: { 'linear-issues': slice } }
+    const local: OrchestratorConfig = { plugins: { 'linear-issues': slice } }
+    p().handleCommand!(merged, local, watchCmd('C-758', ['#a', '#b']))
+    const entry = (local.plugins!['linear-issues'] as { watched: { channels: string[] }[] }).watched[0]
+    expect(entry.channels).toEqual(['#a', '#b'])
+  })
+
+  it('refuses to add channels to a tracked-only entry', () => {
+    const merged: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }] } },
+    }
+    const out = p().handleCommand!(merged, {}, watchCmd('C-758', ['#x']))
+    expect(out).toBe('linear issue C-758 in tracked config.json — hand-edit to add channels')
+  })
+
+  it('unwatch removes a local entry', () => {
+    const local: OrchestratorConfig = {
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }, { identifier: 'D-1' }] } },
+    }
+    const merged: OrchestratorConfig = { project: 'proj', ...local }
+    p().handleCommand!(merged, local, unwatchCmd('C-758'))
+    expect((local.plugins!['linear-issues'] as { watched: { identifier: string }[] }).watched)
+      .toEqual([{ identifier: 'D-1' }])
+  })
+
+  it('list shows watched issues', () => {
+    const merged: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }, { identifier: 'ENG-1', channels: ['#x'] }] } },
+    }
+    const out = p().handleCommand!(merged, {}, { kind: 'list', raw: '' } as Command)
+    expect(out).toContain('linear-issues (2):')
+    expect(out).toContain('  C-758')
+    expect(out).toContain('  ENG-1 + #x')
+  })
+
+  it('help advertises the grammar', () => {
+    const out = p().handleCommand!({}, {}, { kind: 'help', raw: '' } as Command)!
+    expect(out).toContain('linear-issues commands')
+    expect(out).toMatch(/watch linear <TEAM>-<N>/)
+  })
+})
+
+// ---- runTick: routing + state ------------------------------------------
+
+describe('LinearIssuesPlugin.runTick — routing', () => {
+  it('emits added_to_watch + backlog when entry is new to a populated state', async () => {
+    // prev is a real state object (post-seed); the entry is new — prevEntry=null
+    // path triggers seed events. prev=null in runTick means orchestrator-wide
+    // seed, which suppresses all events; that's a separate path.
+    const client = mockClient(() => rawIssue({
+      comments: { nodes: [{ id: 'c-old', body: 'old', user: { name: 'a' }, parent: null }] },
+    }))
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }] } },
+    }
+    const result = await plugin(client).runTick(cfg, { issues: {} })
+    const addedToWatch = result.taggedEvents.find(e =>
+      e.payload.kind === 'oneline' && e.payload.text.startsWith('now watching linear issue'))
+    expect(addedToWatch).toBeDefined()
+    expect(addedToWatch?.channels).toEqual(['#proj-leads'])
+
+    const backlog = result.taggedEvents.find(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('BACKLOG'))
+    expect(backlog).toBeDefined()
+    expect(backlog?.channels).toEqual(['#proj-issue-c-758'])
+
+    const state = result.state as LinearIssuePluginState
+    expect(isTombstone(state.issues['C-758'])).toBe(false)
+  })
+
+  it('orchestrator-wide seed (prev=null) tombstones missing issues silently', async () => {
+    const client = mockClient(() => null)
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-9999' }] } },
+    }
+    const result = await plugin(client).runTick(cfg, null)
+    // Seed path emits nothing — mirror github's `prevSnap === undefined` rule.
+    expect(result.taggedEvents).toEqual([])
+    expect(isTombstone((result.state as LinearIssuePluginState).issues['C-9999'])).toBe(true)
+  })
+
+  it('routes per-issue events to #<project>-issue-<team>-<n>', async () => {
+    const prev: LinearIssuePluginState = {
+      issues: {
+        'C-758': {
+          id: 'uuid-1', identifier: 'C-758', title: 't', url: 'https://x',
+          status: 'In Progress', statusType: 'started', labels: [],
+          seen_comment_ids: [], seen_github_attachment_ids: [],
+        } as LinearIssueSnap,
+      },
+    }
+    const client = mockClient(() => rawIssue({
+      state: { type: 'completed', name: 'Done' },
+    }))
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }] } },
+    }
+    const result = await plugin(client).runTick(cfg, prev)
+    const stateEv = result.taggedEvents.find(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('state:'))
+    expect(stateEv).toBeDefined()
+    expect(stateEv?.channels).toEqual(['#proj-issue-c-758'])
+  })
+})
+
+// ---- runTick: disappeared (AC) -----------------------------------------
+
+describe('LinearIssuesPlugin.runTick — disappeared lifecycle', () => {
+  it('AC: `watch linear C-9999` accepted then disappeared fires once next tick', async () => {
+    const client = mockClient(() => null) // 404 every time
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-9999' }] } },
+    }
+
+    // First tick after the DM lands — prev is the post-seed state object,
+    // entry is new (prev.issues[key] undefined → prevEntry=null in scraper).
+    const tick1 = await plugin(client).runTick(cfg, { issues: {} })
+    const disappeared = tick1.taggedEvents.find(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('no longer accessible'))
+    expect(disappeared).toBeDefined()
+    expect(disappeared?.channels).toEqual(['#proj-leads']) // project channel
+    expect(isTombstone((tick1.state as LinearIssuePluginState).issues['C-9999'])).toBe(true)
+
+    // Second tick: prev now carries the tombstone — no re-emit, no fetch.
+    let fetchCalls = 0
+    const guardedClient: LinearClientLike = {
+      graphql: async () => { fetchCalls++; return { issue: null } },
+      getLastRateLimit: () => null,
+    }
+    const tick2 = await new LinearIssuesPlugin('#proj-leads', () => {}, guardedClient)
+      .runTick(cfg, tick1.state as LinearIssuePluginState)
+    expect(fetchCalls).toBe(0)
+    const reEmit = tick2.taggedEvents.find(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('no longer accessible'))
+    expect(reEmit).toBeUndefined()
+    expect(isTombstone((tick2.state as LinearIssuePluginState).issues['C-9999'])).toBe(true)
+  })
+})
+
+// ---- runTick: backlog seed fires once (AC) -----------------------------
+
+describe('LinearIssuesPlugin.runTick — backlog seed once-only', () => {
+  it('first tick (entry new to populated state) emits backlog; second tick does not re-emit', async () => {
+    const client = mockClient(() => rawIssue({
+      comments: { nodes: [{ id: 'c1', body: 'old', user: null, parent: null }] },
+    }))
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [{ identifier: 'C-758' }] } },
+    }
+
+    const tick1 = await plugin(client).runTick(cfg, { issues: {} })
+    expect(tick1.taggedEvents.some(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('BACKLOG'))).toBe(true)
+
+    const tick2 = await plugin(client).runTick(cfg, tick1.state as LinearIssuePluginState)
+    expect(tick2.taggedEvents.some(e =>
+      e.payload.kind === 'oneline' && e.payload.text.includes('BACKLOG'))).toBe(false)
+  })
+})
+
+// ---- runTick: no watches -----------------------------------------------
+
+describe('LinearIssuesPlugin.runTick — no watches', () => {
+  it('returns empty result without touching the client', async () => {
+    let calls = 0
+    const client: LinearClientLike = {
+      graphql: async () => { calls++; return { issue: null } },
+      getLastRateLimit: () => null,
+    }
+    const result = await plugin(client).runTick({ project: 'proj' }, null)
+    expect(calls).toBe(0)
+    expect(result.taggedEvents).toEqual([])
+    expect(result.channels).toEqual([])
+  })
+})
+
+// ---- desiredChannels ---------------------------------------------------
+
+describe('LinearIssuesPlugin.desiredChannels', () => {
+  it('emits per-issue channel for each watched entry, plus declared extras', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'linear-issues': { watched: [
+        { identifier: 'C-758' },
+        { identifier: 'ENG-1', channels: ['#extra'] },
+      ] } },
+    }
+    const chans = new LinearIssuesPlugin('#proj-leads').desiredChannels(cfg).sort()
+    expect(chans).toEqual(['#extra', '#proj-issue-c-758', '#proj-issue-eng-1'])
+  })
+
+  it('empty when no watches (no project lookup required)', () => {
+    expect(new LinearIssuesPlugin('#proj-leads').desiredChannels({})).toEqual([])
+  })
+})
+
+// ---- isTombstone re-export (used as discriminant) ---------------------
+
+describe('isTombstone helper', () => {
+  it('discriminates between snap and tombstone', () => {
+    const snap: LinearIssueSnap = {
+      id: 'u', identifier: 'C-1', title: null, url: null,
+      status: null, statusType: null, labels: [],
+      seen_comment_ids: [], seen_github_attachment_ids: [],
+    }
+    const tomb: LinearIssueTombstone = { identifier: 'C-1', disappeared: true }
+    expect(isTombstone(snap)).toBe(false)
+    expect(isTombstone(tomb)).toBe(true)
+    expect(isTombstone(null)).toBe(false)
+    expect(isTombstone(undefined)).toBe(false)
+  })
+})

--- a/src/orchestrator/plugins/linear/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/scraper.test.ts
@@ -1,7 +1,34 @@
 import { describe, it, expect } from 'bun:test'
-import { LinearScraper, type LinearGraphqlSurface } from '../scraper.js'
+import { LinearScraper, isLinearNotFoundError, type LinearGraphqlSurface } from '../scraper.js'
 import { isTombstone, type LinearIssueSnap } from '../types.js'
 import type { RawLinearIssue, LinearSeedEvent } from '../diff.js'
+import { LinearError } from '../linear-api.js'
+
+// Empirically-captured Linear not-found body shape — HTTP 200 + errors[]
+// returned for issue(id:"C-99999"). Confirmed against api.linear.app.
+const NOT_FOUND_BODY = JSON.stringify({
+  errors: [{
+    message: 'Entity not found: Issue',
+    path: ['issue'],
+    locations: [{ line: 1, column: 20 }],
+    extensions: {
+      type: 'invalid input',
+      code: 'INPUT_ERROR',
+      statusCode: 400,
+      userError: true,
+      userPresentableMessage: 'Could not find referenced Issue.',
+    },
+  }],
+  data: null,
+})
+
+function notFoundError(): LinearError {
+  return new LinearError('linear graphql returned errors[] (code=INPUT_ERROR)', {
+    status: 200,
+    code: 'INPUT_ERROR',
+    body: NOT_FOUND_BODY,
+  })
+}
 
 function mockClient(response: RawLinearIssue | null): LinearGraphqlSurface {
   return {
@@ -22,6 +49,38 @@ function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
     ...overrides,
   }
 }
+
+// ---- isLinearNotFoundError classifier ----------------------------------
+
+describe('isLinearNotFoundError', () => {
+  it('matches the empirically-captured not-found shape', () => {
+    expect(isLinearNotFoundError(notFoundError())).toBe(true)
+  })
+
+  it('rejects unrelated errors', () => {
+    expect(isLinearNotFoundError(new Error('boom'))).toBe(false)
+    expect(isLinearNotFoundError(null)).toBe(false)
+    expect(isLinearNotFoundError(undefined)).toBe(false)
+  })
+
+  it('rejects LinearError with a different code', () => {
+    expect(isLinearNotFoundError(new LinearError('x', {
+      code: 'AUTHENTICATION_ERROR',
+      body: JSON.stringify({ errors: [{ message: 'Entity not found: Issue', path: ['issue'] }] }),
+    }))).toBe(false)
+  })
+
+  it('rejects LinearError with INPUT_ERROR but wrong path (malformed query)', () => {
+    expect(isLinearNotFoundError(new LinearError('x', {
+      code: 'INPUT_ERROR',
+      body: JSON.stringify({ errors: [{ message: 'Variable required', path: ['someOther'] }] }),
+    }))).toBe(false)
+  })
+
+  it('rejects LinearError with unparseable body', () => {
+    expect(isLinearNotFoundError(new LinearError('x', { code: 'INPUT_ERROR', body: 'not json' }))).toBe(false)
+  })
+})
 
 describe('LinearScraper.scrapeIssue', () => {
   it('seeding (prev=undefined): produces snap, no events', async () => {
@@ -100,6 +159,42 @@ describe('LinearScraper.scrapeIssue', () => {
     expect(calls).toBe(0)
     expect(isTombstone(r.next)).toBe(true)
     expect(r.events).toEqual([])
+  })
+
+  it('disappeared via thrown LinearError (real Linear shape — HTTP 200 + errors[]): emits + tombstone', async () => {
+    const prev: LinearIssueSnap = {
+      id: 'uuid-1', identifier: 'C-99999', title: 't', url: 'https://x', status: null,
+      statusType: 'started', labels: [], seen_comment_ids: [], seen_github_attachment_ids: [],
+    }
+    const client: LinearGraphqlSurface = {
+      graphql: async () => { throw notFoundError() },
+    }
+    const s = new LinearScraper(client)
+    const r = await s.scrapeIssue('C-99999', prev)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events.map(e => e.kind)).toEqual(['linear_issue_disappeared'])
+  })
+
+  it('disappeared-via-error during seeding: tombstone, no event', async () => {
+    const client: LinearGraphqlSurface = {
+      graphql: async () => { throw notFoundError() },
+    }
+    const s = new LinearScraper(client)
+    const r = await s.scrapeIssue('C-99999', undefined)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events).toEqual([])
+  })
+
+  it('rethrows non-not-found LinearErrors (auth/network/real graphql errors)', async () => {
+    // INPUT_ERROR with a non-issue path is a malformed-query failure, not 404.
+    const wrongShape = new LinearError('linear graphql returned errors[]', {
+      status: 200,
+      code: 'INPUT_ERROR',
+      body: JSON.stringify({ errors: [{ message: 'Variable $id is required', path: ['someOther'] }] }),
+    })
+    const client: LinearGraphqlSurface = { graphql: async () => { throw wrongShape } }
+    const s = new LinearScraper(client)
+    await expect(s.scrapeIssue('C-1', null)).rejects.toThrow(LinearError)
   })
 
   it('sends issue identifier as the `id` variable', async () => {

--- a/src/orchestrator/plugins/linear/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/scraper.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'bun:test'
+import { LinearScraper, type LinearGraphqlSurface } from '../scraper.js'
+import { isTombstone, type LinearIssueSnap } from '../types.js'
+import type { RawLinearIssue, LinearSeedEvent } from '../diff.js'
+
+function mockClient(response: RawLinearIssue | null): LinearGraphqlSurface {
+  return {
+    graphql: async () => ({ issue: response }),
+  }
+}
+
+function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
+  return {
+    id: 'uuid-1',
+    identifier: 'C-758',
+    title: 't',
+    url: 'https://linear.app/teakio/issue/C-758/t',
+    state: { type: 'started', name: 'In Progress' },
+    labels: { nodes: [] },
+    comments: { nodes: [] },
+    attachments: { nodes: [] },
+    ...overrides,
+  }
+}
+
+describe('LinearScraper.scrapeIssue', () => {
+  it('seeding (prev=undefined): produces snap, no events', async () => {
+    const s = new LinearScraper(mockClient(rawIssue()))
+    const r = await s.scrapeIssue('C-758', undefined)
+    expect(isTombstone(r.next)).toBe(false)
+    expect(r.events).toEqual([])
+  })
+
+  it('new-to-watch (prev=null): emits added_to_watch', async () => {
+    const s = new LinearScraper(mockClient(rawIssue()))
+    const r = await s.scrapeIssue('C-758', null)
+    expect(r.events.map(e => e.kind)).toEqual(['linear_issue_added_to_watch'])
+  })
+
+  it('new-to-watch with pre-existing comments emits backlog seed', async () => {
+    const s = new LinearScraper(mockClient(rawIssue({
+      comments: { nodes: [
+        { id: 'c1', body: 'old', user: null, parent: null },
+        { id: 'c2', body: 'old', user: null, parent: null },
+      ] },
+    })))
+    const r = await s.scrapeIssue('C-758', null)
+    expect(r.events.map(e => e.kind)).toEqual([
+      'linear_issue_added_to_watch',
+      'linear_issue_has_existing_comments',
+    ])
+    const backlog = r.events.find(e => e.kind === 'linear_issue_has_existing_comments') as LinearSeedEvent
+    expect(backlog.comment_count).toBe(2)
+  })
+
+  it('normal diff: emits change events vs. prev snap', async () => {
+    const prev: LinearIssueSnap = {
+      id: 'uuid-1', identifier: 'C-758', title: 't', url: 'https://x', status: 'In Progress',
+      statusType: 'started', labels: [], seen_comment_ids: [], seen_github_attachment_ids: [],
+    }
+    const s = new LinearScraper(mockClient(rawIssue({
+      state: { type: 'completed', name: 'Done' },
+    })))
+    const r = await s.scrapeIssue('C-758', prev)
+    expect(r.events.map(e => e.kind)).toContain('linear_state_changed')
+  })
+
+  it('disappeared on prev=normal: emits disappeared event + tombstone next', async () => {
+    const prev: LinearIssueSnap = {
+      id: 'uuid-1', identifier: 'C-758', title: 't', url: 'https://x', status: 'In Progress',
+      statusType: 'started', labels: [], seen_comment_ids: [], seen_github_attachment_ids: [],
+    }
+    const s = new LinearScraper(mockClient(null))
+    const r = await s.scrapeIssue('C-758', prev)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events.map(e => e.kind)).toEqual(['linear_issue_disappeared'])
+  })
+
+  it('disappeared on prev=null (new watch, immediately 404): emits once + tombstone next', async () => {
+    const s = new LinearScraper(mockClient(null))
+    const r = await s.scrapeIssue('C-9999', null)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events.map(e => e.kind)).toEqual(['linear_issue_disappeared'])
+  })
+
+  it('disappeared on prev=undefined (seeding): tombstone next, NO event (silent during seed)', async () => {
+    const s = new LinearScraper(mockClient(null))
+    const r = await s.scrapeIssue('C-9999', undefined)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events).toEqual([])
+  })
+
+  it('prev=tombstone: no fetch, no event, passes through', async () => {
+    let calls = 0
+    const c: LinearGraphqlSurface = {
+      graphql: async () => { calls++; return { issue: null } },
+    }
+    const s = new LinearScraper(c)
+    const r = await s.scrapeIssue('C-758', { identifier: 'C-758', disappeared: true })
+    expect(calls).toBe(0)
+    expect(isTombstone(r.next)).toBe(true)
+    expect(r.events).toEqual([])
+  })
+
+  it('sends issue identifier as the `id` variable', async () => {
+    let captured: Record<string, unknown> | undefined
+    const c: LinearGraphqlSurface = {
+      graphql: async (_q, vars) => { captured = vars; return { issue: rawIssue() } },
+    }
+    const s = new LinearScraper(c)
+    await s.scrapeIssue('ENG-42', null)
+    expect(captured).toEqual({ id: 'ENG-42' })
+  })
+})

--- a/src/orchestrator/plugins/linear/diff.ts
+++ b/src/orchestrator/plugins/linear/diff.ts
@@ -139,7 +139,8 @@ export function selectGithubAttachments(atts: RawLinearAttachment[]): GithubAtta
     if (a.sourceType !== 'github') continue
     const parsed = parseGithubPrUrl(a.url)
     if (!parsed) continue
-    out.push({ id: a.id, pr_repo: parsed.repo, pr_number: parsed.number, pr_url: a.url ?? '' })
+    // parseGithubPrUrl short-circuits on falsy URL, so `a.url` is truthy here.
+    out.push({ id: a.id, pr_repo: parsed.repo, pr_number: parsed.number, pr_url: a.url as string })
   }
   return out
 }

--- a/src/orchestrator/plugins/linear/diff.ts
+++ b/src/orchestrator/plugins/linear/diff.ts
@@ -1,0 +1,300 @@
+import type { LinearIssueSnap } from './types.js'
+
+// ---- Event types -----------------------------------------------------------
+
+export interface BaseLinearEvent {
+  kind: string
+  identifier: string
+  url?: string
+  title?: string
+}
+
+export interface LinearStateEvent extends BaseLinearEvent {
+  kind: 'linear_state_changed'
+  fromType: string | null
+  toType: string | null
+  fromStatus: string | null
+  toStatus: string | null
+}
+
+export interface LinearCommentEvent extends BaseLinearEvent {
+  kind: 'linear_comment'
+  comment_id: string
+  comment_url: string
+  author: string | null
+  body: string
+  body_preview: string
+}
+
+export interface LinearThreadReplyEvent extends BaseLinearEvent {
+  kind: 'linear_thread_reply'
+  comment_id: string
+  comment_url: string
+  parent_comment_id: string
+  parent_author: string | null
+  parent_comment_url: string | null
+  author: string | null
+}
+
+export interface LinearLabelEvent extends BaseLinearEvent {
+  kind: 'linear_labels_changed'
+  added: string[]
+  removed: string[]
+}
+
+export interface LinearGithubPrLinkedEvent extends BaseLinearEvent {
+  kind: 'linear_github_pr_linked'
+  attachment_id: string
+  pr_repo: string
+  pr_number: number
+  pr_url: string
+}
+
+export interface LinearSeedEvent extends BaseLinearEvent {
+  kind:
+    | 'linear_issue_added_to_watch'
+    | 'linear_issue_has_existing_comments'
+    | 'linear_issue_disappeared'
+  comment_count?: number
+}
+
+export type LinearEvent =
+  | BaseLinearEvent
+  | LinearStateEvent
+  | LinearCommentEvent
+  | LinearThreadReplyEvent
+  | LinearLabelEvent
+  | LinearGithubPrLinkedEvent
+  | LinearSeedEvent
+
+// All linear events currently reach IRC — there's no equivalent of the github
+// filter (skip-noisy labels, skip non-terminal CI). Drop the wrapper for now;
+// if a future event needs gating, add it back with the predicate inline.
+
+// ---- GraphQL shape -------------------------------------------------------
+
+// Trimmed view of Linear's `issue` response — only fields we read. Tests
+// build mocks against this shape; runtime ignores extra fields.
+export interface RawLinearComment {
+  id: string
+  body: string | null
+  user?: { name: string | null } | null
+  parent?: { id: string } | null
+}
+
+export interface RawLinearAttachment {
+  id: string
+  sourceType: string | null
+  url: string | null
+  title: string | null
+}
+
+export interface RawLinearIssue {
+  id: string
+  identifier: string
+  title: string | null
+  url: string | null
+  state: { type: string | null; name: string | null } | null
+  labels: { nodes: Array<{ name: string }> } | null
+  comments: { nodes: RawLinearComment[] } | null
+  attachments: { nodes: RawLinearAttachment[] } | null
+}
+
+// ---- Pure helpers --------------------------------------------------------
+
+function labelDiff(prev: string[] | undefined, cur: string[] | undefined): { added: string[]; removed: string[] } {
+  const prevS = new Set(prev ?? [])
+  const curS = new Set(cur ?? [])
+  return {
+    added: [...curS].filter(l => !prevS.has(l)).sort(),
+    removed: [...prevS].filter(l => !curS.has(l)).sort(),
+  }
+}
+
+// Strict github PR URL matcher — `pull/<N>` only. `pulls/<N>` (an API alias)
+// and other variants are intentionally ignored: design spec is authoritative
+// and matching observed-but-unspecified shapes risks ambiguous-source bugs.
+const GITHUB_PR_URL_RE = /^https:\/\/github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*)\/pull\/(\d+)(?:[/?#].*)?$/
+
+export function parseGithubPrUrl(url: string | null | undefined): { repo: string; number: number } | null {
+  if (!url) return null
+  const m = url.match(GITHUB_PR_URL_RE)
+  if (!m) return null
+  return { repo: m[1], number: Number(m[2]) }
+}
+
+// Snapshot a top-level subset of attachments (sourceType=github with a
+// well-formed pull/<N> URL). Returned ids drive the seen-set; the parsed
+// repo+number pair feeds the linked event when the id is new.
+export interface GithubAttachmentEntry {
+  id: string
+  pr_repo: string
+  pr_number: number
+  pr_url: string
+}
+
+export function selectGithubAttachments(atts: RawLinearAttachment[]): GithubAttachmentEntry[] {
+  const out: GithubAttachmentEntry[] = []
+  for (const a of atts) {
+    if (a.sourceType !== 'github') continue
+    const parsed = parseGithubPrUrl(a.url)
+    if (!parsed) continue
+    out.push({ id: a.id, pr_repo: parsed.repo, pr_number: parsed.number, pr_url: a.url ?? '' })
+  }
+  return out
+}
+
+// Stable-sorted ids — mirrors `sortedIds(...)` at github/scraper.ts:36.
+function sortedStringIds<T extends { id: string }>(items: T[]): string[] {
+  return items.map(i => i.id).sort()
+}
+
+// ---- Snapshot builder ----------------------------------------------------
+
+// Build a snap from a raw Linear `issue` response. Pure — no I/O. Caller
+// handles the null-issue (disappeared) path before getting here.
+export function buildLinearSnap(raw: RawLinearIssue): LinearIssueSnap {
+  const labels = (raw.labels?.nodes ?? []).map(n => n.name).sort()
+  const comments = raw.comments?.nodes ?? []
+  const githubAtts = selectGithubAttachments(raw.attachments?.nodes ?? [])
+  return {
+    id: raw.id,
+    identifier: raw.identifier,
+    title: raw.title ?? null,
+    url: raw.url ?? null,
+    status: raw.state?.name ?? null,
+    statusType: raw.state?.type ?? null,
+    labels,
+    seen_comment_ids: sortedStringIds(comments),
+    seen_github_attachment_ids: sortedStringIds(githubAtts),
+  }
+}
+
+// ---- Diff ----------------------------------------------------------------
+
+// Index comments and attachments by id so the diff can look up parent / pr
+// metadata for the ids that landed this tick.
+export interface ScrapeContext {
+  comments: RawLinearComment[]
+  githubAttachments: GithubAttachmentEntry[]
+}
+
+function indexComments(comments: RawLinearComment[]): Record<string, RawLinearComment> {
+  const out: Record<string, RawLinearComment> = {}
+  for (const c of comments) out[c.id] = c
+  return out
+}
+
+function indexGithubAtts(atts: GithubAttachmentEntry[]): Record<string, GithubAttachmentEntry> {
+  const out: Record<string, GithubAttachmentEntry> = {}
+  for (const a of atts) out[a.id] = a
+  return out
+}
+
+function newIds(prev: string[] | undefined, cur: string[]): string[] {
+  const prevSet = new Set(prev ?? [])
+  return cur.filter(id => !prevSet.has(id))
+}
+
+function commentBase(snap: LinearIssueSnap): Pick<BaseLinearEvent, 'identifier' | 'url' | 'title'> {
+  return { identifier: snap.identifier, url: snap.url ?? '', title: snap.title ?? '' }
+}
+
+function formatCommentEvent(
+  c: RawLinearComment,
+  snap: LinearIssueSnap,
+  parentLookup: Record<string, RawLinearComment>,
+): LinearCommentEvent | LinearThreadReplyEvent {
+  const body = c.body ?? ''
+  const author = c.user?.name ?? null
+  // Linear comment permalinks: <issue.url>#comment-<id>.
+  const commentUrl = `${snap.url ?? ''}#comment-${c.id}`
+  if (c.parent?.id) {
+    const parent = parentLookup[c.parent.id]
+    const parentAuthor = parent?.user?.name ?? null
+    return {
+      kind: 'linear_thread_reply',
+      ...commentBase(snap),
+      comment_id: c.id,
+      comment_url: commentUrl,
+      parent_comment_id: c.parent.id,
+      parent_author: parentAuthor,
+      parent_comment_url: parent ? `${snap.url ?? ''}#comment-${c.parent.id}` : null,
+      author,
+    }
+  }
+  return {
+    kind: 'linear_comment',
+    ...commentBase(snap),
+    comment_id: c.id,
+    comment_url: commentUrl,
+    author,
+    body,
+    body_preview: body.slice(0, 280),
+  }
+}
+
+export function diffLinearIssue(
+  prev: LinearIssueSnap,
+  cur: LinearIssueSnap,
+  ctx: ScrapeContext,
+): LinearEvent[] {
+  const events: LinearEvent[] = []
+  const base = commentBase(cur)
+
+  if (prev.statusType !== cur.statusType) {
+    events.push({
+      kind: 'linear_state_changed',
+      ...base,
+      fromType: prev.statusType,
+      toType: cur.statusType,
+      fromStatus: prev.status,
+      toStatus: cur.status,
+    } as LinearStateEvent)
+  }
+
+  const { added, removed } = labelDiff(prev.labels, cur.labels)
+  if (added.length || removed.length) {
+    events.push({ kind: 'linear_labels_changed', ...base, added, removed } as LinearLabelEvent)
+  }
+
+  const commentLookup = indexComments(ctx.comments)
+  for (const cid of newIds(prev.seen_comment_ids, cur.seen_comment_ids)) {
+    const c = commentLookup[cid]
+    if (!c) continue
+    events.push(formatCommentEvent(c, cur, commentLookup))
+  }
+
+  const attLookup = indexGithubAtts(ctx.githubAttachments)
+  for (const aid of newIds(prev.seen_github_attachment_ids, cur.seen_github_attachment_ids)) {
+    const a = attLookup[aid]
+    if (!a) continue
+    events.push({
+      kind: 'linear_github_pr_linked',
+      ...base,
+      attachment_id: a.id,
+      pr_repo: a.pr_repo,
+      pr_number: a.pr_number,
+      pr_url: a.pr_url,
+    } as LinearGithubPrLinkedEvent)
+  }
+
+  return events
+}
+
+// Seed events emitted when a snap is new to the watch list (prevSnap === null).
+export function seedLinearIssue(snap: LinearIssueSnap): LinearEvent[] {
+  const base = commentBase(snap)
+  const events: LinearEvent[] = [{ kind: 'linear_issue_added_to_watch', ...base }]
+  // Count top-level only — threaded replies are tracked but not surfaced in
+  // the seed line (mirrors github's count-by-primary-feed convention).
+  const topLevelCount = snap.seen_comment_ids.length
+  if (topLevelCount > 0) {
+    events.push({ kind: 'linear_issue_has_existing_comments', ...base, comment_count: topLevelCount } as LinearSeedEvent)
+  }
+  return events
+}
+
+export function disappearedLinearIssue(identifier: string): LinearSeedEvent {
+  return { kind: 'linear_issue_disappeared', identifier }
+}

--- a/src/orchestrator/plugins/linear/format.ts
+++ b/src/orchestrator/plugins/linear/format.ts
@@ -37,8 +37,17 @@ function formatThreadReply(ev: LinearThreadReplyEvent): string {
 function formatDisappeared(ev: LinearSeedEvent): string {
   return (
     `WARN Issue ${ev.identifier} no longer accessible — dropping from watch. ` +
-    `Re-watch with \`watch linear ${ev.identifier}\` if the issue is restored.`
+    `Re-watch with \`watch linear ${ev.identifier}\` if the issue is restored, ` +
+    `or \`unwatch linear ${ev.identifier}\` to drop the channel.`
   )
+}
+
+// `linear_issue_added_to_watch` is normally formatted inline in
+// `LinearIssuesPlugin.runTick` because its text references the routing
+// channels (not present on the event). This branch is a defensive fallback
+// for any out-of-band caller — keeps the format surface complete.
+function formatAddedToWatch(ev: LinearSeedEvent): string {
+  return `now watching linear issue ${ev.identifier}`
 }
 
 function formatBacklogSeed(ev: LinearSeedEvent): string {
@@ -57,6 +66,7 @@ export function formatLinearEvent(event: LinearEvent): string {
   if (kind === 'linear_thread_reply') return formatThreadReply(event as LinearThreadReplyEvent)
   if (kind === 'linear_issue_disappeared') return formatDisappeared(event as LinearSeedEvent)
   if (kind === 'linear_issue_has_existing_comments') return formatBacklogSeed(event as LinearSeedEvent)
+  if (kind === 'linear_issue_added_to_watch') return formatAddedToWatch(event as LinearSeedEvent)
   return `[${kind}] ${JSON.stringify(event).slice(0, 280)}`
 }
 

--- a/src/orchestrator/plugins/linear/format.ts
+++ b/src/orchestrator/plugins/linear/format.ts
@@ -1,0 +1,74 @@
+import type {
+  LinearEvent,
+  LinearStateEvent,
+  LinearCommentEvent,
+  LinearThreadReplyEvent,
+  LinearLabelEvent,
+  LinearGithubPrLinkedEvent,
+  LinearSeedEvent,
+} from './diff.js'
+import type { TaggedEventPayload } from '../../plugin.js'
+
+const MULTILINE_COMMENT_KINDS: ReadonlySet<string> = new Set([
+  'linear_comment',
+])
+
+function formatStateChange(ev: LinearStateEvent): string {
+  return `Issue ${ev.identifier} state: ${ev.fromType ?? '?'} → ${ev.toType ?? '?'} — ${ev.url ?? ''}`
+}
+
+function formatLabels(ev: LinearLabelEvent): string {
+  const parts: string[] = []
+  if (ev.added.length) parts.push('+' + ev.added.join(','))
+  if (ev.removed.length) parts.push('-' + ev.removed.join(','))
+  return `Issue ${ev.identifier} labels: ${parts.join(' ')}`
+}
+
+function formatPrLinked(ev: LinearGithubPrLinkedEvent): string {
+  return `Issue ${ev.identifier} PR linked: ${ev.pr_repo}#${ev.pr_number} — ${ev.pr_url}`
+}
+
+function formatThreadReply(ev: LinearThreadReplyEvent): string {
+  const author = ev.author ?? '?'
+  const parent = ev.parent_author ?? '?'
+  return `Issue ${ev.identifier} thread reply by ${author} on ${parent}'s comment — ${ev.comment_url}`
+}
+
+function formatDisappeared(ev: LinearSeedEvent): string {
+  return (
+    `WARN Issue ${ev.identifier} no longer accessible — dropping from watch. ` +
+    `Re-watch with \`watch linear ${ev.identifier}\` if the issue is restored.`
+  )
+}
+
+function formatBacklogSeed(ev: LinearSeedEvent): string {
+  return `Issue ${ev.identifier} BACKLOG: ${ev.comment_count ?? 0} comments existed before watch — scan manually: ${ev.url ?? ''}`
+}
+
+function formatCommentHeader(ev: LinearCommentEvent): string {
+  return `Issue ${ev.identifier} comment by ${ev.author ?? '?'}:`
+}
+
+export function formatLinearEvent(event: LinearEvent): string {
+  const kind = event.kind
+  if (kind === 'linear_state_changed') return formatStateChange(event as LinearStateEvent)
+  if (kind === 'linear_labels_changed') return formatLabels(event as LinearLabelEvent)
+  if (kind === 'linear_github_pr_linked') return formatPrLinked(event as LinearGithubPrLinkedEvent)
+  if (kind === 'linear_thread_reply') return formatThreadReply(event as LinearThreadReplyEvent)
+  if (kind === 'linear_issue_disappeared') return formatDisappeared(event as LinearSeedEvent)
+  if (kind === 'linear_issue_has_existing_comments') return formatBacklogSeed(event as LinearSeedEvent)
+  return `[${kind}] ${JSON.stringify(event).slice(0, 280)}`
+}
+
+export function formatLinearPayload(event: LinearEvent): TaggedEventPayload {
+  if (MULTILINE_COMMENT_KINDS.has(event.kind)) {
+    const ev = event as LinearCommentEvent
+    return {
+      kind: 'multiline',
+      header: formatCommentHeader(ev),
+      body: ev.body ?? '',
+      url: ev.comment_url ?? ev.url ?? '',
+    }
+  }
+  return { kind: 'oneline', text: formatLinearEvent(event) }
+}

--- a/src/orchestrator/plugins/linear/issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/issues-plugin.ts
@@ -1,0 +1,254 @@
+import type { Command } from '../../dispatcher-dm-handler.js'
+import type { OrchestratorConfig } from '../../config.js'
+import { defaultProject, linearIssueChannel, resolveProjectChannel } from '../../naming.js'
+import {
+  BasePlugin,
+  defaultPluginLogger,
+  type ParseResult,
+  type PluginLogger,
+  type PluginTickResult,
+  type TaggedEvent,
+} from '../../plugin.js'
+import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { tryClaimPerLinearId, type PerLinearIdCommand } from '../grammar.js'
+import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../_rate-limit.js'
+import { LinearClient } from './linear-api.js'
+import { LinearScraper } from './scraper.js'
+import { formatLinearPayload } from './format.js'
+import { isTombstone, type LinearIssuePluginState, type LinearIssueState, type LinearWatchedEntry } from './types.js'
+
+interface LinearIssuesPluginConfig {
+  watched?: LinearWatchedEntry[]
+}
+
+// Minimal client surface used by the plugin — graphql() + rate-limit telemetry.
+// Both the real `LinearClient` and unit-test mocks implement this.
+export interface LinearClientLike {
+  graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>
+  getLastRateLimit(): RateLimitInfo | null
+}
+
+export class LinearIssuesPlugin extends BasePlugin {
+  readonly name = 'linear-issues'
+  protected readonly log: PluginLogger
+  private _client: LinearClientLike | null
+  private _envClient: LinearClient | null = null
+
+  // Rate-limit warning state — mirrors GhPluginBase. History is per-instance;
+  // the warn-cooldown is static so multi-plugin Linear futures don't double-warn.
+  private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
+  private static _warnedAt: number | null = null
+  private static readonly WARN_COOLDOWN_MS = 10 * 60_000
+
+  constructor(
+    defaultChannel: string,
+    log: PluginLogger = defaultPluginLogger,
+    injectedClient: LinearClientLike | null = null,
+  ) {
+    super(defaultChannel)
+    this.log = log
+    this._client = injectedClient
+  }
+
+  // Lazy env-read so dispatcher boot doesn't fail when LINEAR_API_KEY isn't
+  // set but the plugin has no watches yet. First tick with a watched entry
+  // will throw cleanly via LinearClient.fromEnv if the key is missing.
+  private getClient(): LinearClientLike {
+    if (this._client) return this._client
+    if (!this._envClient) this._envClient = LinearClient.fromEnv(this.log)
+    return this._envClient
+  }
+
+  protected watched(config: OrchestratorConfig): LinearWatchedEntry[] {
+    return this.pluginConfig<LinearIssuesPluginConfig>(config)?.watched ?? []
+  }
+
+  desiredChannels(config: OrchestratorConfig): string[] {
+    const entries = this.watched(config)
+    if (!entries.length) return []
+    const project = defaultProject(config)
+    const chans = new Set<string>()
+    for (const e of entries) {
+      chans.add(linearIssueChannel(project, e.identifier))
+      for (const c of e.channels ?? []) chans.add(c)
+    }
+    return [...chans]
+  }
+
+  // ---- DM command handling --------------------------------------------
+
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerLinearId(line)
+  }
+
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerLinearIdCommand
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.identifier, c.channels)
+      return this.applyUnwatch(merged, local, c.identifier)
+    }
+    return null
+  }
+
+  private matchEntry(identifier: string): (e: LinearWatchedEntry) => boolean {
+    return e => e.identifier === identifier
+  }
+
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, identifier: string, channels: string[]): string {
+    const labelStr = `linear issue ${identifier}`
+    const match = this.matchEntry(identifier)
+    if (!this.watched(merged).some(match)) {
+      const slice = this.localSlice<LinearIssuesPluginConfig>(local)
+      slice.watched ??= []
+      const entry: LinearWatchedEntry = { identifier }
+      if (channels.length) entry.channels = [...channels]
+      slice.watched.push(entry)
+      return channels.length ? `watching ${labelStr} + ${channels.join(' ')}` : `watching ${labelStr}`
+    }
+    const localEntry = (this.pluginConfig<LinearIssuesPluginConfig>(local)?.watched ?? []).find(match)
+    if (!localEntry) return channels.length ? trackedRefusal(labelStr, 'add channels') : `already watching ${labelStr}`
+    return addChannelsToEntry(localEntry, channels, labelStr)
+  }
+
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, identifier: string): string {
+    return applyUnwatchEntry<LinearWatchedEntry>(
+      this.watched(merged),
+      this.pluginConfig<LinearIssuesPluginConfig>(local)?.watched ?? [],
+      this.matchEntry(identifier),
+      `linear issue ${identifier}`,
+    )
+  }
+
+  private formatListSection(merged: OrchestratorConfig): string {
+    const entries = this.watched(merged)
+    // Dedup by identifier with channel union — concat-merge can carry the
+    // same id from tracked + overlay slices.
+    const byKey = new Map<string, { identifier: string; channels: Set<string> }>()
+    const order: string[] = []
+    for (const e of entries) {
+      let bucket = byKey.get(e.identifier)
+      if (!bucket) {
+        bucket = { identifier: e.identifier, channels: new Set<string>() }
+        byKey.set(e.identifier, bucket)
+        order.push(e.identifier)
+      }
+      for (const c of e.channels ?? []) bucket.channels.add(c)
+    }
+    const header = `${this.name} (${byKey.size}):`
+    if (!byKey.size) return `${header}\n  (none)`
+    const lines = order.map(k => {
+      const bucket = byKey.get(k)!
+      const chans = bucket.channels.size ? ` + ${[...bucket.channels].join(' ')}` : ''
+      return `  ${bucket.identifier}${chans}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch linear <TEAM>-<N> [#chan ...]   — watch Linear issue (e.g. watch linear C-758)`,
+      `  unwatch linear <TEAM>-<N>             — stop watching Linear issue`,
+      `  watch list                            — include this plugin's watched issues in the reply`,
+    ].join('\n')
+  }
+
+  // ---- Tick ------------------------------------------------------------
+
+  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
+    const project = defaultProject(config)
+    const projectChannel = resolveProjectChannel(config)
+    const watched = this.watched(config)
+    const prev = prevState as LinearIssuePluginState | null
+
+    if (!watched.length) {
+      // No watches → no client needed → no rate-limit telemetry either.
+      return { state: { issues: {} }, taggedEvents: [], channels: [] }
+    }
+
+    const client = this.getClient()
+    const scraper = new LinearScraper(client)
+
+    const scraped = await Promise.all(watched.map(async entry => {
+      const key = entry.identifier
+      const prevEntry: LinearIssueState | null | undefined =
+        prev === null ? undefined : (prev.issues[key] ?? null)
+      const { next, events } = await scraper.scrapeIssue(entry.identifier, prevEntry)
+      return { key, next, events, entryChannels: entry.channels ?? [] }
+    }))
+
+    const curState: LinearIssuePluginState = { issues: {} }
+    const taggedEvents: TaggedEvent[] = []
+    for (const { key, next, events, entryChannels } of scraped) {
+      curState.issues[key] = next
+      for (const event of events) {
+        if (event.kind === 'linear_issue_added_to_watch') {
+          const issueChan = linearIssueChannel(project, key)
+          const routingChannels = [issueChan, ...entryChannels].filter(ch => ch !== projectChannel)
+          taggedEvents.push({
+            channels: [projectChannel],
+            payload: {
+              kind: 'oneline',
+              text: `now watching linear issue ${key} — routing events to ${routingChannels.join(', ')}`,
+            },
+          })
+          continue
+        }
+        if (event.kind === 'linear_issue_disappeared') {
+          // Project-channel only — the per-issue channel will be orphaned and
+          // the operator needs the heads-up where they read leads traffic.
+          taggedEvents.push({
+            channels: [projectChannel],
+            payload: formatLinearPayload(event),
+          })
+          continue
+        }
+        const issueChan = linearIssueChannel(project, key)
+        taggedEvents.push({
+          channels: this.resolveChannels([issueChan], entryChannels),
+          payload: formatLinearPayload(event),
+        })
+      }
+    }
+
+    taggedEvents.push(...this.observeRateLimit(projectChannel))
+    return { state: curState, taggedEvents, channels: this.desiredChannels(config) }
+  }
+
+  // End-of-tick threshold check — reads `getLastRateLimit()` from the client
+  // (already populated by spawnLinear on each successful call). Mirrors
+  // `GhPluginBase.observeRateLimit`: history ring, projection via
+  // computeRateLimitWarning, cooldown-gated emit.
+  protected observeRateLimit(projectChannel: string): TaggedEvent[] {
+    const info = this._client?.getLastRateLimit() ?? this._envClient?.getLastRateLimit() ?? null
+    if (!info) return []
+
+    const now = Date.now()
+    const cutoff = now - RATE_LIMIT_WINDOW_MS
+    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
+
+    const prev = this._rateLimitHistory.length > 0
+      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
+      : null
+    const delta = prev != null ? prev.remaining - info.remaining : null
+    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
+    const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
+    this.log(`[ratelimit] linear: remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
+
+    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now, 'Linear')
+    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
+    if (!warning) return []
+
+    const cooldownElapsed = LinearIssuesPlugin._warnedAt == null
+      || now - LinearIssuesPlugin._warnedAt > LinearIssuesPlugin.WARN_COOLDOWN_MS
+    if (!cooldownElapsed) return []
+
+    LinearIssuesPlugin._warnedAt = now
+    return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
+  }
+}
+
+// Re-export so tests can verify tombstone behavior without importing types.js.
+export { isTombstone }

--- a/src/orchestrator/plugins/linear/issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/issues-plugin.ts
@@ -220,9 +220,10 @@ export class LinearIssuesPlugin extends BasePlugin {
   // End-of-tick threshold check — reads `getLastRateLimit()` from the client
   // (already populated by spawnLinear on each successful call). Mirrors
   // `GhPluginBase.observeRateLimit`: history ring, projection via
-  // computeRateLimitWarning, cooldown-gated emit.
+  // computeRateLimitWarning, cooldown-gated emit. Only called after a
+  // watched-entry tick, so `getClient()` is guaranteed to have been seeded.
   protected observeRateLimit(projectChannel: string): TaggedEvent[] {
-    const info = this._client?.getLastRateLimit() ?? this._envClient?.getLastRateLimit() ?? null
+    const info = this.getClient().getLastRateLimit()
     if (!info) return []
 
     const now = Date.now()

--- a/src/orchestrator/plugins/linear/scraper.ts
+++ b/src/orchestrator/plugins/linear/scraper.ts
@@ -1,0 +1,91 @@
+// Linear scraper — fetch a single issue snapshot and diff against the previous
+// one. Mirrors the github scraper's shape: pure event computation + a
+// per-tick handle (`LinearScraper`) that bundles the client.
+//
+// prevSnap meanings (parallel to github):
+//   undefined → seeding (global seed or first daemon run); emit nothing
+//   null      → new to watch list; emit seed/backlog events
+//   LinearIssueSnap → normal tick; diff and emit change events
+//   LinearIssueTombstone → already-disappeared; skip fetch + re-emit
+import type { LinearIssueSnap, LinearIssueState } from './types.js'
+import { isTombstone } from './types.js'
+import {
+  buildLinearSnap,
+  diffLinearIssue,
+  disappearedLinearIssue,
+  seedLinearIssue,
+  selectGithubAttachments,
+  type RawLinearIssue,
+  type LinearEvent,
+  type ScrapeContext,
+} from './diff.js'
+
+// Caller surface: scrapeIssue returns the next state entry + events to emit
+// for that entry this tick. `next === null` is unused — we always return a
+// LinearIssueSnap or a tombstone.
+export interface ScrapeResult {
+  next: LinearIssueState
+  events: LinearEvent[]
+}
+
+export const ISSUE_QUERY = `query LinearIssue($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    state { type name }
+    labels { nodes { name } }
+    comments { nodes { id body user { name } parent { id } } }
+    attachments { nodes { id sourceType url title } }
+  }
+}`
+
+export interface LinearGraphqlSurface {
+  graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>
+}
+
+// Per-tick handle. Constructor takes the client so tests can inject a mock
+// (mirrors `GhScraper(client, agentLogins)`). The client argument is typed
+// against the minimal `LinearGraphqlSurface` so unit tests don't have to
+// stand up a full `LinearClient` instance.
+export class LinearScraper {
+  constructor(private readonly client: LinearGraphqlSurface) {}
+
+  async scrapeIssue(identifier: string, prev: LinearIssueState | null | undefined): Promise<ScrapeResult> {
+    // Already-disappeared: pass the tombstone through, emit nothing. Never
+    // re-fetch — the issue is gone; the operator drops it via `unwatch`.
+    if (isTombstone(prev)) {
+      return { next: prev, events: [] }
+    }
+
+    const data = (await this.client.graphql(ISSUE_QUERY, { id: identifier })) as
+      | { issue: RawLinearIssue | null }
+      | null
+      | undefined
+    const raw = data?.issue
+
+    if (!raw) {
+      // 404 / inaccessible. Mute on subsequent ticks by storing a tombstone.
+      // Seeding (prev === undefined) suppresses the event but still seats the
+      // tombstone so a later tick doesn't re-emit.
+      const tombstone: LinearIssueState = { identifier, disappeared: true }
+      if (prev === undefined) return { next: tombstone, events: [] }
+      return { next: tombstone, events: [disappearedLinearIssue(identifier)] }
+    }
+
+    const snap = buildLinearSnap(raw)
+    const ctx: ScrapeContext = {
+      comments: raw.comments?.nodes ?? [],
+      githubAttachments: selectGithubAttachments(raw.attachments?.nodes ?? []),
+    }
+
+    if (prev === undefined) return { next: snap, events: [] }
+    if (prev === null) return { next: snap, events: seedLinearIssue(snap) }
+    // Tombstone branch handled above — prev is a LinearIssueSnap here.
+    return { next: snap, events: diffLinearIssue(prev as LinearIssueSnap, snap, ctx) }
+  }
+}
+
+// Re-export for the plugin's runTick.
+export type { LinearEvent } from './diff.js'

--- a/src/orchestrator/plugins/linear/scraper.ts
+++ b/src/orchestrator/plugins/linear/scraper.ts
@@ -9,6 +9,7 @@
 //   LinearIssueTombstone → already-disappeared; skip fetch + re-emit
 import type { LinearIssueSnap, LinearIssueState } from './types.js'
 import { isTombstone } from './types.js'
+import { LinearError } from './linear-api.js'
 import {
   buildLinearSnap,
   diffLinearIssue,
@@ -47,6 +48,29 @@ export interface LinearGraphqlSurface {
   graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>
 }
 
+// Linear's not-found shape — HTTP 200 with errors[]:
+//   { message: "Entity not found: Issue", path: ["issue"],
+//     extensions: { code: "INPUT_ERROR", type: "invalid input" } }
+// Empirically confirmed against api.linear.app. The LinearClient turns the
+// errors[] envelope into a LinearError with .code='INPUT_ERROR' and the raw
+// body in .body — re-parse the body to disambiguate not-found from other
+// INPUT_ERROR causes (malformed query, bad variables, etc.).
+export function isLinearNotFoundError(e: unknown): boolean {
+  if (!(e instanceof LinearError)) return false
+  if (e.code !== 'INPUT_ERROR') return false
+  let parsed: { errors?: Array<{ message?: string; path?: unknown[] }> }
+  try {
+    parsed = JSON.parse(e.body || '{}')
+  } catch { return false }
+  const errs = parsed.errors ?? []
+  return errs.some(err =>
+    typeof err.message === 'string'
+    && err.message.startsWith('Entity not found')
+    && Array.isArray(err.path)
+    && err.path[0] === 'issue'
+  )
+}
+
 // Per-tick handle. Constructor takes the client so tests can inject a mock
 // (mirrors `GhScraper(client, agentLogins)`). The client argument is typed
 // against the minimal `LinearGraphqlSurface` so unit tests don't have to
@@ -61,11 +85,20 @@ export class LinearScraper {
       return { next: prev, events: [] }
     }
 
-    const data = (await this.client.graphql(ISSUE_QUERY, { id: identifier })) as
-      | { issue: RawLinearIssue | null }
-      | null
-      | undefined
-    const raw = data?.issue
+    let raw: RawLinearIssue | null | undefined
+    try {
+      const data = (await this.client.graphql(ISSUE_QUERY, { id: identifier })) as
+        | { issue: RawLinearIssue | null }
+        | null
+        | undefined
+      raw = data?.issue
+    } catch (e) {
+      // Linear's not-found shape is HTTP 200 + errors[], which LinearClient
+      // rethrows as LinearError. Translate to the disappeared path; rethrow
+      // anything else (auth, rate-limit, network, real graphql errors).
+      if (!isLinearNotFoundError(e)) throw e
+      raw = null
+    }
 
     if (!raw) {
       // 404 / inaccessible. Mute on subsequent ticks by storing a tombstone.

--- a/src/orchestrator/plugins/linear/scraper.ts
+++ b/src/orchestrator/plugins/linear/scraper.ts
@@ -28,6 +28,8 @@ export interface ScrapeResult {
   events: LinearEvent[]
 }
 
+// `parent { id }` is equivalent to the spec's flat `parentId` — Linear's
+// GraphQL accepts either form for thread-reply linkage.
 export const ISSUE_QUERY = `query LinearIssue($id: String!) {
   issue(id: $id) {
     id

--- a/src/orchestrator/plugins/linear/types.ts
+++ b/src/orchestrator/plugins/linear/types.ts
@@ -1,0 +1,43 @@
+// Snapshot of a watched Linear issue. `seen_comment_ids` covers both
+// top-level and threaded comments — Linear doesn't allow moving comments
+// between the two, so a single set prevents double-emit on re-classification.
+// `seen_github_attachment_ids` is restricted to attachments with
+// `sourceType == 'github'`; the PR-linked event fires once per attachment id.
+export interface LinearIssueSnap {
+  identifier: string
+  id: string
+  title: string | null
+  url: string | null
+  status: string | null
+  statusType: string | null
+  labels: string[]
+  seen_comment_ids: string[]
+  seen_github_attachment_ids: string[]
+}
+
+// Tombstone for an issue that was watched then became 404 / inaccessible. Held
+// in state so the disappeared event fires exactly once. Cleared only via
+// `unwatch`. Distinguished from `LinearIssueSnap` by the literal `disappeared:
+// true` discriminant; consumers use `isTombstone()` rather than truthy checks.
+export interface LinearIssueTombstone {
+  identifier: string
+  disappeared: true
+}
+
+export type LinearIssueState = LinearIssueSnap | LinearIssueTombstone
+
+export function isTombstone(s: LinearIssueState | null | undefined): s is LinearIssueTombstone {
+  return s != null && 'disappeared' in s && s.disappeared === true
+}
+
+export interface LinearIssuePluginState {
+  issues: Record<string, LinearIssueState>
+}
+
+// Watch-list entry — `identifier` is the spec-required uppercase Linear id
+// (e.g. `C-758`). Channels are optional extra routing targets, unioned with
+// the per-issue channel at event time.
+export interface LinearWatchedEntry {
+  identifier: string
+  channels?: string[]
+}

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -5,8 +5,10 @@ import { GitHubPrsPlugin } from './plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
 import { GitHubNewIssuesPlugin } from './plugins/github/new-issues-plugin.js'
 import { GitHubCommitsPlugin } from './plugins/github/commits-plugin.js'
+import { LinearIssuesPlugin } from './plugins/linear/issues-plugin.js'
 
 registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
 registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))
 registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log))
 registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log))
+registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log))


### PR DESCRIPTION
Closes #493

## Summary

- New `linear-issues` plugin (slice 2 of the Linear family) parallel to `github-issues`. DM grammar: `watch linear <TEAM>-<N>` via new `tryClaimPerLinearId` helper. Channel naming: `#<project>-issue-<team-lower>-<n>` — uniquely shaped vs. github-issues because Linear identifiers always lead with `[A-Z]+-`.
- Per-tick scrape pulls state, labels, comments (top-level + threaded), and attachments via the slice-1 `LinearClient`. Diff emits `linear_state_changed`, `linear_labels_changed`, `linear_comment` (multiline), `linear_thread_reply` (oneline, option (a) from the sub-design-call — silence is the documented UX footgun), `linear_github_pr_linked` (strict `pull/<N>` matcher only, fail-closed), and `linear_issue_disappeared`.
- 404 path seats a tombstone in state so the disappeared event fires exactly once. Tombstones drop naturally on `unwatch`. End-of-tick rate-limit threshold WARN mirrors `GhPluginBase.observeRateLimit` (reads `LinearClient.getLastRateLimit`, no extra API call).

## Design notes (resolved sub-design-call)

Issue body flagged a thread-reply UX call: emit a `linear_thread_reply` event or stay silent. **Picked option (a).** Cost is ~20 LOC + one event kind; the alternative ("operator wonders why the channel is quiet") was the documented UX footgun. The event carries `author`, `parent_author`, `parent_comment_url`, `comment_url`; format renders `Issue C-758 thread reply by alice on bob's comment — <url>`.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 799 passing (added 67 new tests across 4 files: diff, scraper, format, plugin).
- [x] Grammar AC: `watch linear C-758` claims; `watch linear c-758` rejected with fixit; `unwatch linear C-758` claims.
- [x] State-change / comment / thread-reply / label / PR-linked / disappeared events each verified end-to-end via diff + scraper + plugin tests.
- [x] Backlog seed fires once on new watch; second tick does not re-emit.
- [x] Disappeared lifecycle: emits once, tombstone seated, subsequent ticks no-op without re-fetching.
- [ ] Live test against api.linear.app — deferred to lead's pre-review pressure-test (per §#449 — load-bearing on Linear API behavior we can mock but should empirically confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)