### PR TITLE
feat: add --multi-repo to roost init, drop autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Bootstrap your project, then kick off lead-pm:
 
 ```bash
 cd ~/Dev/myproject
-roost init                          # writes .orchestrator/{config.json, config.local.json, .gitignore} + copies role prompts
+roost init --repo Owner/myproject   # writes .orchestrator/{config.json, config.local.json, .gitignore} + copies role prompts
 roost spawn myproject-lead-pm \
   --agent lead-pm \
   --channels '#myproject-leads' \
@@ -202,7 +202,7 @@ to control which issues and PRs are tracked:
 
 ```bash
 cd ~/Dev/myproject
-roost init                              # first-time: writes .orchestrator/{config.json, config.local.json, .gitignore} + prompts
+roost init --repo Owner/myapp           # single-repo: writes .orchestrator/{config.json, config.local.json, .gitignore} + prompts
 CONFIG_DIR="$(pwd)/.orchestrator"
 "$ROOST_DIR/bin/start-dispatcher" "$CONFIG_DIR"
 ```
@@ -211,7 +211,7 @@ To manage multiple repos from a shared directory instead:
 
 ```bash
 mkdir ~/Dev/shared && cd ~/Dev/shared
-roost init --project myapp --repo Owner/myapp
+roost init --multi-repo --project myapp
 ```
 
 DM the dispatcher (`<project>-dispatcher`) to manage the watch list:

--- a/bin/roost
+++ b/bin/roost
@@ -64,16 +64,24 @@ Usage: roost init [options]
 Bootstrap .orchestrator/config.json + config.local.json + .gitignore for a
 new project and copy roost prompt templates to .claude/commands/ and agent
 definitions to .claude/agents/ for local customization.
-Autodetects project name, repo, and GitHub user; each value can be overridden.
+
+Pass exactly one of --repo or --multi-repo:
+
+  Single-repo: --repo OWNER/REPO wires one repo as the top-level watched
+               target. Plugin entries may inherit or match it.
+
+  Multi-repo:  --multi-repo generates a bare skeleton with no top-level repo
+               and empty plugins: {}. Add per-plugin watch entries (each
+               carrying their own repo field) after init.
 
 config.json is tracked (shareable project shape); config.local.json is
 gitignored (dispatcher-mutated overlay for github-prs/github-issues watches
 added via DM). See docs/DISPATCHER.md.
 
 Options:
+  --repo OWNER/REPO      Single-repo mode. Mutually exclusive with --multi-repo.
+  --multi-repo           Multi-repo mode. Mutually exclusive with --repo.
   --project NAME         Project name (default: basename of cwd, lowercased).
-  --repo OWNER/REPO      GitHub repo. Required outside a git repo; inside one
-                         defaults to the origin remote URL.
   --agent-login LOGIN    GitHub login for agent_logins. Repeatable.
                          Default: current gh user.
   --force                Overwrite everything: config.json, config.local.json,
@@ -88,9 +96,10 @@ Options:
   --dry-run              Print what would be written; do not write files.
 
 Examples:
-  roost init
-  roost init --project myapp --repo Owner/myapp
-  roost init --agent-login alice --agent-login bob
+  roost init --repo Owner/myapp
+  roost init --multi-repo
+  roost init --multi-repo --project services
+  roost init --repo Owner/myapp --agent-login alice --agent-login bob
   roost init --force
   roost init --force-prompts
   roost init --no-prompts
@@ -323,8 +332,13 @@ EOF
 # their `plugins.<name>` key in the merged config still enables them — the
 # loader unions `Object.keys(plugins)` across both files.
 _init_config_json() {
-  printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-new-prs": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
-    "$1" "$2" "$3"
+  if [ -n "$2" ]; then
+    printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-new-prs": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
+      "$1" "$2" "$3"
+  else
+    printf '{\n  "project": "%s",\n  "agent_logins": %s,\n  "plugins": {}\n}\n' \
+      "$1" "$3"
+  fi
 }
 
 # Gitignored dispatcher-mutated overlay scaffold. Mirrors
@@ -342,6 +356,7 @@ _init_gitignore() {
 cmd_init() {
   local project=""
   local repo=""
+  local multi_repo=0
   local agent_logins=()
   local login_re='^[a-zA-Z0-9][a-zA-Z0-9-]*$'
   local force=0
@@ -355,6 +370,7 @@ cmd_init() {
     case "$1" in
       --project)       project="$2";         shift 2 ;;
       --repo)          repo="$2";            shift 2 ;;
+      --multi-repo)    multi_repo=1;         shift ;;
       --agent-login)
         if [[ ! "$2" =~ $login_re ]]; then
           echo "error: invalid --agent-login \"$2\": must match ^[a-zA-Z0-9][a-zA-Z0-9-]*$" >&2
@@ -372,6 +388,11 @@ cmd_init() {
     esac
   done
 
+  if [ -n "$repo" ] && [ "$multi_repo" -eq 1 ]; then
+    echo "error: --repo and --multi-repo are mutually exclusive" >&2
+    exit 1
+  fi
+
   if ! gh auth status &>/dev/null; then
     echo "error: gh is not authenticated — run \`gh auth login\` first" >&2
     exit 1
@@ -387,26 +408,12 @@ cmd_init() {
     exit 1
   fi
 
-  if [ -z "$repo" ]; then
-    if git rev-parse --is-inside-work-tree &>/dev/null; then
-      local url
-      if ! url="$(git remote get-url origin 2>/dev/null)"; then
-        echo "error: no \`origin\` remote and no \`--repo\` flag — pass \`--repo Owner/repo\` or run \`git remote add origin ...\`" >&2
-        exit 1
-      fi
-      url="${url%.git}"
-      repo="$(printf '%s' "$url" | sed -E 's|.*[:/]([^/:]+/[^/]+)$|\1|')"
-      if [ "$repo" = "$url" ]; then
-        echo "error: could not parse Owner/repo from remote URL: ${url} — pass \`--repo Owner/repo\` explicitly" >&2
-        exit 1
-      fi
-    else
-      echo "error: not inside a git repo and \`--repo\` not provided — pass \`--repo Owner/repo\` to set the watched repo explicitly" >&2
-      exit 1
-    fi
+  if [ -z "$repo" ] && [ "$multi_repo" -eq 0 ] && [ "$force_prompts" -eq 0 ] && [ "$force_agents" -eq 0 ]; then
+    echo "error: pass \`--repo OWNER/REPO\` for single-repo or \`--multi-repo\` for multi-repo setup" >&2
+    exit 1
   fi
 
-  if ! gh repo view "$repo" &>/dev/null; then
+  if [ -n "$repo" ] && ! gh repo view "$repo" &>/dev/null; then
     echo "error: repo \`${repo}\` not reachable via gh — check the repo name + your gh auth" >&2
     exit 1
   fi
@@ -550,7 +557,12 @@ cmd_init() {
     fi
   fi
 
-  printf '\nNext step:\n'
+  if [ "$multi_repo" -eq 1 ]; then
+    printf '\nNext: add per-plugin watch entries (each with a "repo" field) to\n'
+    printf '  .orchestrator/config.json, then spawn:\n'
+  else
+    printf '\nNext step:\n'
+  fi
   printf '  roost spawn %s-lead-pm \\\n' "$project"
   printf '    --agent lead-pm \\\n'
   printf "    --channels '#%s-leads' \\\n" "$project"

--- a/bin/roost
+++ b/bin/roost
@@ -326,16 +326,15 @@ Example:
 EOF
 }
 
-# Tracked, shareable shape: project + repo identity + the static plugin
-# slices (github-new-issues / github-new-prs / github-commits are operator-set, not DM-mutated).
-# The dynamic slices (github-prs / github-issues) live in the local overlay;
-# their `plugins.<name>` key in the merged config still enables them — the
-# loader unions `Object.keys(plugins)` across both files.
 _init_config_json() {
   if [ -n "$2" ]; then
+    # Single-repo: project + repo + the static plugin slices (operator-set,
+    # not DM-mutated). Dynamic slices (github-prs / github-issues) live in the
+    # local overlay; their plugins.<name> key still enables them via union merge.
     printf '{\n  "project": "%s",\n  "repo": "%s",\n  "agent_logins": %s,\n  "plugins": {\n    "github-new-issues": { "watched": [] },\n    "github-new-prs": { "watched": [] },\n    "github-commits": { "watched": [] }\n  }\n}\n' \
       "$1" "$2" "$3"
   else
+    # Multi-repo: no top-level repo; operator adds plugin keys + per-entry repos.
     printf '{\n  "project": "%s",\n  "agent_logins": %s,\n  "plugins": {}\n}\n' \
       "$1" "$3"
   fi
@@ -408,9 +407,13 @@ cmd_init() {
     exit 1
   fi
 
-  if [ -z "$repo" ] && [ "$multi_repo" -eq 0 ] && [ "$force_prompts" -eq 0 ] && [ "$force_agents" -eq 0 ]; then
-    echo "error: pass \`--repo OWNER/REPO\` for single-repo or \`--multi-repo\` for multi-repo setup" >&2
-    exit 1
+  local _mode_err="error: pass \`--repo OWNER/REPO\` for single-repo or \`--multi-repo\` for multi-repo setup"
+  if [ -z "$repo" ] && [ "$multi_repo" -eq 0 ]; then
+    if [ "$force_prompts" -eq 0 ] && [ "$force_agents" -eq 0 ]; then
+      echo "$_mode_err" >&2; exit 1
+    elif [ ! -f ".orchestrator/config.json" ]; then
+      echo "$_mode_err" >&2; exit 1
+    fi
   fi
 
   if [ -n "$repo" ] && ! gh repo view "$repo" &>/dev/null; then
@@ -558,7 +561,7 @@ cmd_init() {
   fi
 
   if [ "$multi_repo" -eq 1 ]; then
-    printf '\nNext: add per-plugin watch entries (each with a "repo" field) to\n'
+    printf '\nNext: add plugin keys + per-entry watch items (each with a "repo" field) to\n'
     printf '  .orchestrator/config.json, then spawn:\n'
   else
     printf '\nNext step:\n'

--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -18,8 +18,9 @@ See `src/orchestrator/naming.ts`.
 
 ## Setup
 
-Run `bin/roost init` (writes both config files plus the gitignore), or do
-it by hand:
+Run `bin/roost init --repo OWNER/NAME` (single-repo) or
+`bin/roost init --multi-repo` (multi-repo), which writes both config files
+plus the gitignore. Or do it by hand:
 
 ```sh
 cp .orchestrator/config.example.json       .orchestrator/config.json

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -378,11 +378,12 @@ fi
 cd - >/dev/null
 teardown
 
