### PR TITLE
maint: bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bumps package.json 0.7.0 → 0.8.0.

what's new since v0.7.0:
- dispatcher `help plugins` verb — enumerates all registered plugin classes with descriptions (#542)
- `github-new-prs` plugin + lead-pm in-flight PR triage section (#509)
- lead-pm plan pressure-test expanded to 5 questions (#295)
- `script/teardown` helper for fast worktree cleanup (#537)
- worker surprises line + in-flight issue triage protocol + postmortem slot (#423, #508)
- auto-allow roost-irc MCP tools in loopback sessions (#532)
- Linear github link + team signal plugins (#495, #516)
- dispatcher tick interval 30s + rate limit helper (#515)