### PR TITLE
add learning from #509

### DIFF
--- a/.claude/rules/project-learnings.md
+++ b/.claude/rules/project-learnings.md
@@ -25,3 +25,7 @@ Treat reviewer "fyi: this is narrower than the failure mode" as a blocker on the
 ## 2026-05-21: CLAUDE.local.md is a doc, not a permission grant — credential workers need explicit onboarding (from #492) [audience=lead-pm,apm]
 
 CLAUDE.local.md is a doc, not a permission grant. When a worker needs to fetch a credential, the auto-mode classifier blocks the call regardless of the doc. Lead either pre-injects the retrieval chain via `roost send` before the worker's first credential-touching command, or approves via permbot when it fires. Required onboarding step for any credential-fetching worker.
+
+## 2026-05-22: Anchoring language makes referenced defaults a design constraint (from #509)
+
+When an issue body anchors a new artifact to an existing one (any "like X", "mirror of", "symmetric counterpart", "extends pattern X" language), X's defaults are a design constraint, not a starting suggestion. Worker default-deviation must be explicitly justified in plan; reviewer treats unjustified deviation as a blocker per §#486.


### PR DESCRIPTION
from #509 postmortem.

learning added to `.claude/rules/project-learnings.md`:

> When an issue body anchors a new artifact to an existing one (any "like X", "mirror of", "symmetric counterpart", "extends pattern X" language), X's defaults are a design constraint, not a starting suggestion. Worker default-deviation must be explicitly justified in plan; reviewer treats unjustified deviation as a blocker per §#486.