### PR TITLE
fix first-run ergo failures and document dev-channels flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ from a working directory of your choice — relative paths in the config
 (`logs/`, `ircd.db`, etc.) resolve from there:
 
 ```bash
-mkdir -p ~/roost-ircd && cd ~/roost-ircd
+mkdir -p ~/roost-ircd/logs && cd ~/roost-ircd
 nohup ergo run --conf "$(roost root)/etc/ergo.yaml" > /tmp/ergo.out 2>&1 &
 ```
 
@@ -117,6 +117,17 @@ roost status
 after forwards to claude verbatim). Default channel is `#roost`;
 default model is `opus` (Opus 4.7 — required for `--permission-mode
 auto`, which the wrapper always passes).
+
+### Debugging a failed spawn
+
+If you need to invoke `claude` directly to debug a failed `roost spawn`, the `--dangerously-load-development-channels` flag (hidden from `claude --help`) takes a server-id. The format depends on how roost is loaded:
+
+- Via plugin loader (installed via brew): `server:plugin:roost:roost-irc`
+- As a bare MCP server (dev checkout, manual `--mcp-config`): `server:roost-irc`
+
+```bash
+claude --dangerously-load-development-channels server:plugin:roost:roost-irc
+```
 
 ### Observe as a human (no Claude needed)
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Coverage includes `src/irc-server.ts` via the in-process tests
   before hosting multi-tenant work.
 - **`channel_history` is per-MCP-instance.** Restarting an MCP loses
   the buffer. For durable history use ergo's audit log
-  (`var/ergo/logs/audit.log`) or the IRCv3 `CHATHISTORY` command.
+  (`~/roost-ircd/logs/audit.log`) or the IRCv3 `CHATHISTORY` command.
 - **`alwaysLoad: true`** keeps all six tools non-deferred. Empirical
   baseline-vs-alwaysLoad probe (2026-04-28) showed 0 `tools_changed`
   misses with the flag vs 2 without (see `docs/LEARNINGS.md` Finding A).

--- a/etc/ergo.yaml
+++ b/etc/ergo.yaml
@@ -43,7 +43,7 @@ server:
     # Send-queue cap per client.
     max-sendq: 96k
 
-    # Where to put the IPC bits when ergo runs from var/ergo.
+    # Where to put the IPC bits when ergo runs.
     relaymsg:
         enabled: false
 

--- a/etc/ergo.yaml
+++ b/etc/ergo.yaml
@@ -7,8 +7,8 @@
 # negotiates the relevant caps and falls back to a chunk-and-buffer
 # heuristic for any peer that doesn't speak them.
 #
-# Working dir is <roost-root>/var/ergo when launched per README.
-# All relative paths in this file resolve there.
+# Working dir is ~/roost-ircd (or whatever the operator chose) when
+# launched per README. All relative paths in this file resolve there.
 
 network:
     name: roost
@@ -164,7 +164,7 @@ datastore:
     autoupgrade: true
 
 languages:
-    enabled: true
+    enabled: false
     default: en
     path: languages
 

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -147,7 +147,7 @@ Ergo must be running on `127.0.0.1:6667`. `roost status` checks;
 `roost spawn` aborts with a hint if it's down. Start with:
 
 ```bash
-mkdir -p ~/roost-ircd && cd ~/roost-ircd
+mkdir -p ~/roost-ircd/logs && cd ~/roost-ircd
 nohup ergo run --conf "$(roost root)/etc/ergo.yaml" > /tmp/ergo.out 2>&1 &
 ```
 


### PR DESCRIPTION
Closes #517
Closes #518
Closes #520

Three first-run pain points from the same Linux-from-source audit, all small.

**#517** — `etc/ergo.yaml`: `languages.enabled: false`. Ergo looked for `./languages/` relative to cwd (`~/roost-ircd`); that dir is never present. Option 2 from the issue — i18n unneeded for an agent-chat server.

**#518** — README: `mkdir -p ~/roost-ircd/logs`. Ergo's audit log path is relative; the parent dir must exist before first launch.

**#520** — README: new "Debugging a failed spawn" subsection with the `--dangerously-load-development-channels` server-id format and plugin-vs-bare distinction.

Also corrects a stale comment in `ergo.yaml` that said the working dir is `<roost-root>/var/ergo`; the README has always used `~/roost-ircd`.