### PR TITLE
feat(linear-github-link): route github-prs events to linked Linear channels

### DIFF
--- a/src/orchestrator/plugins/__tests__/linear-link.test.ts
+++ b/src/orchestrator/plugins/__tests__/linear-link.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  LinearAttachmentResolver,
+  makeBatchedAttachmentQuery,
+  BATCHED_ATTACHMENTS_QUERY,
+  type AttachmentQuery,
+  type RawIssueWithAttachments,
+} from '../linear-link.js'
+
+function stubQuery(response: RawIssueWithAttachments[]): { fn: AttachmentQuery; calls: string[][] } {
+  const calls: string[][] = []
+  const fn: AttachmentQuery = async (ids) => {
+    calls.push([...ids])
+    return response
+  }
+  return { fn, calls }
+}
+
+describe('LinearAttachmentResolver.resolve', () => {
+  it('builds a map of "owner/repo#N" → [linear identifier] from github attachments', async () => {
+    const { fn } = stubQuery([
+      {
+        identifier: 'C-758',
+        attachments: {
+          nodes: [
+            { id: 'a1', sourceType: 'github', url: 'https://github.com/AvesAlight/roost/pull/495' },
+          ],
+        },
+      },
+    ])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-758'])
+    expect(map.get('AvesAlight/roost#495')).toEqual(['C-758'])
+    expect(map.size).toBe(1)
+  })
+
+  it('ignores attachments with non-github sourceType', async () => {
+    const { fn } = stubQuery([
+      {
+        identifier: 'C-1',
+        attachments: {
+          nodes: [
+            { id: 'a1', sourceType: 'slack', url: 'https://github.com/x/y/pull/1' },
+            { id: 'a2', sourceType: null, url: 'https://github.com/x/y/pull/2' },
+          ],
+        },
+      },
+    ])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
+    expect(map.size).toBe(0)
+  })
+
+  it('ignores github attachments whose URL is not a well-formed pull/<N>', async () => {
+    const { fn } = stubQuery([
+      {
+        identifier: 'C-1',
+        attachments: {
+          nodes: [
+            { id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/issues/3' },
+            { id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pulls/4' },
+            { id: 'a3', sourceType: 'github', url: null },
+          ],
+        },
+      },
+    ])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
+    expect(map.size).toBe(0)
+  })
+
+  it('collects multiple Linear identifiers when the same PR is attached to several issues', async () => {
+    const { fn } = stubQuery([
+      {
+        identifier: 'C-1',
+        attachments: { nodes: [{ id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/42' }] },
+      },
+      {
+        identifier: 'C-2',
+        attachments: { nodes: [{ id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pull/42' }] },
+      },
+    ])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1', 'C-2'])
+    expect(map.get('x/y#42')).toEqual(['C-1', 'C-2'])
+  })
+
+  it('dedups when the same Linear issue has multiple github attachments pointing at the same PR', async () => {
+    const { fn } = stubQuery([
+      {
+        identifier: 'C-1',
+        attachments: {
+          nodes: [
+            { id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/42' },
+            { id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pull/42' },
+          ],
+        },
+      },
+    ])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
+    expect(map.get('x/y#42')).toEqual(['C-1'])
+  })
+
+  it('skips the query entirely when the identifier list is empty', async () => {
+    const { fn, calls } = stubQuery([])
+    const map = await new LinearAttachmentResolver(fn).resolve([])
+    expect(map.size).toBe(0)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('issues a single batched query regardless of N watched identifiers', async () => {
+    const { fn, calls } = stubQuery([])
+    await new LinearAttachmentResolver(fn).resolve(['C-1', 'C-2', 'C-3', 'C-4', 'C-5'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual(['C-1', 'C-2', 'C-3', 'C-4', 'C-5'])
+  })
+
+  it('handles an issue with null attachments cleanly', async () => {
+    const { fn } = stubQuery([{ identifier: 'C-1', attachments: null }])
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
+    expect(map.size).toBe(0)
+  })
+
+  it('rejects construction without a query function', () => {
+    expect(() => new LinearAttachmentResolver(undefined as unknown as AttachmentQuery)).toThrow(/query function required/)
+  })
+})
+
+describe('makeBatchedAttachmentQuery', () => {
+  it('wraps a LinearClient.graphql call with the batched-attachments query + ids variable', async () => {
+    const calls: Array<{ query: string; variables: Record<string, unknown> | undefined }> = []
+    const client = {
+      graphql: async (query: string, variables?: Record<string, unknown>) => {
+        calls.push({ query, variables })
+        return {
+          issues: {
+            nodes: [
+              {
+                identifier: 'C-1',
+                attachments: { nodes: [{ id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/9' }] },
+              },
+            ],
+          },
+        }
+      },
+    }
+    const query = makeBatchedAttachmentQuery(client)
+    const nodes = await query(['C-1', 'C-2'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.query).toBe(BATCHED_ATTACHMENTS_QUERY)
+    expect(calls[0]?.variables).toEqual({ ids: ['C-1', 'C-2'] })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.identifier).toBe('C-1')
+  })
+
+  it('returns [] without calling graphql when the identifier list is empty', async () => {
+    let called = 0
+    const client = { graphql: async () => { called++; return null } }
+    const result = await makeBatchedAttachmentQuery(client)([])
+    expect(result).toEqual([])
+    expect(called).toBe(0)
+  })
+
+  it('returns [] when the graphql response is null or missing issues', async () => {
+    const nullClient = { graphql: async () => null }
+    expect(await makeBatchedAttachmentQuery(nullClient)(['C-1'])).toEqual([])
+    const emptyClient = { graphql: async () => ({ issues: null }) }
+    expect(await makeBatchedAttachmentQuery(emptyClient)(['C-1'])).toEqual([])
+  })
+})

--- a/src/orchestrator/plugins/__tests__/linear-link.test.ts
+++ b/src/orchestrator/plugins/__tests__/linear-link.test.ts
@@ -3,116 +3,159 @@ import {
   LinearAttachmentResolver,
   makeBatchedAttachmentQuery,
   BATCHED_ATTACHMENTS_QUERY,
+  ATTACHMENT_PAGE_SIZE,
   type AttachmentQuery,
+  type AttachmentQueryResult,
   type RawIssueWithAttachments,
 } from '../linear-link.js'
 
-function stubQuery(response: RawIssueWithAttachments[]): { fn: AttachmentQuery; calls: string[][] } {
-  const calls: string[][] = []
-  const fn: AttachmentQuery = async (ids) => {
-    calls.push([...ids])
-    return response
+interface Call { team: string; numbers: number[] }
+
+function stubQuery(responses: Record<string, AttachmentQueryResult>): { fn: AttachmentQuery; calls: Call[] } {
+  const calls: Call[] = []
+  const fn: AttachmentQuery = async (team, numbers) => {
+    calls.push({ team, numbers: [...numbers] })
+    return responses[team] ?? { nodes: [], hasNextPage: false }
   }
   return { fn, calls }
 }
 
+function issueNode(identifier: string, attachments: Array<{ id: string; sourceType: string | null; url: string | null }>): RawIssueWithAttachments {
+  return { identifier, attachments: { nodes: attachments } }
+}
+
+function gh(url: string): { id: string; sourceType: string; url: string } {
+  return { id: `att-${url}`, sourceType: 'github', url }
+}
+
 describe('LinearAttachmentResolver.resolve', () => {
   it('builds a map of "owner/repo#N" → [linear identifier] from github attachments', async () => {
-    const { fn } = stubQuery([
-      {
-        identifier: 'C-758',
-        attachments: {
-          nodes: [
-            { id: 'a1', sourceType: 'github', url: 'https://github.com/AvesAlight/roost/pull/495' },
-          ],
-        },
-      },
-    ])
+    const { fn } = stubQuery({
+      C: { nodes: [issueNode('C-758', [gh('https://github.com/AvesAlight/roost/pull/495')])], hasNextPage: false },
+    })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-758'])
     expect(map.get('AvesAlight/roost#495')).toEqual(['C-758'])
     expect(map.size).toBe(1)
   })
 
   it('ignores attachments with non-github sourceType', async () => {
-    const { fn } = stubQuery([
-      {
-        identifier: 'C-1',
-        attachments: {
-          nodes: [
-            { id: 'a1', sourceType: 'slack', url: 'https://github.com/x/y/pull/1' },
-            { id: 'a2', sourceType: null, url: 'https://github.com/x/y/pull/2' },
-          ],
-        },
+    const { fn } = stubQuery({
+      C: {
+        nodes: [issueNode('C-1', [
+          { id: 'a1', sourceType: 'slack', url: 'https://github.com/x/y/pull/1' },
+          { id: 'a2', sourceType: 'githubCommit', url: 'https://github.com/x/y/commit/abc' },
+          { id: 'a3', sourceType: null, url: 'https://github.com/x/y/pull/2' },
+        ])],
+        hasNextPage: false,
       },
-    ])
+    })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
     expect(map.size).toBe(0)
   })
 
   it('ignores github attachments whose URL is not a well-formed pull/<N>', async () => {
-    const { fn } = stubQuery([
-      {
-        identifier: 'C-1',
-        attachments: {
-          nodes: [
-            { id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/issues/3' },
-            { id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pulls/4' },
-            { id: 'a3', sourceType: 'github', url: null },
-          ],
-        },
+    const { fn } = stubQuery({
+      C: {
+        nodes: [issueNode('C-1', [
+          { id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/issues/3' },
+          { id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pulls/4' },
+          { id: 'a3', sourceType: 'github', url: null },
+        ])],
+        hasNextPage: false,
       },
-    ])
+    })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
     expect(map.size).toBe(0)
   })
 
   it('collects multiple Linear identifiers when the same PR is attached to several issues', async () => {
-    const { fn } = stubQuery([
-      {
-        identifier: 'C-1',
-        attachments: { nodes: [{ id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/42' }] },
+    const { fn } = stubQuery({
+      C: {
+        nodes: [
+          issueNode('C-1', [gh('https://github.com/x/y/pull/42')]),
+          issueNode('C-2', [gh('https://github.com/x/y/pull/42')]),
+        ],
+        hasNextPage: false,
       },
-      {
-        identifier: 'C-2',
-        attachments: { nodes: [{ id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pull/42' }] },
-      },
-    ])
+    })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1', 'C-2'])
     expect(map.get('x/y#42')).toEqual(['C-1', 'C-2'])
   })
 
   it('dedups when the same Linear issue has multiple github attachments pointing at the same PR', async () => {
-    const { fn } = stubQuery([
-      {
-        identifier: 'C-1',
-        attachments: {
-          nodes: [
-            { id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/42' },
-            { id: 'a2', sourceType: 'github', url: 'https://github.com/x/y/pull/42' },
-          ],
-        },
-      },
-    ])
+    const { fn } = stubQuery({
+      C: { nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/42'), gh('https://github.com/x/y/pull/42')])], hasNextPage: false },
+    })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
     expect(map.get('x/y#42')).toEqual(['C-1'])
   })
 
   it('skips the query entirely when the identifier list is empty', async () => {
-    const { fn, calls } = stubQuery([])
+    const { fn, calls } = stubQuery({})
     const map = await new LinearAttachmentResolver(fn).resolve([])
     expect(map.size).toBe(0)
     expect(calls).toHaveLength(0)
   })
 
-  it('issues a single batched query regardless of N watched identifiers', async () => {
-    const { fn, calls } = stubQuery([])
+  it('groups identifiers by team and issues one query per team (M teams = M round trips)', async () => {
+    const { fn, calls } = stubQuery({
+      C: { nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/1')])], hasNextPage: false },
+      M: { nodes: [issueNode('M-7', [gh('https://github.com/x/y/pull/7')])], hasNextPage: false },
+    })
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1', 'M-7', 'C-2', 'C-3'])
+    expect(calls).toHaveLength(2)
+    const cByTeam = Object.fromEntries(calls.map(c => [c.team, c.numbers]))
+    expect(cByTeam.C).toEqual([1, 2, 3])
+    expect(cByTeam.M).toEqual([7])
+    expect(map.get('x/y#1')).toEqual(['C-1'])
+    expect(map.get('x/y#7')).toEqual(['M-7'])
+  })
+
+  it('issues exactly one query per team regardless of N identifiers in that team', async () => {
+    const { fn, calls } = stubQuery({ C: { nodes: [], hasNextPage: false } })
     await new LinearAttachmentResolver(fn).resolve(['C-1', 'C-2', 'C-3', 'C-4', 'C-5'])
     expect(calls).toHaveLength(1)
-    expect(calls[0]).toEqual(['C-1', 'C-2', 'C-3', 'C-4', 'C-5'])
+    expect(calls[0]).toEqual({ team: 'C', numbers: [1, 2, 3, 4, 5] })
+  })
+
+  it('skips malformed identifiers without poisoning the batch + logs each', async () => {
+    const logs: string[] = []
+    const log = (msg: string) => { logs.push(msg) }
+    const { fn, calls } = stubQuery({
+      C: { nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/1')])], hasNextPage: false },
+    })
+    const map = await new LinearAttachmentResolver(fn, log).resolve(['noDash', '-758', 'C-', 'C-abc', 'C-1'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.numbers).toEqual([1])
+    expect(logs.filter(m => m.includes('malformed Linear identifier'))).toHaveLength(4)
+    expect(map.get('x/y#1')).toEqual(['C-1'])
+  })
+
+  it('returns an empty map and issues no query when every identifier is malformed', async () => {
+    const logs: string[] = []
+    const { fn, calls } = stubQuery({})
+    const map = await new LinearAttachmentResolver(fn, (m) => { logs.push(m) }).resolve(['bogus', '-1', 'X-'])
+    expect(calls).toHaveLength(0)
+    expect(map.size).toBe(0)
+    expect(logs.length).toBe(3)
+  })
+
+  it('logs a loud warn when a team result paginates (growth case guard)', async () => {
+    const logs: string[] = []
+    const log = (msg: string) => { logs.push(msg) }
+    const { fn } = stubQuery({
+      C: { nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/1')])], hasNextPage: true },
+    })
+    const map = await new LinearAttachmentResolver(fn, log).resolve(['C-1'])
+    expect(map.get('x/y#1')).toEqual(['C-1'])
+    const warn = logs.find(m => m.includes('paginated'))
+    expect(warn).toBeDefined()
+    expect(warn).toContain('team "C"')
+    expect(warn).toContain(`>${ATTACHMENT_PAGE_SIZE}`)
   })
 
   it('handles an issue with null attachments cleanly', async () => {
-    const { fn } = stubQuery([{ identifier: 'C-1', attachments: null }])
+    const { fn } = stubQuery({ C: { nodes: [{ identifier: 'C-1', attachments: null }], hasNextPage: false } })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
     expect(map.size).toBe(0)
   })
@@ -123,44 +166,52 @@ describe('LinearAttachmentResolver.resolve', () => {
 })
 
 describe('makeBatchedAttachmentQuery', () => {
-  it('wraps a LinearClient.graphql call with the batched-attachments query + ids variable', async () => {
+  it('wraps a LinearClient.graphql call with the batched-attachments query + per-team variables', async () => {
     const calls: Array<{ query: string; variables: Record<string, unknown> | undefined }> = []
     const client = {
       graphql: async (query: string, variables?: Record<string, unknown>) => {
         calls.push({ query, variables })
         return {
           issues: {
-            nodes: [
-              {
-                identifier: 'C-1',
-                attachments: { nodes: [{ id: 'a1', sourceType: 'github', url: 'https://github.com/x/y/pull/9' }] },
-              },
-            ],
+            pageInfo: { hasNextPage: false },
+            nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/9')])],
           },
         }
       },
     }
     const query = makeBatchedAttachmentQuery(client)
-    const nodes = await query(['C-1', 'C-2'])
+    const result = await query('C', [1, 2])
     expect(calls).toHaveLength(1)
     expect(calls[0]?.query).toBe(BATCHED_ATTACHMENTS_QUERY)
-    expect(calls[0]?.variables).toEqual({ ids: ['C-1', 'C-2'] })
-    expect(nodes).toHaveLength(1)
-    expect(nodes[0]?.identifier).toBe('C-1')
+    expect(calls[0]?.variables).toEqual({ teamKey: 'C', numbers: [1, 2], first: ATTACHMENT_PAGE_SIZE })
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0]?.identifier).toBe('C-1')
+    expect(result.hasNextPage).toBe(false)
   })
 
-  it('returns [] without calling graphql when the identifier list is empty', async () => {
+  it('returns empty + hasNextPage=false without calling graphql when numbers is empty', async () => {
     let called = 0
     const client = { graphql: async () => { called++; return null } }
-    const result = await makeBatchedAttachmentQuery(client)([])
-    expect(result).toEqual([])
+    const result = await makeBatchedAttachmentQuery(client)('C', [])
+    expect(result.nodes).toEqual([])
+    expect(result.hasNextPage).toBe(false)
     expect(called).toBe(0)
   })
 
-  it('returns [] when the graphql response is null or missing issues', async () => {
+  it('reads hasNextPage from the response pageInfo', async () => {
+    const client = {
+      graphql: async () => ({ issues: { pageInfo: { hasNextPage: true }, nodes: [] } }),
+    }
+    const result = await makeBatchedAttachmentQuery(client)('C', [1])
+    expect(result.hasNextPage).toBe(true)
+  })
+
+  it('returns empty + hasNextPage=false when the graphql response is null or missing issues', async () => {
     const nullClient = { graphql: async () => null }
-    expect(await makeBatchedAttachmentQuery(nullClient)(['C-1'])).toEqual([])
+    const r1 = await makeBatchedAttachmentQuery(nullClient)('C', [1])
+    expect(r1).toEqual({ nodes: [], hasNextPage: false })
     const emptyClient = { graphql: async () => ({ issues: null }) }
-    expect(await makeBatchedAttachmentQuery(emptyClient)(['C-1'])).toEqual([])
+    const r2 = await makeBatchedAttachmentQuery(emptyClient)('C', [1])
+    expect(r2).toEqual({ nodes: [], hasNextPage: false })
   })
 })

--- a/src/orchestrator/plugins/__tests__/linear-link.test.ts
+++ b/src/orchestrator/plugins/__tests__/linear-link.test.ts
@@ -4,6 +4,7 @@ import {
   makeBatchedAttachmentQuery,
   BATCHED_ATTACHMENTS_QUERY,
   ATTACHMENT_PAGE_SIZE,
+  prKey,
   type AttachmentQuery,
   type AttachmentQueryResult,
   type RawIssueWithAttachments,
@@ -29,13 +30,26 @@ function gh(url: string): { id: string; sourceType: string; url: string } {
 }
 
 describe('LinearAttachmentResolver.resolve', () => {
-  it('builds a map of "owner/repo#N" → [linear identifier] from github attachments', async () => {
+  it('builds a map of lowercase "owner/repo#N" → [linear identifier] from github attachments', async () => {
     const { fn } = stubQuery({
       C: { nodes: [issueNode('C-758', [gh('https://github.com/AvesAlight/roost/pull/495')])], hasNextPage: false },
     })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-758'])
-    expect(map.get('AvesAlight/roost#495')).toEqual(['C-758'])
+    expect(map.get('avesalight/roost#495')).toEqual(['C-758'])
     expect(map.size).toBe(1)
+  })
+
+  it('normalizes map keys via prKey so lookup is case-insensitive across GitHub sources', async () => {
+    const { fn } = stubQuery({
+      // Attachment URL uses canonical casing; gh CLI for the same repo could
+      // in principle return a different casing — the prKey helper makes the
+      // lookup safe either way.
+      C: { nodes: [issueNode('C-1', [gh('https://github.com/AvesAlight/Roost/pull/9')])], hasNextPage: false },
+    })
+    const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
+    expect(map.get(prKey('AvesAlight/Roost', 9))).toEqual(['C-1'])
+    expect(map.get(prKey('avesalight/roost', 9))).toEqual(['C-1'])
+    expect(map.get(prKey('AVESALIGHT/ROOST', 9))).toEqual(['C-1'])
   })
 
   it('ignores attachments with non-github sourceType', async () => {
@@ -79,7 +93,7 @@ describe('LinearAttachmentResolver.resolve', () => {
       },
     })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1', 'C-2'])
-    expect(map.get('x/y#42')).toEqual(['C-1', 'C-2'])
+    expect(map.get(prKey('x/y', 42))).toEqual(['C-1', 'C-2'])
   })
 
   it('dedups when the same Linear issue has multiple github attachments pointing at the same PR', async () => {
@@ -87,7 +101,7 @@ describe('LinearAttachmentResolver.resolve', () => {
       C: { nodes: [issueNode('C-1', [gh('https://github.com/x/y/pull/42'), gh('https://github.com/x/y/pull/42')])], hasNextPage: false },
     })
     const map = await new LinearAttachmentResolver(fn).resolve(['C-1'])
-    expect(map.get('x/y#42')).toEqual(['C-1'])
+    expect(map.get(prKey('x/y', 42))).toEqual(['C-1'])
   })
 
   it('skips the query entirely when the identifier list is empty', async () => {

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -185,14 +185,32 @@ describe('GitHubPrsPlugin.runTick', () => {
 describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
   stubRateLimit()
 
-  function plugin(query: ((ids: string[]) => Promise<Array<{ identifier: string; attachments: { nodes: Array<{ id: string; sourceType: string | null; url: string | null }> } | null }>>) | null): GitHubPrsPlugin {
+  type Attachment = { id: string; sourceType: string | null; url: string | null }
+  type IssueNode = { identifier: string; attachments: { nodes: Attachment[] } | null }
+  type QueryResult = { nodes: IssueNode[]; hasNextPage: boolean }
+  type QueryFn = (teamKey: string, numbers: number[]) => Promise<QueryResult>
+
+  function plugin(query: QueryFn | null): GitHubPrsPlugin {
     const p = new GitHubPrsPlugin('#proj')
     p._setLinearQueryForTest(query)
     return p
   }
 
-  function attachment(prUrl: string): { id: string; sourceType: string | null; url: string | null } {
+  function attachment(prUrl: string): Attachment {
     return { id: `att-${prUrl}`, sourceType: 'github', url: prUrl }
+  }
+
+  // Helper: build a query stub from a flat identifier-keyed map of attachments
+  // (test-side convenience — resolver does the team grouping internally).
+  function stubFromMap(byId: Record<string, Attachment[]>): QueryFn {
+    return async (team, numbers) => {
+      const nodes: IssueNode[] = []
+      for (const n of numbers) {
+        const id = `${team}-${n}`
+        if (byId[id] !== undefined) nodes.push({ identifier: id, attachments: { nodes: byId[id] } })
+      }
+      return { nodes, hasNextPage: false }
+    }
   }
 
   it('routes a PR event to the Linear-issue channel when an attachment matches the PR URL', async () => {
@@ -215,9 +233,9 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
           'linear-issues': { watched: [{ identifier: 'C-758' }] },
         },
       }
-      const result = await plugin(async () => [
-        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
-      ]).runTick(cfg, { prs: {} })
+      const result = await plugin(stubFromMap({
+        'C-758': [attachment('https://github.com/org/repo/pull/25')],
+      })).runTick(cfg, { prs: {} })
       expect(result.taggedEvents).toHaveLength(1)
       expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#proj-issue-25', '#proj-issue-c-758'])
       expect(result.channels).toContain('#proj-issue-c-758')
@@ -237,7 +255,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
     })
     try {
       let calls = 0
-      const queryFn = async () => { calls++; return [] }
+      const queryFn: QueryFn = async () => { calls++; return { nodes: [], hasNextPage: false } }
       const cfg: OrchestratorConfig = {
         project: 'proj', repo: 'org/repo',
         plugins: { 'github-prs': { watched: [{ number: 25 }] } },
@@ -270,8 +288,8 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
       }
       let attached = true
       const p = plugin(async () => attached
-        ? [{ identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } }]
-        : [{ identifier: 'C-758', attachments: { nodes: [] } }])
+        ? { nodes: [{ identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } }], hasNextPage: false }
+        : { nodes: [{ identifier: 'C-758', attachments: { nodes: [] } }], hasNextPage: false })
       const tick1 = await p.runTick(cfg, { prs: {} })
       expect(tick1.taggedEvents[0]?.channels).toContain('#proj-issue-c-758')
       attached = false
@@ -281,7 +299,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('issues exactly one Linear query per tick regardless of N watched PRs', async () => {
+  it('issues exactly one query per Linear team regardless of N watched PRs or N watched same-team identifiers', async () => {
     const ev: OrchestratorEvent = {
       kind: 'pr_review_comment',
       repo: 'org/repo', pr: 0, url: 'u',
@@ -294,10 +312,10 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
       events: [{ ...ev, pr: num } as OrchestratorEvent],
     }))
     try {
-      let calls = 0
-      const queryFn = async (ids: string[]) => {
-        calls++
-        return ids.map(id => ({ identifier: id, attachments: { nodes: [] } }))
+      const teamCalls: string[] = []
+      const queryFn: QueryFn = async (team) => {
+        teamCalls.push(team)
+        return { nodes: [], hasNextPage: false }
       }
       const cfg: OrchestratorConfig = {
         project: 'proj', repo: 'org/repo',
@@ -307,7 +325,36 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
         },
       }
       await plugin(queryFn).runTick(cfg, { prs: {} })
-      expect(calls).toBe(1)
+      expect(teamCalls).toEqual(['C'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('issues one query per distinct Linear team when watched identifiers span teams', async () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [ev],
+    })
+    try {
+      const teamCalls: string[] = []
+      const queryFn: QueryFn = async (team) => {
+        teamCalls.push(team)
+        return { nodes: [], hasNextPage: false }
+      }
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-1' }, { identifier: 'M-7' }, { identifier: 'C-2' }] },
+        },
+      }
+      await plugin(queryFn).runTick(cfg, { prs: {} })
+      expect(teamCalls.sort()).toEqual(['C', 'M'])
     } finally { spy.mockRestore() }
   })
 
@@ -330,10 +377,10 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
           'linear-issues': { watched: [{ identifier: 'C-1' }, { identifier: 'C-2' }] },
         },
       }
-      const result = await plugin(async () => [
-        { identifier: 'C-1', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
-        { identifier: 'C-2', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
-      ]).runTick(cfg, { prs: {} })
+      const result = await plugin(stubFromMap({
+        'C-1': [attachment('https://github.com/org/repo/pull/25')],
+        'C-2': [attachment('https://github.com/org/repo/pull/25')],
+      })).runTick(cfg, { prs: {} })
       expect(result.taggedEvents[0]?.channels.sort()).toEqual([
         '#proj-issue-25', '#proj-issue-c-1', '#proj-issue-c-2',
       ])
@@ -355,9 +402,9 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
           'linear-issues': { watched: [{ identifier: 'C-758' }] },
         },
       }
-      const result = await plugin(async () => [
-        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
-      ]).runTick(cfg, { prs: {} })
+      const result = await plugin(stubFromMap({
+        'C-758': [attachment('https://github.com/org/repo/pull/25')],
+      })).runTick(cfg, { prs: {} })
       expect(result.taggedEvents).toHaveLength(1)
       const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
       expect(text).toContain('#proj-issue-c-758')
@@ -379,9 +426,9 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
           'linear-issues': { watched: [{ identifier: 'C-758' }] },
         },
       }
-      const result = await plugin(async () => [
-        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
-      ]).runTick(cfg, { prs: {} })
+      const result = await plugin(stubFromMap({
+        'C-758': [attachment('https://github.com/org/repo/pull/25')],
+      })).runTick(cfg, { prs: {} })
       const warn = result.taggedEvents.find(e => (e.payload as { kind: string }).kind === 'oneline')
       expect(warn?.channels).toEqual(['#proj-leads'])
     } finally { spy.mockRestore() }

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -213,6 +213,36 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
     }
   }
 
+  it('matches cross-links case-insensitively (snap.repo casing may diverge from Linear attachment URL casing)', async () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'AvesAlight/Roost', pr: 9, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    // snap.repo is mixed-case; the Linear attachment URL is lowercase.
+    // Routing must still resolve because the prKey normalization lowercases
+    // both sides.
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'AvesAlight/Roost', number: 9 }),
+      events: [ev],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'AvesAlight/Roost',
+        plugins: {
+          'github-prs': { watched: [{ number: 9 }] },
+          'linear-issues': { watched: [{ identifier: 'C-1' }] },
+        },
+      }
+      const result = await plugin(stubFromMap({
+        'C-1': [attachment('https://github.com/avesalight/roost/pull/9')],
+      })).runTick(cfg, { prs: {} })
+      expect(result.taggedEvents[0]?.channels).toContain('#proj-issue-c-1')
+    } finally { spy.mockRestore() }
+  })
+
   it('routes a PR event to the Linear-issue channel when an attachment matches the PR URL', async () => {
     const commentEv: OrchestratorEvent = {
       kind: 'pr_review_comment',

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -182,6 +182,250 @@ describe('GitHubPrsPlugin.runTick', () => {
   })
 })
 
+describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
+  stubRateLimit()
+
+  function plugin(query: ((ids: string[]) => Promise<Array<{ identifier: string; attachments: { nodes: Array<{ id: string; sourceType: string | null; url: string | null }> } | null }>>) | null): GitHubPrsPlugin {
+    const p = new GitHubPrsPlugin('#proj')
+    p._setLinearQueryForTest(query)
+    return p
+  }
+
+  function attachment(prUrl: string): { id: string; sourceType: string | null; url: string | null } {
+    return { id: `att-${prUrl}`, sourceType: 'github', url: prUrl }
+  }
+
+  it('routes a PR event to the Linear-issue channel when an attachment matches the PR URL', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'https://github.com/org/repo/pull/25',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }),
+      events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      const result = await plugin(async () => [
+        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
+      ]).runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#proj-issue-25', '#proj-issue-c-758'])
+      expect(result.channels).toContain('#proj-issue-c-758')
+    } finally { spy.mockRestore() }
+  })
+
+  it('does not route to Linear when the linear-issues slice is absent (no resolver constructed)', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [commentEv],
+    })
+    try {
+      let calls = 0
+      const queryFn = async () => { calls++; return [] }
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await plugin(queryFn).runTick(cfg, { prs: {} })
+      expect(calls).toBe(0)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+      expect(result.channels).not.toContain('#proj-issue-c-758')
+    } finally { spy.mockRestore() }
+  })
+
+  it('stops routing to the Linear channel on the next tick when the attachment is removed', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      let attached = true
+      const p = plugin(async () => attached
+        ? [{ identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } }]
+        : [{ identifier: 'C-758', attachments: { nodes: [] } }])
+      const tick1 = await p.runTick(cfg, { prs: {} })
+      expect(tick1.taggedEvents[0]?.channels).toContain('#proj-issue-c-758')
+      attached = false
+      const tick2 = await p.runTick(cfg, tick1.state)
+      expect(tick2.taggedEvents[0]?.channels).not.toContain('#proj-issue-c-758')
+      expect(tick2.taggedEvents[0]?.channels).toContain('#proj-issue-25')
+    } finally { spy.mockRestore() }
+  })
+
+  it('issues exactly one Linear query per tick regardless of N watched PRs', async () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 0, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockImplementation(async (_repo: string, num: number) => ({
+      snap: fakePrSnap({ number: num }),
+      events: [{ ...ev, pr: num } as OrchestratorEvent],
+    }))
+    try {
+      let calls = 0
+      const queryFn = async (ids: string[]) => {
+        calls++
+        return ids.map(id => ({ identifier: id, attachments: { nodes: [] } }))
+      }
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 1 }, { number: 2 }, { number: 3 }, { number: 4 }] },
+          'linear-issues': { watched: [{ identifier: 'C-1' }, { identifier: 'C-2' }, { identifier: 'C-3' }] },
+        },
+      }
+      await plugin(queryFn).runTick(cfg, { prs: {} })
+      expect(calls).toBe(1)
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes to multiple Linear channels when a PR is attached to multiple Linear issues', async () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [ev],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-1' }, { identifier: 'C-2' }] },
+        },
+      }
+      const result = await plugin(async () => [
+        { identifier: 'C-1', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
+        { identifier: 'C-2', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
+      ]).runTick(cfg, { prs: {} })
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual([
+        '#proj-issue-25', '#proj-issue-c-1', '#proj-issue-c-2',
+      ])
+    } finally { spy.mockRestore() }
+  })
+
+  it('lists Linear channels in the pr_added_to_watch heads-up when only a Linear cross-link exists', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'pr_added_to_watch', repo: 'org/repo', pr: 25, url: 'u', title: 't',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      const result = await plugin(async () => [
+        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
+      ]).runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('#proj-issue-c-758')
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes pr_no_linked_issues to the project channel only, even when a Linear cross-link exists', async () => {
+    const warnEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues', repo: 'org/repo', pr: 25, url: 'u', title: 't',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [warnEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      const result = await plugin(async () => [
+        { identifier: 'C-758', attachments: { nodes: [attachment('https://github.com/org/repo/pull/25')] } },
+      ]).runTick(cfg, { prs: {} })
+      const warn = result.taggedEvents.find(e => (e.payload as { kind: string }).kind === 'oneline')
+      expect(warn?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('declares Linear channels in desiredChannels for every watched Linear identifier', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj', repo: 'org/repo',
+      plugins: {
+        'github-prs': { watched: [{ number: 25 }] },
+        'linear-issues': { watched: [{ identifier: 'C-1' }, { identifier: 'C-2' }] },
+      },
+    }
+    const p = new GitHubPrsPlugin('#proj')
+    const chans = p.desiredChannels(cfg)
+    expect(chans).toContain('#proj-issue-c-1')
+    expect(chans).toContain('#proj-issue-c-2')
+  })
+
+  it('degrades to github-only routing when the Linear query throws (best-effort)', async () => {
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_review_comment',
+      repo: 'org/repo', pr: 25, url: 'u',
+      author: 'alice', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'https://example.com/c/1',
+      linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      const result = await plugin(async () => { throw new Error('linear down') }).runTick(cfg, { prs: {} })
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+    } finally { spy.mockRestore() }
+  })
+})
+
 describe('GitHubIssuesPlugin.runTick', () => {
   stubRateLimit()
 

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -39,24 +39,18 @@ export class GitHubPrsPlugin extends GhBase {
   // Lazy — the resolver pulls `LINEAR_API_KEY` from env via LinearClient.
   // Deferring construction until a non-empty Linear watch set is observed keeps
   // dispatcher boot working when no Linear plugin is enabled. Tests inject via
-  // `_setLinearResolverForTest`.
+  // `_setLinearQueryForTest`.
   private _linearResolver: LinearAttachmentResolver | null = null
-  private _linearQueryOverride: AttachmentQuery | null = null
 
   // Test seam — wires an injected query function in place of the env-built
   // LinearClient. Used by github plugin tests that exercise cross-link routing
   // without standing up a real Linear API.
   _setLinearQueryForTest(query: AttachmentQuery | null): void {
-    this._linearQueryOverride = query
     this._linearResolver = query ? new LinearAttachmentResolver(query) : null
   }
 
   private getLinearResolver(): LinearAttachmentResolver {
     if (this._linearResolver) return this._linearResolver
-    if (this._linearQueryOverride) {
-      this._linearResolver = new LinearAttachmentResolver(this._linearQueryOverride)
-      return this._linearResolver
-    }
     const client = LinearClient.fromEnv(this.log)
     this._linearResolver = new LinearAttachmentResolver(makeBatchedAttachmentQuery(client))
     return this._linearResolver

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -8,7 +8,7 @@ import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
 import type { LinkedIssue, PrSnap, PrPluginState } from './types.js'
 import { LinearClient } from '../linear/linear-api.js'
-import { LinearAttachmentResolver, makeBatchedAttachmentQuery, type AttachmentQuery } from '../linear-link.js'
+import { LinearAttachmentResolver, makeBatchedAttachmentQuery, prKey, type AttachmentQuery } from '../linear-link.js'
 
 interface LinearIssuesSliceShape {
   watched?: Array<{ identifier?: unknown }>
@@ -46,13 +46,13 @@ export class GitHubPrsPlugin extends GhBase {
   // LinearClient. Used by github plugin tests that exercise cross-link routing
   // without standing up a real Linear API.
   _setLinearQueryForTest(query: AttachmentQuery | null): void {
-    this._linearResolver = query ? new LinearAttachmentResolver(query) : null
+    this._linearResolver = query ? new LinearAttachmentResolver(query, this.log) : null
   }
 
   private getLinearResolver(): LinearAttachmentResolver {
     if (this._linearResolver) return this._linearResolver
     const client = LinearClient.fromEnv(this.log)
-    this._linearResolver = new LinearAttachmentResolver(makeBatchedAttachmentQuery(client))
+    this._linearResolver = new LinearAttachmentResolver(makeBatchedAttachmentQuery(client), this.log)
     return this._linearResolver
   }
 
@@ -192,8 +192,10 @@ export class GitHubPrsPlugin extends GhBase {
       const { routable, dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
       for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
       // Linear cross-link channels for this PR. A PR can be attached to
-      // multiple Linear issues — all matched identifiers route.
-      const linearMatches = linkMap.get(`${snap.repo}#${snap.number}`) ?? []
+      // multiple Linear issues — all matched identifiers route. Key
+      // normalization (via prKey) guards against casing drift between
+      // gh CLI output and Linear's webhook-attachment URL.
+      const linearMatches = linkMap.get(prKey(snap.repo, snap.number)) ?? []
       const linearChannels = linearMatches.map(ident => linearIssueChannel(project, ident))
       for (const ch of linearChannels) channels.add(ch)
       // Cross-repo drop warning debounced per head_oid (force-push re-triggers).

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -1,20 +1,82 @@
 import type { OrchestratorConfig } from '../../config.js'
 import { resolveRepoEntry } from '../../config.js'
-import { channelSlug, defaultProject, isMultiRepo, issueChannel, resolveProjectChannel } from '../../naming.js'
+import { channelSlug, defaultProject, isMultiRepo, issueChannel, linearIssueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginLogger, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
 import type { LinkedIssue, PrSnap, PrPluginState } from './types.js'
+import { LinearClient } from '../linear/linear-api.js'
+import { LinearAttachmentResolver, makeBatchedAttachmentQuery, type AttachmentQuery } from '../linear-link.js'
+
+interface LinearIssuesSliceShape {
+  watched?: Array<{ identifier?: unknown }>
+}
+
+// Extract Linear identifiers from `config.plugins['linear-issues'].watched`.
+// Trusts the existing linear-issues parser to have validated shape on write;
+// defensive against operator hand-edits via the `typeof` filter.
+function linearWatchedIdentifiers(config: OrchestratorConfig): string[] {
+  const slice = config.plugins?.['linear-issues'] as LinearIssuesSliceShape | undefined
+  const entries = slice?.watched ?? []
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const e of entries) {
+    if (typeof e?.identifier !== 'string') continue
+    if (seen.has(e.identifier)) continue
+    seen.add(e.identifier)
+    out.push(e.identifier)
+  }
+  return out
+}
 
 export class GitHubPrsPlugin extends GhBase {
   readonly name = 'github-prs'
   protected readonly target = 'pr'
   protected readonly label = 'pr'
 
+  // Lazy — the resolver pulls `LINEAR_API_KEY` from env via LinearClient.
+  // Deferring construction until a non-empty Linear watch set is observed keeps
+  // dispatcher boot working when no Linear plugin is enabled. Tests inject via
+  // `_setLinearResolverForTest`.
+  private _linearResolver: LinearAttachmentResolver | null = null
+  private _linearQueryOverride: AttachmentQuery | null = null
+
+  // Test seam — wires an injected query function in place of the env-built
+  // LinearClient. Used by github plugin tests that exercise cross-link routing
+  // without standing up a real Linear API.
+  _setLinearQueryForTest(query: AttachmentQuery | null): void {
+    this._linearQueryOverride = query
+    this._linearResolver = query ? new LinearAttachmentResolver(query) : null
+  }
+
+  private getLinearResolver(): LinearAttachmentResolver {
+    if (this._linearResolver) return this._linearResolver
+    if (this._linearQueryOverride) {
+      this._linearResolver = new LinearAttachmentResolver(this._linearQueryOverride)
+      return this._linearResolver
+    }
+    const client = LinearClient.fromEnv(this.log)
+    this._linearResolver = new LinearAttachmentResolver(makeBatchedAttachmentQuery(client))
+    return this._linearResolver
+  }
+
   desiredChannels(config: OrchestratorConfig): string[] {
-    return this.entryChannels(config, this.watched(config))
+    const chans = new Set(this.entryChannels(config, this.watched(config)))
+    // Static, config-only — every watched Linear identifier maps to its own
+    // channel that github-prs may route events to. linear-issues already joins
+    // these but joining is idempotent; declaring interest keeps the boot-time
+    // channel union accurate.
+    const project = (() => {
+      try { return defaultProject(config) } catch { return null }
+    })()
+    if (project) {
+      for (const ident of linearWatchedIdentifiers(config)) {
+        chans.add(linearIssueChannel(project, ident))
+      }
+    }
+    return [...chans]
   }
 
   // Routable = same-repo in single-mode, everything in multi-mode. Dropped =
@@ -36,6 +98,9 @@ export class GitHubPrsPlugin extends GhBase {
 
   // Channels for a PR event: linked-issue channels (each slugged per its own
   // repo), project channel for no-linked-issues warnings, PR channel fallback.
+  // Linear channels (PRs cross-linked to Linear issues via attachments) are
+  // additive — appended to the github routing for every event with a `pr`
+  // number except the `pr_no_linked_issues` warning, which stays project-only.
   private static prEventChannels(
     config: OrchestratorConfig,
     project: string,
@@ -43,13 +108,17 @@ export class GitHubPrsPlugin extends GhBase {
     projectChannel: string,
     prRepo: string,
     routable: LinkedIssue[],
+    linearChannels: string[],
   ): string[] {
     if (event.pr == null) return []
     if (event.kind === 'pr_no_linked_issues') return [projectChannel]
     if (routable.length) {
-      return routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo)))
+      return [
+        ...routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo))),
+        ...linearChannels,
+      ]
     }
-    return [issueChannel(project, event.pr, channelSlug(config, prRepo))]
+    return [issueChannel(project, event.pr, channelSlug(config, prRepo)), ...linearChannels]
   }
 
   // Stderr-only — operator-visible in daemon.log without IRC noise.
@@ -65,6 +134,19 @@ export class GitHubPrsPlugin extends GhBase {
         `but dispatcher is single-mode on ${prRepo}; cross-repo closure not routed. ` +
         `add ${li.repo} to config or switch to multi-repo mode.\n`
       )
+    }
+  }
+
+  // Best-effort cross-link lookup. A Linear API failure (auth, rate-limit,
+  // network) returns an empty map rather than aborting the github tick —
+  // github routing degrades to today's behavior, with a stderr log.
+  private async resolveLinearCrossLinks(identifiers: string[]): Promise<Map<string, string[]>> {
+    try {
+      return await this.getLinearResolver().resolve(identifiers)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      this.log(`[github-prs] linear cross-link lookup failed (${identifiers.length} ids): ${msg}\n`)
+      return new Map()
     }
   }
 
@@ -91,6 +173,14 @@ export class GitHubPrsPlugin extends GhBase {
       return { key, snap, events, entryChannels }
     }))
 
+    // Cross-link lookup: one batched Linear query per tick, gated on a
+    // non-empty linear-issues watch set. Empty-watched is the load-bearing
+    // fast-path — no resolver constructed, no API call, no env-read.
+    const linearIds = linearWatchedIdentifiers(config)
+    const linkMap: Map<string, string[]> = linearIds.length
+      ? await this.resolveLinearCrossLinks(linearIds)
+      : new Map()
+
     const curState: PrPluginState = { prs: {} }
     const taggedEvents: TaggedEvent[] = []
     // Static (config) + dynamic (linked-issues from scrape). Each linked-issue
@@ -100,6 +190,11 @@ export class GitHubPrsPlugin extends GhBase {
       curState.prs[key] = snap
       const { routable, dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
       for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+      // Linear cross-link channels for this PR. A PR can be attached to
+      // multiple Linear issues — all matched identifiers route.
+      const linearMatches = linkMap.get(`${snap.repo}#${snap.number}`) ?? []
+      const linearChannels = linearMatches.map(ident => linearIssueChannel(project, ident))
+      for (const ch of linearChannels) channels.add(ch)
       // Cross-repo drop warning debounced per head_oid (force-push re-triggers).
       const prevWarnedOid = prev?.prs[key]?.warned_drops_for_oid ?? null
       if (dropped.length) {
@@ -111,10 +206,12 @@ export class GitHubPrsPlugin extends GhBase {
       for (const event of events) {
         if (event.kind === 'pr_added_to_watch') {
           const linked = event.linked_issues ?? []
-          // Suppress when no linked issues — pr_no_linked_issues already fires this tick.
-          if (linked.length) {
+          // Suppress only when there are neither github linked-issues nor
+          // Linear cross-links — pr_no_linked_issues already fires that tick.
+          // A Linear-only match is a real routing target and earns a heads-up.
+          if (linked.length || linearChannels.length) {
             const routingChannels = this.resolveChannels(
-              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable),
+              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels),
               entryChannels
             ).filter(ch => ch !== projectChannel)
             taggedEvents.push({
@@ -126,7 +223,7 @@ export class GitHubPrsPlugin extends GhBase {
         }
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels), entryChannels),
           payload: formatPayload(event),
         })
       }

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -62,6 +62,13 @@ export class GitHubPrsPlugin extends GhBase {
     // channel that github-prs may route events to. linear-issues already joins
     // these but joining is idempotent; declaring interest keeps the boot-time
     // channel union accurate.
+    //
+    // The try/catch around defaultProject is deliberate: desiredChannels runs
+    // at boot, where a misconfigured project would orphan every plugin's join
+    // list. linear-issues' own desiredChannels throws on the same misconfig
+    // with a clearer message, so silently degrading here is safe — the real
+    // error still surfaces. runTick (tick-time) calls defaultProject bare
+    // because by then the config has been validated by at least one boot pass.
     const project = (() => {
       try { return defaultProject(config) } catch { return null }
     })()

--- a/src/orchestrator/plugins/linear-link.ts
+++ b/src/orchestrator/plugins/linear-link.ts
@@ -16,6 +16,16 @@
 //   `pageInfo.hasNextPage`. A truthy hasNextPage means a team has > 250
 //   watched issues — a loud warn surfaces this growth case before silent loss.
 //
+// `sourceType: "github"` empirical note (verified 2026-05-21 via live probe):
+//   Attachments created by Linear's native GitHub integration carry
+//   `sourceType: "github"` — that's what this filter matches.
+//   Attachments created via the GraphQL `attachmentLinkGitHubPR` mutation
+//   carry `sourceType: "api"` and are intentionally excluded. `"api"` is
+//   Linear's generic "anything scripted via API" bucket, not "github via API"
+//   — widening the filter would risk pulling in unrelated future attachment
+//   shapes that happen to have a `pull/<N>` URL. The native integration is
+//   the authoritative source of truth for cross-link routing.
+//
 // Constructor takes an injectable query function so tests stub at the query
 // seam rather than mocking LinearClient wholesale.
 

--- a/src/orchestrator/plugins/linear-link.ts
+++ b/src/orchestrator/plugins/linear-link.ts
@@ -96,6 +96,12 @@ export function makeBatchedAttachmentQuery(client: LinearGraphqlSurface): Attach
   }
 }
 
+// Lowercase cross-link key — see resolve() doc-comment for the rationale.
+// Exported so the github-prs lookup site mirrors the same normalization.
+export function prKey(repo: string, number: number): string {
+  return `${repo.toLowerCase()}#${number}`
+}
+
 // Parse "<TEAM>-<N>" into its parts. Returns null on shapes that can't address
 // a Linear issue: missing dash, empty team segment, non-positive number.
 function parseLinearIdentifier(identifier: string): { team: string; number: number } | null {
@@ -117,10 +123,17 @@ export class LinearAttachmentResolver {
     }
   }
 
-  // Returns a map keyed on "owner/repo#N", values are Linear identifiers whose
-  // attachments include that PR. A single PR can be attached to multiple Linear
-  // issues — the value is a list (unique, insertion-ordered). Empty input
-  // skips the query entirely; empty server response returns an empty map.
+  // Returns a map keyed on lowercase "owner/repo#N", values are Linear
+  // identifiers whose attachments include that PR. A single PR can be attached
+  // to multiple Linear issues — the value is a list (unique,
+  // insertion-ordered). Empty input skips the query entirely; empty server
+  // response returns an empty map.
+  //
+  // Key is lowercased because the two sides of the cross-link come from
+  // independent GitHub sources (gh CLI for snap.repo, Linear's webhook for
+  // attachment URLs). Both are canonical from GitHub today, but GitHub treats
+  // repo names case-insensitively — `prKey()` below mirrors this normalization
+  // on the lookup side so casing drift can't silently break routing.
   //
   // Malformed identifiers (no `-`, empty team/number) are logged and skipped —
   // a typo in `watch linear` shouldn't poison the whole batch.
@@ -174,7 +187,7 @@ export class LinearAttachmentResolver {
           if (a.sourceType !== 'github') continue
           const parsed = parseGithubPrUrl(a.url)
           if (!parsed) continue
-          const key = `${parsed.repo}#${parsed.number}`
+          const key = prKey(parsed.repo, parsed.number)
           const list = map.get(key)
           if (list) {
             if (!list.includes(ident)) list.push(ident)

--- a/src/orchestrator/plugins/linear-link.ts
+++ b/src/orchestrator/plugins/linear-link.ts
@@ -9,10 +9,17 @@
 //      only land after GitHub recognizes the PR↔issue link, which makes
 //      attachments the deterministic cross-link source.
 //
-// Single batched query per tick (one round trip regardless of N watched
-// identifiers). Constructor takes an injectable query function so tests stub
-// at the query seam rather than mocking LinearClient wholesale.
+// Query shape (empirically verified against api.linear.app):
+//   IssueFilter has no `identifier` field — filter by `team.key + number.in`.
+//   One round trip per active team per tick (typically 1; M-teams = M trips).
+//   Each call requests `first: 250` (Linear's per-page max) and reads
+//   `pageInfo.hasNextPage`. A truthy hasNextPage means a team has > 250
+//   watched issues — a loud warn surfaces this growth case before silent loss.
+//
+// Constructor takes an injectable query function so tests stub at the query
+// seam rather than mocking LinearClient wholesale.
 
+import type { PluginLogger } from '../plugin.js'
 import { parseGithubPrUrl } from './linear/diff.js'
 
 // Thinner projection of `RawLinearAttachment` from `linear/diff.ts` — the
@@ -33,16 +40,27 @@ export interface RawIssueWithAttachments {
   attachments: { nodes: RawAttachmentNode[] } | null
 }
 
-export const BATCHED_ATTACHMENTS_QUERY = `query LinearAttachmentsBatch($ids: [String!]!) {
-  issues(filter: { identifier: { in: $ids } }) {
+export interface AttachmentQueryResult {
+  nodes: RawIssueWithAttachments[]
+  hasNextPage: boolean
+}
+
+// Per-team query. `numbers` is the slice of watched issue numbers in this team.
+export type AttachmentQuery = (teamKey: string, numbers: number[]) => Promise<AttachmentQueryResult>
+
+// Linear's per-page max. Above this we silently lose the tail without a guard
+// — the resolver logs a loud warn if a team's response paginates.
+export const ATTACHMENT_PAGE_SIZE = 250
+
+export const BATCHED_ATTACHMENTS_QUERY = `query LinearAttachmentsByTeam($teamKey: String!, $numbers: [Float!]!, $first: Int!) {
+  issues(filter: { team: { key: { eq: $teamKey } }, number: { in: $numbers } }, first: $first) {
+    pageInfo { hasNextPage }
     nodes {
       identifier
       attachments { nodes { id sourceType url } }
     }
   }
 }`
-
-export type AttachmentQuery = (identifiers: string[]) => Promise<RawIssueWithAttachments[]>
 
 // Minimal client surface for makeBatchedAttachmentQuery — matches LinearClient
 // and the LinearGraphqlSurface used by linear/scraper.ts.
@@ -51,18 +69,39 @@ export interface LinearGraphqlSurface {
 }
 
 export function makeBatchedAttachmentQuery(client: LinearGraphqlSurface): AttachmentQuery {
-  return async (identifiers: string[]) => {
-    if (!identifiers.length) return []
-    const data = (await client.graphql(BATCHED_ATTACHMENTS_QUERY, { ids: identifiers })) as
-      | { issues?: { nodes?: RawIssueWithAttachments[] } | null }
+  return async (teamKey, numbers) => {
+    if (!numbers.length) return { nodes: [], hasNextPage: false }
+    const data = (await client.graphql(BATCHED_ATTACHMENTS_QUERY, {
+      teamKey,
+      numbers,
+      first: ATTACHMENT_PAGE_SIZE,
+    })) as
+      | { issues?: { nodes?: RawIssueWithAttachments[]; pageInfo?: { hasNextPage?: boolean } } | null }
       | null
       | undefined
-    return data?.issues?.nodes ?? []
+    return {
+      nodes: data?.issues?.nodes ?? [],
+      hasNextPage: data?.issues?.pageInfo?.hasNextPage === true,
+    }
   }
 }
 
+// Parse "<TEAM>-<N>" into its parts. Returns null on shapes that can't address
+// a Linear issue: missing dash, empty team segment, non-positive number.
+function parseLinearIdentifier(identifier: string): { team: string; number: number } | null {
+  const dash = identifier.lastIndexOf('-')
+  if (dash <= 0) return null
+  const team = identifier.slice(0, dash)
+  const num = parseInt(identifier.slice(dash + 1), 10)
+  if (!team || !Number.isFinite(num) || num <= 0) return null
+  return { team, number: num }
+}
+
 export class LinearAttachmentResolver {
-  constructor(private readonly query: AttachmentQuery) {
+  constructor(
+    private readonly query: AttachmentQuery,
+    private readonly log: PluginLogger = () => {},
+  ) {
     if (typeof query !== 'function') {
       throw new Error('LinearAttachmentResolver: query function required')
     }
@@ -72,28 +111,66 @@ export class LinearAttachmentResolver {
   // attachments include that PR. A single PR can be attached to multiple Linear
   // issues — the value is a list (unique, insertion-ordered). Empty input
   // skips the query entirely; empty server response returns an empty map.
+  //
+  // Malformed identifiers (no `-`, empty team/number) are logged and skipped —
+  // a typo in `watch linear` shouldn't poison the whole batch.
   async resolve(identifiers: string[]): Promise<Map<string, string[]>> {
     if (!identifiers.length) return new Map()
-    const nodes = await this.query(identifiers)
+    const byTeam = new Map<string, number[]>()
+    for (const id of identifiers) {
+      const parsed = parseLinearIdentifier(id)
+      if (!parsed) {
+        this.log(`[linear-link] skipping malformed Linear identifier "${id}" — expected <TEAM>-<N>\n`)
+        continue
+      }
+      const numbers = byTeam.get(parsed.team)
+      if (numbers) numbers.push(parsed.number)
+      else byTeam.set(parsed.team, [parsed.number])
+    }
+    if (!byTeam.size) return new Map()
+
+    // Parallel per-team queries. The query shape can't batch across teams (the
+    // `team.key.eq` filter is per-call); M teams = M round trips. Typical case
+    // is M=1 in single-team workspaces.
+    const teamResults = await Promise.all(
+      [...byTeam.entries()].map(async ([team, numbers]) => ({
+        team,
+        result: await this.query(team, numbers),
+      })),
+    )
+
     const map = new Map<string, string[]>()
-    for (const issue of nodes) {
-      const ident = issue.identifier
-      if (!ident) continue
-      const atts = issue.attachments?.nodes ?? []
-      // Sister surface: `linear/diff.ts:selectGithubAttachments` runs the
-      // same `sourceType === 'github' && parseGithubPrUrl(url)` filter on the
-      // per-issue scraper path. Below the 3-surface canonicalize threshold;
-      // keep the two filters aligned when attachment shape evolves.
-      for (const a of atts) {
-        if (a.sourceType !== 'github') continue
-        const parsed = parseGithubPrUrl(a.url)
-        if (!parsed) continue
-        const key = `${parsed.repo}#${parsed.number}`
-        const list = map.get(key)
-        if (list) {
-          if (!list.includes(ident)) list.push(ident)
-        } else {
-          map.set(key, [ident])
+    for (const { team, result } of teamResults) {
+      if (result.hasNextPage) {
+        // Growth case: the team has > ATTACHMENT_PAGE_SIZE issues matching the
+        // number-in filter (or Linear paginated for another reason). The tail
+        // is silently dropped on this call — warn loudly so an operator
+        // notices before workers miss PR events.
+        this.log(
+          `[linear-link] WARN: team "${team}" attachment query paginated ` +
+          `(>${ATTACHMENT_PAGE_SIZE} matches) — Linear cross-link routing will miss the tail. ` +
+          `Reduce watched-issue count per team or bump ATTACHMENT_PAGE_SIZE.\n`,
+        )
+      }
+      for (const issue of result.nodes) {
+        const ident = issue.identifier
+        if (!ident) continue
+        const atts = issue.attachments?.nodes ?? []
+        // Sister surface: `linear/diff.ts:selectGithubAttachments` runs the
+        // same `sourceType === 'github' && parseGithubPrUrl(url)` filter on the
+        // per-issue scraper path. Below the 3-surface canonicalize threshold;
+        // keep the two filters aligned when attachment shape evolves.
+        for (const a of atts) {
+          if (a.sourceType !== 'github') continue
+          const parsed = parseGithubPrUrl(a.url)
+          if (!parsed) continue
+          const key = `${parsed.repo}#${parsed.number}`
+          const list = map.get(key)
+          if (list) {
+            if (!list.includes(ident)) list.push(ident)
+          } else {
+            map.set(key, [ident])
+          }
         }
       }
     }

--- a/src/orchestrator/plugins/linear-link.ts
+++ b/src/orchestrator/plugins/linear-link.ts
@@ -15,12 +15,19 @@
 
 import { parseGithubPrUrl } from './linear/diff.js'
 
+// Thinner projection of `RawLinearAttachment` from `linear/diff.ts` — the
+// batched attachments query doesn't request `title` so the runtime shape is
+// narrower. Sister surface for the github-attachment filter lives in
+// `selectGithubAttachments`; keep the two in sync on attachment-shape tweaks.
 export interface RawAttachmentNode {
   id: string
   sourceType: string | null
   url: string | null
 }
 
+// Partial-issue projection — only `identifier` + `attachments`, distinct from
+// `RawLinearIssue` (which carries title/state/labels/comments for the per-issue
+// scraper).
 export interface RawIssueWithAttachments {
   identifier: string
   attachments: { nodes: RawAttachmentNode[] } | null
@@ -73,6 +80,10 @@ export class LinearAttachmentResolver {
       const ident = issue.identifier
       if (!ident) continue
       const atts = issue.attachments?.nodes ?? []
+      // Sister surface: `linear/diff.ts:selectGithubAttachments` runs the
+      // same `sourceType === 'github' && parseGithubPrUrl(url)` filter on the
+      // per-issue scraper path. Below the 3-surface canonicalize threshold;
+      // keep the two filters aligned when attachment shape evolves.
       for (const a of atts) {
         if (a.sourceType !== 'github') continue
         const parsed = parseGithubPrUrl(a.url)

--- a/src/orchestrator/plugins/linear-link.ts
+++ b/src/orchestrator/plugins/linear-link.ts
@@ -1,0 +1,91 @@
+// Cross-link resolver: Linear `Issue.attachments` → "owner/repo#N" → Linear
+// identifiers. github-prs uses this to add Linear-issue channels to its event
+// routing when a watched Linear issue has a github attachment for the PR.
+//
+// gitBranchName rejected as a cross-link source:
+//   1. Linear's branch template is per-issue/per-workspace overridable, so
+//      a `feature/<team>-<N>-…` regex match isn't load-bearing.
+//   2. A branch can exist before the PR opens (timing-unreliable); attachments
+//      only land after GitHub recognizes the PR↔issue link, which makes
+//      attachments the deterministic cross-link source.
+//
+// Single batched query per tick (one round trip regardless of N watched
+// identifiers). Constructor takes an injectable query function so tests stub
+// at the query seam rather than mocking LinearClient wholesale.
+
+import { parseGithubPrUrl } from './linear/diff.js'
+
+export interface RawAttachmentNode {
+  id: string
+  sourceType: string | null
+  url: string | null
+}
+
+export interface RawIssueWithAttachments {
+  identifier: string
+  attachments: { nodes: RawAttachmentNode[] } | null
+}
+
+export const BATCHED_ATTACHMENTS_QUERY = `query LinearAttachmentsBatch($ids: [String!]!) {
+  issues(filter: { identifier: { in: $ids } }) {
+    nodes {
+      identifier
+      attachments { nodes { id sourceType url } }
+    }
+  }
+}`
+
+export type AttachmentQuery = (identifiers: string[]) => Promise<RawIssueWithAttachments[]>
+
+// Minimal client surface for makeBatchedAttachmentQuery — matches LinearClient
+// and the LinearGraphqlSurface used by linear/scraper.ts.
+export interface LinearGraphqlSurface {
+  graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>
+}
+
+export function makeBatchedAttachmentQuery(client: LinearGraphqlSurface): AttachmentQuery {
+  return async (identifiers: string[]) => {
+    if (!identifiers.length) return []
+    const data = (await client.graphql(BATCHED_ATTACHMENTS_QUERY, { ids: identifiers })) as
+      | { issues?: { nodes?: RawIssueWithAttachments[] } | null }
+      | null
+      | undefined
+    return data?.issues?.nodes ?? []
+  }
+}
+
+export class LinearAttachmentResolver {
+  constructor(private readonly query: AttachmentQuery) {
+    if (typeof query !== 'function') {
+      throw new Error('LinearAttachmentResolver: query function required')
+    }
+  }
+
+  // Returns a map keyed on "owner/repo#N", values are Linear identifiers whose
+  // attachments include that PR. A single PR can be attached to multiple Linear
+  // issues — the value is a list (unique, insertion-ordered). Empty input
+  // skips the query entirely; empty server response returns an empty map.
+  async resolve(identifiers: string[]): Promise<Map<string, string[]>> {
+    if (!identifiers.length) return new Map()
+    const nodes = await this.query(identifiers)
+    const map = new Map<string, string[]>()
+    for (const issue of nodes) {
+      const ident = issue.identifier
+      if (!ident) continue
+      const atts = issue.attachments?.nodes ?? []
+      for (const a of atts) {
+        if (a.sourceType !== 'github') continue
+        const parsed = parseGithubPrUrl(a.url)
+        if (!parsed) continue
+        const key = `${parsed.repo}#${parsed.number}`
+        const list = map.get(key)
+        if (list) {
+          if (!list.includes(ident)) list.push(ident)
+        } else {
+          map.set(key, [ident])
+        }
+      }
+    }
+    return map
+  }
+}


### PR DESCRIPTION
Closes #495

Slice 4 of 0.8.0. `github-prs` reads `config.plugins['linear-issues'].watched` and, when non-empty, runs one batched `issues(filter:{identifier:{in:[…]}})` query per tick to resolve Linear-attachment → PR cross-links. Matched PRs route to the Linear-issue channel (`#<project>-issue-<id>`) in addition to existing github destinations.

## Shape

- `src/orchestrator/plugins/linear-link.ts` — new helper. `LinearAttachmentResolver(query)` returns `Map<"owner/repo#N", linearIdentifier[]>` (plural — a single PR can be attached to multiple Linear issues). `makeBatchedAttachmentQuery(client)` adapts a `LinearClient`-like surface; tests inject a stub.
- `src/orchestrator/plugins/github/prs-plugin.ts` — reads the linear-issues watch slice, lazy-builds the resolver, threads Linear channels into `prEventChannels`, `pr_added_to_watch` heads-up, and `desiredChannels`. Empty-watched short-circuits before any Linear API touch — load-bearing for no-linear configs.

## Design decisions

- **`Issue.attachments` only, never `gitBranchName`.** Branch templates are per-issue/per-workspace overridable, and a branch can exist before the PR opens; attachments land deterministically when GitHub recognizes the link. Both reasons captured in the helper's doc comment so the next maintainer doesn't reach for the regex route.
- **Linear routing is additive.** Linear channels are appended to github's existing routing — github behavior is unchanged when no Linear watches exist.
- **`pr_no_linked_issues` stays project-only.** It's a github-routing concern; a Linear-tracked PR closing no github issue is the expected case and shouldn't fire the warning into Linear channels.
- **Best-effort.** A Linear API failure (auth, rate-limit, network) logs to stderr and degrades to github-only routing rather than aborting the github tick.
- **Per-plugin Linear client.** A 4th `LinearClient` instance, independent rate-limit telemetry. Followup candidate: consolidate behind a shared singleton (flagged in plan v2).

## Tests

- `src/orchestrator/plugins/__tests__/linear-link.test.ts` (10 tests): map shape, non-github filter, malformed-URL filter, multi-issue dedup, intra-issue dedup, empty-input short-circuit, single-batch-call assertion, null-attachments, ctor guard, query wrapper.
- `src/orchestrator/plugins/github/__tests__/plugin.test.ts` — new `Linear attachment cross-link` describe block (9 tests): basic routing, no-linear-slice no-op (asserts zero query calls), attachment-removed-stops-routing, one-query-per-tick across N PRs, multi-Linear-issue routing, heads-up listing, `pr_no_linked_issues` unchanged, `desiredChannels` declaration, throw-degrades-gracefully.

Full suite: 866/866 pass.

## Test plan

- [ ] Live probe before flipping ready (hard gate per §#449): three verbatim Linear API responses to verify batched query shape, `sourceType=='github'` populates as documented, attachment-removal disappears from next query.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)