### PR TITLE
route hook commands through `roost hook-exec` instead of per-session shims

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -1175,6 +1175,10 @@ cmd_hook_exec() {
   local name="$1"
   shift
   local target="${ROOST_DIR}/bin/${name}"
+  if [ ! -e "${target}" ]; then
+    echo "roost hook-exec: not found: ${target}" >&2
+    exit 127
+  fi
   if [ ! -x "${target}" ]; then
     echo "roost hook-exec: not executable: ${target}" >&2
     exit 127

--- a/bin/roost
+++ b/bin/roost
@@ -16,6 +16,14 @@
 
 set -uo pipefail
 
+# Capture the absolute path to *this* roost script before any symlink walk —
+# embedded into roost-settings.json so hook commands invoke us at a stable
+# path. For brew installs this is `/opt/homebrew/bin/roost` (a brew-managed
+# symlink that survives Cellar rotation); for dev checkouts it's the absolute
+# clone path. Resolving via $PATH at hook-call time would re-introduce the
+# dev-clone-moved footgun, so we always embed the absolute path captured here.
+ROOST_BIN="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/$( basename "${BASH_SOURCE[0]}" )"
+
 # Walk symlinks so ROOST_DIR resolves to the real plugin tree, not the
 # parent of a /usr/local/bin/roost-style shim.
 _src="${BASH_SOURCE[0]}"
@@ -44,6 +52,7 @@ Commands:
   status                   ergo state + roost session count.
   root                     Print the roost plugin root directory.
   send <nick> <message...> Inject text into a nick's tmux pane.
+  hook-exec <name>         Exec a hook entry point — used in spawned hook configs.
 
 Quick start:
   roost init
@@ -326,6 +335,20 @@ Example:
 EOF
 }
 
