### PR TITLE
fix(permbot): auto-reconnect on IRC drop + forensic lifecycle logging

### DIFF
--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -399,6 +399,24 @@ export class RoostIrcClientImpl implements RoostIrcClient {
     this.irc.on(`batch end ${BATCH_TYPE_CHATHISTORY}`, (e: BatchEndEvent) => this.handleChathistoryBatch(e))
     this.irc.on('socket close', () => this.handleSocketClose())
     this.irc.on('socket error', (err: Error) => this.handleSocketError(err))
+    // Forensic lifecycle events — surfaced for permbot's on-disk log. See SystemKind
+    // declaration for why these are exposed despite being noisy.
+    this.irc.on('ping', (e: { message?: string }) => this.emitSystem('ping', `PING received${e?.message ? ' ' + e.message : ''}, PONG sent`))
+    this.irc.on('pong', (e: { message?: string }) => this.emitSystem('pong', `PONG received${e?.message ? ' ' + e.message : ''}`))
+    this.irc.on('reconnecting', (e: { attempt?: number; max_retries?: number; wait?: number }) =>
+      this.emitSystem('reconnecting', `reconnect attempt ${e?.attempt ?? '?'}/${e?.max_retries ?? '?'} in ${e?.wait ?? '?'}ms`))
+    this.irc.on('cap ls', (e: { capabilities?: Record<string, string | boolean> }) => {
+      const names = e?.capabilities ? Object.keys(e.capabilities).sort().join(',') : ''
+      this.emitSystem('cap-ls', `CAP LS: ${names || '(empty)'}`)
+    })
+    this.irc.on('cap ack', (e: { capabilities?: string[] | Record<string, unknown> }) => {
+      const caps = Array.isArray(e?.capabilities) ? e.capabilities : Object.keys(e?.capabilities ?? {})
+      this.emitSystem('cap-ack', `CAP ACK: ${caps.sort().join(',') || '(none)'}`)
+    })
+    this.irc.on('cap nak', (e: { capabilities?: string[] | Record<string, unknown> }) => {
+      const caps = Array.isArray(e?.capabilities) ? e.capabilities : Object.keys(e?.capabilities ?? {})
+      this.emitSystem('cap-nak', `CAP NAK: ${caps.sort().join(',') || '(none)'}`)
+    })
     // 432 ERR_ERRONEUSNICKNAME, 433 ERR_NICKNAMEINUSE, 436 ERR_NICKCOLLISION
     for (const code of ['432', '433', '436']) {
       this.irc.on(code, () => {

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -54,8 +54,18 @@ export interface ConnectOpts {
   autoReconnectMaxRetries?: number
 }
 
-export type SystemKind = 'disconnected' | 'reconnected' | 'cap-missing' | 'registered' | 'registration-failed'
-// string for disconnected/reconnected/cap-missing; { nick } for registered; { code } for registration-failed
+// The 'lifecycle' kinds (ping/pong/reconnecting/cap-*) are forensic — the permbot
+// listens to them and appends to its on-disk log so an operator can confirm post-hoc
+// that PING/PONG handshakes are healthy and a disconnect was followed by a reconnect
+// attempt. Without these, a permbot that drops at ~60s into a session leaves no trail
+// to distinguish "missed PONG" from "cap-negotiation race" from "real network drop".
+// Other consumers (the worker MCP) only need the registered/disconnected/reconnected
+// signals and can ignore the lifecycle kinds.
+export type SystemKind =
+  | 'disconnected' | 'reconnected' | 'cap-missing' | 'registered' | 'registration-failed'
+  | 'ping' | 'pong' | 'reconnecting' | 'cap-ack' | 'cap-nak' | 'cap-ls'
+// string for disconnected/reconnected/cap-missing/ping/pong/reconnecting/cap-*;
+// { nick } for registered; { code } for registration-failed.
 export type SystemContent = string | { code?: number; nick?: string }
 
 export type MembershipKind = 'join' | 'leave' | 'nick'

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -318,7 +318,18 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
     process.stderr.write(`roost-irc[${NICK}]: <- [${kind}] ${summary}\n`)
   })
 
+  // Forensic SystemKinds (see SystemKind decl in irc-client.ts) are emitted on every
+  // client; here we keep them out of the worker agent's notification stream — wire
+  // details aren't actionable from the agent's side (cf. project-learnings §#562).
+  // Permbot subscribes via its own client.on('system') and still gets the full set.
+  const WORKER_FILTERED_SYSTEM_KINDS = new Set<string>([
+    'ping', 'pong', 'cap-ls', 'cap-ack', 'cap-nak', 'reconnecting',
+  ])
   client.on('system', (kind, content) => {
+    if (WORKER_FILTERED_SYSTEM_KINDS.has(kind)) {
+      process.stderr.write(`roost-irc[${NICK}]: [${kind}] ${typeof content === 'string' ? content : JSON.stringify(content)}\n`)
+      return
+    }
     const ts = localeTs(new Date())
     const text = typeof content === 'string' ? content : JSON.stringify(content)
     pushNotification(text, { event: kind, channel: '', sender: '', isDirect: 'false', ts })

--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -549,6 +549,8 @@ async function runOwnerMcp(args: {
       nick: permbotNick,
       username: permbotNick,
       gecos: 'roost-permbot',
+      autoReconnect: true,
+      autoReconnectMaxRetries: 10,
     })
     process.stderr.write(`roost-irc[${NICK}]: started in-process permbot (nick ${permbotNick}, sock ${PERM_SOCK})\n`)
   }

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -247,9 +247,8 @@ export function startPermbot(
       stop()
     } else if (kind === 'disconnected') {
       // The unix socket stays open while IRC reconnects; in-flight requests time
-      // out as usual (no operator on the other end to answer). New requests queue
-      // and dispatch once we re-register. The hook's askDaemon falls back only if
-      // the socket itself is gone, which it isn't during a transient drop.
+      // out as usual. The hook's askDaemon falls back only if the socket itself
+      // is gone, which it isn't during a transient drop.
       log('IRC connection lost — waiting for auto-reconnect')
     } else if (kind === 'reconnected') {
       log(`IRC reconnected${detail ? ': ' + detail : ''}`)

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -238,19 +238,27 @@ export function startPermbot(
     }
   })
 
-  client.on('system', (kind) => {
+  client.on('system', (kind, content) => {
+    const detail = typeof content === 'string' ? content : ''
     if (kind === 'registered') {
-      log('registered with IRC')
+      log('registered with IRC (001 received)')
     } else if (kind === 'registration-failed') {
       log('FATAL nick registration failure, shutting down')
       stop()
     } else if (kind === 'disconnected') {
-      // Tear down on disconnect. The hook's askDaemon detects the missing
-      // socket and falls back to a transient-DM + emit('ask'), so the
-      // worker degrades cleanly. Owner-gate eliminates the collision-driven disconnect;
-      // if a real network drop becomes a recurring failure mode, add auto-reconnect.
-      log('IRC connection lost, shutting down')
-      stop()
+      // The unix socket stays open while IRC reconnects; in-flight requests time
+      // out as usual (no operator on the other end to answer). New requests queue
+      // and dispatch once we re-register. The hook's askDaemon falls back only if
+      // the socket itself is gone, which it isn't during a transient drop.
+      log('IRC connection lost — waiting for auto-reconnect')
+    } else if (kind === 'reconnected') {
+      log(`IRC reconnected${detail ? ': ' + detail : ''}`)
+    } else if (kind === 'reconnecting') {
+      log(detail || 'reconnect attempt scheduled')
+    } else if (kind === 'ping' || kind === 'pong') {
+      log(detail || kind.toUpperCase())
+    } else if (kind === 'cap-ls' || kind === 'cap-ack' || kind === 'cap-nak') {
+      log(detail || kind)
     } else if (kind === 'cap-missing') {
       log('cap-missing (ignored)')
     }

--- a/test/permbot-reconnect.test.ts
+++ b/test/permbot-reconnect.test.ts
@@ -98,11 +98,17 @@ describe.if(isErgoAvailable())('permbot IRC drop mid-session', () => {
       // No operator replies, so we expect a clean timeout — proves the socket+queue path is intact.
       expect(resp).toEqual({ timeout: true })
 
-      // permbot.log carries the forensic milestones an operator greps for.
+      // permbot.log carries the forensic milestones an operator greps for. CAP
+      // negotiation fires on both initial connect and reconnect, so this asserts
+      // the grep-contract slice that's observable without waiting for the 30s
+      // PING tick. (PING/PONG line shape is locked by the mock-based unit test
+      // in permbot.test.ts → 'permbot lifecycle logging'.)
       const logContent = fs.readFileSync(logFile, 'utf8')
       expect(logContent).toMatch(/registered with IRC/)
       expect(logContent).toMatch(/IRC connection lost/)
       expect(logContent).toMatch(/IRC reconnected/)
+      expect(logContent).toMatch(/CAP LS:/)
+      expect(logContent).toMatch(/CAP ACK:/)
     } finally {
       try { stopPermbot?.() } catch { /* ignore */ }
       try { fs.unlinkSync(logFile) } catch { /* ignore */ }

--- a/test/permbot-reconnect.test.ts
+++ b/test/permbot-reconnect.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'bun:test'
+import * as fs from 'node:fs'
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { startPermbot } from '../src/permbot.js'
+import { RoostIrcClientImpl } from '../src/irc-client-impl.js'
+import { startErgoDedicated, isErgoAvailable } from './helpers/ergo.js'
+import { suppressLateRejection } from './helpers/tool.js'
+import type { SystemContent, SystemKind } from '../src/irc-client.js'
+
+function tmpSock(): string {
+  return path.join(os.tmpdir(), `permbot-recon-${process.pid}-${Math.random().toString(36).slice(2)}.sock`)
+}
+
+function socketRoundtrip(sockPath: string, req: object): Promise<object> {
+  return suppressLateRejection(new Promise((resolve, reject) => {
+    const sock = net.createConnection(sockPath)
+    let buf = ''
+    sock.on('connect', () => sock.write(JSON.stringify(req) + '\n'))
+    sock.on('data', (d) => {
+      buf += d.toString('utf8')
+      if (buf.includes('\n')) {
+        try { resolve(JSON.parse(buf.split('\n')[0])) } catch (e) { reject(e) }
+        sock.destroy()
+      }
+    })
+    sock.on('error', reject)
+  }))
+}
+
+async function waitFor<T>(predicate: () => T | undefined, deadlineMs: number, errMsg: string): Promise<T> {
+  const start = Date.now()
+  while (true) {
+    const v = predicate()
+    if (v !== undefined) return v
+    if (Date.now() - start > deadlineMs) throw new Error(errMsg)
+    await new Promise<void>(res => setTimeout(res, 50))
+  }
+}
+
+describe.if(isErgoAvailable())('permbot IRC drop mid-session', () => {
+  it('kill + restart ergo → permbot reconnects, socket survives, lifecycle hits permbot.log', async () => {
+    const dedicated = await startErgoDedicated()
+    if (!dedicated) return
+
+    const logFile = path.join(os.tmpdir(), `permbot-recon-${process.pid}-${Math.random().toString(36).slice(2)}.log`)
+    const sockPath = tmpSock()
+    const events: Array<{ kind: SystemKind; content: SystemContent }> = []
+    let stopPermbot: (() => void) | null = null
+
+    try {
+      const client = new RoostIrcClientImpl({
+        nick: 'permbot-recon',
+        autoJoin: [],
+        historySize: 0,
+        joinHistoryLines: 0,
+        joinHistoryMinutes: 0,
+      })
+      client.on('system', (kind, content) => { events.push({ kind, content }) })
+
+      const { stop, ready } = startPermbot(
+        { nick: 'permbot-recon', sockPath, worker: 'wkr', debugLog: logFile },
+        client,
+      )
+      stopPermbot = stop
+      await ready
+
+      client.connect({
+        host: dedicated.host,
+        port: dedicated.port,
+        nick: 'permbot-recon',
+        username: 'permbot-recon',
+        gecos: 'permbot',
+        autoReconnect: true,
+        autoReconnectMaxRetries: 10,
+      })
+
+      await waitFor(() => events.find(e => e.kind === 'registered'), 5000, 'permbot did not register within 5s')
+
+      // irc-framework only schedules auto_reconnect if registered_ms_ago > 5000.
+      await new Promise<void>(res => setTimeout(res, 6000))
+
+      // Drop and bring back the server.
+      const eventsAtKill = events.length
+      await dedicated.kill()
+      await waitFor(() => events.slice(eventsAtKill).find(e => e.kind === 'disconnected'), 5000, 'permbot did not observe disconnect')
+
+      await dedicated.restart()
+      await waitFor(() => events.find(e => e.kind === 'reconnected'), 15000, 'permbot did not reconnect within 15s')
+
+      // Daemon stayed up — the unix socket is still listening; new requests are answerable.
+      expect(fs.existsSync(sockPath)).toBe(true)
+      const resp = await Promise.race([
+        socketRoundtrip(sockPath, { summary: 'post-reconnect', timeout: 0.1, kind: 'permission', replyTarget: 'operator' }),
+        new Promise<object>((_, rej) => setTimeout(() => rej(new Error('socket roundtrip stalled')), 3000).unref?.()),
+      ])
+      // No operator replies, so we expect a clean timeout — proves the socket+queue path is intact.
+      expect(resp).toEqual({ timeout: true })
+
+      // permbot.log carries the forensic milestones an operator greps for.
+      const logContent = fs.readFileSync(logFile, 'utf8')
+      expect(logContent).toMatch(/registered with IRC/)
+      expect(logContent).toMatch(/IRC connection lost/)
+      expect(logContent).toMatch(/IRC reconnected/)
+    } finally {
+      try { stopPermbot?.() } catch { /* ignore */ }
+      try { fs.unlinkSync(logFile) } catch { /* ignore */ }
+      try { fs.unlinkSync(sockPath) } catch { /* ignore */ }
+      await dedicated.cleanup()
+    }
+  }, 40_000)
+})

--- a/test/permbot.test.ts
+++ b/test/permbot.test.ts
@@ -7,6 +7,10 @@ import * as path from 'node:path'
 import { startPermbot } from '../src/permbot.js'
 import type { IrcMessage, MessageMeta, RoostIrcClient, SystemKind, SystemContent, UnreadInfo } from '../src/irc-client.js'
 
+function tmpLog(): string {
+  return path.join(os.tmpdir(), `permbot-log-test-${process.pid}-${Math.random().toString(36).slice(2)}.log`)
+}
+
 // ---- Mock client ------------------------------------------------------------
 
 function makeMockClient() {
@@ -367,5 +371,47 @@ describe('permbot ask-question channel routing', () => {
     replyChannel('operator', '#ch', 'chat')
     const resp = await respPromise
     expect(resp).toEqual({ reply: 'chat' })
+  })
+})
+
+describe('permbot lifecycle logging', () => {
+  it('writes lifecycle milestones to debugLog so operator grep contract holds', async () => {
+    // Issue #578 acceptance: `grep -E 'PING|PONG|reconnect|CAP|registered' permbot.log`
+    // must surface the full handshake/reconnect lifecycle. Lock the contract via the
+    // mock so a future SystemKind rename or handler tweak can't silently break it.
+    const sockPath = tmpSock()
+    const logFile = tmpLog()
+    const { client, emitSystem } = makeMockClient()
+    const { stop, ready } = startPermbot(
+      { nick: 'permbot-test', sockPath, worker: 'wkr', debugLog: logFile },
+      client,
+    )
+    stops.push(stop)
+    await ready
+
+    emitSystem('registered', { nick: 'wkr-permbot' })
+    emitSystem('cap-ls', 'CAP LS: server-time,draft/multiline')
+    emitSystem('cap-ack', 'CAP ACK: server-time,draft/multiline')
+    emitSystem('cap-nak', 'CAP NAK: invalid-cap')
+    emitSystem('ping', 'PING received foo, PONG sent')
+    emitSystem('pong', 'PONG received bar')
+    emitSystem('reconnecting', 'reconnect attempt 1/10 in 2000ms')
+    emitSystem('disconnected', '[roost] disconnected from IRC')
+    emitSystem('reconnected', '[roost] reconnected to IRC')
+
+    const content = fs.readFileSync(logFile, 'utf8')
+    try {
+      expect(content).toMatch(/registered with IRC/)
+      expect(content).toMatch(/PING received/)
+      expect(content).toMatch(/PONG received/)
+      expect(content).toMatch(/CAP LS:/)
+      expect(content).toMatch(/CAP ACK:/)
+      expect(content).toMatch(/CAP NAK:/)
+      expect(content).toMatch(/reconnect attempt/)
+      expect(content).toMatch(/IRC connection lost/)
+      expect(content).toMatch(/IRC reconnected/)
+    } finally {
+      try { fs.unlinkSync(logFile) } catch { /* ignore */ }
+    }
   })
 })


### PR DESCRIPTION
Closes #578

## Summary
- Permbot auto-reconnects on IRC drop instead of tearing the daemon down.
- Disconnect now just logs and waits; the reconnect path mirrors what the worker already uses.
- Handshake milestones (ping/pong/cap/reconnect) land in permbot.log so operators can reconstruct a 60s-drop after the fact.

## Test plan
- [x] integration test: kill + restart ergo, permbot stays up and the socket still serves
- [x] mock-based unit test locks the lifecycle log contract
- [x] lint, typecheck, full suite (927 pass)