### PR TITLE
maint: add worker learnings from #578 and #579

### DIFF
--- a/.claude/learnings/worker.md
+++ b/.claude/learnings/worker.md
@@ -26,6 +26,14 @@ When extracting N inline copies into one shared helper, add arg validation to th
 
 When migrating N call sites to a new helper, scan each migrated function for *every* invocation of the old primitive — including within-function retry/fallback branches that weren't the initial migration target. The #473 worker migrated `writeDispatcherPid`'s initial `wx` attempt to `exclusiveCreate` but left the function's stale-retry path on raw `writeFile(wx)`. Distinct from §#419 (adjacent files): same file, same function, different code branch. Migration is incomplete until every callsite of the old primitive within migrated scope uses the new helper.
 
+## 2026-05-26: irc-framework reconnect + PING/PONG timing gotchas for test authors (from #578)
+
+irc-framework's auto_reconnect gates on `registered_ms_ago > 5000` — reconnect tests must sleep ≥6s after register before killing the server, or reconnect never fires. ping_interval is client-initiated (30s default), so PING/PONG line shapes are not observable in integration test windows; assert them in mock-based unit tests instead. The existing `test/reconnect.test.ts` already encodes the 6s wait — reuse it rather than re-discovering the constraint.
+
+## 2026-05-26: Stage-entry timer arming: each stage's timer must arm at stage entry, not all at connect (from #579)
+
+When splitting connect-time timers into stages (registration → ready → flush), arm each stage's timer at stage entry, not all at connect. Arming both upfront recreates the all-or-nothing race in two timers instead of one — the flush window collapses while you wait on registration. Also: irc-framework's `registration-failed` only fires on nick-collision numerics (432/433/436), not on stalled CAP or a silent server. Use a wall-clock regTimer for hung-handshake detection.
+
 ## 2026-05-20: When you see N copies of the same intervention accumulating, debounce at the producer (from #470)
 
 When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.


### PR DESCRIPTION
adds two irc-framework gotcha learnings to worker.md: reconnect timing (from #578) and stage-entry timer arming (from #579).