+usage_hook_exec() {
+  cat <<EOF
+Usage: roost hook-exec <name> [args...]
+
+Exec the matching hook entry point under \${ROOST_DIR}/bin/. Used by
+roost-settings.json so hook commands resolve via this PATH-stable binary
+rather than per-session shims under ROOST_DATA_DIR (which macOS tmp_cleaner
+nukes after 3 days of atime+mtime+ctime idleness).
+
+Example:
+  roost hook-exec irc-permission-prompt
+EOF
+}
+
 _init_config_json() {
   if [ -n "$2" ]; then
     # Single-repo: project + repo + the static plugin slices (operator-set,
@@ -592,19 +615,6 @@ require_ircd() {
   fi
 }
 
-# Write a thin resolver shim to DIR/NAME. The shim re-resolves the plugin
-# root via `roost root` at exec time so Cellar-dir rotation after a
-# `brew upgrade roost` doesn't break wired hook commands.
-_write_shim() {
-  local name="$1"
-  local dest="$2/${name}"
-  # intentionally single-quoted: $() and $@ are shell syntax written to the
-  # shim file, not expanded here.
-  # shellcheck disable=SC2016
-  printf '#!/bin/sh\nexec "$(roost root)/bin/%s" "$@"\n' "${name}" > "${dest}"
-  chmod 755 "${dest}"
-}
-
 # All per-session files live under a mktemp-generated directory created at
 # spawn time (ROOST_DATA_DIR). The dir is stored in the tmux session env so
 # shutdown can find it:
@@ -822,31 +832,27 @@ cmd_spawn() {
   if [ "${perm_irc}" -eq 1 ] || [ "${ask_routing}" -eq 1 ]; then
     perm_sock="${ROOST_DATA_DIR}/permbot.sock"
   fi
-  # Resolver shims re-resolve the plugin root via `roost root` at exec time so
-  # Cellar-dir rotation (brew upgrade roost) doesn't invalidate hook paths
-  # baked at spawn time.
-  _write_shim roost-post-compact-hook "${ROOST_DATA_DIR}"
-  _write_shim roost-session-start-hook "${ROOST_DATA_DIR}"
+  # Hook commands invoke `${ROOST_BIN} hook-exec <name>` rather than a
+  # per-session shim path. ROOST_BIN is the absolute path to the invoking
+  # roost script (brew symlink or dev clone) captured at the top of this file
+  # — stable across brew upgrades because brew re-points the symlink, and
+  # immune to /tmp cleanup because nothing under DATA_DIR is in the path.
   local precompact_hook_json=""
   if [ "${steer_compact}" -eq 1 ]; then
-    _write_shim roost-compact-hook "${ROOST_DATA_DIR}"
-    precompact_hook_json="\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-compact-hook\"}]}],"
+    precompact_hook_json="\"PreCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec roost-compact-hook\"}]}],"
   fi
   if [ "${perm_irc}" -eq 1 ]; then
-    _write_shim irc-permission-prompt "${ROOST_DATA_DIR}"
-    perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-permission-prompt\"}]}]"
+    perm_hook_json=",\"PermissionRequest\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec irc-permission-prompt\"}]}]"
   fi
   # PreToolUse may hold up to two matcher entries: Bash (when --perm-irc, so
   # the safety-analyzer can't bypass the operator's review) and
   # AskUserQuestion (when --ask-irc / --ask-target routes questions to IRC).
   local pretooluse_entries=()
   if [ "${perm_irc}" -eq 1 ]; then
-    _write_shim irc-pretooluse-prompt "${ROOST_DATA_DIR}"
-    pretooluse_entries+=("{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-pretooluse-prompt\"}]}")
+    pretooluse_entries+=("{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec irc-pretooluse-prompt\"}]}")
   fi
   if [ "${ask_routing}" -eq 1 ]; then
-    _write_shim irc-ask-question "${ROOST_DATA_DIR}"
-    pretooluse_entries+=("{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/irc-ask-question\"}]}")
+    pretooluse_entries+=("{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec irc-ask-question\"}]}")
   fi
   if [ "${#pretooluse_entries[@]}" -gt 0 ]; then
     local _ptu_joined=""
@@ -868,7 +874,7 @@ cmd_spawn() {
       ;;
   esac
   local ROOST_SETTINGS="${ROOST_DATA_DIR}/roost-settings.json"
-  printf '%s\n' "{\"hooks\":{${precompact_hook_json}\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_DATA_DIR}/roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}${permissions_json}}" > "${ROOST_SETTINGS}"
+  printf '%s\n' "{\"hooks\":{${precompact_hook_json}\"PostCompact\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec roost-post-compact-hook\"}]}],\"SessionStart\":[{\"matcher\":\"compact\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec roost-session-start-hook\"}]}]${perm_hook_json}${pretooluse_hook_json}}${permissions_json}}" > "${ROOST_SETTINGS}"
   # Test seam: ROOST_SPAWN_KEEP_DATA_DIR=1 echoes the data-dir path early and
   # suppresses the failure-cleanup trap, so spawn_test.sh can read the files
   # written above after a preflight failure exits the spawn. Prod operators
@@ -1154,6 +1160,28 @@ cmd_send() {
   printf '%s' "${message}" | "${ROOST_DIR}/bin/roost-tmux-inject" "${session_name}" "roost-send-${nick}"
 }
 
+# Hook entry-point dispatcher. roost-settings.json wires hook commands as
+# `${ROOST_BIN} hook-exec <name>`; this subcommand exec's the matching script
+# under ${ROOST_DIR}/bin/. ROOST_DIR is re-resolved via the symlink walk at
+# the top of this file on every call, so post-brew-upgrade calls land on the
+# current Cellar version. Lives at the roost-binary level (not a per-session
+# shim file) so /tmp cleanup of ROOST_DATA_DIR can't strand the hook path.
+cmd_hook_exec() {
+  if [ "$#" -lt 1 ]; then
+    echo "error: hook-exec requires a hook name" >&2
+    echo "usage: roost hook-exec <name> [args...]" >&2
+    exit 1
+  fi
+  local name="$1"
+  shift
+  local target="${ROOST_DIR}/bin/${name}"
+  if [ ! -x "${target}" ]; then
+    echo "roost hook-exec: not executable: ${target}" >&2
+    exit 127
+  fi
+  exec "${target}" "$@"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 if [ "$#" -eq 0 ]; then
   usage
@@ -1164,30 +1192,32 @@ shift
 case "${1:-}" in
   -h|--help)
     case "${cmd}" in
-      init)     usage_init ;;
-      spawn)    usage_spawn ;;
-      shutdown) usage_shutdown ;;
-      list)     usage_list ;;
-      attach)   usage_attach ;;
-      tail)     usage_tail ;;
-      status)   usage_status ;;
-      send)     usage_send ;;
-      root)     usage_root ;;
-      *)        usage ;;
+      init)      usage_init ;;
+      spawn)     usage_spawn ;;
+      shutdown)  usage_shutdown ;;
+      list)      usage_list ;;
+      attach)    usage_attach ;;
+      tail)      usage_tail ;;
+      status)    usage_status ;;
+      send)      usage_send ;;
+      hook-exec) usage_hook_exec ;;
+      root)      usage_root ;;
+      *)         usage ;;
     esac
     exit 0
     ;;
 esac
 case "${cmd}" in
