### PR TITLE
add dispatcher help plugins verb + registry descriptions

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -36,7 +36,7 @@ Your IRC nick is `<project>-apm`. On boot:
    Steps 2–5 below (dispatcher start, hello post) are gated on having both values, so if the lead never replies the hello never lands and `#<project>-leads` is left holding the rescue post as the only signal. That's the intended behavior — no timeout, no nag.
 2. Read `.orchestrator/config.json` in your cwd. The `project` field is your project namespace — use it as `<project>` in every command below.
 3. Make sure the dispatcher daemon is running for this project: `"$(roost root)/bin/start-dispatcher" "$(pwd)/.orchestrator"`. The helper is idempotent — it reports "already running" if a live dispatcher owns this config dir, or spawns one otherwise. The dispatcher's allowlist defaults to accepting DMs from `<project>-lead-pm` and `<project>-apm`, so your `watch`/`unwatch` DMs will work out of the box.
-4. DM `<project>-dispatcher` with `help`. This pulls its command vocabulary into your context so you know what's available (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`) and smoke-tests that DMs to it work.
+4. DM `<project>-dispatcher` with `help` and `help plugins`. The `help` reply shows per-plugin DM grammar (`watch <N>`, `watch <N> #ch1 #ch2`, `unwatch <N>`, `watch pr <N>`, `unwatch pr <N>`, `watch list`). The `help plugins` reply lists all registered plugin classes, including any not yet in config. Both smoke-test that DMs to the dispatcher work.
 5. Post a one-line hello in `#<project>-leads` so the lead knows you're alive.
 
 ## Trust boundaries

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -159,7 +159,7 @@ SIGTERM, waits up to 30s (`STOP_TIMEOUT=<seconds>` overrides). No SIGKILL escala
 
 The dispatcher accepts a small grammar via DM from nicks in
 `irc.command_senders` (defaults to lead-pm + APM). Plugins own their watch/
