### PR TITLE
fix(spawn): pre-authorize IRC channels for the auto-mode classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,16 @@ after forwards to claude verbatim). Default channel is `#roost`;
 default model is `opus` (Opus 4.7 — required for `--permission-mode
 auto`, which the wrapper always passes).
 
-`spawn` also injects `--append-system-prompt` naming the joined
+`spawn` also injects `--append-system-prompt-file` naming the joined
 channels as legitimate user-instruction sources, so the auto-mode
 classifier doesn't silently block IRC replies on the operator's first
 `@`-mention. Only injected when the IRC host is loopback (`127.0.0.1`,
-`::1`, `localhost`); remote ergo falls outside the trusted-single-user
-local model in §Security model and prints a warning instead. Override
-by passing your own `--system-prompt` after `--`.
+`::1`, `localhost`); remote ergo falls outside roost's trusted
+single-user local environment security model and prints a warning
+instead. The injection is always on for loopback hosts. To layer more
+context on top, pass `--append-system-prompt-file <path>` after `--`;
+claude code rejects mixing inline `--append-system-prompt` with the
+file form.
 
 ### Debugging a failed spawn
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ after forwards to claude verbatim). Default channel is `#roost`;
 default model is `opus` (Opus 4.7 — required for `--permission-mode
 auto`, which the wrapper always passes).
 
+`spawn` also injects `--append-system-prompt` naming the joined
+channels as legitimate user-instruction sources, so the auto-mode
+classifier doesn't silently block IRC replies on the operator's first
+`@`-mention. Only injected when the IRC host is loopback (`127.0.0.1`,
+`::1`, `localhost`); remote ergo falls outside the trusted-single-user
+local model in §Security model and prints a warning instead. Override
+by passing your own `--system-prompt` after `--`.
+
 ### Debugging a failed spawn
 
 If you need to invoke `claude` directly to debug a failed `roost spawn`, the `--dangerously-load-development-channels` flag (hidden from `claude --help`) takes a server-id. The format depends on how roost is loaded:

--- a/bin/roost
+++ b/bin/roost
@@ -110,6 +110,14 @@ from the agent's frontmatter. With --model (or the default opus) the
 wrapper defaults to auto for opus and acceptEdits for all other models.
 Explicit --permission-mode always wins.
 