-  init)     cmd_init "$@" ;;
-  spawn)    cmd_spawn "$@" ;;
-  shutdown) cmd_shutdown "$@" ;;
-  list)     cmd_list "$@" ;;
-  attach)   cmd_attach "$@" ;;
-  tail)     cmd_tail "$@" ;;
-  status)   cmd_status "$@" ;;
-  send)     cmd_send "$@" ;;
-  root)     echo "${ROOST_DIR}" ;;
+  init)      cmd_init "$@" ;;
+  spawn)     cmd_spawn "$@" ;;
+  shutdown)  cmd_shutdown "$@" ;;
+  list)      cmd_list "$@" ;;
+  attach)    cmd_attach "$@" ;;
+  tail)      cmd_tail "$@" ;;
+  status)    cmd_status "$@" ;;
+  send)      cmd_send "$@" ;;
+  hook-exec) cmd_hook_exec "$@" ;;
+  root)      echo "${ROOST_DIR}" ;;
   -h|--help|help) usage ;;
   *) echo "error: unknown command: ${cmd}" >&2; usage; exit 1 ;;
 esac

--- a/test/hook-exec.test.ts
+++ b/test/hook-exec.test.ts
@@ -71,12 +71,28 @@ describe('hook-exec dispatch', () => {
     expect(await run()).toBe(cellarB)
   })
 
