### PR TITLE
add script/teardown to collapse APM cleanup compounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ Requires ergo (IRCv3 server). Install with `bin/install-ergo` or set `ERGO_BIN` 
 
 Use `script/worktree <branch> [--from <base>] [path]` to bootstrap a new worktree — it creates the sibling worktree, runs `bun install`, and copies `.claude/settings.local.json` from the main worktree so spawned workers don't hit a permission-prompt flood.
 
+Use `script/teardown <branch> [--delete-branch]` to clean up a worktree after merge — fetches and ff-merges main, removes the worktree, and optionally deletes the local branch.
+
 ## Layout
 
 ```

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -184,8 +184,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
      If a reviewer was never spawned for this issue (e.g. lead-authored PR), drop the reviewer nick from the args. If the tool stderr-warns about an unknown model (`$?` somewhere in the output), relay the warning in both posts — that means `src/pricing.ts` needs a bump for the new model id before the dollar figure is trustworthy.
    - Terminate the worker: `roost shutdown <project>-worker-<I>`.
    - Part `#<project>-issue-<I>`.
-   - Pull main in the primary worktree (HTTPS one-shot is safe: `git fetch https://github.com/<owner>/<repo>.git main && git merge --ff-only FETCH_HEAD`).
-   - Remove the worktree: `git worktree remove <path>`.
+   - If `./script/teardown` exists in the primary worktree: run `./script/teardown <branch> --delete-branch` from the primary worktree — one allow-listed call, no compound operators, handles ff-merge main + worktree removal + branch cleanup. Otherwise: `git fetch origin main && git merge --ff-only FETCH_HEAD` in the primary worktree, then `git worktree remove <path>`.
    - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running across issues; full shutdown is the milestone teardown dance below.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -184,7 +184,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
      If a reviewer was never spawned for this issue (e.g. lead-authored PR), drop the reviewer nick from the args. If the tool stderr-warns about an unknown model (`$?` somewhere in the output), relay the warning in both posts — that means `src/pricing.ts` needs a bump for the new model id before the dollar figure is trustworthy.
    - Terminate the worker: `roost shutdown <project>-worker-<I>`.
    - Part `#<project>-issue-<I>`.
-   - If `./script/teardown` exists in the primary worktree: run `./script/teardown <branch> --delete-branch` from the primary worktree — one allow-listed call, no compound operators, handles ff-merge main + worktree removal + branch cleanup. Otherwise: `git fetch origin main && git merge --ff-only FETCH_HEAD` in the primary worktree, then `git worktree remove <path>`.
+   - Clean up the worktree per the project's conventions (the project's `CLAUDE.md` typically documents this — read it if you haven't). Final fallback: `git fetch origin main && git merge --ff-only FETCH_HEAD` in the primary worktree, then `git worktree remove <path>`.
    - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running across issues; full shutdown is the milestone teardown dance below.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -184,7 +184,7 @@ Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're track
      If a reviewer was never spawned for this issue (e.g. lead-authored PR), drop the reviewer nick from the args. If the tool stderr-warns about an unknown model (`$?` somewhere in the output), relay the warning in both posts — that means `src/pricing.ts` needs a bump for the new model id before the dollar figure is trustworthy.
    - Terminate the worker: `roost shutdown <project>-worker-<I>`.
    - Part `#<project>-issue-<I>`.
-   - Clean up the worktree per the project's conventions (the project's `CLAUDE.md` typically documents this — read it if you haven't). Final fallback: `git fetch origin main && git merge --ff-only FETCH_HEAD` in the primary worktree, then `git worktree remove <path>`.
+   - Pull main + remove the worktree per the project's conventions (the project's `CLAUDE.md` typically documents this — read it if you haven't). Final fallback: `git fetch origin main && git merge --ff-only FETCH_HEAD` in the primary worktree, then `git worktree remove <path>`.
    - DM `<project>-dispatcher`: `unwatch <I>` then `unwatch pr <N>` — the daemon keeps running across issues; full shutdown is the milestone teardown dance below.
 3. Post in `#<project>-leads`: `#<N> merged, cleanup done`.
 

--- a/script/teardown
+++ b/script/teardown
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# script/teardown — Remove a git worktree and update main
+#
+# Usage:
+#   script/teardown <branch> [--delete-branch]
+#
+# Examples:
+#   script/teardown feat/my-feature
+#   script/teardown feat/my-feature --delete-branch
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: script/teardown <branch> [--delete-branch]"
+  echo ""
+  echo "  branch           Branch whose worktree to remove"
+  echo "  --delete-branch  Also delete the local branch after removing the worktree"
+  exit 1
+fi
+
+branch="$1"
+shift
+
+delete_branch=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --delete-branch)
+      delete_branch=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+main_tree="$(git worktree list --porcelain | head -1 | sed 's/worktree //')"
+sanitized_branch="$(echo "$branch" | tr '/' '-')"
+worktree_path="$(dirname "$main_tree")/roost-${sanitized_branch}"
+
+if [ ! -d "$worktree_path" ]; then
+  echo "Error: worktree not found at $worktree_path"
+  echo "  (branch: $branch)"
+  exit 1
+fi
+
+echo "Updating main..."
+(cd "$main_tree" && git fetch origin main && git merge --ff-only FETCH_HEAD)
+
+echo ""
+echo "Removing worktree: $worktree_path"
+git worktree remove "$worktree_path"
+
+if "$delete_branch"; then
+  echo "Deleting branch: $branch"
+  git branch -d "$branch"
+fi
+
+echo ""
+echo "Teardown complete: $branch"


### PR DESCRIPTION
Closes #537

Adds `script/teardown <branch> [--delete-branch]`, mirroring `script/worktree`. APM calls it once; `Bash(./script/teardown:*)` covers all cleanup steps without hitting the compound-operator classifier.

**What the script does:**
- Derives the worktree path the same way `script/worktree` does (main tree sibling + sanitized branch name)
- Exits early with a clear error if the path doesn't exist (typo guard)
- Fetches and ff-merges `origin/main` in the primary worktree
- Removes the worktree
- With `--delete-branch`: `git branch -d <branch>` (safe delete, refuses if unmerged)

**Also updates:**
- `CLAUDE.md` Worktrees section — documents `script/teardown` alongside `script/worktree`
- `agents/associate-pm.md` merge+cleanup dance — use `./script/teardown <branch> --delete-branch` when the script exists; fall back to manual steps otherwise (shipped-prompt hygiene for downstream projects)

**Operators:** add these two entries to `.claude/settings.local.json` to let the APM call the script without permbot. The script works without the entry — it just permbots the first time. `.claude/settings.local.json` is gitignored so this is a per-checkout manual step:
```
"Bash(./script/teardown:*)",
"Bash(script/teardown:*)"
```