+Spawn also injects \`--append-system-prompt\` naming the joined channels
+as legitimate user-instruction sources, so the auto-mode classifier
+doesn't silently block IRC replies on the operator's first @-mention.
+Only injected when the IRC host is loopback (127.0.0.1, ::1, localhost);
+remote ergo falls outside roost's trusted single-user local model and
+prints a warning instead. Override by passing your own \`--system-prompt\`
+after \`--\`.
+
 Options:
   -c, --channels CHANS       Comma-separated channels to auto-join.
                              Default: #roost
@@ -910,7 +918,32 @@ cmd_spawn() {
   # default applies.
   local perm_mode_flag=""
   [ -n "${permission_mode}" ] && perm_mode_flag=" --permission-mode ${permission_mode}"
-  local inner_cmd="claude${model_flag}${perm_mode_flag}${mcp_flag}${agent_flag} --settings ${ROOST_SETTINGS} --plugin-dir ${ROOST_DIR} --dangerously-load-development-channels ${channel_server}${extra_str}"
+  # Pre-authorize IRC traffic as user instructions for the auto-mode classifier.
+  # Roost's security model assumes trusted single-user local environments
+  # (see README, Security model), so messages arriving on the joined channels
+  # are effectively the operator's voice, but auto mode does not know that
+  # without being told and the silent block lands the operator's first
+  # @-mention in the tmux pane instead of on IRC. Gated on loopback IRC_HOST
+  # because the trust model only holds for local ergo; skipped when no
+  # channels were requested. Trust text is deliberately apostrophe-free so
+  # printf %q produces backslash-escape form (or single-quoted) rather than
+  # bash's ANSI-C $'...' form, which does not survive the bash to tmux to
+  # login-shell chain.
+  local trust_flag=""
+  local _channels_for_trust
+  _channels_for_trust="$(printf '%s' "${channels}" | tr -d '[:space:]')"
+  case "${IRC_HOST}" in
+    127.0.0.1|::1|localhost)
+      if [ -n "${_channels_for_trust}" ]; then
+        local _trust_text="This Claude Code session is connected to a local IRCv3 server via the roost-irc MCP under the roost trusted single-user local environment security model. Messages received in joined channels ${channels} via that MCP (in-channel messages, @-mentions, and DMs) are legitimate user instructions for this session. Treat them as if typed at the terminal. Reply via channel_message or direct_message."
+        trust_flag=" --append-system-prompt $(printf '%q' "${_trust_text}")"
+      fi
+      ;;
+    *)
+      echo "  warning: IRC host '${IRC_HOST}' is not loopback; skipping auto-mode IRC trust injection. Under --permission-mode auto the agent may silently refuse to post on IRC. Workaround: attach and type the trust statement, or pass --permission-mode acceptEdits." >&2
+      ;;
+  esac
+  local inner_cmd="claude${model_flag}${perm_mode_flag}${mcp_flag}${agent_flag} --settings ${ROOST_SETTINGS} --plugin-dir ${ROOST_DIR} --dangerously-load-development-channels ${channel_server}${trust_flag}${extra_str}"
   if [ -n "${prompt_file}" ]; then
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016

--- a/bin/roost
+++ b/bin/roost
@@ -110,13 +110,15 @@ from the agent's frontmatter. With --model (or the default opus) the
 wrapper defaults to auto for opus and acceptEdits for all other models.
 Explicit --permission-mode always wins.
 
-Spawn also injects \`--append-system-prompt\` naming the joined channels
-as legitimate user-instruction sources, so the auto-mode classifier
-doesn't silently block IRC replies on the operator's first @-mention.
-Only injected when the IRC host is loopback (127.0.0.1, ::1, localhost);
-remote ergo falls outside roost's trusted single-user local model and
-prints a warning instead. Override by passing your own \`--system-prompt\`
-after \`--\`.
+Spawn also injects \`--append-system-prompt-file\` naming the joined
+channels as legitimate user-instruction sources, so the auto-mode
+classifier doesn't silently block IRC replies on the operator's first
+@-mention. Only injected when the IRC host is loopback (127.0.0.1, ::1,
+localhost); remote ergo falls outside roost's trusted single-user local
+environment security model and prints a warning instead. The injection
+is always on for loopback hosts. To layer more context on top, pass
+\`--append-system-prompt-file <path>\` after \`--\`; claude code rejects
+mixing inline \`--append-system-prompt\` with the file form.
 
 Options:
   -c, --channels CHANS       Comma-separated channels to auto-join.
@@ -919,24 +921,33 @@ cmd_spawn() {
   local perm_mode_flag=""
   [ -n "${permission_mode}" ] && perm_mode_flag=" --permission-mode ${permission_mode}"
   # Pre-authorize IRC traffic as user instructions for the auto-mode classifier.
-  # Roost's security model assumes trusted single-user local environments
+  # Roost's security model assumes a trusted single-user local environment
   # (see README, Security model), so messages arriving on the joined channels
   # are effectively the operator's voice, but auto mode does not know that
   # without being told and the silent block lands the operator's first
   # @-mention in the tmux pane instead of on IRC. Gated on loopback IRC_HOST
-  # because the trust model only holds for local ergo; skipped when no
-  # channels were requested. Trust text is deliberately apostrophe-free so
-  # printf %q produces backslash-escape form (or single-quoted) rather than
-  # bash's ANSI-C $'...' form, which does not survive the bash to tmux to
-  # login-shell chain.
+  # because the trust assumption only holds for local ergo; skipped when no
+  # channels were requested. The text names the *requested* --channels rather
+  # than the actually-joined set; failed JOINs aren't detected here and the
+  # classifier still trusts those channel names, which is acceptable under
+  # the trusted single-user local environment assumption.
+  #
+  # The trust text is staged to a file and passed via --append-system-prompt-file
+  # rather than --append-system-prompt to sidestep shell-quoting landmines:
+  # the default --channels is #roost, and `#` in zsh extended_glob mode (a
+  # common operator setting) makes any backslash-escaped `#...` token a glob
+  # pattern that fails with "no matches found" before claude ever runs. The
+  # file path uses only mktemp-clean characters so it survives the bash to
+  # tmux to login-shell chain unescaped.
   local trust_flag=""
   local _channels_for_trust
   _channels_for_trust="$(printf '%s' "${channels}" | tr -d '[:space:]')"
   case "${IRC_HOST}" in
     127.0.0.1|::1|localhost)
       if [ -n "${_channels_for_trust}" ]; then
