### PR TITLE
fix: extend classifyBash to route command-substitution-argv0 through permbot

### DIFF
--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -58,8 +58,10 @@ export type BashMissKind =
   | 'shell-operators'              // CC: "shell-operators"
   | 'flag-validation'              // CC: "flag-validation"
   | 'too-complex'                  // CC: "too-complex"
-  | 'command-substitution-argv0'   // CC: no equivalent — our extension. argv0 is $(...) or `...`;
-                                   // the shell must exec it to resolve the binary, defeating static analysis.
+  | 'command-substitution-argv0'   // CC 2.1.150: no bashMissKind for argv0-substitution found (grepped binary
+                                   // for command-substitution, subst-argv, argv-subst, runtime-determined).
+                                   // Our extension: argv0 is $(...) or `...` — shell must exec it to resolve
+                                   // the binary, defeating static analysis.
 
 /**
  * Returns the bashMissKind a command resembles, or null if it should pass
@@ -130,10 +132,11 @@ export function classifyBash(command: string): BashMissKind | null {
   // refs) — the bash AST parser rejects these.
   if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return 'too-complex'
 
-  // CC: no equivalent — our extension. argv0 is a command substitution ($(...) or `...`)
-  // so the shell must exec it to resolve the binary, defeating static analysis.
-  // Covers: direct ("?$(...) args, `...` args) and output-capture assignment (VAR=$(...),
-  // VAR="$(...), VAR=`...`). (?!\() excludes arithmetic $((...)).
+  // CC 2.1.150: no equivalent bashMissKind (grepped binary for command-substitution,
+  // subst-argv, argv-subst, runtime-determined — not found). Our extension.
+  // argv0 is a command substitution ($(...) or `...`) — shell must exec it to resolve
+  // the binary, defeating static analysis. Covers: direct ("?$(...), `...`) and
+  // output-capture assignment (VAR=$(...), VAR="$(...), VAR=`...`). (?!\() excludes $((...)).
   if (/^\s*(?:"?\$\((?!\()|[A-Za-z_][A-Za-z0-9_]*=(?:"?\$\((?!\()|`)|`)/.test(command)) {
     return 'command-substitution-argv0'
   }

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -14,6 +14,8 @@
 // Reuses the permbot socket and DM fallback from permission-prompt.ts so the
 // queue, nudge logic, and operator UX stay in one place.
 
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 import { checkOwnership } from './owner-gate.js'
 import { socketRoundtrip } from './permbot-socket.js'
 import {
@@ -29,6 +31,9 @@ const SOCK_PATH   = process.env['ROOST_PERM_SOCK'] ?? ''
 const PERM_TARGET = process.env['ROOST_PERM_TARGET'] ?? ''
 const DATA_DIR    = process.env['ROOST_DATA_DIR'] ?? ''
 const SESSION_ID  = process.env['CLAUDE_CODE_SESSION_ID'] ?? ''
+const LOG_PATH    = SOCK_PATH  ? path.join(path.dirname(SOCK_PATH), 'permbot.log')
+                  : DATA_DIR   ? path.join(DATA_DIR, 'permbot.log')
+                  : ''
 // 570s default — just under Claude Code's 600s hook timeout. Override via
 // ROOST_PERM_TIMEOUT_SECS for tests that need to exercise the timeout path
 // without waiting nine minutes.
@@ -44,15 +49,17 @@ const SOCKET_SAFETY_TIMEOUT = Math.min(570, Math.max(1, Number(process.env['ROOS
 // (e.g. `cd-git-compound`) lands here. Tests pin one example per kind from
 // the issue table so any classifier drift surfaces as a test failure.
 export type BashMissKind =
-  | 'newline-hash'          // CC: "semantics"
-  | 'process-substitution'  // CC: "process-substitution"
-  | 'multi-cd'              // CC: "multi-cd"
-  | 'cd-compound'           // CC: "cd-git-compound" | "cd-compound-write" | "cd-compound-redirect"
-  | 'cd-multi-positional'   // CC: "cd-multi-positional"
-  | 'sed-dangerous'         // CC: "sed-dangerous"
-  | 'shell-operators'       // CC: "shell-operators"
-  | 'flag-validation'       // CC: "flag-validation"
-  | 'too-complex'           // CC: "too-complex"
+  | 'newline-hash'                 // CC: "semantics"
+  | 'process-substitution'         // CC: "process-substitution"
+  | 'multi-cd'                     // CC: "multi-cd"
+  | 'cd-compound'                  // CC: "cd-git-compound" | "cd-compound-write" | "cd-compound-redirect"
+  | 'cd-multi-positional'          // CC: "cd-multi-positional"
+  | 'sed-dangerous'                // CC: "sed-dangerous"
+  | 'shell-operators'              // CC: "shell-operators"
+  | 'flag-validation'              // CC: "flag-validation"
+  | 'too-complex'                  // CC: "too-complex"
+  | 'command-substitution-argv0'   // CC: no equivalent — our extension. argv0 is $(...) or `...`;
+                                   // the shell must exec it to resolve the binary, defeating static analysis.
 
 /**
  * Returns the bashMissKind a command resembles, or null if it should pass
@@ -123,7 +130,28 @@ export function classifyBash(command: string): BashMissKind | null {
   // refs) — the bash AST parser rejects these.
   if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return 'too-complex'
 
+  // CC: no equivalent — our extension.
+  // argv0 is a command substitution ($(...) or `...`) so the shell must
+  // execute it to resolve the binary name, making static analysis impossible.
+  // Negative lookahead (?!\() excludes arithmetic $((...)). Backtick at argv0
+  // is the legacy form of the same footgun.
+  if (/^\s*"?\$\((?!\()/.test(command)) return 'command-substitution-argv0'
+  if (/^\s*`/.test(command)) return 'command-substitution-argv0'
+
   return null
+}
+
+// ---- Classifier logging -----------------------------------------------------
+
+// Writes a greppable classifier outcome line to stderr and, when a log path
+// is resolvable, to permbot.log. One appendFileSync call per line keeps writes
+// under PIPE_BUF so concurrent appends from permbot and this hook don't interleave.
+export function classifierLog(outcome: string): void {
+  const line = `pretooluse-hook[${WORKER}]: classifier: ${outcome}\n`
+  process.stderr.write(line)
+  if (LOG_PATH) {
+    try { fs.appendFileSync(LOG_PATH, line, { flag: 'a' }) } catch { /* ignore */ }
+  }
 }
 
 // ---- Output -----------------------------------------------------------------
