### PR TITLE
add github-new-prs plugin + lead-pm in-flight PR handling

### DIFF
--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -184,7 +184,7 @@ New PRs land in `#<project>-leads` from the dispatcher's `new PR <repo>#<N>: <ti
    - **Defer**: the PR is unrelated to the current wave and can wait. Note it in the in-flight DAG; mention it in `#<project>-leads` when picking it up. Shape: `PR <repo>#<N> — deferring (unrelated to current wave)`
    - **Decline / redirect**: the PR is out of scope, duplicates existing work, or belongs in a different direction. Comment on the PR with the redirect; post one line in the channel. Shape: `PR <repo>#<N> — declining (see comment on PR)`
 
-The rationale phrase is the lever — it gives the channel a concrete handle to push back on without re-reading the PR.
+The rationale phrase is the lever. It gives the channel a concrete handle to push back on without re-reading the PR.
 
 ## When you author a PR yourself
 

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -174,6 +174,18 @@ New issues land in `#<project>-leads` mid-milestone from two sources: the dispat
 
 The rationale phrase is the lever. It gives the channel a concrete handle to push back on without re-reading the issue.
 
+## When a new PR arrives in-flight
+
+New PRs land in `#<project>-leads` from the dispatcher's `new PR <repo>#<N>: <title>` announcement (if `github-new-prs` is configured), or a human pointer. Triage on arrival.
+
+1. Read the PR: author, title, description, and what files it touches.
+2. Decide and post a one-liner in `#<project>-leads` with your decision and a rationale phrase. Three options:
+   - **Engage now**: the PR touches in-flight work, looks like a clean contribution, or needs blocking feedback before it drifts further. Start a review — spawn a reviewer agent or review directly. Shape: `PR <repo>#<N> from <author> — engaging, spawning reviewer (touches in-flight #<I>)`
+   - **Defer**: the PR is unrelated to the current wave and can wait. Note it in the in-flight DAG; mention it in `#<project>-leads` when picking it up. Shape: `PR <repo>#<N> — deferring (unrelated to current wave)`
+   - **Decline / redirect**: the PR is out of scope, duplicates existing work, or belongs in a different direction. Comment on the PR with the redirect; post one line in the channel. Shape: `PR <repo>#<N> — declining (see comment on PR)`
+
+The rationale phrase is the lever — it gives the channel a concrete handle to push back on without re-reading the PR.
+
 ## When you author a PR yourself
 
 Some changes are small enough that spawning a worker is overhead — a doc tweak, a prompt update, a one-line fix you spotted while reviewing. You can author the PR yourself; the APM still helps with the setup and teardown:

--- a/bin/roost
+++ b/bin/roost
@@ -318,12 +318,12 @@ EOF
 }
 
 # Tracked, shareable shape: project + repo identity + the static plugin
-# slices (github-new-issues / github-commits are operator-set, not DM-mutated).
+# slices (github-new-issues / github-new-prs / github-commits are operator-set, not DM-mutated).
 # The dynamic slices (github-prs / github-issues) live in the local overlay;
 # their `plugins.<name>` key in the merged config still enables them — the
 # loader unions `Object.keys(plugins)` across both files.
 _init_config_json() {
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
+  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-new-prs": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
     "$1" "$2" "$3"
 }
 

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -30,7 +30,7 @@ cp .orchestrator/config.local.example.json .orchestrator/config.local.json
 
 `.orchestrator/config.json` is **tracked** and holds the shareable project
 shape: `project`, `repo`, `agent_logins`, `irc`, plus static plugin slices