-# --- prompts: --force-prompts overwrites (no mode flag needed) ---
+# --- prompts: --force-prompts overwrites (no mode flag when config.json exists) ---
 
 setup ""
 cd "$TDIR"
-mkdir -p .claude/commands
+mkdir -p .claude/commands .orchestrator
+echo '{"project":"test"}' > .orchestrator/config.json
 echo 'custom content' > .claude/commands/worker.md
 roost_init --force-prompts >/dev/null 2>&1
 if ! grep -q 'custom content' "${TDIR}/.claude/commands/worker.md" \
@@ -390,6 +391,20 @@ if ! grep -q 'custom content' "${TDIR}/.claude/commands/worker.md" \
   ok "prompts: --force-prompts overwrites existing"
 else
   fail "prompts: --force-prompts overwrites existing"
+fi
+cd - >/dev/null
+teardown
+
+# --- prompts: --force-prompts without config.json requires mode flag ---
+
+setup ""
+cd "$TDIR"
+mkdir -p .claude/commands
+echo 'custom content' > .claude/commands/worker.md
+if ! roost_init --force-prompts >/dev/null 2>&1; then
+  ok "prompts: --force-prompts without config.json requires mode flag"
+else
+  fail "prompts: --force-prompts without config.json requires mode flag"
 fi
 cd - >/dev/null
 teardown
