### PR TITLE
add learnings from #585

### DIFF
--- a/.claude/learnings/apm.md
+++ b/.claude/learnings/apm.md
@@ -14,6 +14,10 @@ When filing a followup issue, ask whether the work is primarily in service of a 
 
 Agents reliably obey explicit output-shaping rules — an instruction to name one specific X produces one specific X. So in prompt gates, the artifact instruction IS the entire lever; "if you fail X, do Y" backstops and "gate failure" framing add no safety, only paranoia. Frame prompt gates around the team putting its best foot forward for leadership, not around catching skimping. The suspicion is decoration; the artifact instruction does the work.
 
+## 2026-05-26: Files in /tmp die on a schedule — don't store session-persistent state there (from #585)
+
+macOS tmp_cleaner runs daily at midnight, wiping files with atime+mtime+ctime all >3d (verified via `/System/Library/LaunchDaemons/com.apple.tmp_cleaner.plist` + `strings /usr/libexec/tmp_cleaner`). Long-running sessions that don't touch a /tmp file for 3+ days will lose it. The APM runs for days at a time — anything it writes to /tmp is on borrowed time. Prefer absolute paths to stable locations (brew-symlinked binary, ~/.cache) for any state that must survive overnight.
+
 ## 2026-05-24: Include #<project>-leads when watching a PR with no linked issue (from #576)
 
 When watching a PR that has no closing reference, append `#<project>-leads` to the watch DM: `watch pr <N> #<project>-leads`. Without a trailing channel, unlinked-PR events route to `#<project>-issue-<PR>` — a channel neither APM nor lead-pm join. Maint PRs (version bumps, learning commits, doc-only fixes) never have a closing reference, so always include `#<project>-leads` for these.

--- a/.claude/learnings/lead-pm.md
+++ b/.claude/learnings/lead-pm.md
@@ -46,6 +46,10 @@ Agents reliably obey explicit output-shaping rules — an instruction to name on
 
 When a learning applies to "anyone touching these files" rather than to a specific role's behavior, path-scope beats audience-scope. Audience-scope limits reach to the named roles; path-scope fires for any agent reading matching files regardless of role. The test: does the rule hold because of who the agent is, or because of what code they're reading? If the latter, use paths: frontmatter.
 
+## 2026-05-26: Park defense-in-depth fix and observe after direct fix ships (from #585)
+
+When a symptom could plausibly be caused by two in-flight fixes (one direct, one defense-in-depth), park the defense-in-depth and observe after the direct fix ships. Shipping both at once means you can't tell which was load-bearing, and you may have spent budget on a band-aid that was solving a symptom of the real bug. Concrete: #585's data-dir-deletion fix (#586) and #580's classifyBash narrowness fix (#583) — parked #583, observed. If no escapes post-upgrade, #583 closes.
+
 ## 2026-05-21: Frame live-probe gating as milestone-savings, not pre-flip overhead (from #495)
 
 Frame live-probe gating as milestone-savings, not pre-flip overhead. When a worker (or you) treats the probe as optional polish, the gate stops firing — but the catch (a rewrite from scratch) costs far less than shipping a query that 400s on every tick. #495's Linear schema bug and #519's zsh extended_glob bug were both caught this way; neither would have surfaced from mocked tests.

--- a/.claude/learnings/worker.md
+++ b/.claude/learnings/worker.md
@@ -34,6 +34,10 @@ irc-framework's auto_reconnect gates on `registered_ms_ago > 5000` — reconnect
 
 When splitting connect-time timers into stages (registration → ready → flush), arm each stage's timer at stage entry, not all at connect. Arming both upfront recreates the all-or-nothing race in two timers instead of one — the flush window collapses while you wait on registration. Also: irc-framework's `registration-failed` only fires on nick-collision numerics (432/433/436), not on stalled CAP or a silent server. Use a wall-clock regTimer for hung-handshake detection.
 
+## 2026-05-26: Files in /tmp die on a schedule — don't store session-persistent state there (from #585)
+
+macOS tmp_cleaner runs daily at midnight, wiping files with atime+mtime+ctime all >3d (verified via `/System/Library/LaunchDaemons/com.apple.tmp_cleaner.plist` + `strings /usr/libexec/tmp_cleaner`). Long-running sessions that don't touch a /tmp file for 3+ days will lose it. For any path re-used across days (shim, lock, socket, log), prefer a brew-symlink-stable or absolute-clone-stable location. Only use /tmp for transient single-session state.
+
 ## 2026-05-20: When you see N copies of the same intervention accumulating, debounce at the producer (from #470)
 
 When N copies of the same intervention accumulate in a queue, debounce at the producer — not the receiver. The receiver can't tell stale from fresh; the producer knows it just fired. Add a TTL-gated lock at injection time rather than retrofitting dedup downstream. Pattern: lock-before-inject when an inject point has no idempotency guarantee.


### PR DESCRIPTION
Adds three learning entries from postmortem #585 (data-dir tmp-cleanup bug):

- worker.md + apm.md: files in /tmp die on macOS's daily midnight tmp_cleaner (atime+mtime+ctime >3d); use stable locations for session-persistent state
- lead-pm.md: park defense-in-depth fix and observe after direct fix ships before concluding it was load-bearing