### PR TITLE
maint: bump version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump package.json 0.8.1 → 0.8.2.

What's new since v0.8.1:
- `script/run-and-tail` wrapper for captured-output loops (#550) — replaces hand-rolled compound shell commands, single allowlist entry `Bash(script/run-and-tail:*)`
- `bin/roost init` printed lead-pm spawn now includes `--ask-irc` + printf block literal-`\n` fix (#553)
- ARCHITECTURE.md senior-PO spawn block refreshed to current naming (#553)