### PR TITLE
refactor: extract observeRateLimitFromInfo helper across plugin bases

### DIFF
--- a/src/orchestrator/plugins/__tests__/rate-limit-helper.test.ts
+++ b/src/orchestrator/plugins/__tests__/rate-limit-helper.test.ts
@@ -111,7 +111,6 @@ describe('observeRateLimitFromInfo — cooldown gate', () => {
     expect(first.events).toHaveLength(1)
 
     // Second call immediately after: same statics, warnedAt is set → no event
-    const seed2 = [...first.history, { remaining: 5000, ts: now - 160_000 }].filter(h => h.ts >= now - RATE_LIMIT_WINDOW_MS)
     const second = observeRateLimitFromInfo(info(80, 60 * 60_000), first.history, s, noop, '#proj', 'GH', now + 1_000)
     expect(second.events).toHaveLength(0)
   })

--- a/src/orchestrator/plugins/__tests__/rate-limit-helper.test.ts
+++ b/src/orchestrator/plugins/__tests__/rate-limit-helper.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'bun:test'
+import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, RATE_LIMIT_WINDOW_MS, type RateLimitStatics } from '../_rate-limit.js'
+import type { RateLimitInfo } from '../_rate-limit.js'
+
+const noop = () => {}
+
+function statics(): RateLimitStatics {
+  return { warnedAt: null }
+}
+
+function info(remaining: number, resetInMs = 60 * 60_000): RateLimitInfo {
+  return {
+    remaining,
+    limit: 5000,
+    resetAt: Math.floor((Date.now() + resetInMs) / 1000),
+  }
+}
+
+// ---- arg validation -------------------------------------------------------
+
+describe('observeRateLimitFromInfo — arg validation', () => {
+  it('throws on null info', () => {
+    expect(() =>
+      observeRateLimitFromInfo(null as unknown as RateLimitInfo, [], statics(), noop, '#proj', 'GH')
+    ).toThrow('observeRateLimitFromInfo: info must be a valid RateLimitInfo')
+  })
+
+  it('throws on info with non-numeric remaining', () => {
+    expect(() =>
+      observeRateLimitFromInfo({ remaining: 'x', limit: 5000, resetAt: 0 } as unknown as RateLimitInfo, [], statics(), noop, '#proj', 'GH')
+    ).toThrow('observeRateLimitFromInfo: info must be a valid RateLimitInfo')
+  })
+
+  it('throws on empty projectChannel', () => {
+    expect(() =>
+      observeRateLimitFromInfo(info(5000), [], statics(), noop, '', 'GH')
+    ).toThrow('observeRateLimitFromInfo: projectChannel is required')
+  })
+
+  it('throws on empty tag', () => {
+    expect(() =>
+      observeRateLimitFromInfo(info(5000), [], statics(), noop, '#proj', '')
+    ).toThrow('observeRateLimitFromInfo: tag is required')
+  })
+})
+
+// ---- history management ---------------------------------------------------
+
+describe('observeRateLimitFromInfo — history', () => {
+  it('appends current sample to returned history', () => {
+    const now = Date.now()
+    const { history } = observeRateLimitFromInfo(info(5000), [], statics(), noop, '#proj', 'GH', now)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toEqual({ remaining: 5000, ts: now })
+  })
+
+  it('prunes stale entries from history', () => {
+    const now = Date.now()
+    const stale = { remaining: 5000, ts: now - RATE_LIMIT_WINDOW_MS - 1 }
+    const fresh = { remaining: 4800, ts: now - 60_000 }
+    const { history } = observeRateLimitFromInfo(info(4700), [stale, fresh], statics(), noop, '#proj', 'GH', now)
+    expect(history.some(h => h.ts === stale.ts)).toBe(false)
+    expect(history.some(h => h.ts === fresh.ts)).toBe(true)
+  })
+})
+
+// ---- warning emission -----------------------------------------------------
+
+describe('observeRateLimitFromInfo — warning emission', () => {
+  it('no events on cold start (empty history)', () => {
+    const { events } = observeRateLimitFromInfo(info(5000), [], statics(), noop, '#proj', 'GH')
+    expect(events).toEqual([])
+  })
+
+  it('no events when consumption rate is safe', () => {
+    const now = Date.now()
+    // 5000 → 4800 in 300s = 40/min. 4800 remaining at 40/min = 120 min to exhaust; reset in 60 min. safe.
+    const seed = [{ remaining: 5000, ts: now - 300_000 }]
+    const { events } = observeRateLimitFromInfo(info(4800, 60 * 60_000), seed, statics(), noop, '#proj', 'GH', now)
+    expect(events).toEqual([])
+  })
+
+  it('emits warning event when rolling rate predicts exhaustion before reset', () => {
+    const now = Date.now()
+    // 5000 → 100 in 160s → very high burn rate → warns
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const { events } = observeRateLimitFromInfo(info(100, 60 * 60_000), seed, statics(), noop, '#proj', 'GH', now)
+    expect(events).toHaveLength(1)
+    expect(events[0]?.channels).toEqual(['#proj'])
+    expect((events[0]?.payload as { text: string }).text).toMatch(/rate limit warning/)
+    expect((events[0]?.payload as { text: string }).text).toContain('GH')
+  })
+
+  it('uses tag in log line', () => {
+    const now = Date.now()
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const lines: string[] = []
+    observeRateLimitFromInfo(info(100, 60 * 60_000), seed, statics(), msg => lines.push(msg), '#proj', 'MyAPI', now)
+    expect(lines.some(l => l.includes('myapi remaining='))).toBe(true)
+  })
+})
+
+// ---- cooldown gate --------------------------------------------------------
+
+describe('observeRateLimitFromInfo — cooldown gate', () => {
+  it('does not re-emit within cooldown window', () => {
+    const now = Date.now()
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const s = statics()
+    const first = observeRateLimitFromInfo(info(100, 60 * 60_000), seed, s, noop, '#proj', 'GH', now)
+    expect(first.events).toHaveLength(1)
+
+    // Second call immediately after: same statics, warnedAt is set → no event
+    const seed2 = [...first.history, { remaining: 5000, ts: now - 160_000 }].filter(h => h.ts >= now - RATE_LIMIT_WINDOW_MS)
+    const second = observeRateLimitFromInfo(info(80, 60 * 60_000), first.history, s, noop, '#proj', 'GH', now + 1_000)
+    expect(second.events).toHaveLength(0)
+  })
+
+  it('re-emits after cooldown elapses', () => {
+    const now = Date.now()
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const s = statics()
+    const first = observeRateLimitFromInfo(info(100, 60 * 60_000), seed, s, noop, '#proj', 'GH', now)
+    expect(first.events).toHaveLength(1)
+
+    const later = now + WARN_COOLDOWN_MS + 1_000
+    const seed2 = [{ remaining: 5000, ts: later - 160_000 }]
+    const second = observeRateLimitFromInfo(info(100, 60 * 60_000), seed2, s, noop, '#proj', 'GH', later)
+    expect(second.events).toHaveLength(1)
+  })
+
+  it('updates statics.warnedAt when emitting', () => {
+    const now = Date.now()
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const s = statics()
+    expect(s.warnedAt).toBeNull()
+    observeRateLimitFromInfo(info(100, 60 * 60_000), seed, s, noop, '#proj', 'GH', now)
+    expect(s.warnedAt).toBe(now)
+  })
+
+  it('independent statics handles gate independently', () => {
+    const now = Date.now()
+    const seed = [{ remaining: 5000, ts: now - 160_000 }]
+    const s1 = statics()
+    const s2 = statics()
+    observeRateLimitFromInfo(info(100, 60 * 60_000), seed, s1, noop, '#proj', 'GH', now)
+    // s2 not yet warned — should still emit
+    const { events } = observeRateLimitFromInfo(info(100, 60 * 60_000), seed, s2, noop, '#proj', 'Linear', now)
+    expect(events).toHaveLength(1)
+  })
+})

