### PR TITLE
docs(lead-pm): add in-flight new-issue triage protocol

### DIFF
--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -153,16 +153,14 @@ New issues land in `#<project>-leads` mid-milestone from two sources: the dispat
 
 1. Read the issue body, labels, and any blocking relationships. `gh issue view <N> --comments` is the minimum.
 2. Decide which milestone the work belongs in. The concrete test is "when does this work's primary consumer arrive?" — current milestone, a future one, or no milestone yet.
-3. Pick the action based on the milestone decision:
-   - Current milestone, urgent: **Interrupt** the in-flight wave. Urgency means it blocks or unblocks an in-flight issue, or fixes an active production failure.
-   - Current milestone, not urgent: **Queue**. The next wave starts only after the current wave fully drains (all in-flight PRs merged). If no drain point is in sight (long-running worker), treat as Park instead.
-   - Future milestone: **Defer**. No action this wave.
-   - No milestone: **Park**. Pair with a self-note in the issue ("re-evaluate when X lands") so the trigger lives in the issue itself.
+3. Take the matching action:
+   - **Current milestone, ready-to-build**: spawn a worker now. Concurrent waves are fine — agents parallelize cheaply.
+   - **Future milestone**: leave it where it is. The future-milestone wave picks it up.
+   - **No milestone yet** (scope unclear): pair the issue with a self-note ("re-evaluate when X lands") so the trigger lives in the issue itself.
 4. Milestone reassignment is lead-direct: `gh issue edit --milestone "0.X.Y" <N>`. Single-flag write on existing data, no APM dance.
 5. Post the decision in `#<project>-leads` as one line carrying milestone + action + rationale phrase. Shape:
-   - `#<N> → 0.8.0, interrupting current wave (blocks #<I>)`
-   - `#<N> → 0.8.0, queued (current-milestone but not urgent)`
-   - `#<N> → 0.9.0, deferred (consumer is <future-feature>, not <current-feature>)`
+   - `#<N> → 0.8.0, spawning worker now (in scope)`
+   - `#<N> → 0.9.0, no action (future wave picks it up)`
    - `#<N> → no milestone, parked (re-evaluate when <unrelated-work> lands)`
 
 The rationale phrase is the lever. It gives the channel a concrete handle to push back on without re-reading the issue.

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -149,21 +149,21 @@ If the followup widens the milestone in a way you didn't anticipate, the APM wil
 
 ## When a new issue arrives in-flight
 
-New issues land in `#<project>-leads` mid-milestone from three sources: the dispatcher's `new issue <repo>#<N>: <title>` announcement, a human pointer ("look at #<N>"), or an APM mention. Triage on arrival rather than letting it pile up.
+New issues land in `#<project>-leads` mid-milestone from two sources: the dispatcher's `new issue <repo>#<N>: <title>` announcement, or a human pointer ("look at #<N>"). Triage on arrival rather than letting it pile up.
 
 1. Read the issue body, labels, and any blocking relationships. `gh issue view <N> --comments` is the minimum.
-2. Decide milestone via §#458: current, future, or no milestone. The concrete test is "when does this work's primary consumer arrive?"
-3. Decide how it interacts with the in-flight wave:
-   - **Interrupt** when it blocks or unblocks an in-flight issue, or fixes an active production failure in roost itself.
-   - **Queue** when it's current-milestone work but not urgent. Queue means the next wave starts only after the current wave fully drains — all in-flight PRs merged. If no drain point is in sight (long-running worker), promote it to a deferred decision instead.
-   - **Defer** when §#458 puts the primary consumer in a future milestone.
-   - **Park** (no milestone) when scope is unclear. Park always pairs with a self-note in the issue ("re-evaluate when X lands") so the trigger lives in the issue itself.
+2. Decide which milestone the work belongs in. The concrete test is "when does this work's primary consumer arrive?" — current milestone, a future one, or no milestone yet.
+3. Pick the action based on the milestone decision:
+   - Current milestone, urgent: **Interrupt** the in-flight wave. Urgency means it blocks or unblocks an in-flight issue, or fixes an active production failure.
+   - Current milestone, not urgent: **Queue**. The next wave starts only after the current wave fully drains (all in-flight PRs merged). If no drain point is in sight (long-running worker), treat as Park instead.
+   - Future milestone: **Defer**. No action this wave.
+   - No milestone: **Park**. Pair with a self-note in the issue ("re-evaluate when X lands") so the trigger lives in the issue itself.
 4. Milestone reassignment is lead-direct: `gh issue edit --milestone "0.X.Y" <N>`. Single-flag write on existing data, no APM dance.
 5. Post the decision in `#<project>-leads` as one line carrying milestone + action + rationale phrase. Shape:
    - `#<N> → 0.8.0, interrupting current wave (blocks #<I>)`
    - `#<N> → 0.8.0, queued (current-milestone but not urgent)`