@@ -423,11 +438,12 @@ fi
 cd - >/dev/null
 teardown
 
-# --- agents: --force-agents overwrites existing (no mode flag needed) ---
+# --- agents: --force-agents overwrites existing (no mode flag when config.json exists) ---
 
 setup ""
 cd "$TDIR"
-mkdir -p .claude/agents
+mkdir -p .claude/agents .orchestrator
+echo '{"project":"test"}' > .orchestrator/config.json
 echo 'custom content' > .claude/agents/lead-pm.md
 roost_init --force-agents >/dev/null 2>&1
 if ! grep -q 'custom content' "${TDIR}/.claude/agents/lead-pm.md" \

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -42,30 +42,11 @@ roost_init() {
   PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init "$@"
 }
 
-# --- URL parsing: all four remote shapes ---
+# --- agent_logins: autodetected (single-repo) ---
 
-for shape in \
-  "git@github.com:TestOwner/myproject.git" \
-  "https://github.com/TestOwner/myproject.git" \
-  "https://github.com/TestOwner/myproject" \
-  "ssh://git@github.com/TestOwner/myproject.git"; do
-  setup "$shape"
-  cd "$TDIR"
-  if roost_init >/dev/null 2>&1 \
-      && grep -q '"repo": "TestOwner/myproject"' "${TDIR}/.orchestrator/config.json"; then
-    ok "url-parse: ${shape}"
-  else
-    fail "url-parse: ${shape}"
-  fi
-  cd - >/dev/null
-  teardown
-done
-
-# --- agent_logins: autodetected (single) ---
-
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" >/dev/null 2>&1 \
     && grep -q '"agent_logins": \["testuser"\]' "${TDIR}/.orchestrator/config.json"; then
   ok "agent_logins: autodetected"
 else