-the team agrees on (currently `github-new-issues.watched` and
+the team agrees on (currently `github-new-issues.watched`, `github-new-prs.watched`, and
 `github-commits.watched`). PR-reviewed changes go here.
 
 `.orchestrator/config.local.json` is **gitignored** and holds the
@@ -63,6 +63,7 @@ Fields:
 | `plugins.github-prs.watched` | `[{"number": N, "repo"?: "OWNER/NAME", "channels"?: [...]}]` |
 | `plugins.github-issues.watched` | Same shape as `plugins.github-prs.watched`. |
 | `plugins.github-new-issues.watched` | `[{"repo": "OWNER/NAME", "channels"?: [...]}]`. Multi-repo new-issue feed — `repo` required per entry, `channels` defaults to the project channel. |
+| `plugins.github-new-prs.watched` | Same shape as `plugins.github-new-issues.watched`. Multi-repo new-PR feed — announces newly-opened PRs not authored by `agent_logins`. `repo` required per entry, `channels` defaults to the project channel. |
 | `plugins.github-commits.watched` | `[{"repo": "OWNER/NAME", "branch"?: "main", "path"?: "Formula/x.rb", "channels"?: [...]}]`. Multi-repo commit feed — `repo` required per entry, `branch` defaults to `main`, optional `path` filters to commits touching that file, `channels` defaults to the project channel. State key is `<repo>@<branch>` (or `<repo>@<branch>:<path>` when path is set). |
 
 For watched entries, `repo` defaults to the top-level in single mode and is
@@ -84,11 +85,11 @@ B. Each linked-issue channel is slugged from its own repo, not the PR's:
   (gh did return a linked issue, just not addressable) — read stderr when in doubt.
 
 A plugin not listed under `plugins` is not instantiated. First-party set:
-`github-prs`, `github-issues`, `github-new-issues`, `github-commits`. External
+`github-prs`, `github-issues`, `github-new-issues`, `github-new-prs`, `github-commits`. External
 plugins load via `plugin_paths` (see [PLUGINS.md](./PLUGINS.md)) before the
 registry walks.
 
-`github-new-issues` needs an explicit slice with ≥1 `watched` entry to run.
+`github-new-issues` and `github-new-prs` each need an explicit slice with ≥1 `watched` entry to run.
 
 ## Running
 
@@ -168,7 +169,7 @@ JSDoc.
 ```
 watch [<target>] <N> [<owner>/<repo>] [#chan ...]      # github-prs, github-issues
 unwatch [<target>] <N> [<owner>/<repo>]
-watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  # github-commits (target=repo), github-new-issues (target=new-issues; no @/: allowed)
+watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  # github-commits (target=repo), github-new-issues (target=new-issues; no @/: allowed), github-new-prs (target=new-prs; no @/: allowed)
 unwatch <target> <owner>/<repo>[@<branch>[:<path>]]
 watch list      # every plugin's active entries
 help            # synopsis + per-plugin help
@@ -182,6 +183,7 @@ Target keywords currently claimed by first-party plugins:
 | `pr` | `github-prs` | `watch pr <N> [<owner>/<repo>] [#chan ...]` |
 | `repo` | `github-commits` | `watch repo <owner>/<repo>[@<branch>[:<path>]] [#chan ...]` |
 | `new-issues` | `github-new-issues` | `watch new-issues <owner>/<repo> [#chan ...]` |
+| `new-prs` | `github-new-prs` | `watch new-prs <owner>/<repo> [#chan ...]` |
 
 Notes:
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -2,7 +2,7 @@
 
 A plugin polls a source on each dispatcher tick and returns IRC events. It owns a config slice at `config.plugins[name]` and a state slice at `state.plugins[name]`. The same name keys both.
 
-The built-ins (`github-prs`, `github-issues`, `github-new-issues`, `github-commits`) all use this contract. External plugins load via `plugin_paths` in your dispatcher config and use the same contract.
+The built-ins (`github-prs`, `github-issues`, `github-new-issues`, `github-new-prs`, `github-commits`) all use this contract. External plugins load via `plugin_paths` in your dispatcher config and use the same contract.
 
 ## The seam
 

--- a/src/orchestrator/__tests__/init-template.test.ts
+++ b/src/orchestrator/__tests__/init-template.test.ts
@@ -13,6 +13,7 @@ const INIT_CONFIG: OrchestratorConfig = {
   repo: 'org/repo',
   plugins: {
     'github-new-issues': { watched: [] },
+    'github-new-prs': { watched: [] },
     'github-commits': { watched: [] },
   },
 }
@@ -27,10 +28,10 @@ const INIT_LOCAL: OrchestratorConfig = {
 }
 
 describe('bin/roost init template', () => {
-  it('merged shape enables all four built-in plugins', () => {
+  it('merged shape enables all five built-in plugins', () => {
     const merged = mergeConfigs(INIT_CONFIG, INIT_LOCAL)
     expect(Object.keys(merged.plugins ?? {}).sort()).toEqual([
-      'github-commits', 'github-issues', 'github-new-issues', 'github-prs',
+      'github-commits', 'github-issues', 'github-new-issues', 'github-new-prs', 'github-prs',
     ])
   })
 

--- a/src/orchestrator/plugins/github/__tests__/new-prs-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-prs-plugin.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, spyOn } from 'bun:test'
+import { GitHubNewPrsPlugin, type NewPrsPluginState } from '../new-prs-plugin.js'
+import { GhClient, type GhRepoPr } from '../github-api.js'
+import type { OrchestratorConfig } from '../../../config.js'
+import { stubRateLimit } from './gh-test-helpers.js'
+
+function pr(n: number, overrides: Partial<GhRepoPr> = {}): GhRepoPr {
+  return {
+    number: n,
+    title: `PR ${n}`,
+    html_url: `https://github.com/org/repo/pull/${n}`,
+    labels: [],
+    user: { login: 'external-user' },
+    ...overrides,
+  }
+}
+
+function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    project: 'proj',
+    repo: 'org/repo',
+    plugins: { 'github-new-prs': { watched: [{ repo: 'org/repo' }] } },
+    ...overrides,
+  }
+}
+
+function stubFetch(response: GhRepoPr[]) {
+  return spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockResolvedValue(response)
+}
+
+function prevState(numbers: number[], repo = 'org/repo'): NewPrsPluginState {
+  return { repos: { [repo]: numbers } }
+}
+
+describe('GitHubNewPrsPlugin.runTick', () => {
+  stubRateLimit()
+
+  it('seeds without emitting on first run (prev === null)', async () => {
+    const spy = stubFetch([pr(1), pr(2), pr(3)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), null)
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2, 3])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits a oneline announcement for PRs new since last tick', async () => {
+    const spy = stubFetch([pr(1), pr(2), pr(3)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([1]))
+      expect(result.taggedEvents).toHaveLength(2)
+      expect(result.taggedEvents[0]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'new PR org/repo#2: PR 2 — https://github.com/org/repo/pull/2',
+      })
+      expect(result.taggedEvents[1]?.payload).toEqual({
+        kind: 'oneline',
+        text: 'new PR org/repo#3: PR 3 — https://github.com/org/repo/pull/3',
+      })
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes announcements to the project channel by default', async () => {
+    const spy = stubFetch([pr(5)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('honors entry.channels override when set', async () => {
+    const spy = stubFetch([pr(5)])
+    try {
+      const config = baseConfig({ plugins: { 'github-new-prs': { watched: [{ repo: 'org/repo', channels: ['#triage', '#leads'] }] } } })
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, prevState([]))
+      expect(result.taggedEvents[0]?.channels).toEqual(['#triage', '#leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits a defensive per-event channel copy — sibling mutation does not leak', async () => {
+    const spy = stubFetch([pr(1), pr(2)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
+      result.taggedEvents[0]?.channels.push('#tampered')
+      expect(result.taggedEvents[1]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('includes labels in the announcement when present', async () => {
+    const spy = stubFetch([pr(7, { labels: [{ name: 'enhancement' }, { name: 'good first issue' }] })])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toBe('new PR org/repo#7: PR 7 [enhancement, good first issue] — https://github.com/org/repo/pull/7')
+    } finally { spy.mockRestore() }
+  })
+
+  it('accumulates seen numbers across ticks', async () => {
+    const spy = stubFetch([pr(1), pr(2)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([5]))
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2, 5])
+    } finally { spy.mockRestore() }
+  })
+
+  it('does not re-announce PRs already in seen', async () => {
+    const spy = stubFetch([pr(1), pr(2)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([1, 2]))
+      expect(result.taggedEvents).toHaveLength(0)
+    } finally { spy.mockRestore() }
+  })
+
+  it('no-ops when watched list is empty', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-new-prs': { watched: [] } },
+    }
+    const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
+  })
+
+  it('no-ops when watched is absent', async () => {
+    const config: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-new-prs': {} },
+    }
+    const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, null)
+    expect(result.taggedEvents).toHaveLength(0)
+  })
+
+  it('orders announcements by PR number', async () => {
+    const spy = stubFetch([pr(20), pr(5), pr(11)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), prevState([]))
+      const numbers = result.taggedEvents.map(e =>
+        ((e.payload as { kind: 'oneline'; text: string }).text.match(/#(\d+)/)?.[1])
+      )
+      expect(numbers).toEqual(['5', '11', '20'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('desiredChannels returns empty when no entry has channels', () => {
+    const plugin = new GitHubNewPrsPlugin('#proj-leads')
+    expect(plugin.desiredChannels(baseConfig())).toEqual([])
+  })
+
+  it('desiredChannels unions channels across all watched entries', () => {
+    const plugin = new GitHubNewPrsPlugin('#proj-leads')
+    const config = baseConfig({
+      plugins: {
+        'github-new-prs': {
+          watched: [
+            { repo: 'org/repo', channels: ['#triage'] },
+            { repo: 'org/other', channels: ['#triage', '#leads'] },
+          ],
+        },
+      },
+    })
+    expect(plugin.desiredChannels(config)).toEqual(['#triage', '#leads'])
+  })
+
+  it('polls each watched repo independently', async () => {
+    const calls: string[] = []
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockImplementation(async (repo: string) => {
+      calls.push(repo)
+      return repo === 'org/a' ? [pr(1)] : [pr(2)]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'github-new-prs': {
+            watched: [
+              { repo: 'org/a' },
+              { repo: 'org/b' },
+            ],
+          },
+        },
+      }
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, { repos: { 'org/a': [], 'org/b': [] } })
+      expect(calls).toEqual(['org/a', 'org/b'])
+      expect(result.taggedEvents).toHaveLength(2)
+      expect((result.taggedEvents[0]?.payload as { text: string }).text).toContain('org/a#1')
+      expect((result.taggedEvents[1]?.payload as { text: string }).text).toContain('org/b#2')
+    } finally { spy.mockRestore() }
+  })
+
+  it('seeds a new repo entry without emitting when added to an existing config', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockImplementation(async (repo: string) => {
+      return repo === 'org/a' ? [pr(1)] : [pr(10), pr(11)]
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'github-new-prs': {
+            watched: [
+              { repo: 'org/a' },
+              { repo: 'org/new' },
+            ],
+          },
+        },
+      }
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, { repos: { 'org/a': [] } })
+      const texts = result.taggedEvents.map(e => (e.payload as { text: string }).text)
+      expect(texts.every(t => t.includes('org/a'))).toBe(true)
+      expect(texts.some(t => t.includes('org/new'))).toBe(false)
+      expect((result.state as NewPrsPluginState).repos['org/new']).toEqual([10, 11])
+    } finally { spy.mockRestore() }
+  })
+
+  it('carries forward removed-entry state — remove-then-readd does not replay history', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockResolvedValue([pr(5)])
+    try {
+      const config = baseConfig()
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(
+        config,
+        { repos: { 'org/repo': [], 'org/gone': [10, 11] } },
+      )
+      const state = result.state as NewPrsPluginState
+      expect(state.repos['org/gone']).toEqual([10, 11])
+    } finally { spy.mockRestore() }
+  })
+
+  it('suppresses PRs authored by agent_logins', async () => {
+    const spy = stubFetch([
+      pr(1, { user: { login: 'roost-agent' } }),
+      pr(2, { user: { login: 'external-user' } }),
+      pr(3, { user: { login: 'another-agent' } }),
+    ])
+    try {
+      const config = baseConfig({ agent_logins: ['roost-agent', 'another-agent'] })
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, prevState([]))
+      expect(result.taggedEvents).toHaveLength(1)
+      expect((result.taggedEvents[0]?.payload as { text: string }).text).toContain('org/repo#2')
+    } finally { spy.mockRestore() }
+  })
+
+  it('seeds agent PR numbers into state even when suppressed — prevents replay on agent_logins change', async () => {
+    const spy = stubFetch([
+      pr(1, { user: { login: 'roost-agent' } }),
+      pr(2, { user: { login: 'external-user' } }),
+    ])
+    try {
+      const config = baseConfig({ agent_logins: ['roost-agent'] })
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, prevState([]))
+      // Both numbers seeded, only #2 announced.
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2])
+      expect(result.taggedEvents).toHaveLength(1)
+    } finally { spy.mockRestore() }
+  })
+
+  it('announces PRs with no user login (author unknown) — conservative default', async () => {
+    const spy = stubFetch([pr(1, { user: undefined })])
+    try {
+      const config = baseConfig({ agent_logins: ['roost-agent'] })
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(config, prevState([]))
+      expect(result.taggedEvents).toHaveLength(1)
+    } finally { spy.mockRestore() }
+  })
+
+  it('treats old flat state format as null and re-seeds', async () => {
+    const spy = stubFetch([pr(1), pr(2)])
+    try {
+      const oldState = { seen_pr_numbers: [1, 2, 3] }
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(baseConfig(), oldState)
+      expect(result.taggedEvents).toHaveLength(0)
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2])
+    } finally { spy.mockRestore() }
+  })
+})

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -190,6 +190,14 @@ export interface GhRepoIssue {
   pull_request?: Record<string, unknown>
 }
 