-  it('exits 127 with stderr when the target hook is missing', async () => {
+  it('exits 127 with `not found` when the hook name does not exist', async () => {
     const proc = Bun.spawn([ROOST_BIN, 'hook-exec', 'no-such-hook'], { stdout: 'pipe', stderr: 'pipe' })
     const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
     expect(exitCode).toBe(127)
-    expect(stderr).toContain('not executable')
+    expect(stderr).toContain('not found')
     expect(stderr).toContain('no-such-hook')
+  })
+
+  it('exits 127 with `not executable` when the target exists but lacks +x', async () => {
+    const cellar = join(tmpDir, 'unexec-cellar')
+    mkdirSync(join(cellar, 'bin'), { recursive: true })
+    copyFileSync(ROOST_BIN, join(cellar, 'bin', 'roost'))
+    chmodSync(join(cellar, 'bin', 'roost'), 0o755)
+    const hook = join(cellar, 'bin', 'unexec-hook')
+    writeFileSync(hook, '#!/bin/sh\necho ran\n')
+    chmodSync(hook, 0o644)
+
+    const proc = Bun.spawn([join(cellar, 'bin', 'roost'), 'hook-exec', 'unexec-hook'], { stdout: 'pipe', stderr: 'pipe' })
+    const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    expect(exitCode).toBe(127)
+    expect(stderr).toContain('not executable')
+    expect(stderr).toContain('unexec-hook')
   })
 
   it('exits 1 with usage when called with no hook name', async () => {

--- a/test/spawn-shim.test.ts
+++ b/test/spawn-shim.test.ts
@@ -1,68 +1,107 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
-import { mkdtempSync, chmodSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, chmodSync, mkdirSync, writeFileSync, rmSync, symlinkSync, copyFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-const BIN_DIR = join(import.meta.dirname, '../bin')
-const HOOK_NAME = 'roost-compact-hook'
+const ROOST_BIN = join(import.meta.dirname, '../bin/roost')
 
-describe('spawn shim', () => {
+// `hook-exec` is the PATH-stable dispatcher that replaced the per-session shim
+// files under ROOST_DATA_DIR. The invariants under test mirror what the old
+// shim did, minus the `/tmp/roost-*` file dependency that macOS tmp_cleaner
+// could erase out from under a long-running session:
+//
+//   1. ROOST_DIR is re-resolved on every invocation by walking the symlinks
+//      at the top of bin/roost. After `brew upgrade roost` re-points the
+//      brew-opt symlink, the next hook-exec call lands on the new Cellar.
+//   2. Missing or non-executable target exits 127 with a clear stderr; a
+//      missing name exits 1 with usage hint.
+
+describe('hook-exec dispatch', () => {
   let tmpDir: string
-  let shimPath: string
-  let stubsDir: string
 
-  beforeAll(async () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'roost-shim-test-'))
-    stubsDir = join(tmpDir, 'stubs')
-    mkdirSync(stubsDir, { recursive: true })
-
-    shimPath = join(tmpDir, HOOK_NAME)
-
-    // Write the shim via _write_shim from bin/roost so the test stays in sync
-    // with the production format — if the template changes, this test fails.
-    const proc = Bun.spawn(
-      ['bash', '-c', `source "${join(BIN_DIR, 'roost')}" && _write_shim "${HOOK_NAME}" "${tmpDir}"`],
-      { stdout: 'pipe', stderr: 'pipe' },
-    )
-    const [stderr, exitCode] = await Promise.all([
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ])
-    expect(exitCode, `_write_shim setup failed: ${stderr}`).toBe(0)
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'roost-hook-exec-test-'))
   })
 
   afterAll(() => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  async function runShimWithRoot(root: string): Promise<string> {
-    mkdirSync(join(root, 'bin'), { recursive: true })
-    // Stub hook echoes its root path so we can verify which root was reached
-    writeFileSync(join(root, 'bin', HOOK_NAME), `#!/bin/sh\necho "${root}"\n`)
-    chmodSync(join(root, 'bin', HOOK_NAME), 0o755)
-    // Stub `roost`: `roost root` returns the given root path
-    writeFileSync(join(stubsDir, 'roost'), `#!/bin/sh\necho "${root}"\n`)
-    chmodSync(join(stubsDir, 'roost'), 0o755)
-
-    const proc = Bun.spawn([shimPath], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: { ...process.env, PATH: `${stubsDir}:${process.env.PATH ?? ''}` },
-    })
-    const [stdout, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      proc.exited,
-    ])
-    expect(exitCode).toBe(0)
-    return stdout.trim()
+  // Build a fake Cellar at <cellar>/bin/{roost,<hookName>}. bin/roost is a
+  // *copy* of the real roost script (not a symlink) so the symlink walk at
+  // the top of bin/roost terminates inside <cellar> rather than chasing the
+  // symlink back to the real source tree. The stub hook echoes <cellar>.
+  function makeFakeCellar(cellar: string, hookName: string): void {
+    mkdirSync(join(cellar, 'bin'), { recursive: true })
+    copyFileSync(ROOST_BIN, join(cellar, 'bin', 'roost'))
+    chmodSync(join(cellar, 'bin', 'roost'), 0o755)
+    const hook = join(cellar, 'bin', hookName)
+    writeFileSync(hook, `#!/bin/sh\necho "${cellar}"\n`)
+    chmodSync(hook, 0o755)
   }
 
-  it('re-resolves roost root at exec time, not at shim-write time', async () => {
-    const rootA = join(tmpDir, 'root-a')
-    const rootB = join(tmpDir, 'root-b')
+  it('re-resolves ROOST_DIR via the symlink walk on every call', async () => {
+    // Mirror the brew layout: <prefix>/bin/roost -> <prefix>/opt/roost/bin/roost,
+    // <prefix>/opt/roost -> <prefix>/Cellar/roost/<version>.
+    const prefix = tmpDir
+    const cellarA = join(prefix, 'Cellar/roost/0.0.1')
+    const cellarB = join(prefix, 'Cellar/roost/0.0.2')
+    makeFakeCellar(cellarA, 'irc-stub-hook')
+    makeFakeCellar(cellarB, 'irc-stub-hook')
 
-    // Same shim file; swapping what `roost root` returns routes to a different hook binary
-    expect(await runShimWithRoot(rootA)).toBe(rootA)
-    expect(await runShimWithRoot(rootB)).toBe(rootB)
+    mkdirSync(join(prefix, 'opt'), { recursive: true })
+    mkdirSync(join(prefix, 'bin'), { recursive: true })
+    const optSymlink = join(prefix, 'opt/roost')
+    const brewBin    = join(prefix, 'bin/roost')
+    symlinkSync(cellarA, optSymlink)
+    symlinkSync(join(optSymlink, 'bin/roost'), brewBin)
+
+    const run = async (): Promise<string> => {
+      const proc = Bun.spawn([brewBin, 'hook-exec', 'irc-stub-hook'], { stdout: 'pipe', stderr: 'pipe' })
+      const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+      return stdout.trim()
+    }
+
+    expect(await run()).toBe(cellarA)
+
+    // Simulate `brew upgrade`: re-point the opt symlink at the new Cellar.
+    rmSync(optSymlink)
+    symlinkSync(cellarB, optSymlink)
+
+    expect(await run()).toBe(cellarB)
+  })
+
+  it('exits 127 with stderr when the target hook is missing', async () => {
+    const proc = Bun.spawn([ROOST_BIN, 'hook-exec', 'no-such-hook'], { stdout: 'pipe', stderr: 'pipe' })
+    const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    expect(exitCode).toBe(127)
+    expect(stderr).toContain('not executable')
+    expect(stderr).toContain('no-such-hook')
+  })
+
+  it('exits 1 with usage when called with no hook name', async () => {
+    const proc = Bun.spawn([ROOST_BIN, 'hook-exec'], { stdout: 'pipe', stderr: 'pipe' })
+    const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('requires a hook name')
+  })
+
+  // Direct regression for the bug: tmp_cleaner wiped ROOST_DATA_DIR overnight,
+  // the next hook call landed on a non-existent shim path and exited 127, and
+  // the worker hung on a TUI prompt nobody could see. Now that hook entry
+  // points live at the roost binary instead of inside DATA_DIR, rm -rf'ing
+  // DATA_DIR mid-session has no effect on hook resolution.
+  it('hook entry point still resolves after ROOST_DATA_DIR is deleted', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'roost-deleted-data-dir-'))
+    rmSync(dataDir, { recursive: true, force: true })
+
+    const proc = Bun.spawn([ROOST_BIN, 'hook-exec', 'roost-session-start-hook'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, ROOST_DATA_DIR: dataDir },
+    })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('hookEventName')
   })
 })

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -351,7 +351,7 @@ data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 if [ -n "$data_dir" ] \
     && [ -f "$data_dir/roost-settings.json" ] \
     && grep -qF '"PreCompact"' "$data_dir/roost-settings.json" \