--- a/src/orchestrator/plugins/_rate-limit.ts
+++ b/src/orchestrator/plugins/_rate-limit.ts
@@ -1,6 +1,8 @@
 // Shared rate-limit budget predictor — same math for any API that exposes
 // (remaining, limit, resetAt) telemetry. Pure functional util; no I/O.
 
+import type { PluginLogger, TaggedEvent } from '../plugin.js'
+
 export interface RateLimitInfo {
   remaining: number
   limit: number
@@ -9,6 +11,15 @@ export interface RateLimitInfo {
 
 // 5 minute rolling window — stable cross-tick average without missing spikes.
 export const RATE_LIMIT_WINDOW_MS = 5 * 60_000
+
+// Cross-instance warning cooldown: one warning per 10 min per statics handle.
+export const WARN_COOLDOWN_MS = 10 * 60_000
+
+// Mutable handle passed by reference — one per plugin class so GH and Linear
+// warning cooldowns stay independent. Initialized as `{ warnedAt: null }`.
+export interface RateLimitStatics {
+  warnedAt: number | null
+}
 
 // Returns a warning string when the rolling rate predicts exhaustion before
 // reset; null otherwise. `history` is window-pruned by the caller, oldest first.
@@ -42,4 +53,47 @@ export function computeRateLimitWarning(
     ` current rate ~${Math.round(ratePerMin)}/min —` +
     ` projected exhaustion in ${exhaustionStr}`
   )
+}
+
+// End-of-tick rate-limit observation shared across plugin bases.
+// Trims history to the rolling window, logs current budget, emits a cooldown-
+// gated IRC warning event when the rolling rate predicts exhaustion before reset.
+// Returns updated history (caller reassigns its instance field) and any events.
+export function observeRateLimitFromInfo(
+  info: RateLimitInfo,
+  history: ReadonlyArray<{ remaining: number; ts: number }>,
+  statics: RateLimitStatics,
+  log: PluginLogger,
+  projectChannel: string,
+  tag: string,
+  now = Date.now(),
+): { events: TaggedEvent[]; history: Array<{ remaining: number; ts: number }> } {
+  if (!info || typeof info.remaining !== 'number' || typeof info.limit !== 'number' || typeof info.resetAt !== 'number') {
+    throw new Error('observeRateLimitFromInfo: info must be a valid RateLimitInfo')
+  }
+  if (!projectChannel) throw new Error('observeRateLimitFromInfo: projectChannel is required')
+  if (!tag) throw new Error('observeRateLimitFromInfo: tag is required')
+
+  const cutoff = now - RATE_LIMIT_WINDOW_MS
+  const trimmed = history.filter(h => h.ts >= cutoff)
+
+  const prev = trimmed.length > 0 ? trimmed[trimmed.length - 1] : null
+  const delta = prev != null ? prev.remaining - info.remaining : null
+  const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
+  const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
+  log(`[ratelimit] ${tag.toLowerCase()} remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
+
+  const warning = computeRateLimitWarning(info, trimmed, now, tag)
+  const updatedHistory = [...trimmed, { remaining: info.remaining, ts: now }]
+
+  if (!warning) return { events: [], history: updatedHistory }
+
+  const cooldownElapsed = statics.warnedAt == null || now - statics.warnedAt > WARN_COOLDOWN_MS
+  if (!cooldownElapsed) return { events: [], history: updatedHistory }
+
+  statics.warnedAt = now
+  return {
+    events: [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }],
+    history: updatedHistory,
+  }
 }

--- a/src/orchestrator/plugins/_rate-limit.ts
+++ b/src/orchestrator/plugins/_rate-limit.ts
@@ -1,5 +1,6 @@
-// Shared rate-limit budget predictor — same math for any API that exposes
-// (remaining, limit, resetAt) telemetry. Pure functional util; no I/O.
+// Shared rate-limit utilities for any API that exposes (remaining, limit, resetAt) telemetry.
+// computeRateLimitWarning is pure. observeRateLimitFromInfo logs via its PluginLogger arg
+// and mutates the caller-supplied RateLimitStatics handle.
 
 import type { PluginLogger, TaggedEvent } from '../plugin.js'
 

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -6,7 +6,7 @@ import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, t
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { tryClaimPerN, type PerNCommand } from '../grammar.js'
 import { GhClient, fetchRateLimit } from './github-api.js'
-import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../_rate-limit.js'
+import { observeRateLimitFromInfo, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
 
 // Shared base for plugins needing GhClient. GhBase extends this for watch-list
 // scaffolding; non-watching plugins (e.g. GitHubNewIssuesPlugin) extend directly.
@@ -16,10 +16,8 @@ export abstract class GhPluginBase extends BasePlugin {
 
   private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
 
-  // Cross-instance — one warning per 10 min total. 60-min reset window means
-  // ~6 signals max, enough without spamming.
-  private static _warnedAt: number | null = null
-  private static readonly WARN_COOLDOWN_MS = 10 * 60_000
+  // Cross-instance cooldown handle — one warning per 10 min total.
+  private static readonly _statics: RateLimitStatics = { warnedAt: null }
 
   constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
     super(defaultChannel)
@@ -40,28 +38,9 @@ export abstract class GhPluginBase extends BasePlugin {
   ): Promise<TaggedEvent[]> {
     const info = await _fetch(this.log)
     if (!info) return []
-
-    const now = Date.now()
-    const cutoff = now - RATE_LIMIT_WINDOW_MS
-    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
-
-    const prev = this._rateLimitHistory.length > 0
-      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
-      : null
-    const delta = prev != null ? prev.remaining - info.remaining : null
-    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
-    const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
-    this.log(`[ratelimit] remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
-
-    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now, 'GH')
-    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
-    if (!warning) return []
-
-    const cooldownElapsed = GhPluginBase._warnedAt == null || now - GhPluginBase._warnedAt > GhPluginBase.WARN_COOLDOWN_MS
-    if (!cooldownElapsed) return []
-
-    GhPluginBase._warnedAt = now
-    return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
+    const { events, history } = observeRateLimitFromInfo(info, this._rateLimitHistory, GhPluginBase._statics, this.log, projectChannel, 'GH')
+    this._rateLimitHistory = history
+    return events
   }
 }
 

