### PR TITLE
fix: split sendFallbackDm registration vs flush deadlines + log lifecycle

### DIFF
--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -205,11 +205,15 @@ export async function sendFallbackDm(summary: string, reason: string): Promise<v
     let flushTimer: ReturnType<typeof setTimeout> | null = null
 
     let sent = false
-    client.on('system', (kind) => {
+    client.on('system', (kind, content) => {
       if ((kind === 'registered' || kind === 'cap-missing') && !sent) {
         sent = true
         clearTimeout(regTimer)
-        flog('registered successfully')
+        // Both states mean the connection is ready for PRIVMSGs, but
+        // cap-missing carries the reason (which cap wasn't advertised) and the
+        // operator usually wants that signal. Keep "registered" as the
+        // canonical grep prefix; append the cap-missing reason verbatim.
+        flog(kind === 'cap-missing' ? `registered (cap-missing: ${String(content)})` : 'registered successfully')
         const lines = [
           `[${WORKER}] terminal fallback: ${reason}`,
           ...summary.split('\n').filter(l => l.trim()).map(l => `  ${l.trimEnd()}`),
@@ -223,8 +227,7 @@ export async function sendFallbackDm(summary: string, reason: string): Promise<v
           finish()
         }, FALLBACK_FLUSH_TIMEOUT_MS)
       } else if (kind === 'disconnected') {
-        flog('received disconnected event')
-        flog('quit completed')
+        flog('transient client disconnected (quit complete)')
         clearTimeout(regTimer)
         if (flushTimer) clearTimeout(flushTimer)
         finish()

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -18,6 +18,14 @@ const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
 // keep in sync with src/pretooluse-prompt.ts (SOCKET_SAFETY_TIMEOUT)
 const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOST_PERM_TIMEOUT_SECS'] ?? '570')))
 
+// Fallback-DM deadlines. Split in two so a slow ergo registration doesn't eat
+// the budget reserved for flushing PRIVMSGs through quit(). The previous single
+// 10s timer meant a 9.5s register left 0.5s for say+quit+disconnect — under
+// load the parent process exited before quit() drained, the operator saw no
+// DM, and there was no log line to explain why. Tests override via env.
+const FALLBACK_REG_TIMEOUT_MS   = Math.max(1, Number(process.env['ROOST_FALLBACK_REG_TIMEOUT_MS']   ?? '5000'))
+const FALLBACK_FLUSH_TIMEOUT_MS = Math.max(1, Number(process.env['ROOST_FALLBACK_FLUSH_TIMEOUT_MS'] ?? '5000'))
+
 const PASSTHROUGH_PREFIXES = ['mcp__roost-irc__', 'mcp__plugin_roost_roost-irc__']
 
 // ---- Output -----------------------------------------------------------------
@@ -165,32 +173,66 @@ export async function askDaemon(summary: string): Promise<string | null> {
 
 // ---- Fallback DM via RoostIrcClient (transient connection) ------------------
 
+function flog(msg: string): void {
+  process.stderr.write(`perm-hook[${WORKER}]: fallback-dm: ${msg}\n`)
+}
+
 export async function sendFallbackDm(summary: string, reason: string): Promise<void> {
   if (!PERM_TARGET) return
   const nick = `pnotify-${WORKER}`
+  flog(`starting transient connection -> ${PERM_TARGET}`)
   const { RoostIrcClientImpl } = await import('./irc-client-impl.js')
   const client = new RoostIrcClientImpl({
     nick, autoJoin: [], historySize: 0, joinHistoryLines: 0, joinHistoryMinutes: 0,
   })
   await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, 10_000)
+    let done = false
+    const finish = (): void => { if (!done) { done = true; resolve() } }
+
+    // Registration deadline: armed at connect, cleared once 'registered' or
+    // 'cap-missing' fires. If it expires first, the IRC handshake never
+    // completed (ergo unreachable, CAP negotiation hung, etc.) and we bail
+    // without attempting PRIVMSGs.
+    const regTimer = setTimeout(() => {
+      flog(`registration timeout fired at ${FALLBACK_REG_TIMEOUT_MS}ms`)
+      try { client.quit() } catch { /* socket may already be dead */ }
+      finish()
+    }, FALLBACK_REG_TIMEOUT_MS)
+
+    // Flush deadline: armed only AFTER PRIVMSGs are sent + quit() called.
+    // Lets us wait for the 'disconnected' event (proof quit() drained the
+    // outbound buffer) without racing the registration timer.
+    let flushTimer: ReturnType<typeof setTimeout> | null = null
+
     let sent = false
     client.on('system', (kind) => {
-      // 'registered' fires when multiline cap is available (real ergo);
-      // 'cap-missing' fires otherwise — both mean the connection is ready.
       if ((kind === 'registered' || kind === 'cap-missing') && !sent) {
         sent = true
-        client.say(PERM_TARGET, `[${WORKER}] terminal fallback: ${reason}`)
-        for (const ln of summary.split('\n')) {
-          if (ln.trim()) client.say(PERM_TARGET, `  ${ln.trimEnd()}`)
-        }
-        client.say(PERM_TARGET, `(worker blocked on terminal — use \`roost tail ${WORKER}\` to see context, \`roost send ${WORKER} y\` to unblock)`)
-        // quit() flushes buffered writes before the connection drops;
-        // wait for 'disconnected' so PRIVMSGs are actually delivered.
+        clearTimeout(regTimer)
+        flog('registered successfully')
+        const lines = [
+          `[${WORKER}] terminal fallback: ${reason}`,
+          ...summary.split('\n').filter(l => l.trim()).map(l => `  ${l.trimEnd()}`),
+          `(worker blocked on terminal — use \`roost tail ${WORKER}\` to see context, \`roost send ${WORKER} y\` to unblock)`,
+        ]
+        for (const l of lines) client.say(PERM_TARGET, l)
+        flog(`PRIVMSGs sent (count=${lines.length})`)
         client.quit()
-      } else if (kind === 'disconnected' || kind === 'registration-failed') {
-        clearTimeout(timer)
-        resolve()
+        flushTimer = setTimeout(() => {
+          flog(`flush timeout fired at ${FALLBACK_FLUSH_TIMEOUT_MS}ms — DM may not have delivered`)
+          finish()
+        }, FALLBACK_FLUSH_TIMEOUT_MS)
+      } else if (kind === 'disconnected') {
+        flog('received disconnected event')
+        flog('quit completed')
+        clearTimeout(regTimer)
+        if (flushTimer) clearTimeout(flushTimer)
+        finish()
+      } else if (kind === 'registration-failed') {
+        flog('registration failed')
+        clearTimeout(regTimer)
+        if (flushTimer) clearTimeout(flushTimer)
+        finish()
       }
     })
     client.connect({ host: PERM_HOST, port: PERM_PORT, nick, username: nick, gecos: 'perm-notify' })

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -397,7 +397,7 @@ describe.if(isErgoAvailable())('sendFallbackDm against real ergo', () => {
     expect(stderr).toContain('starting transient connection')
     expect(stderr).toContain('registered successfully')
     expect(stderr).toContain('PRIVMSGs sent')
-    expect(stderr).toContain('received disconnected event')
+    expect(stderr).toContain('transient client disconnected (quit complete)')
   }, 15_000)
 
   it('logs registration timeout when ergo never answers', async () => {

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, it, expect, beforeAll } from 'bun:test'
 import * as fs from 'node:fs'
 import * as net from 'node:net'
 import * as os from 'node:os'
@@ -6,6 +6,8 @@ import * as path from 'node:path'
 import { summarize, extractIntent, resolveTranscriptPath } from '../src/permission-prompt.js'
 import { suppressLateRejection } from './helpers/tool.js'
 import { startPermbotStub, makeSock, captureIRC } from './helpers/permbot-stub.js'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { connectPeer } from './helpers/peer.js'
 
 const HOOK = path.join(import.meta.dirname, '../src/permission-prompt.ts')
 
@@ -335,4 +337,99 @@ describe('permission-prompt hook', () => {
       fs.rmSync(dataDir, { recursive: true, force: true })
     }
   })
+})
+
+// ---- fallback DM against real ergo -----------------------------------------
+//
+// Wire-level coverage (test above, line ~191) verifies PRIVMSGs are emitted
+// against a stub IRC server. That stub skips CAP negotiation timing, server
+// caps the real ergo advertises, and the registered→say→quit→disconnected
+// ordering — which is exactly where the production failure landed (the hook
+// ran, the fallback path fired, but no DM reached the operator). This test
+// drives the hook subprocess against a real ergo and asserts the ask-target
+// receives the PRIVMSG, with a loose timing bound to catch regressions where
+// delivery still works but takes 30s.
+
+describe.if(isErgoAvailable())('sendFallbackDm against real ergo', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('delivers DM to operator when permbot socket is absent', async () => {
+    const operator = await connectPeer(ergo, 'op-real-1')
+    // Hook sends a header PRIVMSG, then one PRIVMSG per summary line. Wait for
+    // both: the header confirms the "terminal fallback" framing, the Bash line
+    // confirms summary lines actually made it across before quit().
+    const seenHeader = operator.waitForMessage(
+      operator.nick,
+      (m) => m.text.includes('terminal fallback') && m.nick.startsWith('pnotify-'),
+      8000,
+    )
+    const seenSummary = operator.waitForMessage(
+      operator.nick,
+      (m) => m.text.includes('Bash') && m.nick.startsWith('pnotify-'),
+      8000,
+    )
+
+    const start = Date.now()
+    const proc = Bun.spawn(['bun', HOOK], {
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        ROOST_IRC_NICK: 'worker-real-1',
+        ROOST_PERM_TARGET: operator.nick,
+        ROOST_PERM_HOST: ergo.host,
+        ROOST_PERM_PORT: String(ergo.port),
+      },
+      stdin: new TextEncoder().encode(PAYLOAD),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stderr] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    const [header, summary] = await Promise.all([seenHeader, seenSummary])
+    const elapsed = Date.now() - start
+
+    expect(header.text).toContain('permbot unavailable')
+    expect(summary.text).toContain('Bash')
+    expect(elapsed).toBeLessThan(8000)
+    expect(stderr).toContain('starting transient connection')
+    expect(stderr).toContain('registered successfully')
+    expect(stderr).toContain('PRIVMSGs sent')
+    expect(stderr).toContain('received disconnected event')
+  }, 15_000)
+
+  it('logs registration timeout when ergo never answers', async () => {
+    // Sink that accepts TCP but never speaks IRC — registration deadline must
+    // fire and the hook must still exit 0 with the documented log line.
+    const sink = net.createServer(() => { /* hold socket open, send nothing */ })
+    await new Promise<void>(r => sink.listen(0, '127.0.0.1', () => r()))
+    const { port } = sink.address() as net.AddressInfo
+
+    try {
+      const proc = Bun.spawn(['bun', HOOK], {
+        env: {
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+          ROOST_IRC_NICK: 'worker-real-2',
+          ROOST_PERM_TARGET: 'op-real-2',
+          ROOST_PERM_HOST: '127.0.0.1',
+          ROOST_PERM_PORT: String(port),
+          ROOST_FALLBACK_REG_TIMEOUT_MS: '300',
+          ROOST_FALLBACK_FLUSH_TIMEOUT_MS: '300',
+        },
+        stdin: new TextEncoder().encode(PAYLOAD),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      const stderr = await new Response(proc.stderr).text()
+      await proc.exited
+
+      expect(stderr).toContain('starting transient connection')
+      expect(stderr).toContain('registration timeout fired')
+      expect(proc.exitCode).toBe(0)
+    } finally {
+      await new Promise<void>(r => sink.close(() => r()))
+    }
+  }, 10_000)
 })


### PR DESCRIPTION
Closes #579

## Summary
- Split the fallback DM's single 10s timer into reg (5s) and flush (5s) so a slow handshake can't starve the quit budget.
- Added stderr lifecycle logging so silent fallback failures are visible in `roost tail`.
- Both deadlines override via env for tests.

## Test plan
- [x] Real-ergo delivery test, asserts the operator receives the DM and the log lines land.
- [x] Real-ergo timeout test, asserts the registration-timeout path logs and exits clean.
- [x] Both written first, confirmed to fail pre-fix.
- [x] Full suite green, lint + typecheck clean.