-    && grep -qF 'roost-compact-hook' "$data_dir/roost-settings.json" \
+    && grep -qF 'hook-exec roost-compact-hook' "$data_dir/roost-settings.json" \
     && [ -f "$data_dir/session-name.txt" ] \
     && [ "$(cat "$data_dir/session-name.txt")" = "roost-testnick" ]; then
   ok "--steer-compact: PreCompact entry wired + session-name.txt written"
@@ -371,7 +371,7 @@ data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 if [ -n "$data_dir" ] \
     && [ -f "$data_dir/roost-settings.json" ] \
     && ! grep -qF '"PreCompact"' "$data_dir/roost-settings.json" \
-    && ! grep -qF 'roost-compact-hook' "$data_dir/roost-settings.json" \
+    && ! grep -qF 'hook-exec roost-compact-hook' "$data_dir/roost-settings.json" \
     && [ -f "$data_dir/session-name.txt" ]; then
   ok "no flag: PreCompact omitted from settings, session-name.txt written"
 else


### PR DESCRIPTION
Closes #585

## Root cause (confirmed)

macOS ships `/System/Library/LaunchDaemons/com.apple.tmp_cleaner.plist` (StartCalendarInterval Hour=0, runs daily at midnight). Underlying `/usr/libexec/tmp_cleaner` invokes `find /tmp -atime +3 -mtime +3 -ctime +3` and rms anything that matches. A long-running APM/dispatcher that doesn't fire a permission hook for >3 days has its shim atime age out, the midnight cron nukes it, and the next hook invocation hits exit 127 (the path's gone). Worker hangs on a TUI prompt nobody sees.

## Fix

Hook commands now invoke `${ROOST_BIN} hook-exec <name>` instead of `${ROOST_DATA_DIR}/<name>`. The new `roost hook-exec` subcommand re-resolves `${ROOST_DIR}` via the same symlink walk at the top of `bin/roost` and execs `${ROOST_DIR}/bin/<name>`. Hook entry points live at the roost binary level — `/tmp` cleanup can't strand them, and Cellar rotation still works because brew re-points `/opt/homebrew/bin/roost` on upgrade.

`_write_shim` is dead code after this; deleted.

## Backcompat

In-flight 0.8.3 sessions have `${DATA_DIR}/<shim>` baked into their already-written `roost-settings.json` — they stay vulnerable until restart. Operators on long-lived sessions should `roost shutdown <nick> && roost spawn ...` to pick up the new wiring. Patch release semantics; no migration tooling for in-flight sessions.

## Test plan

- [x] `bun test` (933 pass, 0 fail)
- [x] `bun run lint` + `bun run typecheck` clean
- [x] `bash test/spawn_test.sh` (32 pass)
- [x] `bash test/compact-hook_test.sh` (14 pass)
- [x] `test/spawn-shim.test.ts` updated to cover the new dispatcher: re-resolves ROOST_DIR via symlink walk (brew-style two-hop chain, mid-test re-pointed to simulate upgrade), exit 127 on missing target, exit 1 on missing name, regression case where ROOST_DATA_DIR is rm -rf'd before the hook call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)