@@ -76,9 +57,9 @@ teardown
 
 # --- agent_logins: single --agent-login ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init --agent-login alice >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --agent-login alice >/dev/null 2>&1 \
     && grep -q '"agent_logins": \["alice"\]' "${TDIR}/.orchestrator/config.json"; then
   ok "agent_logins: single flag"
 else
@@ -89,9 +70,9 @@ teardown
 
 # --- agent_logins: multiple --agent-login ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init --agent-login alice --agent-login bob >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --agent-login alice --agent-login bob >/dev/null 2>&1 \
     && grep -q '"agent_logins": \["alice","bob"\]' "${TDIR}/.orchestrator/config.json"; then
   ok "agent_logins: multiple flags"
 else
@@ -102,9 +83,9 @@ teardown
 
 # --- --project override ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init --project custom-name >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --project custom-name >/dev/null 2>&1 \
     && grep -q '"project": "custom-name"' "${TDIR}/.orchestrator/config.json"; then
   ok "--project override"
 else
@@ -113,25 +94,26 @@ fi
 cd - >/dev/null
 teardown
 
-# --- --repo override (no remote needed) ---
+# --- --repo flag wires single-repo ---
 
 setup ""
 cd "$TDIR"
 if roost_init --repo "SomeOwner/other-repo" >/dev/null 2>&1 \
     && grep -q '"repo": "SomeOwner/other-repo"' "${TDIR}/.orchestrator/config.json"; then
-  ok "--repo override"
+  ok "--repo: wires single-repo"
 else
-  fail "--repo override"
+  fail "--repo: wires single-repo"
 fi
 cd - >/dev/null
 teardown
 
 # --- --dry-run: prints content, writes nothing ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-dry_out="$(roost_init --dry-run 2>/dev/null)"
+dry_out="$(roost_init --repo "TestOwner/myproject" --dry-run 2>/dev/null)"
 if echo "$dry_out" | grep -q '"project"' \
+    && echo "$dry_out" | grep -q '"repo"' \
     && echo "$dry_out" | grep -q 'config.local.json' \
     && [ ! -f "${TDIR}/.orchestrator/config.json" ] \
     && [ ! -f "${TDIR}/.orchestrator/config.local.json" ]; then
