### PR TITLE
maint: bump version to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bumps package.json 0.8.0 → 0.8.1.

what's new since v0.8.0:
- `roost init --multi-repo` — explicit multi-repo mode; bare `roost init` now requires a mode flag (breaking change: drops silent git-remote autodetect) (#548)