-   - `#<N> → 0.9.0, deferred (consumer is Linear-side, not dispatcher-side)`
-   - `#<N> → no milestone, parked (re-evaluate when worker-driven-design lands)`
+   - `#<N> → 0.9.0, deferred (consumer is <future-feature>, not <current-feature>)`
+   - `#<N> → no milestone, parked (re-evaluate when <unrelated-work> lands)`
 
 The rationale phrase is the lever. It gives the channel a concrete handle to push back on without re-reading the issue.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -147,6 +147,26 @@ All follow-up issues — whether surfaced by a worker mid-PR, by the reviewer ag
 
 If the followup widens the milestone in a way you didn't anticipate, the APM will surface that — re-evaluate the in-flight DAG before confirming.
 
+## When a new issue arrives in-flight
+
+New issues land in `#<project>-leads` mid-milestone from three sources: the dispatcher's `new issue <repo>#<N>: <title>` announcement, a human pointer ("look at #<N>"), or an APM mention. Triage on arrival rather than letting it pile up.
+
+1. Read the issue body, labels, and any blocking relationships. `gh issue view <N> --comments` is the minimum.
+2. Decide milestone via §#458: current, future, or no milestone. The concrete test is "when does this work's primary consumer arrive?"
+3. Decide how it interacts with the in-flight wave:
+   - **Interrupt** when it blocks or unblocks an in-flight issue, or fixes an active production failure in roost itself.
+   - **Queue** when it's current-milestone work but not urgent. Queue means the next wave starts only after the current wave fully drains — all in-flight PRs merged. If no drain point is in sight (long-running worker), promote it to a deferred decision instead.
+   - **Defer** when §#458 puts the primary consumer in a future milestone.
+   - **Park** (no milestone) when scope is unclear. Park always pairs with a self-note in the issue ("re-evaluate when X lands") so the trigger lives in the issue itself.
+4. Milestone reassignment is lead-direct: `gh issue edit --milestone "0.X.Y" <N>`. Single-flag write on existing data, no APM dance.
+5. Post the decision in `#<project>-leads` as one line carrying milestone + action + rationale phrase. Shape:
+   - `#<N> → 0.8.0, interrupting current wave (blocks #<I>)`
+   - `#<N> → 0.8.0, queued (current-milestone but not urgent)`
+   - `#<N> → 0.9.0, deferred (consumer is Linear-side, not dispatcher-side)`
+   - `#<N> → no milestone, parked (re-evaluate when worker-driven-design lands)`
+
+The rationale phrase is the lever. It gives the channel a concrete handle to push back on without re-reading the issue.
+
 ## When you author a PR yourself
 
 Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself; the APM still helps with the setup and teardown:

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -154,12 +154,15 @@ New issues land in `#<project>-leads` mid-milestone from two sources: the dispat
 1. Read the issue body, labels, and any blocking relationships. `gh issue view <N> --comments` is the minimum.
 2. Decide which milestone the work belongs in. The concrete test is "when does this work's primary consumer arrive?" — current milestone, a future one, or no milestone yet.
 3. Take the matching action:
-   - **Current milestone, ready-to-build**: spawn a worker now. Concurrent waves are fine — agents parallelize cheaply.
+   - **Current milestone**: slot in the spawn decision.
+     - If it's independent of in-flight work: spawn a worker now. Concurrent waves are fine — agents parallelize cheaply.
+     - If it builds on or depends on an in-flight issue: queue after that issue lands.
    - **Future milestone**: leave it where it is. The future-milestone wave picks it up.
    - **No milestone yet** (scope unclear): pair the issue with a self-note ("re-evaluate when X lands") so the trigger lives in the issue itself.
 4. Milestone reassignment is lead-direct: `gh issue edit --milestone "0.X.Y" <N>`. Single-flag write on existing data, no APM dance.
 5. Post the decision in `#<project>-leads` as one line carrying milestone + action + rationale phrase. Shape:
-   - `#<N> → 0.8.0, spawning worker now (in scope)`
+   - `#<N> → 0.8.0, spawning worker now (independent)`
+   - `#<N> → 0.8.0, spawning after #<I> lands (extends its API)`
    - `#<N> → 0.9.0, no action (future wave picks it up)`
    - `#<N> → no milestone, parked (re-evaluate when <unrelated-work> lands)`
 


### PR DESCRIPTION
Closes #508

Adds a new section to `agents/lead-pm.md` ("When a new issue arrives in-flight") covering how lead-pm handles a GitHub issue that lands mid-milestone:

- Trigger covers dispatcher announcements, human pointers, and APM mentions (not dispatcher-only).
- Milestone decision uses §#458 ("when does the primary consumer arrive?") for current/future/no-milestone.
- Wave interaction: interrupt (blocks/unblocks in-flight, or production failure in roost itself), queue (current-milestone, waits for full wave drain), defer (future-milestone consumer), park (scope unclear, self-note in the issue).
- Milestone reassignment is lead-direct via `gh issue edit --milestone` — single-flag write, no APM dance.
- One-line announcement in `#<project>-leads` carries milestone + action + rationale phrase so the channel can push back without re-reading the issue.