--- a/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
@@ -5,6 +5,7 @@ import type { Command } from '../../../dispatcher-dm-handler.js'
 import type { LinearIssuePluginState, LinearIssueSnap, LinearIssueTombstone } from '../types.js'
 import { isTombstone } from '../types.js'
 import type { RawLinearIssue } from '../diff.js'
+import { RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../../_rate-limit.js'
 
 // ---- Test scaffolding ----------------------------------------------------
 
@@ -297,5 +298,59 @@ describe('isTombstone helper', () => {
     expect(isTombstone(tomb)).toBe(true)
     expect(isTombstone(null)).toBe(false)
     expect(isTombstone(undefined)).toBe(false)
+  })
+})
+
+// ---- rate-limit observation -----------------------------------------------
+
+function rlClient(rl: RateLimitInfo | null): LinearClientLike {
+  return {
+    graphql: async () => ({ issue: null }),
+    getLastRateLimit: () => rl,
+  }
+}
+
+function rlInfo(remaining: number, resetInMs = 60 * 60_000): RateLimitInfo {
+  return {
+    remaining,
+    limit: 2500,
+    resetAt: Math.floor((Date.now() + resetInMs) / 1000),
+  }
+}
+
+describe('LinearIssuesPlugin.observeRateLimit — warning emission', () => {
+  it('emits a warning when rolling rate predicts exhaustion before reset', () => {
+    const p = plugin(rlClient(rlInfo(100)))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(p as any)._rateLimitHistory = [
+      { remaining: 2500, ts: Date.now() - 160_000 },
+    ]
+    const events = (p as any).observeRateLimit('#proj-leads')
+    const warnings = events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]?.channels).toEqual(['#proj-leads'])
+    expect(warnings[0]?.payload.text).toContain('Linear')
+  })
+
+  it('no warning on cold start (empty history)', () => {
+    const p = plugin(rlClient(rlInfo(100)))
+    const events = (p as any).observeRateLimit('#proj-leads')
+    expect(events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))).toHaveLength(0)
+  })
+
+  it('no warning when getLastRateLimit returns null', () => {
+    const p = plugin(rlClient(null))
+    const events = (p as any).observeRateLimit('#proj-leads')
+    expect(events).toEqual([])
+  })
+
+  it('prunes stale history — no warning after a long gap', () => {
+    const p = plugin(rlClient(rlInfo(100)))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(p as any)._rateLimitHistory = [
+      { remaining: 2500, ts: Date.now() - RATE_LIMIT_WINDOW_MS - 10_000 },
+    ]
+    const events = (p as any).observeRateLimit('#proj-leads')
+    expect(events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))).toHaveLength(0)
   })
 })