@@ -169,15 +197,21 @@ if (import.meta.main) {
   const kind = classifyBash(command)
   if (kind === null) passthrough()
 
+  classifierLog(kind!)
+
   // Owner-gate short-circuit: nested claudes inherit ROOST_DATA_DIR
   // via tmux env and would otherwise route the parent's prompt to the
   // owner's permbot. Fall through to the local TUI for non-owner sessions.
   if (DATA_DIR && SESSION_ID) {
     const ownership = checkOwnership(DATA_DIR, SESSION_ID)
-    if (ownership === 'passive') passthrough()
+    if (ownership === 'passive') {
+      classifierLog('passive')
+      passthrough()
+    }
   }
 
   if (!SOCK_PATH || !PERM_TARGET) {
+    classifierLog('no-socket')
     process.stderr.write(`pretooluse-hook[${WORKER}]: not configured (missing ROOST_PERM_SOCK or ROOST_PERM_TARGET), falling through\n`)
     passthrough()
   }
@@ -196,14 +230,22 @@ if (import.meta.main) {
   const reply = await askDaemon(summary)
   if (reply === null) {
     await sendFallbackDm(summary, 'permbot unavailable / timed out (PreToolUse Bash)')
+    classifierLog('ask: timed-out')
     emit('ask', 'permbot unavailable / timed out; falling back to terminal')
   }
 
   const parts = reply!.trim().split(/\s+/, 2)
   const norm = (parts[0] ?? '').toLowerCase()
   const msg  = parts[1] ?? ''
-  if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) emit('allow', msg || 'operator approved via IRC')
-  if (['n', 'no', 'deny', 'block'].includes(norm)) emit('deny', msg || 'operator denied via IRC')
+  if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) {
+    classifierLog('approved')
+    emit('allow', msg || 'operator approved via IRC')
+  }
+  if (['n', 'no', 'deny', 'block'].includes(norm)) {
+    classifierLog('denied')
+    emit('deny', msg || 'operator denied via IRC')
+  }
   await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(reply)}`)
+  classifierLog(`ask: unrecognized-reply`)
   emit('ask', `unrecognized reply ${JSON.stringify(reply)}; falling back to terminal`)
 }

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -130,13 +130,13 @@ export function classifyBash(command: string): BashMissKind | null {
   // refs) — the bash AST parser rejects these.
   if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return 'too-complex'
 
-  // CC: no equivalent — our extension.
-  // argv0 is a command substitution ($(...) or `...`) so the shell must
-  // execute it to resolve the binary name, making static analysis impossible.
-  // Negative lookahead (?!\() excludes arithmetic $((...)). Backtick at argv0
-  // is the legacy form of the same footgun.
-  if (/^\s*"?\$\((?!\()/.test(command)) return 'command-substitution-argv0'
-  if (/^\s*`/.test(command)) return 'command-substitution-argv0'
+  // CC: no equivalent — our extension. argv0 is a command substitution ($(...) or `...`)
+  // so the shell must exec it to resolve the binary, defeating static analysis.
+  // Covers: direct ("?$(...) args, `...` args) and output-capture assignment (VAR=$(...),
+  // VAR="$(...), VAR=`...`). (?!\() excludes arithmetic $((...)).
+  if (/^\s*(?:"?\$\((?!\()|[A-Za-z_][A-Za-z0-9_]*=(?:"?\$\((?!\()|`)|`)/.test(command)) {
+    return 'command-substitution-argv0'
+  }
 
   return null
 }
@@ -230,7 +230,7 @@ if (import.meta.main) {
   const reply = await askDaemon(summary)
   if (reply === null) {
     await sendFallbackDm(summary, 'permbot unavailable / timed out (PreToolUse Bash)')
-    classifierLog('ask: timed-out')
+    classifierLog('ask-timeout')
     emit('ask', 'permbot unavailable / timed out; falling back to terminal')
   }
 
@@ -246,6 +246,6 @@ if (import.meta.main) {
     emit('deny', msg || 'operator denied via IRC')
   }
   await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(reply)}`)
-  classifierLog(`ask: unrecognized-reply`)
+  classifierLog('ask-unrecognized-reply')
   emit('ask', `unrecognized reply ${JSON.stringify(reply)}; falling back to terminal`)
 }

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -97,7 +97,23 @@ describe('classifyBash', () => {
     expect(classifyBash('cd -P /tmp')).toBeNull()
   })
 
-  it('null: command substitution $(...)', () => {
+  it('command-substitution-argv0: double-quoted $(...) as argv0 (roost root pattern)', () => {
+    expect(classifyBash('"$(roost root)/bin/foo" arg')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: unquoted $(...) as argv0', () => {
+    expect(classifyBash('$(cmd) arg')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: backtick form as argv0', () => {
+    expect(classifyBash('`roost root`/bin/foo arg')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: leading whitespace before $(...)', () => {
+    expect(classifyBash('  "$(roost root)/bin/foo" arg')).toBe('command-substitution-argv0')
+  })
+
+  it('null: command substitution $(...) as argument (not argv0)', () => {
     expect(classifyBash('echo $(date)')).toBeNull()
   })
 
@@ -107,6 +123,10 @@ describe('classifyBash', () => {
 
   it('null: arithmetic with literals only', () => {
     expect(classifyBash('echo $((1+1))')).toBeNull()
+  })
+
+  it('null: arithmetic $((1+1)) as argv0 does not match command-substitution-argv0', () => {
+    expect(classifyBash('$((1+1))')).toBeNull()
   })
 
   it('null: typical pipeline', () => {
@@ -155,6 +175,12 @@ const SAFETY_CHECK_PAYLOAD = JSON.stringify({
 const BENIGN_PAYLOAD = JSON.stringify({
   tool_name: 'Bash',
   tool_input: { command: 'ls /tmp', description: 'list tmp' },
+  transcript_path: '',
+})
+
+const CMD_SUBST_ARGV0_PAYLOAD = JSON.stringify({
+  tool_name: 'Bash',
+  tool_input: { command: '"$(roost root)/bin/roost-token-usage" snapshot', description: 'token usage snapshot' },
   transcript_path: '',
 })
 
@@ -300,6 +326,49 @@ describe('pretooluse-prompt hook subprocess', () => {
     expect(exit).toBe(0)
     expect(stdout.trim()).toBe('')
   }, 5_000)
+
+  it('logs classifier kind to stderr for command-substitution-argv0', async () => {
+    const sockPath = makeSock('classifier-stderr')
+    const stub = startPermbotStub(sockPath, { reply: 'y' })
+    await stub.ready
+
+    const [{ stderr }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+      }, CMD_SUBST_ARGV0_PAYLOAD),
+      stub.done,
+    ])
+
+    expect(stderr).toContain('classifier: command-substitution-argv0')
+    expect(stderr).toContain('classifier: approved')
+  }, 10_000)
+
+  it('writes classifier entries to permbot.log', async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'classifier-log-test-'))
+    const sockPath = path.join(dataDir, 'permbot.sock')
+    const logPath  = path.join(dataDir, 'permbot.log')
+    const stub = startPermbotStub(sockPath, { reply: 'y' })
+    await stub.ready
+
+    try {
+      await Promise.all([
+        runHook({
+          ROOST_IRC_NICK: 'worker-test',
+          ROOST_PERM_SOCK: sockPath,
+          ROOST_PERM_TARGET: 'operator',
+        }, CMD_SUBST_ARGV0_PAYLOAD),
+        stub.done,
+      ])
+
+      const log = fs.readFileSync(logPath, 'utf8')
+      expect(log).toContain('classifier: command-substitution-argv0')
+      expect(log).toContain('classifier: approved')
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    }
+  }, 10_000)
 
   it('owner-gate short-circuits when nested (#188)', async () => {
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pretooluse-gate-test-'))

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -113,6 +113,22 @@ describe('classifyBash', () => {
     expect(classifyBash('  "$(roost root)/bin/foo" arg')).toBe('command-substitution-argv0')
   })
 
+  it('command-substitution-argv0: double-quoted $(...) as argv0 with additional substituted args', () => {
+    expect(classifyBash('"$(roost root)/bin/roost-token-usage" report "$(pwd)/.orchestrator" 1')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: output-capture assignment VAR=$(\"$(...)\") — the associate-pm.md:171 shape', () => {
+    expect(classifyBash('cost_block=$("$(roost root)/bin/roost-token-usage" report)')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: VAR=$(cmd) unquoted', () => {
+    expect(classifyBash('VAR=$(cmd) arg')).toBe('command-substitution-argv0')
+  })
+
+  it('command-substitution-argv0: VAR=`cmd` backtick assignment', () => {
+    expect(classifyBash('VAR=`cmd` arg')).toBe('command-substitution-argv0')
+  })
+
   it('null: command substitution $(...) as argument (not argv0)', () => {
     expect(classifyBash('echo $(date)')).toBeNull()
   })
@@ -127,6 +143,14 @@ describe('classifyBash', () => {
 
   it('null: arithmetic $((1+1)) as argv0 does not match command-substitution-argv0', () => {
     expect(classifyBash('$((1+1))')).toBeNull()
+  })
+
+  it('null: echo with cost_block= in string is not a var-assignment at argv0', () => {
+    expect(classifyBash('echo cost_block="$(foo)"')).toBeNull()
+  })
+
+  it('null: VAR=literal-value env-prefix invocation (real argv0 is cmd)', () => {
+    expect(classifyBash('VAR=value $(cmd)')).toBeNull()
   })
 
   it('null: typical pipeline', () => {


### PR DESCRIPTION
Closes #580

- adds `command-substitution-argv0` miss-kind so commands whose argv0 is a `$(...)` substitution route through permbot instead of falling to terminal unnoticed
- covers direct `$(...)`/backtick and output-capture assignment `VAR=$(...)` — the associate-pm.md token-usage shape that caused the ~5hr stall
- adds `classifierLog(outcome)` writing `classifier: <outcome>` to stderr and permbot.log at every decision point

## Test plan
- [x] `script/run-and-tail bun test --filter pretooluse-prompt` — 52 tests pass
- [x] lint + typecheck clean