### PR TITLE
fix(spawn): auto-allow roost-irc MCP tools for loopback sessions

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -840,8 +840,18 @@ cmd_spawn() {
     done
     pretooluse_hook_json=",\"PreToolUse\":[${_ptu_joined}]"
   fi
+  # Allow roost-irc MCP tools without a permission prompt on loopback sessions
+  # (same gate as trust injection below). Remote ergo doesn't get the allow.
+  # "permissions" is the only top-level key added here alongside "hooks"; keep
+  # it that way to avoid duplicate-key collisions in the written JSON.
+  local permissions_json=""
+  case "${IRC_HOST}" in
+    127.0.0.1|::1|localhost)
+      permissions_json=",\"permissions\":{\"allow\":[\"mcp__plugin_roost_roost-irc__*\",\"mcp__roost-irc__*\"]}"
+      ;;
+  esac
   local ROOST_SETTINGS="${ROOST_DATA_DIR}/roost-settings.json"
-  printf '%s\n' "{\"hooks\":{${precompact_hook_json}\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}}" > "${ROOST_SETTINGS}"
+  printf '%s\n' "{\"hooks\":{${precompact_hook_json}\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}${permissions_json}}" > "${ROOST_SETTINGS}"
   # Test seam: ROOST_SPAWN_KEEP_DATA_DIR=1 echoes the data-dir path early and
   # suppresses the failure-cleanup trap, so spawn_test.sh can read the files
   # written above after a preflight failure exits the spawn. Prod operators

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -483,6 +483,42 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
+# -- Test 26: loopback host injects permissions.allow into roost-settings.json --
+# Non-perm-irc non-automode sessions would otherwise hit an in-pane permission
+# dialog for every roost-irc MCP call. Gated on the same loopback check as
+# trust injection so remote ergo doesn't get blanket auto-allow.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if [ -n "$data_dir" ] \
+    && [ -f "$data_dir/roost-settings.json" ] \
+    && grep -qF '"mcp__plugin_roost_roost-irc__*"' "$data_dir/roost-settings.json" \
+    && grep -qF '"mcp__roost-irc__*"' "$data_dir/roost-settings.json" \
+    && grep -qF '"permissions"' "$data_dir/roost-settings.json"; then
+  ok "loopback: roost-settings.json has permissions.allow with both roost-irc wildcards"
+else
+  fail "loopback: roost-settings.json has permissions.allow with both roost-irc wildcards" "data_dir=$data_dir settings=$(cat "$data_dir/roost-settings.json" 2>/dev/null)"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 27: non-loopback host omits permissions block from roost-settings.json -
+# Remote ergo is outside the trusted single-user local environment; no auto-allow.
+
+setup
+out="$(ROOST_IRC_SERVER=192.0.2.1 ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if [ -n "$data_dir" ] \
+    && [ -f "$data_dir/roost-settings.json" ] \
+    && ! grep -qF '"permissions"' "$data_dir/roost-settings.json"; then
+  ok "non-loopback: roost-settings.json has no permissions block"
+else
+  fail "non-loopback: roost-settings.json has no permissions block" "data_dir=$data_dir settings=$(cat "$data_dir/roost-settings.json" 2>/dev/null)"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #532

Adds `"permissions":{"allow":["mcp__plugin_roost_roost-irc__*","mcp__roost-irc__*"]}` to the per-session `roost-settings.json` written at spawn time. Gated on the same `127.0.0.1|::1|localhost` check as the #519 trust injection — remote ergo installs are unaffected.

**Live probe:** spawned a sonnet worker (`probe-532`) without `--perm-irc` into `#roost-532-probe`, sent an @-ping, received `pong from probe-532` at 4:36:28 PM with no pane permission dialog.

**Tests:** 2 new tests in `spawn_test.sh` (tests 26+27: loopback injects permissions, non-loopback omits). All 32 spawn tests + 901 bun tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)