--- a/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/issues-plugin.test.ts
@@ -325,6 +325,7 @@ describe('LinearIssuesPlugin.observeRateLimit — warning emission', () => {
     ;(p as any)._rateLimitHistory = [
       { remaining: 2500, ts: Date.now() - 160_000 },
     ]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events = (p as any).observeRateLimit('#proj-leads')
     const warnings = events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))
     expect(warnings).toHaveLength(1)
@@ -334,12 +335,14 @@ describe('LinearIssuesPlugin.observeRateLimit — warning emission', () => {
 
   it('no warning on cold start (empty history)', () => {
     const p = plugin(rlClient(rlInfo(100)))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events = (p as any).observeRateLimit('#proj-leads')
     expect(events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))).toHaveLength(0)
   })
 
   it('no warning when getLastRateLimit returns null', () => {
     const p = plugin(rlClient(null))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events = (p as any).observeRateLimit('#proj-leads')
     expect(events).toEqual([])
   })
@@ -350,6 +353,7 @@ describe('LinearIssuesPlugin.observeRateLimit — warning emission', () => {
     ;(p as any)._rateLimitHistory = [
       { remaining: 2500, ts: Date.now() - RATE_LIMIT_WINDOW_MS - 10_000 },
     ]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events = (p as any).observeRateLimit('#proj-leads')
     expect(events.filter((e: { payload: { text?: string } }) => e.payload.text?.includes('rate limit warning'))).toHaveLength(0)
   })

