### PR TITLE
maint: bump dispatcher tick interval 10s → 30s

### DIFF
--- a/.orchestrator/config.json
+++ b/.orchestrator/config.json
@@ -7,7 +7,7 @@
     "project_channel": "#roost-leads",
     "server": "127.0.0.1",
     "port": 6667,
-    "interval_seconds": 10
+    "interval_seconds": 30
   },
   "plugins": {
     "github-new-issues": { "watched": [{ "repo": "AvesAlight/roost" }] },


### PR DESCRIPTION
## Summary

- GH API rate limits exceeded under 10s polling in production (see `[dispatcher_error]` cascade in `#roost-leads`).
- 30s triples the budget headroom while keeping signal responsiveness fine for normal workflow events.

Filed urgently as live dispatcher is currently in 403-loop.

## Test plan

- [ ] After merge, restart dispatcher and confirm rate-limit errors stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)