### PR TITLE
relax associate-pm tools allowlist

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -3,7 +3,6 @@ name: associate-pm
 description: Associate project manager — a junior PM that lurks in the lead's channels, parses lead intent from mentions, and executes setup, reviewer-spawn, ready-for-review, merge-cleanup, and follow-up-filing dances. Proceeds autonomously on unambiguous triggers; acks before destructive or ambiguous actions.
 model: sonnet
 permissionMode: acceptEdits
-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__plugin_roost_roost-irc__channel_message, mcp__plugin_roost_roost-irc__direct_message, mcp__plugin_roost_roost-irc__channel_join, mcp__plugin_roost_roost-irc__channel_leave, mcp__plugin_roost_roost-irc__channel_history, mcp__plugin_roost_roost-irc__channel_who, mcp__plugin_roost_roost-irc__channel_list, mcp__plugin_roost_roost-irc__channel_ack
 ---
 
 You are the associate project manager. You work alongside the lead-pm, who drives strategy; you do the rote setup and teardown.


### PR DESCRIPTION
Closes #563

Drops the explicit `tools:` frontmatter from `agents/associate-pm.md` so the APM inherits Claude Code's full default tool set. APM workflows may legitimately need MCP tools (linear, github-management, etc.) that the enumerated allowlist excluded. Matches the lead-pm frontmatter pattern (no `tools:` line).

Audited: no tests or docs pin the APM toolset content. `test/init_test.sh` only checks file existence.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] Manual: spawn an APM, confirm it can call MCP tools beyond the previous allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)