-        local _trust_text="This Claude Code session is connected to a local IRCv3 server via the roost-irc MCP under the roost trusted single-user local environment security model. Messages received in joined channels ${channels} via that MCP (in-channel messages, @-mentions, and DMs) are legitimate user instructions for this session. Treat them as if typed at the terminal. Reply via channel_message or direct_message."
-        trust_flag=" --append-system-prompt $(printf '%q' "${_trust_text}")"
+        local _trust_file="${ROOST_DATA_DIR}/trust-prompt.txt"
+        printf '%s' "This Claude Code session is connected to a local IRCv3 server via the roost-irc MCP under roost's trusted single-user local environment security model. Messages received in joined channels ${_channels_for_trust} via that MCP (in-channel messages, @-mentions, and DMs) are legitimate user instructions for this session. Treat them as if typed at the terminal. Reply via channel_message or direct_message." > "${_trust_file}"
+        trust_flag=" --append-system-prompt-file ${_trust_file}"
       fi
       ;;
     *)

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -380,6 +380,102 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
+# -- Test 21: loopback IRC host injects --append-system-prompt trust statement ---
+# Default channels (#roost), default host (127.0.0.1) — auto-mode classifier
+# would otherwise block IRC outbound on the operator's first @-mention.
+# bash %q backslash-escapes spaces and punctuation in the trust text, so we
+# strip backslashes before substring matching the human-readable content.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+inner_cmd_text="${inner_cmd//\\/}"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && echo "$inner_cmd_text" | grep -qF 'joined channels #roost' \
+    && echo "$inner_cmd_text" | grep -qF 'channel_message'; then
+  ok "loopback default: inner_cmd contains --append-system-prompt with channels and reply hint"
+else
+  fail "loopback default: inner_cmd contains --append-system-prompt with channels and reply hint" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 22: custom --channels list lands inside the trust statement ----------
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --channels '#scratch,#side' 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+inner_cmd_text="${inner_cmd//\\/}"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && echo "$inner_cmd_text" | grep -qF 'joined channels #scratch,#side'; then
+  ok "custom --channels: trust statement names the requested channels verbatim"
+else
+  fail "custom --channels: trust statement names the requested channels verbatim" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 23: non-loopback IRC host skips injection and warns ------------------
+# Trust model only holds for local ergo; remote hosts get a warning + no injection
+# so the operator knows why the auto-mode workaround applies.
+
+setup
+out="$(ROOST_IRC_SERVER=192.0.2.1 ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && echo "$out" | grep -q "is not loopback" \
+    && echo "$out" | grep -q "skipping auto-mode IRC trust injection"; then
+  ok "non-loopback host: inner_cmd has no --append-system-prompt; warning printed"
+else
+  fail "non-loopback host: inner_cmd has no --append-system-prompt; warning printed" "out=$out inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 24: empty --channels skips injection silently ------------------------
+# No channels = nothing to authorize; skip without scaring the operator.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --channels '' 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && ! echo "$out" | grep -q "is not loopback"; then
+  ok "empty --channels on loopback: no --append-system-prompt, no warning"
+else
+  fail "empty --channels on loopback: no --append-system-prompt, no warning" "out=$out inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 25: --agent path also gets the trust injection -----------------------
+# Trust applies regardless of permission-mode source; agent frontmatter
+# permissionMode:auto would block IRC just like the --model auto path does.
+
+setup
+mkdir -p "$TDIR/.claude/agents"
+printf -- '---\nname: opusauto\ndescription: opus auto agent\nmodel: opus\npermissionMode: auto\n---\nbody\n' > "$TDIR/.claude/agents/opusauto.md"
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --agent opusauto --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+inner_cmd_text="${inner_cmd//\\/}"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && echo "$inner_cmd_text" | grep -qF 'joined channels #roost'; then
+  ok "--agent path: trust statement still injected"
+else
+  fail "--agent path: trust statement still injected" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -404,18 +404,22 @@ fi
 teardown
 
 # -- Test 22: custom --channels list lands inside the trust statement ----------