+export interface GhRepoPr {
+  number?: number
+  title?: string
+  html_url?: string
+  labels?: GhLabel[]
+  user?: { login?: string }
+}
+
 // `/repos/{owner}/{repo}/commits` returns newest-first. We only consume sha,
 // html_url, and the message subject — the rest stays untyped vs schema drift.
 export interface GhCommit {
@@ -343,6 +351,10 @@ export class GhClient {
   async fetchRepoOpenIssues(repo: string): Promise<GhRepoIssue[]> {
     const raw = (await this.api(`repos/${repo}/issues?state=open&per_page=100`, true) ?? []) as GhRepoIssue[]
     return raw.filter(i => !i.pull_request)
+  }
+
+  async fetchRepoOpenPrs(repo: string): Promise<GhRepoPr[]> {
+    return (await this.api(`repos/${repo}/pulls?state=open&per_page=100`, true) ?? []) as GhRepoPr[]
   }
 
   // Single page capped at `perPage` — multi-page bursts are caller-logged

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -174,6 +174,7 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
           .filter(p => {
             if (p.number == null || seen.has(p.number)) return false
             const login = p.user?.login
+            // Conservative: no login = external (announce). Known agent login = suppress.
             return !login || !agentLogins.has(login)
           })
           .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -1,0 +1,206 @@
+// Project-level new-PR triage feed. Polls watched repos for open PRs
+// and announces the first time a given (repo, number) is observed.
+// PRs authored by agent_logins are suppressed — those are already tracked
+// by the per-watch github-prs plugin; this plugin surfaces external contributions.
+//
+// DM grammar: claims target=`new-prs` — `watch new-prs <owner>/<repo>
+// [#chan ...]`. `@branch`/`:path` are rejected (entries are repo-only).
+//
+// State slice: `{ repos: Record<string, number[]> }`. Seeding (`prev===null`)
+// and first-observation of a new repo entry both capture without emitting.
+// All open PR numbers (including agent-authored) are seeded into state to
+// prevent replay if agent_logins later changes. Removed entries are carried
+// forward so remove-then-readd doesn't replay.
+import type { Command } from '../../dispatcher-dm-handler.js'
+import type { OrchestratorConfig } from '../../config.js'
+import { assertEntryRepoMode } from '../../config.js'
+import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
+import { resolveProjectChannel } from '../../naming.js'
+import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
+import { labelNames, type GhRepoPr } from './github-api.js'
+import { GhPluginBase } from './base.js'
+
+export interface NewPrsWatchEntry {
+  repo: string
+  channels?: string[]
+}
+
+interface NewPrsPluginConfig {
+  watched?: NewPrsWatchEntry[]
+}
+
+export interface NewPrsPluginState {
+  repos: Record<string, number[]>
+}
+
+export class GitHubNewPrsPlugin extends GhPluginBase {
+  readonly name = 'github-new-prs'
+
+  parseCommand(line: string): ParseResult | null {
+    return tryClaimPerRepo('new-prs', line)
+  }
+
+  handleCommand(merged: OrchestratorConfig, local: OrchestratorConfig, cmd: Command): string | null {
+    if (cmd.kind === 'list') return this.formatListSection(merged)
+    if (cmd.kind === 'help') return this.formatHelpSection()
+    if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
+      const c = cmd.cmd as PerRepoCommand
+      if (c.branch !== null || c.path !== null) {
+        const verb = c.verb
+        return `error: new-prs does not support @branch or :path — try \`${verb} new-prs ${c.repo}\``
+      }
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.repo, c.channels)
+      return this.applyUnwatch(merged, local, c.repo)
+    }
+    return null
+  }
+
+  private mergedWatched(config: OrchestratorConfig): NewPrsWatchEntry[] {
+    return this.pluginConfig<NewPrsPluginConfig>(config)?.watched ?? []
+  }
+
+  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string, channels: string[]): string {
+    const labelStr = `new-prs ${repo}`
+    const match = (e: NewPrsWatchEntry) => e.repo === repo
+    if (!this.mergedWatched(merged).some(match)) {
+      const slice = this.localSlice<NewPrsPluginConfig>(local)
+      slice.watched ??= []
+      const entry: NewPrsWatchEntry = { repo }
+      if (channels.length) entry.channels = [...channels]
+      slice.watched.push(entry)
+      return channels.length ? `watching ${labelStr} + ${channels.join(' ')}` : `watching ${labelStr}`
+    }
+    const localEntry = (this.pluginConfig<NewPrsPluginConfig>(local)?.watched ?? []).find(match)
+    if (!localEntry) return channels.length ? trackedRefusal(labelStr, 'add channels') : `already watching ${labelStr}`
+    return addChannelsToEntry(localEntry, channels, labelStr)
+  }
+
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, repo: string): string {
+    return applyUnwatchEntry<NewPrsWatchEntry>(
+      this.mergedWatched(merged),
+      this.pluginConfig<NewPrsPluginConfig>(local)?.watched ?? [],
+      e => e.repo === repo,
+      `new-prs ${repo}`,
+    )
+  }
+
+  private formatListSection(merged: OrchestratorConfig): string {
+    const entries = this.mergedWatched(merged)
+    const byRepo = new Map<string, Set<string>>()
+    const order: string[] = []
+    for (const e of entries) {
+      let chans = byRepo.get(e.repo)
+      if (!chans) {
+        chans = new Set<string>()
+        byRepo.set(e.repo, chans)
+        order.push(e.repo)
+      }
+      for (const c of e.channels ?? []) chans.add(c)
+    }
+    const header = `${this.name} (${byRepo.size}):`
+    if (!byRepo.size) return `${header}\n  (none)`
+    const lines = order.map(r => {
+      const chans = byRepo.get(r)!
+      const chansStr = chans.size ? ` + ${[...chans].join(' ')}` : ''
+      return `  ${r}${chansStr}`
+    })
+    return [header, ...lines].join('\n')
+  }
+
+  private formatHelpSection(): string {
+    return [
+      `${this.name} commands (DM only):`,
+      `  watch new-prs <owner>/<repo> [#chan ...]   — watch new-prs feed`,
+      `  unwatch new-prs <owner>/<repo>             — stop watching new-prs feed`,
+      `  watch list                                 — include this plugin's watched repos in the reply`,
+    ].join('\n')
+  }
+
+  // Project channel is unioned in by the orchestrator; per-entry channels join at boot.
+  desiredChannels(config: OrchestratorConfig): string[] {
+    const slice = this.pluginConfig<NewPrsPluginConfig>(config) ?? {}
+    const chans = new Set<string>()
+    for (const entry of slice.watched ?? []) {
+      for (const c of entry.channels ?? []) chans.add(c)
+    }
+    return [...chans]
+  }
+
+  // Tracked-only; see `Plugin.assertRepoMode` for rationale. The repo field
+  // is statically required, so the multi-mode missing-repo branch never fires.
+  assertRepoMode(base: OrchestratorConfig): void {
+    const slice = this.pluginConfig<NewPrsPluginConfig>(base) ?? {}
+    const topRepo = base.repo
+    for (const entry of slice.watched ?? []) {
+      assertEntryRepoMode(this.name, `(repo=${entry.repo})`, entry.repo, topRepo)
+    }
+  }
+
+  async runTick(config: OrchestratorConfig, prevState: unknown): Promise<PluginTickResult> {
+    const slice = this.pluginConfig<NewPrsPluginConfig>(config) ?? {}
+    const watchEntries = slice.watched ?? []
+    if (!watchEntries.length) return { state: prevState ?? { repos: {} }, taggedEvents: [], channels: [] }
+
+    // Re-seed cleanly from older shapes (no `repos` key).
+    const prev = (prevState != null && typeof prevState === 'object' && 'repos' in prevState)
+      ? prevState as NewPrsPluginState
+      : null
+
+    const agentLogins = this.agentLogins(config)
+    const taggedEvents: TaggedEvent[] = []
+    const nextRepos: Record<string, number[]> = prev ? { ...prev.repos } : {}
+
+    for (const entry of watchEntries) {
+      const { repo, channels } = entry
+      const announcementChannels = channels?.length
+        ? [...channels]
+        : [resolveProjectChannel(config)]
+
+      const prs = await this.client.fetchRepoOpenPrs(repo)
+
+      // All open PR numbers go into state — prevents replay if agent_logins changes.
+      const currentNumbers = prs
+        .map(p => p.number)
+        .filter((n): n is number => n != null)
+        .sort((a, b) => a - b)
+
+      // First observation of this repo (or full re-seed): capture without emitting.
+      const isFirstForRepo = prev === null || prev.repos[repo] === undefined
+      const seen = new Set<number>(prev?.repos[repo] ?? [])
+
+      if (!isFirstForRepo) {
+        const newPrs = prs
+          .filter(p => {
+            if (p.number == null || seen.has(p.number)) return false
+            const login = p.user?.login
+            return !login || !agentLogins.has(login)
+          })
+          .sort((a, b) => (a.number ?? 0) - (b.number ?? 0))
+        for (const pr of newPrs) {
+          taggedEvents.push({
+            // Per-event copy so a downstream mutation can't leak across siblings.
+            channels: [...announcementChannels],
+            payload: { kind: 'oneline', text: formatNewPr(repo, pr) },
+          })
+        }
+      }
+
+      for (const n of currentNumbers) seen.add(n)
+      nextRepos[repo] = [...seen].sort((a, b) => a - b)
+    }
+
+    const state: NewPrsPluginState = { repos: nextRepos }
+    taggedEvents.push(...await this.observeRateLimit(resolveProjectChannel(config)))
+    return { state, taggedEvents, channels: [] }
+  }
+}
+
+function formatNewPr(repo: string, pr: GhRepoPr): string {
+  const tag = `${repo}#${pr.number}`
+  const title = pr.title ?? ''
+  const labels = labelNames(pr.labels)
+  const labelStr = labels.length ? ` [${labels.join(', ')}]` : ''
+  const url = pr.html_url ?? ''
+  return `new PR ${tag}: ${title}${labelStr} — ${url}`
+}

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -4,6 +4,7 @@ import { registerPlugin } from './plugin.js'
 import { GitHubPrsPlugin } from './plugins/github/prs-plugin.js'
 import { GitHubIssuesPlugin } from './plugins/github/issues-plugin.js'
 import { GitHubNewIssuesPlugin } from './plugins/github/new-issues-plugin.js'