--- a/src/orchestrator/plugins/linear/issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/issues-plugin.ts
@@ -11,7 +11,7 @@ import {
 } from '../../plugin.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { tryClaimPerLinearId, type PerLinearIdCommand } from '../grammar.js'
-import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../_rate-limit.js'
+import { observeRateLimitFromInfo, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
 import { LinearClient } from './linear-api.js'
 import { LinearScraper } from './scraper.js'
 import { formatLinearPayload } from './format.js'
@@ -34,11 +34,8 @@ export class LinearIssuesPlugin extends BasePlugin {
   private _client: LinearClientLike | null
   private _envClient: LinearClient | null = null
 
-  // Rate-limit warning state — mirrors GhPluginBase. History is per-instance;
-  // the warn-cooldown is static so multi-plugin Linear futures don't double-warn.
   private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
-  private static _warnedAt: number | null = null
-  private static readonly WARN_COOLDOWN_MS = 10 * 60_000
+  private static readonly _statics: RateLimitStatics = { warnedAt: null }
 
   constructor(
     defaultChannel: string,
@@ -218,36 +215,14 @@ export class LinearIssuesPlugin extends BasePlugin {
   }
 
   // End-of-tick threshold check — reads `getLastRateLimit()` from the client
-  // (already populated by spawnLinear on each successful call). Mirrors
-  // `GhPluginBase.observeRateLimit`: history ring, projection via
-  // computeRateLimitWarning, cooldown-gated emit. Only called after a
+  // (already populated by each successful call). Only called after a
   // watched-entry tick, so `getClient()` is guaranteed to have been seeded.
   protected observeRateLimit(projectChannel: string): TaggedEvent[] {
     const info = this.getClient().getLastRateLimit()
     if (!info) return []
-
-    const now = Date.now()
-    const cutoff = now - RATE_LIMIT_WINDOW_MS
-    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
-
-    const prev = this._rateLimitHistory.length > 0
-      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
-      : null
-    const delta = prev != null ? prev.remaining - info.remaining : null
-    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
-    const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
-    this.log(`[ratelimit] linear: remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
-
-    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now, 'Linear')
-    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
-    if (!warning) return []
-
-    const cooldownElapsed = LinearIssuesPlugin._warnedAt == null
-      || now - LinearIssuesPlugin._warnedAt > LinearIssuesPlugin.WARN_COOLDOWN_MS
-    if (!cooldownElapsed) return []
-
-    LinearIssuesPlugin._warnedAt = now
-    return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
+    const { events, history } = observeRateLimitFromInfo(info, this._rateLimitHistory, LinearIssuesPlugin._statics, this.log, projectChannel, 'Linear')
+    this._rateLimitHistory = history
+    return events
   }
 }
 

--- a/src/orchestrator/plugins/linear/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/new-issues-plugin.ts
@@ -13,7 +13,7 @@ import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js
 import { BasePlugin, defaultPluginLogger, type PluginLogger } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
-import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS } from '../_rate-limit.js'
+import { observeRateLimitFromInfo, type RateLimitStatics } from '../_rate-limit.js'
 import { tryClaimPerLinearTeam, type PerLinearTeamCommand } from '../grammar.js'
 import { LinearClient, type LinearIssueNode } from './linear-api.js'
 
@@ -37,8 +37,7 @@ export class LinearNewIssuesPlugin extends BasePlugin {
   private readonly client: LinearClient
   private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
 
-  private static _warnedAt: number | null = null
-  private static readonly WARN_COOLDOWN_MS = 10 * 60_000
+  private static readonly _statics: RateLimitStatics = { warnedAt: null }
 
   constructor(
     defaultChannel: string,
@@ -195,28 +194,9 @@ export class LinearNewIssuesPlugin extends BasePlugin {
   private observeLinearRateLimit(projectChannel: string): TaggedEvent[] {
     const info = this.client.getLastRateLimit()
     if (!info) return []
-
-    const now = Date.now()
-    const cutoff = now - RATE_LIMIT_WINDOW_MS
-    this._rateLimitHistory = this._rateLimitHistory.filter(h => h.ts >= cutoff)
-
-    const prev = this._rateLimitHistory.length > 0
-      ? this._rateLimitHistory[this._rateLimitHistory.length - 1]
-      : null
-    const delta = prev != null ? prev.remaining - info.remaining : null
-    const deltaStr = delta != null ? ` (Δ=${delta} since prev sample)` : ''
-    const resetMin = Math.round((info.resetAt * 1000 - now) / 60_000)
-    this.log(`[ratelimit] linear remaining=${info.remaining}/${info.limit}${deltaStr} reset_in=${resetMin}m\n`)
-
-    const warning = computeRateLimitWarning(info, this._rateLimitHistory, now, 'Linear')
-    this._rateLimitHistory.push({ remaining: info.remaining, ts: now })
-    if (!warning) return []
-
-    const cooldownElapsed = LinearNewIssuesPlugin._warnedAt == null || now - LinearNewIssuesPlugin._warnedAt > LinearNewIssuesPlugin.WARN_COOLDOWN_MS
-    if (!cooldownElapsed) return []
-
-    LinearNewIssuesPlugin._warnedAt = now
-    return [{ channels: [projectChannel], payload: { kind: 'oneline', text: warning } }]
+    const { events, history } = observeRateLimitFromInfo(info, this._rateLimitHistory, LinearNewIssuesPlugin._statics, this.log, projectChannel, 'Linear')
+    this._rateLimitHistory = history
+    return events
   }
 }
 


### PR DESCRIPTION
Closes #515

~25 lines of identical rate-limit observation logic lived in GhPluginBase, LinearNewIssuesPlugin, and LinearIssuesPlugin. This extracts it into `observeRateLimitFromInfo` in `_rate-limit.ts`.

**What's new in `_rate-limit.ts`:**
- `RateLimitStatics` interface — mutable `{ warnedAt }` handle, one per plugin class so GH/Linear cooldowns stay independent
- `WARN_COOLDOWN_MS` exported constant (was duplicated as private statics)
- `observeRateLimitFromInfo(info, history, statics, log, projectChannel, tag, now?)` — does the trim/log/warn/cooldown dance; returns `{ events, history }` so callers reassign their instance field

Each of the three callers is now 3 lines instead of ~25.

**Log format shifts:** `observeRateLimitFromInfo` uses `tag.toLowerCase()` as a prefix uniformly. Two callsites change:
- GH: `[ratelimit] remaining=…` → `[ratelimit] gh remaining=…`
- LinearIssuesPlugin: `[ratelimit] linear: remaining=…` → `[ratelimit] linear remaining=…` (colon dropped, now consistent with LinearNewIssuesPlugin)

No external tooling parses these lines.

**New coverage:** `LinearIssuesPlugin.observeRateLimit` had no rate-limit tests before this PR. Added 4 tests covering warning emission, cold-start, null client response, and stale-history pruning. The new `rate-limit-helper.test.ts` covers arg validation, history management, cooldown gate, and independent statics handles directly.