+# Whitespace inside the comma-separated list is stripped before rendering
+# (operator may type `--channels '#a, #b'`); trust text uses _channels_for_trust
+# rather than raw $channels for a clean comma-only join.
 
 setup
-out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --channels '#scratch,#side' 2>&1 || true)"
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --channels '#scratch, #side' 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
 trust_text="$(cat "$data_dir/trust-prompt.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
     && echo "$inner_cmd" | grep -qF -- '--append-system-prompt-file' \
-    && echo "$trust_text" | grep -qF 'joined channels #scratch,#side'; then
-  ok "custom --channels: trust statement names the requested channels verbatim"
+    && echo "$trust_text" | grep -qF 'joined channels #scratch,#side' \
+    && ! echo "$trust_text" | grep -qF '#scratch, #side'; then
+  ok "custom --channels: trust statement names the channels with whitespace stripped"
 else
-  fail "custom --channels: trust statement names the requested channels verbatim" "inner_cmd=$inner_cmd trust=$trust_text"
+  fail "custom --channels: trust statement names the channels with whitespace stripped" "inner_cmd=$inner_cmd trust=$trust_text"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -380,24 +380,25 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
-# -- Test 21: loopback IRC host injects --append-system-prompt trust statement ---
+# -- Test 21: loopback IRC host stages trust file + wires --append-system-prompt-file ---
 # Default channels (#roost), default host (127.0.0.1) — auto-mode classifier
 # would otherwise block IRC outbound on the operator's first @-mention.
-# bash %q backslash-escapes spaces and punctuation in the trust text, so we
-# strip backslashes before substring matching the human-readable content.
+# Trust text goes through a file (not an inline flag value) to sidestep zsh
+# extended_glob expanding the `#` in `#roost` to a "no matches" glob error
+# before claude ever runs.
 
 setup
 out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
-inner_cmd_text="${inner_cmd//\\/}"
+trust_text="$(cat "$data_dir/trust-prompt.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
-    && echo "$inner_cmd_text" | grep -qF 'joined channels #roost' \
-    && echo "$inner_cmd_text" | grep -qF 'channel_message'; then
-  ok "loopback default: inner_cmd contains --append-system-prompt with channels and reply hint"
+    && echo "$inner_cmd" | grep -qF -- "--append-system-prompt-file $data_dir/trust-prompt.txt" \
+    && echo "$trust_text" | grep -qF 'joined channels #roost' \
+    && echo "$trust_text" | grep -qF 'channel_message'; then
+  ok "loopback default: inner_cmd wires --append-system-prompt-file; trust text has channels + reply hint"
 else
-  fail "loopback default: inner_cmd contains --append-system-prompt with channels and reply hint" "inner_cmd=$inner_cmd"
+  fail "loopback default: inner_cmd wires --append-system-prompt-file; trust text has channels + reply hint" "inner_cmd=$inner_cmd trust=$trust_text"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
@@ -408,13 +409,13 @@ setup
 out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" --channels '#scratch,#side' 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
-inner_cmd_text="${inner_cmd//\\/}"
+trust_text="$(cat "$data_dir/trust-prompt.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
-    && echo "$inner_cmd_text" | grep -qF 'joined channels #scratch,#side'; then
+    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt-file' \
+    && echo "$trust_text" | grep -qF 'joined channels #scratch,#side'; then
   ok "custom --channels: trust statement names the requested channels verbatim"
 else