+import { GitHubNewPrsPlugin } from './plugins/github/new-prs-plugin.js'
 import { GitHubCommitsPlugin } from './plugins/github/commits-plugin.js'
 import { LinearIssuesPlugin } from './plugins/linear/issues-plugin.js'
 import { LinearNewIssuesPlugin } from './plugins/linear/new-issues-plugin.js'
@@ -11,6 +12,7 @@ import { LinearNewIssuesPlugin } from './plugins/linear/new-issues-plugin.js'
 registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
 registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))
 registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log))
+registerPlugin('github-new-prs', (defaultChannel, log) => new GitHubNewPrsPlugin(defaultChannel, log))
 registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log))
 registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log))
 registerPlugin('linear-new-issues', (defaultChannel, log) => new LinearNewIssuesPlugin(defaultChannel, log))


### PR DESCRIPTION
Closes #509

Symmetric counterpart to `github-new-issues`. Polls watched repos for newly-opened PRs and announces them once to the project channel (or per-entry override channels).

Key difference from `new-issues`: agent-authored PRs (`agent_logins`) are suppressed — those are already tracked by the per-watch `github-prs` plugin. All PR numbers (including suppressed) are seeded into state so removing `agent_logins` later doesn't replay history.

Also adds a "When a new PR arrives in-flight" section to `lead-pm.md`: engage-now / defer / decline+redirect, same one-liner-with-rationale shape as the existing issue triage section.

**Announcement format:** `new PR org/repo#42: title [labels] — url`

**DM grammar:** `watch new-prs <owner>/<repo> [#chan ...]`

20 new tests. Full suite 921/0 green, typecheck clean.