@@ -144,11 +126,11 @@ teardown
 
 # --- --dry-run on existing config: works without --force ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .orchestrator
 echo '{"old": true}' > .orchestrator/config.json
-dry_out="$(roost_init --dry-run 2>/dev/null)"
+dry_out="$(roost_init --repo "TestOwner/myproject" --dry-run 2>/dev/null)"
 if echo "$dry_out" | grep -q '"project"' \
     && echo "$dry_out" | grep -q 'state.json'; then
   ok "--dry-run: bypasses existing-config guard"
@@ -160,11 +142,11 @@ teardown
 
 # --- --dry-run: lists prompts/agents even when they already exist ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 dry_out=""
-if roost_init >/dev/null 2>&1; then
-  dry_out="$(roost_init --dry-run 2>/dev/null)"
+if roost_init --repo "TestOwner/myproject" >/dev/null 2>&1; then
+  dry_out="$(roost_init --repo "TestOwner/myproject" --dry-run 2>/dev/null)"
 fi
 if echo "$dry_out" | grep -q 'worker.md' \
     && echo "$dry_out" | grep -q 'lead-pm.md'; then
@@ -177,11 +159,11 @@ teardown
 
 # --- --force: overwrites existing config ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .orchestrator
 echo '{"old": true}' > .orchestrator/config.json
-if roost_init --force >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --force >/dev/null 2>&1 \
     && grep -q '"project"' "${TDIR}/.orchestrator/config.json" \
     && ! grep -q '"old"' "${TDIR}/.orchestrator/config.json"; then
   ok "--force: overwrites existing"
@@ -193,12 +175,12 @@ teardown
 
 # --- --force: also overwrites .gitignore ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .orchestrator
 echo '{"old": true}' > .orchestrator/config.json
 printf 'old-entry\n' > .orchestrator/.gitignore
-if roost_init --force >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --force >/dev/null 2>&1 \
     && ! grep -q 'old-entry' "${TDIR}/.orchestrator/.gitignore" \
     && grep -q 'state.json' "${TDIR}/.orchestrator/.gitignore"; then
   ok "--force: overwrites .gitignore"
@@ -210,9 +192,9 @@ teardown
 
 # --- .gitignore written ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-roost_init >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" >/dev/null 2>&1
 if grep -q 'config.local.json' "${TDIR}/.orchestrator/.gitignore" \
     && grep -q 'state.json'     "${TDIR}/.orchestrator/.gitignore" \
     && grep -q 'last-tick.txt'  "${TDIR}/.orchestrator/.gitignore" \
@@ -227,9 +209,9 @@ teardown
 
 # --- config.local.json scaffold written ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-roost_init >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" >/dev/null 2>&1
 if [ -f "${TDIR}/.orchestrator/config.local.json" ] \
     && grep -q '"github-prs"' "${TDIR}/.orchestrator/config.local.json" \
     && grep -q '"github-issues"' "${TDIR}/.orchestrator/config.local.json"; then
@@ -242,12 +224,12 @@ teardown
 
 # --- --force overwrites config.local.json too ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .orchestrator
 echo '{"old": true}' > .orchestrator/config.json
 echo '{"stale": true}' > .orchestrator/config.local.json
-if roost_init --force >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --force >/dev/null 2>&1 \
     && grep -q '"github-prs"' "${TDIR}/.orchestrator/config.local.json" \
     && ! grep -q '"stale"' "${TDIR}/.orchestrator/config.local.json"; then
   ok "--force: overwrites config.local.json"
@@ -259,11 +241,11 @@ teardown
 
 # --- error: existing config without --force ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .orchestrator
 echo '{}' > .orchestrator/config.json
-if ! roost_init >/dev/null 2>&1; then
+if ! roost_init --repo "TestOwner/myproject" >/dev/null 2>&1; then
   ok "error: existing config rejected without --force"
 else
   fail "error: existing config rejected without --force"
@@ -296,7 +278,7 @@ fi
 cd - >/dev/null
 rm -rf "$TDIR"
 
-# --- error: outside git and no --repo ---
+# --- error: no mode flag → clear usage hint ---
 
 TDIR="$(mktemp -d /tmp/roost-test-XXXXXXXX)"
 STUBS="${TDIR}/.stubs"
