### PR TITLE
add learning from #494

### DIFF
--- a/.claude/learnings/lead-pm.md
+++ b/.claude/learnings/lead-pm.md
@@ -41,3 +41,7 @@ When an issue's body describes the output (add X to file Y) but not how the unde
 ## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
+
+## 2026-05-21: Scope learnings by path when the rule is location-bound, not role-bound (from #494)
+
+When a learning applies to "anyone touching these files" rather than to a specific role's behavior, path-scope beats audience-scope. Audience-scope limits reach to the named roles; path-scope fires for any agent reading matching files regardless of role. The test: does the rule hold because of who the agent is, or because of what code they're reading? If the latter, use paths: frontmatter.

--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -89,3 +89,7 @@ Treat reviewer "fyi: this is narrower than the failure mode" as a blocker on the
 ## 2026-05-21: In prompt gates, the artifact instruction is the entire lever (from #496)
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
+
+## 2026-05-21: CLAUDE.local.md is a doc, not a permission grant — credential workers need explicit onboarding (from #492) [audience=lead-pm,apm]
+
+CLAUDE.local.md is a doc, not a permission grant. When a worker needs to fetch a credential, the auto-mode classifier blocks the call regardless of the doc. Lead either pre-injects the retrieval chain via `roost send` before the worker's first credential-touching command, or approves via permbot when it fires. Required onboarding step for any credential-fetching worker.


### PR DESCRIPTION
Learning from the #494 postmortem — scope learnings by path when the rule is location-bound, not role-bound.