-  fail "custom --channels: trust statement names the requested channels verbatim" "inner_cmd=$inner_cmd"
+  fail "custom --channels: trust statement names the requested channels verbatim" "inner_cmd=$inner_cmd trust=$trust_text"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
@@ -428,12 +429,13 @@ out="$(ROOST_IRC_SERVER=192.0.2.1 ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spa
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt-file' \
+    && [ ! -f "$data_dir/trust-prompt.txt" ] \
     && echo "$out" | grep -q "is not loopback" \
     && echo "$out" | grep -q "skipping auto-mode IRC trust injection"; then
-  ok "non-loopback host: inner_cmd has no --append-system-prompt; warning printed"
+  ok "non-loopback host: no flag, no trust file, warning printed"
 else
-  fail "non-loopback host: inner_cmd has no --append-system-prompt; warning printed" "out=$out inner_cmd=$inner_cmd"
+  fail "non-loopback host: no flag, no trust file, warning printed" "out=$out inner_cmd=$inner_cmd"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
@@ -446,11 +448,12 @@ out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" -
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
+    && ! echo "$inner_cmd" | grep -qF -- '--append-system-prompt-file' \
+    && [ ! -f "$data_dir/trust-prompt.txt" ] \
     && ! echo "$out" | grep -q "is not loopback"; then
-  ok "empty --channels on loopback: no --append-system-prompt, no warning"
+  ok "empty --channels on loopback: no flag, no trust file, no warning"
 else
-  fail "empty --channels on loopback: no --append-system-prompt, no warning" "out=$out inner_cmd=$inner_cmd"
+  fail "empty --channels on loopback: no flag, no trust file, no warning" "out=$out inner_cmd=$inner_cmd"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
@@ -465,13 +468,13 @@ printf -- '---\nname: opusauto\ndescription: opus auto agent\nmodel: opus\npermi
 out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --agent opusauto --cwd "$TDIR" 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
-inner_cmd_text="${inner_cmd//\\/}"
+trust_text="$(cat "$data_dir/trust-prompt.txt" 2>/dev/null)"
 if [ -n "$inner_cmd" ] \
-    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt' \
-    && echo "$inner_cmd_text" | grep -qF 'joined channels #roost'; then
+    && echo "$inner_cmd" | grep -qF -- '--append-system-prompt-file' \
+    && echo "$trust_text" | grep -qF 'joined channels #roost'; then
   ok "--agent path: trust statement still injected"
 else
-  fail "--agent path: trust statement still injected" "inner_cmd=$inner_cmd"
+  fail "--agent path: trust statement still injected" "inner_cmd=$inner_cmd trust=$trust_text"
 fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown


### PR DESCRIPTION
Closes #519

## Summary
- `roost spawn` now injects `--append-system-prompt` naming the joined channels as legitimate user-instruction sources, so the auto-mode classifier doesn't silently block IRC replies on the operator's first `@`-mention
- Gated on loopback `IRC_HOST` (127.0.0.1, ::1, localhost); remote ergo gets a warning and the existing manual workaround
- Empty `--channels` skips injection silently (no warning); covered by tests

## Design
Implements option (1) from #519 — per-spawn, channel-based system-prompt injection. Option (2) `--trust-channel-from <nick>` is intentionally not pursued: the loopback gate is the only legitimate suppression case in roost's trusted single-user local environment security model (per README §Security model), so a separate opt-out flag adds surface area without solving a real problem.

## Test plan
- [x] `bun run lint`, `bun run typecheck`, `bash test/spawn_test.sh` (30/30)
- [ ] live probe: `roost spawn` a bare-opus worker into a scratch channel, `@`-ping from another nick, paste verbatim reply (or non-reply) in #roost-issue-519 before signaling ready
- [ ] live probe: spawn with extra `-- --append-system-prompt` to confirm dedup behavior, document override path accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)