### PR TITLE
maint: canonicalize answerer-nick placeholder to <your-nick>

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -51,7 +51,7 @@ Quick start:
     --agent lead-pm \\
     --channels '#<project>-leads' \\
     --steer-compact --cache-ttl 1h \\
-    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'
+    --prompt 'milestone=<milestone> human=<your-nick> gh-login=<your-gh-login>'
 
 Run 'roost <command> --help' for per-command usage.
 EOF
@@ -219,7 +219,7 @@ Agent class guidance:
   should route via IRC so a blocked question surfaces in the leads channel
   instead of freezing the terminal:
     --steer-compact --cache-ttl 1h \
-    --ask-irc '#<project>-leads' --ask-target <answerer>
+    --ask-irc '#<project>-leads' --ask-target <your-nick>
   Workers — multi-turn through reviewer + human review cycles that
   routinely exceed 5 minutes, so \`--cache-ttl 1h\`. But short-lived
   enough that auto-compact rarely fires, so no \`--steer-compact\`:
@@ -571,8 +571,8 @@ cmd_init() {
     "    --agent lead-pm \\" \
     "    --channels '#${project}-leads' \\" \
     "    --steer-compact --cache-ttl 1h \\" \
-    "    --ask-irc '#${project}-leads' --ask-target <your-irc-nick> \\" \
-    "    --prompt 'milestone=<milestone> human=<your-irc-nick> gh-login=<your-gh-login>'"
+    "    --ask-irc '#${project}-leads' --ask-target <your-nick> \\" \
+    "    --prompt 'milestone=<milestone> human=<your-nick> gh-login=<your-gh-login>'"
 }
 
 require_tmux() {

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -194,7 +194,7 @@ with `roost status` (which lists running tmux sessions).
   persistent per-PR worker traffic.
 - `#<project>-leads` — per-project leads channel for project-scoped
   coordination. Lead-pm + APM + dispatcher live here.
-- `#<project>-issue-N` — one per active issue. Created on first JOIN;
+- `#<project>-issue-<N>` — one per active issue. Created on first JOIN;
   dissolves when the last member leaves.
 - `#sandbox` — ad-hoc testing / demos / one-off coordination.
 

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roost
-description: Use this skill when the user asks to spawn, launch, manage, attach to, list, tear down, or shut down roost agents — Claude Code sessions running on the local IRC roost. Trigger phrases include "spawn a worker", "bring up a roost claude", "start a session in #issue-NNN", "kill that worker", "tear down the test", "list the running agents", "spawn a sonnet/haiku worker with permission oversight", "approve its tool calls over IRC", or any reference to the bin/roost wrapper, tmux-claude lifecycle, or roost IRC sessions. Provides the command surface, naming conventions, channel topology, lifecycle rules, and the IRC permission-oversight pattern (Opus orchestrator gating a non-auto-mode worker's tool calls via DMs).
+description: Use this skill when the user asks to spawn, launch, manage, attach to, list, tear down, or shut down roost agents — Claude Code sessions running on the local IRC roost. Trigger phrases include "spawn a worker", "bring up a roost claude", "start a session in #<project>-issue-<N>", "kill that worker", "tear down the test", "list the running agents", "spawn a sonnet/haiku worker with permission oversight", "approve its tool calls over IRC", or any reference to the bin/roost wrapper, tmux-claude lifecycle, or roost IRC sessions. Provides the command surface, naming conventions, channel topology, lifecycle rules, and the IRC permission-oversight pattern (Opus orchestrator gating a non-auto-mode worker's tool calls via DMs).
 ---
 
 # roost — manage Claude sessions on the IRC roost
@@ -192,7 +192,6 @@ with `roost status` (which lists running tmux sessions).
 
 - `#roost` — default landing channel. Cross-cutting only; no
   persistent per-PR worker traffic.
-- `#staff` — standing senior agents (cross-cutting team).
 - `#<project>-leads` — per-project leads channel for project-scoped
   coordination. Lead-pm + APM + dispatcher live here.
 - `#<project>-issue-N` — one per active issue. Created on first JOIN;


### PR DESCRIPTION
Closes #557

Unifies the `--ask-target` and `human=` placeholder spelling across all 5 PM spawn surfaces. `<your-nick>` was already canonical in README, ARCHITECTURE, and SKILL.md; bin/roost had two variants (`<answerer>` and `<your-irc-nick>`).

Also drops the defunct `#staff` channel entry from SKILL.md (stripped from ARCHITECTURE in #555; no replacement) and fixes the trigger-phrase channel example to the canonical `#<project>-issue-<N>` shape.