@@ -312,31 +294,35 @@ chmod +x "${STUBS}/gh"
 cd "$TDIR"
 err_out="$(PATH="${STUBS}:${PATH}" "${ROOST_BIN}" init 2>&1)"
 exit_code=$?
-if [ "$exit_code" -ne 0 ] && echo "$err_out" | grep -q "not inside a git repo and"; then
-  ok "error: outside git and no --repo"
+if [ "$exit_code" -ne 0 ] \
+    && echo "$err_out" | grep -q "\-\-repo" \
+    && echo "$err_out" | grep -q "\-\-multi-repo"; then
+  ok "error: no mode flag gives usage hint naming both modes"
 else
-  fail "error: outside git and no --repo"
+  fail "error: no mode flag gives usage hint naming both modes"
 fi
 cd - >/dev/null
 rm -rf "$TDIR"
 
-# --- error: no origin remote without --repo ---
+# --- error: --repo and --multi-repo together ---
 
 setup ""
 cd "$TDIR"
-if ! roost_init >/dev/null 2>&1; then
-  ok "error: no origin remote"
+err_out="$(roost_init --repo "TestOwner/myproject" --multi-repo 2>&1)"
+exit_code=$?
+if [ "$exit_code" -ne 0 ] && echo "$err_out" | grep -q "mutually exclusive"; then
+  ok "error: --repo and --multi-repo are mutually exclusive"
 else
-  fail "error: no origin remote"
+  fail "error: --repo and --multi-repo are mutually exclusive"
 fi
 cd - >/dev/null
 teardown
 
 # --- prompts: fresh copy ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" >/dev/null 2>&1 \
     && [ -f "${TDIR}/.claude/commands/worker.md" ] \
     && [ -f "${TDIR}/.claude/commands/reviewer.md" ]; then
   ok "prompts: fresh copy to .claude/commands/"
@@ -348,9 +334,9 @@ teardown
 
 # --- agents: fresh copy ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-if roost_init >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" >/dev/null 2>&1 \
     && [ -f "${TDIR}/.claude/agents/lead-pm.md" ] \
     && [ -f "${TDIR}/.claude/agents/associate-pm.md" ]; then
   ok "agents: fresh copy to .claude/agents/"
@@ -362,11 +348,11 @@ teardown
 
 # --- prompts: skip existing (idempotent) ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .claude/commands
 echo 'custom content' > .claude/commands/worker.md
-roost_init >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" >/dev/null 2>&1
 if grep -q 'custom content' "${TDIR}/.claude/commands/worker.md"; then
   ok "prompts: existing file not overwritten without --force-prompts"
 else
@@ -377,12 +363,12 @@ teardown
 
 # --- prompts: --force overwrites (implies --force-prompts) ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .claude/commands .orchestrator
 echo '{"old": true}' > .orchestrator/config.json
 echo 'custom content' > .claude/commands/worker.md
-if roost_init --force >/dev/null 2>&1 \
+if roost_init --repo "TestOwner/myproject" --force >/dev/null 2>&1 \
     && ! grep -q 'custom content' "${TDIR}/.claude/commands/worker.md" \
     && grep -q 'description' "${TDIR}/.claude/commands/worker.md"; then
   ok "prompts: --force overwrites prompts"
@@ -392,9 +378,9 @@ fi
 cd - >/dev/null
 teardown
 
-# --- prompts: --force-prompts overwrites ---
+# --- prompts: --force-prompts overwrites (no mode flag needed) ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .claude/commands
 echo 'custom content' > .claude/commands/worker.md
@@ -410,9 +396,9 @@ teardown
 
 # --- prompts: --no-prompts skips copy ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-roost_init --no-prompts >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" --no-prompts >/dev/null 2>&1
 if [ ! -d "${TDIR}/.claude/commands" ] \
     || [ ! -f "${TDIR}/.claude/commands/worker.md" ]; then
   ok "prompts: --no-prompts skips copy"
