### PR TITLE
add learning from #489

### DIFF
--- a/.claude/learnings/apm.md
+++ b/.claude/learnings/apm.md
@@ -13,3 +13,4 @@ When filing a followup issue, ask whether the work is primarily in service of a 
 ## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
+

--- a/.claude/learnings/lead-pm.md
+++ b/.claude/learnings/lead-pm.md
@@ -41,3 +41,4 @@ When an issue's body describes the output (add X to file Y) but not how the unde
 ## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
+

--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -89,3 +89,7 @@ Treat reviewer "fyi: this is narrower than the failure mode" as a blocker on the
 ## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
+
+## 2026-05-21: CLAUDE.local.md is a doc, not a permission grant — credential workers need explicit onboarding (from #492) [audience=lead-pm,apm]
+
+CLAUDE.local.md is a doc, not a permission grant. When a worker needs to fetch a credential, the auto-mode classifier blocks the call regardless of the doc. Lead either pre-injects the retrieval chain via `roost send` before the worker's first credential-touching command, or approves via permbot when it fires. Required onboarding step for any credential-fetching worker.

--- a/.claude/rules/shipped-prompts.md
+++ b/.claude/rules/shipped-prompts.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - agents/**/*.md
+  - prompts/**/*.md
+  - .claude/commands/**/*.md
+---
+# Shipped Prompt Authoring
+
+Patterns for writing agent prompts, slash commands, and role prompts that ship with roost and install into arbitrary projects.
+
+## 2026-05-21: In shipped agent prompts, don't enumerate project-specific role names (from #489)
+
+Hardcoding a "Valid roles: worker, reviewer, lead-pm, apm" list in a shipped agent prompt couples the artifact to one project's role set. Downstream operators would need to fork the prompt to add their own roles. Use the audience= mechanism instead — let the lead's call at filing time determine scope. Catch this at plan stage: if you see a role enumeration in a shipped prompt, flag it before code lands.


### PR DESCRIPTION
Path-scoped learning from the #489 postmortem — shipped agent prompts must not enumerate project-specific role names.

Creates `.claude/rules/shipped-prompts.md` with `paths:` frontmatter targeting `agents/**/*.md`, `prompts/**/*.md`, `.claude/commands/**/*.md`. Auto-loads whenever anyone reads matching files, regardless of role.