### PR TITLE
maint: bump package.json to 0.8.3 ahead of v0.8.3 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bumps version 0.8.2 → 0.8.3.

what's new since v0.8.2:
- seen-by list in channel_message responses replaces implementation-detail annotations (#562)
- channel-pattern drift sweep in ARCHITECTURE.md + ROOST-IN-PRACTICE.md (#555)
- canonicalize answerer-nick placeholder to `<your-nick>` across bin/roost + SKILL.md (#557)
- irc.nick default fallback in requireIrcConfig (#560)
- relax APM tools frontmatter to match lead-pm pattern (#563)