### PR TITLE
expand lead-pm plan pressure-test list to 5 questions

### DIFF
--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -105,11 +105,11 @@ For each issue:
 3. **Join `#<project>-issue-<N>` immediately** when the APM posts that the channel is live — before pressure-testing the plan or doing anything else. The APM will mention you directly; that's your cue.
 
 4. **Pressure-test the worker's plan** in `#<project>-issue-<N>` once the worker posts it. This is your judgment, not the APM's. Do not be afraid to go for multiple rounds. At a minimum, ask:
-   - Does it believably resolve the issue?
+   - Does your plan believably resolve the issue?
    - Is your fix as broad as the failure mode, or narrower than the trigger the issue describes? If narrower, why?
-   - What does your plan assume about callers, config, ordering, or environment? How do you know those assumptions hold?
-   - Which alternative did you rule out, and why is your approach better?
-   - Does it set the project up for downstream success, or is it a pending footgun?
+   - What does your plan assume about callers, config, ordering, environment, or external API shapes? Have you observed those, or only assumed from docs?
+   - Which alternatives did you rule out, and why is your approach better?
+   - Does your plan set the project up for downstream success, or is it a pending footgun?
 
    When the worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan.
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -106,8 +106,12 @@ For each issue:
 
 4. **Pressure-test the worker's plan** in `#<project>-issue-<N>` once the worker posts it. This is your judgment, not the APM's. Do not be afraid to go for multiple rounds. At a minimum, ask:
    - Does it believably resolve the issue?
+   - Is your fix as broad as the failure mode, or narrower than the trigger the issue describes? If narrower, why?
+   - What does your plan assume about callers, config, ordering, or environment? How do you know those assumptions hold?
+   - Which alternative did you rule out, and why is your approach better?
    - Does it set the project up for downstream success, or is it a pending footgun?
-   - When the worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan.
+
+   When the worker proposes "X is fine for now" and you can already see a real gap, push back before approving the plan.
 
 5. **When the worker posts a draft PR** with a valid `Closes #<I>` reference, the APM spawns a reviewer directly — no ack needed (model is always opus, trigger is unambiguous). If the closing reference is missing, the APM acks first: `draft PR #<N> up — no linked issue detected, want me to add Closes #<I>? (then I'll spawn reviewer)`. The APM posts `reviewer spawned for PR #<N>` in the issue channel. Default reviewer model stays opus regardless of worker model — opus consistently surfaces a class of findings (dead paths, duplicated invariants, misleading comments) sonnet misses, and review cost is small relative to the cost of a stale comment shipping. If you want sonnet for a trivially-sized PR (e.g. doc/prompt tweak well under 100 lines), mention the APM in the channel with that direction.
 


### PR DESCRIPTION
Closes #295

Replaces the hand-rolled 3-bullet pressure-test list in `agents/lead-pm.md` step 4 with five questions, plus a closing posture line. The five:

1. Does it believably resolve the issue? *(kept)*
2. Is your fix as broad as the failure mode, or narrower than the trigger the issue describes? If narrower, why? *(new — captures the §#448/§#486 over-narrow pattern at plan stage, where widening costs a paragraph rather than a re-cycle)*
3. What does your plan assume about callers, config, ordering, or environment? How do you know those assumptions hold? *(new — Socratic spec-phase question; cheap to surface now, expensive in human review)*
4. Which alternative did you rule out, and why is your approach better? *(new — forces a defended choice against anchoring on the first plausible approach)*
5. Does it set the project up for downstream success, or is it a pending footgun? *(kept)*

The existing "X is fine for now" sentence stays as a closing posture line below the bullets — it's the meta-instruction to actually press, not one of the questions.

### Research signal

Web-researched across premortem / RFC / Socratic / devil's-advocate sources. The recurring high-leverage prompts were: surface unstated assumptions, name the strongest objection or ruled-out alternative, and ask whether the proposed fix's scope matches the actual failure mode. Premortem-style "what's most likely to cause a follow-up in a week" lives close to Q2/Q5; the explicit five-question cap kept that out.

### Constraints honored

- Five-question cap.
- Project-agnostic phrasing (these ship into projects we don't know).
- Plan-iteration leverage, not code review.
- No changes to reviewer or worker prompts.

[roost-worker-295]