### PR TITLE
fix(init): include --ask-irc in printed lead-pm spawn + audit canonical wording

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,12 +173,14 @@ instance from durable artifacts. Sequence:
    - The project-specific `worker_conventions.md` path.
 4. Spawns:
 
+<!-- TODO: surrounding narrative (senior-PO/per-project-PO topology, `#leads-{project}` channel pattern) is stale; spawn block here refreshed to current `<project>-lead-pm` / `#<project>-leads` naming. Sweep the rest of this file + docs/ROOST-IN-PRACTICE.md in the followup. -->
+
 ```bash
-roost spawn productops-simplifyrewards \
-  -c '#leads-simplifyrewards,#issue-718,#issue-721,#issue-693' \
+roost spawn <project>-lead-pm \
+  -c '#<project>-leads,#<project>-issue-718,#<project>-issue-721,#<project>-issue-693' \
   --steer-compact --cache-ttl 1h \
-  --ask-irc '#leads-simplifyrewards' --ask-target <your-nick> \
-  --prompt-file /tmp/handoff-2026-04-28.md
+  --ask-irc '#<project>-leads' --ask-target <your-nick> \
+  --prompt-file /tmp/handoff.md
 ```
 
 `--prompt-file` is the load-bearing primitive — it's what lets the

--- a/bin/roost
+++ b/bin/roost
@@ -566,11 +566,13 @@ cmd_init() {
   else
     printf '\nNext step:\n'
   fi
-  printf '  roost spawn %s-lead-pm \\\n' "$project"
-  printf '    --agent lead-pm \\\n'
-  printf "    --channels '#%s-leads' \\\n" "$project"
-  printf '    --steer-compact --cache-ttl 1h \\\n'
-  printf "    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'\n"
+  printf '%s\n' \
+    "  roost spawn ${project}-lead-pm \\" \
+    "    --agent lead-pm \\" \
+    "    --channels '#${project}-leads' \\" \
+    "    --steer-compact --cache-ttl 1h \\" \
+    "    --ask-irc '#${project}-leads' --ask-target <your-irc-nick> \\" \
+    "    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'"
 }
 
 require_tmux() {


### PR DESCRIPTION
Closes #553

## Summary

- `bin/roost` cmd_init "Next step" was printing the lead-pm spawn without `--ask-irc '#<project>-leads' --ask-target <your-irc-nick>`. Operators following the nudge got a lead-pm that froze on AskUserQuestion instead of routing to the leads channel. Added the missing flag pair to match the Agent class guidance block in the same file.
- Refactored the Next-step printf to `printf '%s\n' <args>` — the existing double-quoted format strings were emitting literal `\n` instead of newlines (same-function adjacent bug per §#419). Confirmed via od probe; output is now copy-pasteable.
- `ARCHITECTURE.md` senior-PO respawn spawn block refreshed to current `<project>-lead-pm` / `#<project>-leads` naming. Surrounding narrative still uses old senior-PO/per-project-PO topology + `#leads-{project}` channel pattern — flagged with a TODO comment near the block; the broader sweep (8 more ARCHITECTURE.md spots + 5 in `docs/ROOST-IN-PRACTICE.md`) is a separate follow-up since it's a different invariant.

## §#422 audit — PM spawn surfaces post-fix

All show the canonical 4-flag PM combo with verbatim wording:

| surface | status |
|---|---|
| `bin/roost` Agent class guidance | ✓ canonical source |
| `bin/roost` cmd_init Next step | ✓ fixed |
| `agents/lead-pm.md` Getting started (APM spawn) | ✓ |
| `agents/associate-pm.md` | ✓ (no PM spawn shown) |
| `skills/roost/SKILL.md` AskUserQuestion section | ✓ |
| `README.md` lead-pm spawn | ✓ |
| `ARCHITECTURE.md` spawn block | ✓ fixed |

## Post-fix od probe (cmd_init Next step)

```
\  \n                   -   -   a   g   e   n   t       l   e
a   d   -   p   m       \  \n                   -   -   c   h
a   n   n   e   l   s       '   #   r   o   o   s   t   -   5
5   3   -   t   e   s   t   -   l   e   a   d   s   '       \
\n                   -   -   s   t   e   e   r   -   c   o   m
```

Every line continuation is `\` + real `\n` (real newline). Pre-fix the channels/ask-irc/prompt lines emitted `\   n` (literal backslash + literal `n`).

## Test plan

- [x] `bash -n bin/roost` — syntax ok
- [x] `bun run lint` — clean
- [x] `roost init --repo AvesAlight/roost --force` against a fresh dir — printed spawn now includes `--ask-irc '#<project>-leads' --ask-target <your-irc-nick>` and every continuation is a real newline
- [x] od probe confirms no literal `\n` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)