### PR TITLE
maint: sweep channel-pattern drift across ARCHITECTURE.md + ROOST-IN-PRACTICE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,112 +8,107 @@ from `irssi` and see everything.
 ## Topology
 
 ```
-                        ergo (127.0.0.1:6667)
-                                │
-   ┌─────────────┬──────────────┼──────────────┬───────────┐
-   │             │              │              │           │
- senior PO   dispatcher   per-project       worker-X    alex
- (#staff)    (project,    PO (#leads-{P}    (#issue-NNN)(irssi)
-              event-pub)   + every #issue        │
-              ┌────────┐   for one project)  reviewer-Y
-              │project │       │             (#issue-NNN)
-              │workers │       │
-              │     reviewers ─┘
-              └────────┘
+                       ergo (127.0.0.1:6667)
+                               │
+   ┌─────────────┬──────────────┬─────────────┬──────────┐
+   │             │              │             │          │
+ lead-pm     dispatcher     worker-N      reviewer-N   alex
+ + APM       (per           (#<project>-  (#<project>- (irssi /
+ (#<project>- project,       issue-N,      issue-N,    weechat)
+  leads +     event-pub)     ephemeral)    ephemeral)
+  every
+  active
+  issue
+  channel)
 ```
 
-The channel-of-record for an active piece of work is `#issue-NNN`,
-not `#pr-NNN` — issues outlive any single PR attempt (a PR close +
-restart on the same issue means the channel needs to be stable across
-restarts; per-issue gives that, per-PR doesn't).
+The channel-of-record for an active piece of work is
+`#<project>-issue-<N>`, not `#<project>-pr-<N>` — issues outlive any
+single PR attempt (a PR close + restart on the same issue means the
+channel needs to be stable across restarts; per-issue gives that,
+per-PR doesn't).
 
 ## Channels
 
-| Channel           | Purpose |
-|-------------------|---------|
-| `#staff`          | Standing senior agents (senior PO, CoS, finance, sales, opsmanager, tooldev). Cross-cutting only. |
-| `#leads-{proj}`   | One per project. Per-project PO + project leadership; cross-issue context for that project. |
-| `#issue-{NNN}`    | One per active issue. Dispatcher publishes events directly. Worker joins on pickup, leaves on completion. Reviewer joins on CI green, leaves on conclude. Per-project PO is here continuously (observation, not on-demand). Stable across PR restarts (old PR closes, new PR opens = same `#issue-NNN`). |
+| Channel                | Purpose |
+|------------------------|---------|
+| `#<project>-leads`     | Per-project leadership channel. lead-pm + APM live here continuously; dispatcher posts cross-issue events (new PRs/issues for the watched repo, milestone-level signals). |
+| `#<project>-issue-<N>` | One per active issue. Dispatcher publishes per-issue events. Worker joins on pickup, leaves on completion. Reviewer joins for the review pass, leaves on conclude. lead-pm + APM join while the issue is active. Stable across PR restarts (old PR closes, new PR opens = same `#<project>-issue-<N>`). |
 
 ## Identities
 
-- **Senior ProductOps** — stable nick (`productops`). Sits in
-  `#staff` alongside CoS, MarketingOps, FinanceOps, etc. Owns
-  runbooks + the cross-project pattern catalog. Spawns per-project
-  POs for new projects. Modeled on the FinanceOps/Bookkeeper
-  two-tier pattern Teak already runs.
-- **Per-project ProductOps** — `productops-{project}`. Lives in
-  `#leads-{project}` plus every `#issue-{NNN}` for that project's
-  lifetime. Restartable on compact: senior PO orients a fresh
-  instance from runbook + project artifacts + dispatcher state.
-  This is what makes "PO survives context boundaries" work — not a
-  single resilient instance, but a scoped instance the senior can
-  cheaply respawn.
-- **Other standing roles** — `cos`, `tooldev`, etc. Sit in
-  `#staff`, follow the same senior/scoped pattern when their work
-  goes per-project.
-- **Workers** — ephemeral (`worker-NNN-X`). Join `#issue-NNN` on
-  assignment, leave on completion.
-- **Reviewers** — `reviewer-NNN`. Join `#issue-NNN` on CI green,
-  leave on conclude.
-- **Dispatchers** — one per project. Publish per-issue events
-  directly to `#issue-NNN`. Not Claude sessions; Python scripts.
+- **lead-pm** — `<project>-lead-pm`. Owns a project end-to-end:
+  picks issues off the milestone DAG, pressure-tests worker plans,
+  spawns reviewers, coordinates with the human, posts postmortems.
+  Lives in `#<project>-leads` continuously and joins each
+  `#<project>-issue-<N>` while it's active. Long-running; opts into
+  `--steer-compact` so the in-process compactor preserves role and
+  channels.
+- **APM** — `<project>-apm`. Operational support for lead-pm: flips
+  PRs draft → ready, tags reviewers, files follow-up issues, drives
+  release-bump mechanics, runs cleanup after merge. Lives in the
+  same channels as lead-pm.
+- **Workers** — ephemeral (`<project>-worker-<N>`, or
+  `<project>-<slug>-worker-<N>` in multi-repo mode). Join
+  `#<project>-issue-<N>` on assignment, leave on completion.
+- **Reviewers** — ephemeral (`<project>-reviewer-<N>`). Join
+  `#<project>-issue-<N>` for the review pass, leave on conclude.
+- **Dispatchers** — one per project (`<project>-dispatcher`). Not
+  Claude sessions; a TypeScript daemon (`src/orchestrator/`).
+  Publish per-issue events to `#<project>-issue-<N>` and
+  cross-issue events to `#<project>-leads`.
 
 ## Routing
 
-ProductOps is **observer-and-router**, not just router. The router
-job (handling unclaimed events) is small; the observer job
-(continuous attention for pattern detection) is load-bearing.
-Action ≠ observation: routing can distribute, but pattern
-recognition has to be continuous, because workers don't escalate
-absorbed-and-handled directives upward by design. Without an
-observer present, recurring directives get silently absorbed and
-re-occur next project.
+Routing happens in the channel — there's no separate broker. The
+dispatcher is a plain IRC client writing to channels; every agent
+present receives the message identically via its roost-irc MCP.
 
-- **Routine signals** (CI green, CEO-APPROVED, CHANGES_REQUESTED):
-  dispatcher → `#issue-NNN` → worker. The dispatcher is a plain IRC
-  client writing to a channel; the worker's roost-irc MCP receives
-  that write as an ordinary channel message — no special pipeline.
-  PO is in the channel but not in the action path.
-- **Ambiguous CEO directives**: land in channel with a
-  needs-interpretation flag. Workers clear the flag by claiming
-  ("I've got this") when the directive is unambiguous to them.
-  Unclaimed events → PO's action queue.
-- **Worker ↔ reviewer**: co-located in `#issue-NNN`. No relay.
-- **PO observes everything else.** Pattern detection is the
-  primary deliverable on the attention surface. When a directive
-  hits twice in one project, codify into worker_conventions before
-  it can absorb a third time silently.
+- **Per-issue events** (CI transitions, PR comments, review
+  submissions): dispatcher → `#<project>-issue-<N>`. Worker,
+  reviewer, lead-pm, and APM are all in the channel and read the
+  event off the same notification.
+- **Cross-issue events** (new PRs / issues for the watched repo,
+  milestone-level signals): dispatcher → `#<project>-leads`.
+  lead-pm and APM read these and route to per-issue work.
+- **Ambiguous human directives**: land in channel as ordinary
+  messages. Workers claim what's unambiguous to them ("I've got
+  this"); anything left unclaimed is lead-pm's to interpret.
+- **Worker ↔ reviewer**: co-located in `#<project>-issue-<N>`.
+  No relay.
+- **Worker ↔ lead-pm**: co-located in `#<project>-issue-<N>` for
+  plan pressure-testing, structural updates, ready-flip signaling.
+  APM picks up the operational dances (ready flip, follow-up
+  filing) off the same channel without round-tripping through
+  lead-pm.
 
 ### PR review flow
 
 Sequencing — each step bumps the next:
 
-1. Worker drafts → opens PR.
-2. CI green → dispatcher publishes to `#issue-NNN`.
-3. Reviewer-NNN joins → reviews against spec (cold lens).
-4. Reviewer satisfied → comments on the PR thread.
-5. **Per-project PO spot-checks** — informed by observed project
-   context (the running thread on `#leads-{project}`, prior issues
-   in the project). Reviewer's cold lens + PO's contextual lens
-   are complementary, not redundant.
-6. PO posts spot-check verdict directly on the PR thread (e.g.
-   `[productops] spot-check cleared: ...`), then flips the PR
-   from draft → ready-for-review and adds CEO as reviewer.
-   PO drives the gate flip themselves — they hold the gate
-   signal locally; no need to relay "PO cleared" to the worker
-   only to have the worker flip the PR. Single source of truth
-   on the PR, the dispatcher's existing `pr_review_comment`
-   event surfaces a pointer in `#issue-NNN`. No new substrate
-   primitive.
-7. CEO reviews and merges (or sends back).
+1. Worker drafts → opens PR (with `Closes #<N>` in the body) and
+   posts the link in `#<project>-issue-<N>`.
+2. lead-pm spawns **reviewer-<N>** against the draft (cold lens —
+   no project context).
+3. Reviewer reads the diff, posts findings to GitHub, parts the
+   channel.
+4. Worker addresses findings, pushes, runs the last-look gate,
+   signals ready in `#<project>-issue-<N>` (with a
+   `highest-risk specific:` and a `surprises:` line).
+5. APM flips the PR draft → ready and adds the human as reviewer.
+6. Human reviews and merges (or sends back; on send-back the
+   worker addresses without toggling draft, and APM re-requests
+   review).
+7. After merge: lead-pm posts a one-paragraph postmortem in
+   `#<project>-leads`; APM runs cleanup (unwatch the PR/issue,
+   tear down the worktree, close milestones if applicable).
 
 ## Lifecycle = membership
 
-- Worker pickup = `JOIN #issue-NNN`.
-- Reviewer engagement = `JOIN #issue-NNN`.
+- Worker pickup = `JOIN #<project>-issue-<N>`.
+- Reviewer engagement = `JOIN #<project>-issue-<N>`.
 - Hard restart = kick the worker, fresh worker `JOIN`s the same
-  `#issue-NNN` (channel persists across PR restarts).
+  `#<project>-issue-<N>` (channel persists across PR restarts).
 - Assignment end = `PART` (or issue-resolved → channel cleanup).
 
 The MCP pushes `JOIN`/`PART`/`KICK` events as channel notifications,
@@ -143,37 +138,39 @@ Common spawns:
 
 ```bash
 # Worker pickup on a fresh issue:
-roost spawn worker-718-A -c '#issue-718'
+roost spawn <project>-worker-718 -c '#<project>-issue-718'
 
-# Reviewer joining post-CI:
-roost spawn reviewer-718 -c '#issue-718'
+# Reviewer joining for the review pass:
+roost spawn <project>-reviewer-718 -c '#<project>-issue-718'
 
 # Hard restart (channel-as-lifecycle: kick + new worker JOINs same
 # channel, orients from dispatcher state + channel topic + spawn
 # prompt, not from scrollback):
-roost shutdown worker-718-A
-roost spawn worker-718-B -c '#issue-718'
+roost shutdown <project>-worker-718
+roost spawn <project>-worker-718-B -c '#<project>-issue-718'
 ```
 
-### Senior PO respawning a per-project PO
+### Restarting a long-running lead-pm
 
-A respawn is an orchestrated handoff, not a fresh start. The
-per-project PO is replaceable cheaply because the senior PO holds
-the cross-project knowledge and can re-orient any per-project
-instance from durable artifacts. Sequence:
+lead-pm runs for the lifetime of a milestone, so it has to survive
+both auto-compact and full respawn cleanly.
 
-1. Senior PO reads the project journal + the project's recent
-   `#leads-{project}` topic / pinned conventions.
-2. Queries the dispatcher for current state of every watched issue
-   in the project (open PRs, CI state, pending CEO threads).
-3. Drafts a handoff prompt encoding:
-   - Open escalation-queue items the previous instance was holding.
-   - Active CEO threads needing translation.
-   - The dispatcher endpoint for ongoing state queries.
-   - The project-specific `worker_conventions.md` path.
-4. Spawns:
+In-process recovery is `--steer-compact` at spawn — see Rejoin
+below for the mechanics. That covers most cases.
 
-<!-- TODO: surrounding narrative (senior-PO/per-project-PO topology, `#leads-{project}` channel pattern) is stale; spawn block here refreshed to current `<project>-lead-pm` / `#<project>-leads` naming. Sweep the rest of this file + docs/ROOST-IN-PRACTICE.md in the followup. -->
+For a full respawn (process loss, hard kick, intentional restart),
+an operator (human or APM) drafts a handoff prompt from durable
+artifacts:
+
+1. Project journal + recent `#<project>-leads` topic / pinned
+   conventions.
+2. Dispatcher's view of every watched issue in the project (open
+   PRs, CI state, pending human threads).
+3. Open escalation items the previous instance was holding.
+4. Active human threads needing translation.
+5. Path to the project's `worker_conventions.md` (or equivalent).
+
+Then spawn:
 
 ```bash
 roost spawn <project>-lead-pm \
@@ -198,20 +195,20 @@ For deeper inspection — MCP stderr, IRC connection logs — check
 
 ### When to use the skill vs raw shell
 
-When an agent needs to spawn or manage another agent (senior PO
-respawning a per-project PO post-compact, productops kicking a
-stuck worker, etc.), it should invoke the `roost` skill rather
-than reach for raw shell — same command surface, with naming and
-channel conventions baked into the skill description so spawns are
-consistent across spawners. Raw shell is fine for human operators
-running ad-hoc commands.
+When an agent needs to spawn or manage another agent (lead-pm
+spawning a worker or reviewer, APM kicking a stuck worker, etc.),
+it should invoke the `roost` skill rather than reach for raw shell
+— same command surface, with naming and channel conventions baked
+into the skill description so spawns are consistent across
+spawners. Raw shell is fine for human operators running ad-hoc
+commands.
 
 Parking-lot enhancements (not yet built):
 
-- `--rejoin-project <name>` — auto-enumerate the project's
-  channels (`#leads-<name>` + every `#issue-NNN` where the
-  project's dispatcher is active) so the senior PO doesn't have
-  to hand-list 5–10 channels at respawn.
+- `--rejoin-project <name>` — auto-enumerate the project's channels
+  (`#<project>-leads` + every `#<project>-issue-<N>` where the
+  project's dispatcher is active) so a lead-pm respawn doesn't have
+  to hand-list 5–10 channels.
 
 ## Conventions live as channel state
 
@@ -243,13 +240,13 @@ Short-lived agents (workers, reviewers) skip the flag — auto-compact
 is unlikely to fire in their lifetime and the default behavior is
 fine.
 
-For per-project PO specifically, rejoin is a fresh-instance
-respawn from the senior PO. Senior orients the new instance from:
-runbook + project artifacts (current `worker_conventions`,
-`#leads-{project}` topic / pins, recent journal entries) +
-dispatcher's actionable state. Trade: per-project PO gives up
-perfect scrollback continuity in exchange for cheap
-replaceability. Acceptable.
+For lead-pm specifically, in-process recovery via `--steer-compact`
+covers most cases. For full respawn (process loss, hard kick), see
+"Restarting a long-running lead-pm" above — orient the new instance
+from runbook + recent `#<project>-leads` topic / pins + journal
+entries + dispatcher's actionable state. Trade: lead-pm gives up
+perfect scrollback continuity in exchange for cheap replaceability.
+Acceptable.
 
 ## Discipline
 
@@ -258,7 +255,7 @@ replaceability. Acceptable.
   meaningfully change a reader's design framing, draft it for the
   PR thread, then post a pointer in chat.
 - **Receiver-claims-the-flag.** Workers signal what they're picking
-  up; ProductOps's queue is what's unclaimed.
+  up; lead-pm's queue is what's unclaimed.
 - **Channel membership = lifecycle.** Joining is committing; being
   kicked ends the assignment.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,15 +39,17 @@ per-PR doesn't).
 
 - **lead-pm** — `<project>-lead-pm`. Owns a project end-to-end:
   picks issues off the milestone DAG, pressure-tests worker plans,
-  spawns reviewers, coordinates with the human, posts postmortems.
-  Lives in `#<project>-leads` continuously and joins each
+  coordinates with the human, posts postmortems. Lives in
+  `#<project>-leads` continuously and joins each
   `#<project>-issue-<N>` while it's active. Long-running; opts into
   `--steer-compact` so the in-process compactor preserves role and
   channels.
-- **APM** — `<project>-apm`. Operational support for lead-pm: flips
-  PRs draft → ready, tags reviewers, files follow-up issues, drives
-  release-bump mechanics, runs cleanup after merge. Lives in the
-  same channels as lead-pm.
+- **APM** — `<project>-apm`. Operational support for lead-pm: runs
+  the mechanical dances — worktree + watch + worker-spawn setup,
+  reviewer-agent spawn on draft-PR-open, flip PRs draft → ready +
+  tag the human + re-request review, merge + cleanup, follow-up
+  filing, release-bump mechanics. Lives in the same channels as
+  lead-pm.
 - **Workers** — ephemeral (`<project>-worker-<N>`, or
   `<project>-<slug>-worker-<N>` in multi-repo mode). Join
   `#<project>-issue-<N>` on assignment, leave on completion.
@@ -88,8 +90,9 @@ Sequencing — each step bumps the next:
 
 1. Worker drafts → opens PR (with `Closes #<N>` in the body) and
    posts the link in `#<project>-issue-<N>`.
-2. lead-pm spawns **reviewer-<N>** against the draft (cold lens —
-   no project context).
+2. APM spawns **reviewer-<N>** against the draft (cold lens — no
+   project context). Trigger is draft-PR-open, not CI-green;
+   reviewer + CI run in parallel.
 3. Reviewer reads the diff, posts findings to GitHub, parts the
    channel.
 4. Worker addresses findings, pushes, runs the last-look gate,
@@ -138,7 +141,7 @@ Common spawns:
 
 ```bash
 # Worker pickup on a fresh issue:
-roost spawn <project>-worker-718 -c '#<project>-issue-718'
+roost spawn <project>-worker-718-A -c '#<project>-issue-718'
 
 # Reviewer joining for the review pass:
 roost spawn <project>-reviewer-718 -c '#<project>-issue-718'
@@ -146,7 +149,7 @@ roost spawn <project>-reviewer-718 -c '#<project>-issue-718'
 # Hard restart (channel-as-lifecycle: kick + new worker JOINs same
 # channel, orients from dispatcher state + channel topic + spawn
 # prompt, not from scrollback):
-roost shutdown <project>-worker-718
+roost shutdown <project>-worker-718-A
 roost spawn <project>-worker-718-B -c '#<project>-issue-718'
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,12 +199,12 @@ For deeper inspection — MCP stderr, IRC connection logs — check
 ### When to use the skill vs raw shell
 
 When an agent needs to spawn or manage another agent (lead-pm
-spawning a worker or reviewer, APM kicking a stuck worker, etc.),
-it should invoke the `roost` skill rather than reach for raw shell
-— same command surface, with naming and channel conventions baked
-into the skill description so spawns are consistent across
-spawners. Raw shell is fine for human operators running ad-hoc
-commands.
+spawning the APM at startup, APM spawning a worker or reviewer
+agent, APM kicking a stuck worker, etc.), it should invoke the
+`roost` skill rather than reach for raw shell — same command
+surface, with naming and channel conventions baked into the skill
+description so spawns are consistent across spawners. Raw shell is
+fine for human operators running ad-hoc commands.
 
 Parking-lot enhancements (not yet built):
 

--- a/docs/ROOST-IN-PRACTICE.md
+++ b/docs/ROOST-IN-PRACTICE.md
@@ -83,7 +83,7 @@ channels when something catches your eye.
 
 The IRC channel is doing more work than it looks like. It's the
 namespace boundary — one channel, one issue's scope. It's the
-membership ledger — lead-pm spawns workers and reviewers into the
+membership ledger — the APM spawns workers and reviewers into the
 right channel, and the join/leave events mark pickup and
 completion. It's the audit log — everything any agent did or said
 is in the backlog. It's the subscription primitive — the

--- a/docs/ROOST-IN-PRACTICE.md
+++ b/docs/ROOST-IN-PRACTICE.md
@@ -25,7 +25,7 @@ project actually looks like.
 ## A milestone, end to end
 
 You spawn one agent — the project manager — and hand it the name
-of a GitHub milestone. It joins a channel called `#leads-<project>`
+of a GitHub milestone. It joins a channel called `#<project>-leads`
 and posts its starting strategy: which issues are pickable right
 now (nothing blocking them), which are deferred, which it wants to
 sequence carefully. You read the strategy in your IRC client, push
@@ -34,45 +34,46 @@ back where you disagree, and bless it. From there the agent runs.
 That agent is **lead-pm**. Its operational playbook lives at
 `agents/lead-pm.md` — issue pickup, plan pressure-testing,
 draft PR → reviewer → ready flip → merge → cleanup, in order. It
-sits in `#leads-<project>` continuously and joins each issue
+sits in `#<project>-leads` continuously and joins each issue
 channel while it's active.
 
-For the first issue, lead-pm opens a channel called `#issue-42`,
-DMs the dispatcher (`watch 42`) to subscribe to the issue (so
-GitHub events for it route to that channel), creates an isolated
-git worktree, and spawns a worker into it.
+For the first issue, lead-pm opens a channel called
+`#<project>-issue-42`, DMs the dispatcher (`watch 42`) to subscribe
+to the issue (so GitHub events for it route to that channel),
+creates an isolated git worktree, and spawns a worker into it.
 
 **worker-42** reads the issue, posts an implementation plan in
-`#issue-42`, and waits. lead-pm reads the plan and pushes back —
-this is where rework is cheap, so a few rounds of pressure-testing
-are normal. Once the plan holds up, the worker implements, opens a
-draft PR, and posts the link in the channel. Worker's playbook is
-`prompts/worker.md`.
+`#<project>-issue-42`, and waits. lead-pm reads the plan and pushes
+back — this is where rework is cheap, so a few rounds of
+pressure-testing are normal. Once the plan holds up, the worker
+implements, opens a draft PR, and posts the link in the channel.
+Worker's playbook is `prompts/worker.md`.
 
 Now CI runs. The dispatcher is polling GitHub on a tick; when CI
-flips green, it posts `ci_transitioned: SUCCESS` into `#issue-42`.
-lead-pm sees it and spawns a **reviewer-42** against the PR. The reviewer reads the
-diff cold, posts findings to GitHub, and exits. Its playbook is
+flips green, it posts `ci_transitioned: SUCCESS` into
+`#<project>-issue-42`. lead-pm sees it and spawns a
+**reviewer-42** against the PR. The reviewer reads the diff cold,
+posts findings to GitHub, and exits. Its playbook is
 `prompts/reviewer.md`. The worker addresses the findings; lead-pm
 flips the PR ready and tags you as the human reviewer.
 
 You approve. lead-pm merges, terminates the worker, parts the
 channel, cleans up the worktree, DMs the dispatcher to unsubscribe
 (`unwatch 42`, `unwatch pr 73`), and posts a one-paragraph
-postmortem in `#leads-<project>` — what
-went well, what was painful, what to fix next time. Then it picks
-the next pickable issue off the DAG and the cycle repeats.
+postmortem in `#<project>-leads` — what went well, what was
+painful, what to fix next time. Then it picks the next pickable
+issue off the DAG and the cycle repeats.
 
 ## Parallelism is the channel structure
 
 Nothing in that walkthrough requires one issue at a time. The
-second issue is also in flight in `#issue-43`, with its own worker,
-its own reviewer cycle, its own CI pipeline. So is the third in
-`#issue-44`. lead-pm is in all of them and `#leads-<project>`
-simultaneously, picking the next pickable issue off the DAG when
-bandwidth opens. You're in `#leads-<project>` watching the
-through-line and dipping into individual issue channels when
-something catches your eye.
+second issue is also in flight in `#<project>-issue-43`, with its
+own worker, its own reviewer cycle, its own CI pipeline. So is the
+third in `#<project>-issue-44`. lead-pm is in all of them and
+`#<project>-leads` simultaneously, picking the next pickable issue
+off the DAG when bandwidth opens. You're in `#<project>-leads`
+watching the through-line and dipping into individual issue
+channels when something catches your eye.
 
 The IRC channel is doing more work than it looks like. It's the
 namespace boundary — one channel, one issue's scope. It's the
@@ -93,14 +94,14 @@ not something to debug. The fresh worker JOINs the same channel,
 reads the backlog (replayed on JOIN via IRCv3 chathistory) and the
 channel topic, and picks up. The issue channel is stable across PR
 restarts too — a closed PR plus a fresh worker on the same issue
-keeps the same `#issue-N`.
+keeps the same `#<project>-issue-N`.
 
 You stay in the loop without being in the way. You can answer a
-worker's question in `#issue-42`, redirect a plan, or just lurk and
-let the lead-pm handle it. Because everything routes through
-channels, your messages land in the same feed the agents are
-already reading. There's no second pathway for "human-to-agent" —
-you're just another nick on the IRC server.
+worker's question in `#<project>-issue-42`, redirect a plan, or
+just lurk and let the lead-pm handle it. Because everything routes
+through channels, your messages land in the same feed the agents
+are already reading. There's no second pathway for "human-to-agent"
+— you're just another nick on the IRC server.
 
 The agent and prompt files (`agents/lead-pm.md`,
 `prompts/worker.md`, `prompts/reviewer.md`) are the operational

--- a/docs/ROOST-IN-PRACTICE.md
+++ b/docs/ROOST-IN-PRACTICE.md
@@ -33,14 +33,18 @@ back where you disagree, and bless it. From there the agent runs.
 
 That agent is **lead-pm**. Its operational playbook lives at
 `agents/lead-pm.md` — issue pickup, plan pressure-testing,
-draft PR → reviewer → ready flip → merge → cleanup, in order. It
-sits in `#<project>-leads` continuously and joins each issue
-channel while it's active.
+human-review coordination, postmortems. It sits in
+`#<project>-leads` continuously and joins each issue channel while
+it's active. On startup it spawns an **APM** sidekick
+(`agents/associate-pm.md`) that types the mechanical commands —
+worktree setup, reviewer-spawn on draft PRs, ready-flip, merge,
+cleanup, follow-up filing.
 
-For the first issue, lead-pm opens a channel called
-`#<project>-issue-42`, DMs the dispatcher (`watch 42`) to subscribe
-to the issue (so GitHub events for it route to that channel),
-creates an isolated git worktree, and spawns a worker into it.
+For the first issue, the APM (at lead-pm's nod) opens a channel
+called `#<project>-issue-42`, DMs the dispatcher (`watch 42`) to
+subscribe to the issue (so GitHub events for it route to that
+channel), creates an isolated git worktree, and spawns a worker
+into it.
 
 **worker-42** reads the issue, posts an implementation plan in
 `#<project>-issue-42`, and waits. lead-pm reads the plan and pushes
@@ -49,20 +53,22 @@ pressure-testing are normal. Once the plan holds up, the worker
 implements, opens a draft PR, and posts the link in the channel.
 Worker's playbook is `prompts/worker.md`.
 
-Now CI runs. The dispatcher is polling GitHub on a tick; when CI
-flips green, it posts `ci_transitioned: SUCCESS` into
-`#<project>-issue-42`. lead-pm sees it and spawns a
-**reviewer-42** against the PR. The reviewer reads the diff cold,
-posts findings to GitHub, and exits. Its playbook is
-`prompts/reviewer.md`. The worker addresses the findings; lead-pm
-flips the PR ready and tags you as the human reviewer.
+The draft-PR-open event triggers the APM to spawn a **reviewer-42**
+against the PR. The reviewer reads the diff cold, posts findings to
+GitHub, and exits. Its playbook is `prompts/reviewer.md`. The
+worker addresses the findings and signals ready; the APM flips the
+PR draft → ready and tags you as the human reviewer.
 
-You approve. lead-pm merges, terminates the worker, parts the
-channel, cleans up the worktree, DMs the dispatcher to unsubscribe
-(`unwatch 42`, `unwatch pr 73`), and posts a one-paragraph
-postmortem in `#<project>-leads` — what went well, what was
-painful, what to fix next time. Then it picks the next pickable
-issue off the DAG and the cycle repeats.
+CI runs in parallel on every push; the dispatcher posts
+`ci_transitioned: SUCCESS` into `#<project>-issue-42` so everyone
+in the channel sees when the build is healthy.
+
+You approve. The APM merges, terminates the worker, parts the
+channel, cleans up the worktree, and DMs the dispatcher to
+unsubscribe (`unwatch 42`, `unwatch pr 73`). lead-pm posts a
+one-paragraph postmortem in `#<project>-leads` — what went well,
+what was painful, what to fix next time. Then lead-pm picks the
+next pickable issue off the DAG and the cycle repeats.
 
 ## Parallelism is the channel structure
 


### PR DESCRIPTION
Closes #555

## Summary

- Normalize `#leads-<project>` → `#<project>-leads` and bare `#issue-NNN` → `#<project>-issue-<N>` across ARCHITECTURE.md (9 spots) and docs/ROOST-IN-PRACTICE.md (11 spots).
- Reshape ARCHITECTURE.md's senior-PO / per-project-PO topology to the current shipped roles: lead-pm + APM + worker + reviewer + dispatcher. Topology diagram, channels table, identities, routing, PR review flow, lifecycle, common-spawns, lead-pm respawn, rejoin, discipline — all swept.
- Drop the line-176 TODO signpost left by #553.
- Per reviewer's pass on initial draft: fix reviewer-spawn role-boundary in ARCHITECTURE.md (APM owns reviewer-spawn on draft-PR-open, not lead-pm on CI-green) + corresponding narrative fix in docs/ROOST-IN-PRACTICE.md walkthrough (which had APM-attributable actions throughout misattributed to lead-pm). Hard-restart common-spawns example uses consistent -A → -B suffixes.
- docs/LEARNINGS.md `productops-*` historical references preserved per CLAUDE.md systems-of-record policy.

## Scope decisions (approved by lead-pm in #roost-issue-555)

- Q1 — rolled the `#issue-NNN` → `#<project>-issue-<N>` rename into the same PR (§#419: adjacent same-pattern drift in the same files).
- Q2 — stripped the senior-PO / per-project-PO concept entirely rather than preserving a two-tier abstraction. ARCHITECTURE describes what's deployed today; evolution lives in LEARNINGS.md + git.
- Reviewer findings #1 + #5 rolled in as a single defect (reviewer-spawn / APM-dance role attribution drift across both surfaces this PR already touches). Per §#419 + lead's default-take-more-work.

## SKILL.md cross-reference heads-up (for #557 wave)

`skills/roost/SKILL.md` still has two surfaces that ARCHITECTURE.md has now moved past:
- `:195` — `#staff` described as "standing senior agents (cross-cutting team)" (the last reference to the senior-agents abstraction).
- `:3` — bare `#issue-NNN` in the trigger-phrase list. Per project-learnings §#553 channel-pattern shape is literal-verbatim → strict drift; trigger phrases may intentionally mirror casual user speech but worth folding into the next sweep so the drift doesn't have to be rediscovered.

Not swept in this PR per lead-pm guidance; flagging both for the next wave.

## Test plan

- [ ] Eyeball the ARCHITECTURE.md topology diagram renders cleanly (ASCII art column alignment).
- [ ] Confirm no remaining `#leads-`, `#issue-NNN`, `productops`, `senior PO`, `per-project PO`, `ProductOps`, `CEO`, or `#staff` references in the two swept docs (`grep` clean).
- [ ] Confirm docs/LEARNINGS.md untouched.
- [ ] Read ARCHITECTURE.md and ROOST-IN-PRACTICE.md end-to-end for narrative cohesion (no orphaned references to dropped roles; APM and lead-pm attribution matches `agents/lead-pm.md` + `agents/associate-pm.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)