### PR TITLE
default irc.nick to <project>-dispatcher when missing

### DIFF
--- a/docs/DISPATCHER.md
+++ b/docs/DISPATCHER.md
@@ -55,7 +55,7 @@ Fields:
 | `project` | Lowercase slug used to namespace IRC nicks/channels (`<project>-worker-N`, `#<project>-issue-N`). Falls back to the basename of `repo` when set. Required in multi-repo mode. Must match `^[a-z0-9][a-z0-9-]*$`. |
 | `repo` | Default `OWNER/NAME` for watched items in single-repo mode; per-entry `repo` may omit (inherits) or match this value, but cannot diverge. **Leave unset to enable multi-repo mode**, where every watched entry must carry its own `repo` and per-issue artifacts pick up a `<slug>` segment derived from the entry's repo basename. |
 | `agent_logins` | GitHub logins whose comments are tagged `is_worker_reply: true` (informational). |
-| `irc.nick` | Nick the dispatcher uses on the IRC server. Convention: `<project>-dispatcher`. |
+| `irc.nick` | Nick the dispatcher uses on the IRC server. Defaults to `<project>-dispatcher`. |
 | `irc.project_channel` | Fallback channel for errors and project-level events. Defaults to `#<project>-leads`. |
 | `irc.server` / `irc.port` | IRCv3 server address. Defaults to `127.0.0.1:6667`. |
 | `irc.interval_seconds` | Tick interval. Min 5s; 60s is sane for most repos. |

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -24,7 +24,7 @@ import { assertRepoModeAll, defaultPluginLogger, type Plugin, type PluginLogger,
 import './orchestrator/registry.js'
 import { buildPlugins } from './orchestrator/build-plugins.js'
 import { loadExternalPlugins } from './orchestrator/load-external-plugins.js'
-import { resolveProjectChannel } from './orchestrator/naming.js'
+import { resolveProjectChannel, dispatcherNick } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dispatcher-dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
@@ -70,8 +70,9 @@ function newIrcClient(nick: string, channels: string[]): RoostIrcClientImpl {
 
 function requireIrcConfig(config: OrchestratorConfig, mode: string): { nick: string; server: string; port: number } {
   const ircCfg = config.irc ?? {}
-  if (!ircCfg.nick) throw new Error(`${mode} requires irc.nick in config`)
-  return { nick: ircCfg.nick, server: ircCfg.server ?? '127.0.0.1', port: ircCfg.port ?? 6667 }
+  const nick = ircCfg.nick ?? (config.project ? dispatcherNick(config.project) : undefined)
+  if (!nick) throw new Error(`${mode} requires irc.nick or project in config`)
+  return { nick, server: ircCfg.server ?? '127.0.0.1', port: ircCfg.port ?? 6667 }
 }
 
 async function runOneTick(

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -24,7 +24,7 @@ import { assertRepoModeAll, defaultPluginLogger, type Plugin, type PluginLogger,
 import './orchestrator/registry.js'
 import { buildPlugins } from './orchestrator/build-plugins.js'
 import { loadExternalPlugins } from './orchestrator/load-external-plugins.js'
-import { resolveProjectChannel, dispatcherNick } from './orchestrator/naming.js'
+import { resolveProjectChannel, dispatcherNick, defaultProject } from './orchestrator/naming.js'
 import { handleDm } from './orchestrator/dispatcher-dm-handler.js'
 import { RoostIrcClientImpl } from './irc-client-impl.js'
 
@@ -70,8 +70,11 @@ function newIrcClient(nick: string, channels: string[]): RoostIrcClientImpl {
 
 function requireIrcConfig(config: OrchestratorConfig, mode: string): { nick: string; server: string; port: number } {
   const ircCfg = config.irc ?? {}
-  const nick = ircCfg.nick ?? (config.project ? dispatcherNick(config.project) : undefined)
-  if (!nick) throw new Error(`${mode} requires irc.nick or project in config`)
+  let nick = ircCfg.nick
+  if (!nick) {
+    try { nick = dispatcherNick(defaultProject(config)) } catch { /* no project or repo */ }
+  }
+  if (!nick) throw new Error(`${mode} requires irc.nick, project, or repo in config`)
   return { nick, server: ircCfg.server ?? '127.0.0.1', port: ircCfg.port ?? 6667 }
 }
 


### PR DESCRIPTION
Closes #560

`requireIrcConfig` now falls back to `dispatcherNick(defaultProject(config))` when `irc.nick` is absent. `defaultProject` already handles the project→repo-basename fallback the same way `resolveProjectChannel` does, so both paths are consistent. Error message names all three fallback paths when all are absent. `irc.nick` row in DISPATCHER.md updated from "Convention" to "Defaults to".

## Live probes

**Probe 1** — `project` set, no `irc.nick`:
```
roost-irc[testproj-dispatcher]: registered with the IRC server
roost-irc[testproj-dispatcher]: joined #testproj-leads
orchestrator[--dispatch-irc]: no events to dispatch
```
✓ connected as `testproj-dispatcher`

**Probe 2** — `repo` set, no `project`, no `irc.nick`:
```
roost-irc[myrepo-dispatcher]: registered with the IRC server
roost-irc[myrepo-dispatcher]: joined #myrepo-leads
orchestrator[--dispatch-irc]: no events to dispatch
```
✓ connected as `myrepo-dispatcher` (derived from `org/myrepo` basename)

**Probe 3** — neither `project`, `repo`, nor `irc.nick` (only `irc.project_channel` set to bypass earlier `resolveProjectChannel` throw):
```
Error: --dispatch-irc requires irc.nick, project, or repo in config
    at requireIrcConfig (src/orchestrator.ts:77:24)
```
✓ updated error message fires

## Follow-up

`requireIrcConfig` is private in `orchestrator.ts` which calls `main()` at module-level — can't import for unit testing without side effects. #566 tracks extracting it for direct testability.