-unwatch shapes — the dispatcher only parses `help` / `watch list` centrally
+unwatch shapes — the dispatcher only parses `help`, `help plugins`, and `watch list` centrally
 and hands every other line to plugins in `grammarPriority` order. Operators
 override the priority via `config.plugin_priorities: {<name>: <number>}`
 (higher wins, replaces the plugin's static value). See `docs/PLUGINS.md` for
@@ -173,6 +173,7 @@ watch <target> <owner>/<repo>[@<branch>[:<path>]] [#chan ...]  # github-commits 
 unwatch <target> <owner>/<repo>[@<branch>[:<path>]]
 watch list      # every plugin's active entries
 help            # synopsis + per-plugin help
+help plugins    # all registered plugin classes (enabled or not)
 ```
 
 Target keywords currently claimed by first-party plugins:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -40,7 +40,7 @@ The dispatcher writes each `TaggedEvent` to every channel in `event.channels`. E
 
 ## DM grammar
 
-The dispatcher knows only two global verbs (`help`, `watch list`) and an allowlist. Everything else — `watch <N>`, `watch pr 5`, `watch repo org/r@main`, your own `watch deploy …` — is parsed by the plugin that claims the shape. The canonical semantics live on `Plugin.parseCommand` in `src/orchestrator/plugin.ts` (defer with `null`, claim with `{kind:'ok',cmd}`, fail with `{kind:'error',message}`).
+The dispatcher knows only three global verbs (`help`, `help plugins`, `watch list`) and an allowlist. Everything else — `watch <N>`, `watch pr 5`, `watch repo org/r@main`, your own `watch deploy …` — is parsed by the plugin that claims the shape. The canonical semantics live on `Plugin.parseCommand` in `src/orchestrator/plugin.ts` (defer with `null`, claim with `{kind:'ok',cmd}`, fail with `{kind:'error',message}`).
 
 Shared parser helpers cover the two shipped shapes:
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -73,7 +73,7 @@ Plugins that used to receive every `Command` via `handleCommand` (the central pa
 
 ## Register on load
 
-Each `plugin_paths` entry is imported for its side effects. The module must call `registerPlugin(name, factory)` at the top level. If you bury the call in a function or a default export, the dispatcher fails with `unknown plugin in config: <name>`.
+Each `plugin_paths` entry is imported for its side effects. The module must call `registerPlugin(name, factory, description?)` at the top level. If you bury the call in a function or a default export, the dispatcher fails with `unknown plugin in config: <name>`. The optional `description` string appears in `help plugins` output, so operators discovering plugins before touching config get a one-liner for each.
 
 `registerPlugin` throws on duplicate names. Built-in names are reserved. Pick a unique slug like `acme-deploys` or `linear-issues`.
 
@@ -107,7 +107,7 @@ class MyPlugin extends BasePlugin {
   }
 }
 
-registerPlugin('acme-pulse', (defaultChannel) => new MyPlugin(defaultChannel))
+registerPlugin('acme-pulse', (defaultChannel) => new MyPlugin(defaultChannel), 'one-line description shown in help plugins')
 ```
 
 Operator config:
@@ -137,7 +137,7 @@ From a fresh repo:
 
 1. **Bootstrap.** `bun init` (or pnpm/npm). Add roost via one of the [install patterns](#installing-roostplugin) below: `bun link` for dev, git-dep for stable consumption.
 
-2. **Write the module.** A single file, top-level `registerPlugin(name, factory)`, no default export. See [Minimal example](#minimal-example).
+2. **Write the module.** A single file, top-level `registerPlugin(name, factory, description?)`, no default export. See [Minimal example](#minimal-example).
 
 3. **Wire into a target project's `.orchestrator/config.json`.** `plugin_paths` points at the module file (relative to the config dir, or absolute):
 

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -11,7 +11,7 @@ import {
   type HandlerDeps,
 } from '../dispatcher-dm-handler.js'
 import { loadConfig, loadConfigBase, loadLocalOverlay, writeConfig, type OrchestratorConfig } from '../config.js'
-import type { ParseResult, Plugin, PluginTickResult } from '../plugin.js'
+import { registerPlugin, unregisterPlugin, type ParseResult, type Plugin, type PluginTickResult } from '../plugin.js'
 
 let dir: string
 
@@ -108,6 +108,20 @@ describe('parseCommand (central — global verbs)', () => {
 
   it('rejects trailing tokens after `help`', () => {
     const cmd = parseCommand('help me', [], {}) as Extract<Command, { kind: 'unknown' }>
+    expect(cmd.kind).toBe('unknown')
+    expect(cmd.error).toMatch(/help takes no arguments/)
+  })
+
+  it('parses help plugins', () => {
+    expect(parseCommand('help plugins', [], {})).toEqual({ kind: 'help-plugins' })
+  })
+
+  it('is case-insensitive for help plugins', () => {
+    expect(parseCommand('Help Plugins', [], {})).toEqual({ kind: 'help-plugins' })
+  })
+
+  it('rejects trailing tokens after `help plugins`', () => {
+    const cmd = parseCommand('help plugins foo', [], {}) as Extract<Command, { kind: 'unknown' }>
     expect(cmd.kind).toBe('unknown')
     expect(cmd.error).toMatch(/help takes no arguments/)
   })
@@ -298,6 +312,38 @@ describe('handleDm — routing', () => {
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'help' })
     expect(irc.dms[0].text).toContain('dispatcher DM grammar')
     expect(irc.dms[0].text).toContain('issues: help-section\n\nprs: help-section')
+  })
+
+  it('help plugins returns registered plugin names with descriptions', async () => {
+    registerPlugin('test-help-plugins-alpha', () => new StubPlugin('test-help-plugins-alpha', null), 'alpha description')
+    registerPlugin('test-help-plugins-beta', () => new StubPlugin('test-help-plugins-beta', null))
+    try {
+      await writeConfig(dir, { project: 'roost', plugins: {} })
+      const { deps, irc } = makeDeps(dir, [])
+      await handleDm(deps, { sender: 'roost-lead-pm', text: 'help plugins' })
+      expect(irc.dms).toHaveLength(1)
+      const reply = irc.dms[0].text
+      expect(reply).toContain('test-help-plugins-alpha — alpha description')
+      expect(reply).toContain('test-help-plugins-beta')
+    } finally {
+      unregisterPlugin('test-help-plugins-alpha')
+      unregisterPlugin('test-help-plugins-beta')
+    }
+  })
+
+  it('help plugins is a pure-read (does not touch config.json)', async () => {
+    registerPlugin('test-help-plugins-pure', () => new StubPlugin('test-help-plugins-pure', null))
+    try {
+      await writeConfig(dir, { project: 'roost', plugins: {} })
+      const { mtimeMs: before } = await Bun.file(join(dir, 'config.json')).stat()
+      await new Promise(r => setTimeout(r, 20))
+      const { deps } = makeDeps(dir, [])
+      await handleDm(deps, { sender: 'roost-lead-pm', text: 'help plugins' })
+      const { mtimeMs: after } = await Bun.file(join(dir, 'config.json')).stat()
+      expect(after).toBe(before)
+    } finally {
+      unregisterPlugin('test-help-plugins-pure')
+    }
   })
 
   it('surfaces "no plugin handles" with the raw line + enabled plugins', async () => {

--- a/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
+++ b/src/orchestrator/__tests__/dispatcher-dm-handler.test.ts
@@ -311,6 +311,7 @@ describe('handleDm — routing', () => {
     const { deps, irc } = makeDeps(dir, [issues, prs])
     await handleDm(deps, { sender: 'roost-lead-pm', text: 'help' })
     expect(irc.dms[0].text).toContain('dispatcher DM grammar')
+    expect(irc.dms[0].text).toContain('help plugins')
     expect(irc.dms[0].text).toContain('issues: help-section\n\nprs: help-section')
   })
 

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -132,10 +132,10 @@ async function routeOne(
   if (cmd.kind === 'unknown') return `error: ${cmd.error}`
 
   if (cmd.kind === 'help-plugins') {
-    const plugins = registeredPlugins().sort((a, b) => a.name.localeCompare(b.name))
-    const header = `registered plugins (${plugins.length}):`
-    if (!plugins.length) return `${header}\n  (none)`
-    const lines = plugins.map(p => p.description ? `  ${p.name} — ${p.description}` : `  ${p.name}`)
+    const registered = registeredPlugins().sort((a, b) => a.name.localeCompare(b.name))
+    const header = `registered plugins (${registered.length}):`
+    if (!registered.length) return `${header}\n  (none)`
+    const lines = registered.map(p => p.description ? `  ${p.name} — ${p.description}` : `  ${p.name}`)
     return [header, ...lines].join('\n')
   }
 

--- a/src/orchestrator/dispatcher-dm-handler.ts
+++ b/src/orchestrator/dispatcher-dm-handler.ts
@@ -9,7 +9,7 @@
 
 import { loadConfig, loadConfigBase, loadLocalOverlay, mergeConfigs, mutateConfig, type OrchestratorConfig } from './config.js'
 import { apmNick, defaultProject, leadPmNick } from './naming.js'
-import { assertRepoModeAll, priorityOf, type Plugin } from './plugin.js'
+import { assertRepoModeAll, priorityOf, registeredPlugins, type Plugin } from './plugin.js'
 import { splitCommands } from './plugins/grammar.js'
 
 // `plugin` carries an opaque cmd payload — the plugin that produced it is the
@@ -20,6 +20,7 @@ export type Command =
   | { kind: 'plugin'; plugin: string; cmd: unknown; raw: string }
   | { kind: 'list' }
   | { kind: 'help' }
+  | { kind: 'help-plugins' }
   | { kind: 'unknown'; raw: string; error: string }
 
 export interface HandlerDeps {
@@ -63,8 +64,9 @@ export function parseCommand(line: string, plugins: Plugin[], config: Orchestrat
   const verb = tokens[0].toLowerCase()
 
   if (verb === 'help') {
-    if (tokens.length > 1) return { kind: 'unknown', raw: line, error: `help takes no arguments; got "${tokens.slice(1).join(' ')}"` }
-    return { kind: 'help' }
+    if (tokens.length === 1) return { kind: 'help' }
+    if (tokens.length === 2 && tokens[1].toLowerCase() === 'plugins') return { kind: 'help-plugins' }
+    return { kind: 'unknown', raw: line, error: `help takes no arguments (or "help plugins"); got "${tokens.slice(1).join(' ')}"` }
   }
 
   if (verb === 'watch' && tokens[1]?.toLowerCase() === 'list') {
@@ -116,6 +118,7 @@ const HELP_SYNOPSIS = [
   'dispatcher DM grammar (one per line, or `;`/`,`-separated):',
   '  watch list                 — every plugin\'s active entries',
   '  help                       — this synopsis + per-plugin commands',
+  '  help plugins               — all registered plugin classes (enabled or not)',
   '',
   'plugins claim their own watch/unwatch shapes; per-plugin grammar:',
 ].join('\n')
@@ -127,6 +130,14 @@ async function routeOne(
   plugins: Plugin[],
 ): Promise<string | null> {
   if (cmd.kind === 'unknown') return `error: ${cmd.error}`
+
+  if (cmd.kind === 'help-plugins') {
+    const plugins = registeredPlugins().sort((a, b) => a.name.localeCompare(b.name))
+    const header = `registered plugins (${plugins.length}):`
+    if (!plugins.length) return `${header}\n  (none)`
+    const lines = plugins.map(p => p.description ? `  ${p.name} — ${p.description}` : `  ${p.name}`)
+    return [header, ...lines].join('\n')
+  }
 
   // list/help broadcast — every plugin contributes its own section.
   if (cmd.kind === 'list' || cmd.kind === 'help') {
@@ -190,7 +201,7 @@ export async function handleDm(deps: HandlerDeps, dm: InboundDm): Promise<void> 
     return
   }
 
-  const isPureRead = cmds.every(c => c.kind === 'list' || c.kind === 'help')
+  const isPureRead = cmds.every(c => c.kind === 'list' || c.kind === 'help' || c.kind === 'help-plugins')
 
   // No fsync, no writer queue — list/help never mutate.
   if (isPureRead) {

--- a/src/orchestrator/plugin.ts
+++ b/src/orchestrator/plugin.ts
@@ -125,15 +125,16 @@ export const defaultPluginLogger: PluginLogger = (msg) => { process.stderr.write
 
 export type PluginFactory = (defaultChannel: string, log: PluginLogger) => Plugin
 
-const REGISTRY = new Map<string, PluginFactory>()
+interface RegistryEntry { factory: PluginFactory; description?: string }
+const REGISTRY = new Map<string, RegistryEntry>()
 
 // Throws on duplicate — silent overwrite would shadow another plugin's state
 // slice (registry key === state.plugins[name] key).
-export function registerPlugin(name: string, factory: PluginFactory): void {
+export function registerPlugin(name: string, factory: PluginFactory, description?: string): void {
   if (REGISTRY.has(name)) {
     throw new Error(`plugin already registered: ${name}`)
   }
-  REGISTRY.set(name, factory)
+  REGISTRY.set(name, { factory, description })
 }
 
 // Test-only escape hatch — not exported from `plugin-api.ts`.
@@ -142,11 +143,15 @@ export function unregisterPlugin(name: string): boolean {
 }
 
 export function getPluginFactory(name: string): PluginFactory | undefined {
-  return REGISTRY.get(name)
+  return REGISTRY.get(name)?.factory
 }
 
 export function registeredPluginNames(): string[] {
   return [...REGISTRY.keys()]
+}
+
+export function registeredPlugins(): Array<{ name: string; description?: string }> {
+  return [...REGISTRY.entries()].map(([name, entry]) => ({ name, description: entry.description }))
 }
 
 // Dispatch each plugin's `assertRepoMode` if implemented. Called by every

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -9,10 +9,10 @@ import { GitHubCommitsPlugin } from './plugins/github/commits-plugin.js'
 import { LinearIssuesPlugin } from './plugins/linear/issues-plugin.js'
 import { LinearNewIssuesPlugin } from './plugins/linear/new-issues-plugin.js'
 
-registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log))
-registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log))
-registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log))
-registerPlugin('github-new-prs', (defaultChannel, log) => new GitHubNewPrsPlugin(defaultChannel, log))
-registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log))
-registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log))
-registerPlugin('linear-new-issues', (defaultChannel, log) => new LinearNewIssuesPlugin(defaultChannel, log))
+registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log), 'watches PR activity for tracked issue numbers')
+registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log), 'watches issue activity for tracked issue numbers')
+registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log), 'announces new GitHub issues in watched repos')
+registerPlugin('github-new-prs', (defaultChannel, log) => new GitHubNewPrsPlugin(defaultChannel, log), 'announces new GitHub PRs not authored by agent_logins')
+registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log), 'announces commits to watched repos/branches/paths')
+registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log), 'watches Linear issue activity for tracked issue keys')
+registerPlugin('linear-new-issues', (defaultChannel, log) => new LinearNewIssuesPlugin(defaultChannel, log), 'announces new Linear issues in watched teams')

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -9,10 +9,10 @@ import { GitHubCommitsPlugin } from './plugins/github/commits-plugin.js'
 import { LinearIssuesPlugin } from './plugins/linear/issues-plugin.js'
 import { LinearNewIssuesPlugin } from './plugins/linear/new-issues-plugin.js'
 
-registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log), 'watches PR activity for tracked issue numbers')
+registerPlugin('github-prs', (defaultChannel, log) => new GitHubPrsPlugin(defaultChannel, log), 'watches PR activity for tracked PR numbers')
 registerPlugin('github-issues', (defaultChannel, log) => new GitHubIssuesPlugin(defaultChannel, log), 'watches issue activity for tracked issue numbers')
 registerPlugin('github-new-issues', (defaultChannel, log) => new GitHubNewIssuesPlugin(defaultChannel, log), 'announces new GitHub issues in watched repos')
-registerPlugin('github-new-prs', (defaultChannel, log) => new GitHubNewPrsPlugin(defaultChannel, log), 'announces new GitHub PRs not authored by agent_logins')
+registerPlugin('github-new-prs', (defaultChannel, log) => new GitHubNewPrsPlugin(defaultChannel, log), 'announces new GitHub PRs from non-agent authors')
 registerPlugin('github-commits', (defaultChannel, log) => new GitHubCommitsPlugin(defaultChannel, log), 'announces commits to watched repos/branches/paths')
 registerPlugin('linear-issues', (defaultChannel, log) => new LinearIssuesPlugin(defaultChannel, log), 'watches Linear issue activity for tracked issue keys')
 registerPlugin('linear-new-issues', (defaultChannel, log) => new LinearNewIssuesPlugin(defaultChannel, log), 'announces new Linear issues in watched teams')


### PR DESCRIPTION
Closes #542

adds `help plugins` DM verb to the dispatcher. returns all registered plugin classes with one-line descriptions, regardless of config. operators bootstrapping a new repo can discover what's available without grepping docs/PLUGINS.md.

**dispatcher changes:**
- `help plugins` parses to `{kind:'help-plugins'}`, routes to `registeredPlugins()`, pure-read (no mutateConfig)
- `HELP_SYNOPSIS` and docs updated for the new verb
- `registerPlugin(name, factory, description?)` — optional third param, backward-compat
- all 7 built-ins carry descriptions in registry.ts

**apm boot step 4:** DMs both `help` and `help plugins` on startup

**live probe:** `bun -e 'import registry; registeredPlugins()'` confirms all 7 built-ins present before any DM handling