@@ -424,11 +410,11 @@ teardown
 
 # --- agents: existing file not overwritten without --force-agents ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .claude/agents
 echo 'custom content' > .claude/agents/lead-pm.md
-roost_init >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" >/dev/null 2>&1
 if grep -q 'custom content' "${TDIR}/.claude/agents/lead-pm.md"; then
   ok "agents: existing file not overwritten without --force-agents"
 else
@@ -437,9 +423,9 @@ fi
 cd - >/dev/null
 teardown
 
-# --- agents: --force-agents overwrites existing ---
+# --- agents: --force-agents overwrites existing (no mode flag needed) ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
 mkdir -p .claude/agents
 echo 'custom content' > .claude/agents/lead-pm.md
@@ -455,14 +441,59 @@ teardown
 
 # --- agents: --no-agents skips copy ---
 
-setup "https://github.com/TestOwner/myproject.git"
+setup ""
 cd "$TDIR"
-roost_init --no-agents >/dev/null 2>&1
+roost_init --repo "TestOwner/myproject" --no-agents >/dev/null 2>&1
 if [ ! -d "${TDIR}/.claude/agents" ] \
     || [ ! -f "${TDIR}/.claude/agents/lead-pm.md" ]; then
   ok "agents: --no-agents skips copy"
 else
   fail "agents: --no-agents skips copy"
+fi
+cd - >/dev/null
+teardown
+
+# --- multi-repo: skeleton has no repo field, plugins: {} ---
+
+setup ""
+cd "$TDIR"
+if roost_init --multi-repo >/dev/null 2>&1 \
+    && ! grep -q '"repo"' "${TDIR}/.orchestrator/config.json" \
+    && grep -q '"plugins": {}' "${TDIR}/.orchestrator/config.json" \
+    && grep -q '"project"' "${TDIR}/.orchestrator/config.json"; then
+  ok "--multi-repo: skeleton has no repo key and plugins: {}"
+else
+  fail "--multi-repo: skeleton has no repo key and plugins: {}"
+fi
+cd - >/dev/null
+teardown
+
+# --- multi-repo: --project override ---
+
+setup ""
+cd "$TDIR"
+if roost_init --multi-repo --project my-services >/dev/null 2>&1 \
+    && grep -q '"project": "my-services"' "${TDIR}/.orchestrator/config.json" \
+    && ! grep -q '"repo"' "${TDIR}/.orchestrator/config.json"; then
+  ok "--multi-repo: --project override works"
+else
+  fail "--multi-repo: --project override works"
+fi
+cd - >/dev/null
+teardown
+
+# --- multi-repo: --dry-run shows multi-repo skeleton ---
+
+setup ""
+cd "$TDIR"
+dry_out="$(roost_init --multi-repo --dry-run 2>/dev/null)"
+if echo "$dry_out" | grep -q '"project"' \
+    && echo "$dry_out" | grep -q '"plugins": {}' \
+    && ! echo "$dry_out" | grep -q '"repo"' \
+    && [ ! -f "${TDIR}/.orchestrator/config.json" ]; then
+  ok "--multi-repo --dry-run: shows multi-repo content, writes nothing"
+else
+  fail "--multi-repo --dry-run: shows multi-repo content, writes nothing"
 fi
 cd - >/dev/null
 teardown


### PR DESCRIPTION
Closes #548

**Breaking change:** `roost init` no longer autodetects from the git remote. Pass `--repo OWNER/REPO` (single-repo) or `--multi-repo` explicitly. Bare `roost init` now errors with a hint naming both modes.

## What changed

- `--multi-repo` flag: generates skeleton with no top-level `repo` and `plugins: {}`
- `--repo` unchanged: single-repo mode, validated via `gh repo view`
- `--repo` + `--multi-repo` together: error (mutually exclusive)
- `--force-prompts` / `--force-agents`: bypass mode check (content-only, no repo needed)
- `usage_init`, `README.md`, `docs/DISPATCHER.md` updated to show explicit flags (3 doc surfaces per §#422)
- Dropped 4 url-parse tests; added multi-repo skeleton + mutual-exclusion tests (29 init tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)