### PR TITLE
bump version to v0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
bumps 0.8.3 → 0.8.4.

what's new since v0.8.3:
- fix permbot auto-reconnect on IRC drop (#578 / #581)
- fix fallback DM registration vs flush deadlines (#579 / #582)
- route hook commands through `roost hook-exec` instead of per-session shims (#585 / #586)
- postmortem learnings for worker, apm, lead-pm (#588)