### PR TITLE
fail loud on permbot IRC registration failure; raise nicklen to 48

### DIFF
--- a/etc/ergo.yaml
+++ b/etc/ergo.yaml
@@ -169,7 +169,10 @@ languages:
     path: languages
 
 limits:
-    nicklen: 32
+    # Headroom for the longest derived nicks: permbot-/pnotify- prefixes on a
+    # multi-repo <project>-<slug>-reviewer-<NNNN> worker nick. A nick over this
+    # limit is rejected at registration with 432 — keep it generous.
+    nicklen: 48
     identlen: 20
     realnamelen: 150
     channellen: 64

--- a/src/ask-question-hook.ts
+++ b/src/ask-question-hook.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { checkOwnership } from './owner-gate.js'
-import { socketRoundtrip, CHAT_KEYWORDS, permbotNickFor } from './permbot-socket.js'
+import { socketRoundtrip, CHAT_KEYWORDS, permbotNickFor, type DaemonResponse } from './permbot-socket.js'
 
 const HOOK_EVENT   = 'PreToolUse'
 const WORKER       = process.env['ROOST_IRC_NICK'] ?? 'unknown'
@@ -128,7 +128,7 @@ export function mapReplyToAnswers(reply: string, questions: Question[]): Record<
 
 // ---- Socket round-trip to permbot -------------------------------------------
 
-export async function askPermbot(summary: string): Promise<string | null> {
+export async function askPermbot(summary: string): Promise<DaemonResponse> {
   const req: Record<string, unknown> = { summary, timeout: SOCKET_TIMEOUT, kind: 'question' }
   if (ASK_CHANNEL) req['channel'] = ASK_CHANNEL  // omit → DM mode
   if (ASK_TARGET) req['replyTarget'] = ASK_TARGET
@@ -170,16 +170,19 @@ if (import.meta.main) {
   // In channel mode include the permbot nick so the hint tells operators how to DM.
   const permbotNick = ASK_CHANNEL ? permbotNickFor(WORKER) : undefined
   const summary = formatQuestionsForIRC(questions, permbotNick)
-  const reply = await askPermbot(summary)
+  const res = await askPermbot(summary)
 
-  if (reply === null) {
+  if (res.kind === 'unreachable') {
+    deny(`${res.cause}. Decide without user input or retry after the operator fixes it.`)
+  }
+  if (res.kind !== 'reply') {
     deny(`No IRC reply within ${SOCKET_TIMEOUT}s — permbot unavailable or timed out. Decide without user input or retry.`)
   }
 
-  if (CHAT_KEYWORDS.has(reply!.trim().toLowerCase())) {
+  if (CHAT_KEYWORDS.has(res.reply.trim().toLowerCase())) {
     deny('operator requested to chat — decide without user input or re-ask via a follow-up message')
   }
 
-  const answers = mapReplyToAnswers(reply!, questions)
+  const answers = mapReplyToAnswers(res.reply, questions)
   allow(questions, answers)
 }

--- a/src/irc-client-impl.ts
+++ b/src/irc-client-impl.ts
@@ -417,12 +417,20 @@ export class RoostIrcClientImpl implements RoostIrcClient {
       const caps = Array.isArray(e?.capabilities) ? e.capabilities : Object.keys(e?.capabilities ?? {})
       this.emitSystem('cap-nak', `CAP NAK: ${caps.sort().join(',') || '(none)'}`)
     })
-    // 432 ERR_ERRONEUSNICKNAME, 433 ERR_NICKNAMEINUSE, 436 ERR_NICKCOLLISION
-    for (const code of ['432', '433', '436']) {
-      this.irc.on(code, () => {
-        if (!this.ircReady) this.emitSystem('registration-failed', { code: Number(code) })
-      })
+    // Registration-failure detection. irc-framework remaps these numerics to
+    // NAMED events before emitting — it never emits the bare numeric — so we
+    // listen on the names, not '432'/'433'. 432 ERR_ERRONEOUSNICKNAME →
+    // 'nick invalid', 433 ERR_NICKNAMEINUSE → 'nick in use'. The library does
+    // no auto-rename, so either numeric stalls registration permanently. The
+    // !ircReady gate scopes this to the handshake: a post-registration /NICK
+    // rejection is not a registration failure. (436 ERR_NICKCOLLISION has no
+    // irc-framework event mapping and is a server-to-server numeric that a
+    // single-server ergo never emits, so there's nothing to listen for.)
+    const onNickReject = (code: number) => (e: { nick?: string; reason?: string }) => {
+      if (!this.ircReady) this.emitSystem('registration-failed', { code, nick: e?.nick, reason: e?.reason })
     }
+    this.irc.on('nick invalid', onNickReject(432))
+    this.irc.on('nick in use', onNickReject(433))
   }
 
   // ---- IRC event handlers ------------------------------------------------

--- a/src/irc-client.ts
+++ b/src/irc-client.ts
@@ -65,8 +65,9 @@ export type SystemKind =
   | 'disconnected' | 'reconnected' | 'cap-missing' | 'registered' | 'registration-failed'
   | 'ping' | 'pong' | 'reconnecting' | 'cap-ack' | 'cap-nak' | 'cap-ls'
 // string for disconnected/reconnected/cap-missing/ping/pong/reconnecting/cap-*;
-// { nick } for registered; { code } for registration-failed.
-export type SystemContent = string | { code?: number; nick?: string }
+// { nick } for registered; { code, nick, reason } for registration-failed
+// (reason is the server's text for the numeric, e.g. "Erroneous nickname").
+export type SystemContent = string | { code?: number; nick?: string; reason?: string }
 
 export type MembershipKind = 'join' | 'leave' | 'nick'
 

--- a/src/permbot-socket.ts
+++ b/src/permbot-socket.ts
@@ -7,14 +7,43 @@ export const CHAT_KEYWORDS = new Set(['chat', 'skip', 'cancel'])
 
 export function permbotNickFor(nick: string): string { return `permbot-${nick}` }
 
-/** Connect to the permbot unix socket, send a JSON request, await the response.
- *  Returns the raw `reply` string, or null on missing socket / timeout / error. */
+/** Human-readable cause for an IRC registration rejection, with a remediation
+ *  hint. Shared by the permbot daemon (deny reason + log) and the hook's
+ *  pnotify fallback (log). The 432 hint names nicklen because an over-long
+ *  derived nick is the dominant cause in this system. */
+export function describeNickReject(c: { code?: number; nick?: string; reason?: string }): string {
+  const code = c.code ?? '?'
+  const reason = c.reason?.trim()
+    || (c.code === 432 ? 'Erroneous nickname' : c.code === 433 ? 'Nickname in use' : 'registration rejected')
+  const nick = c.nick || '(unknown)'
+  const len = c.nick ? ` (${c.nick.length} chars)` : ''
+  const hint = c.code === 432
+    ? ' — likely exceeds the server nicklen; raise limits.nicklen in ergo.yaml if the nick exceeds it, then respawn the agent (a wedged permbot cannot self-heal)'
+    : c.code === 433
+      ? ' — nick already held by another client; respawn the agent'
+      : ''
+  return `${code} ${reason} for nick '${nick}'${len}${hint}`
+}
+
+/** Outcome of a permbot socket round-trip.
+ *  - reply: operator answered (raw text).
+ *  - unreachable: the daemon is up but its IRC link never registered (432, etc.);
+ *    cause carries the reason. Callers fail closed — there's no point retrying.
+ *  - timeout: the in-flight prompt expired with no operator answer.
+ *  - unavailable: no socket, connect/parse failure, or a non-fatal daemon error. */
+export type DaemonResponse =
+  | { kind: 'reply'; reply: string }
+  | { kind: 'unreachable'; cause: string }
+  | { kind: 'timeout' }
+  | { kind: 'unavailable' }
+
+/** Connect to the permbot unix socket, send a JSON request, await the response. */
 export async function socketRoundtrip(
   sockPath: string,
   req: Record<string, unknown>,
   logError?: (msg: string) => void,
-): Promise<string | null> {
-  if (!sockPath || !fs.existsSync(sockPath)) return null
+): Promise<DaemonResponse> {
+  if (!sockPath || !fs.existsSync(sockPath)) return { kind: 'unavailable' }
   return new Promise((resolve) => {
     const sock = net.createConnection(sockPath)
     const timeoutMs = Number(req['timeout'] ?? 30) * 1000
@@ -28,15 +57,16 @@ export async function socketRoundtrip(
       sock.destroy()
       try {
         const resp = JSON.parse(line) as Record<string, unknown>
-        if (resp['timeout']) { resolve(null); return }
-        if (resp['error']) { logError?.(`daemon error: ${resp['error']}`); resolve(null); return }
-        resolve(String(resp['reply'] ?? ''))
+        if (resp['unreachable']) { resolve({ kind: 'unreachable', cause: String(resp['error'] ?? 'permbot unreachable') }); return }
+        if (resp['timeout']) { resolve({ kind: 'timeout' }); return }
+        if (resp['error']) { logError?.(`daemon error: ${resp['error']}`); resolve({ kind: 'unavailable' }); return }
+        resolve({ kind: 'reply', reply: String(resp['reply'] ?? '') })
       } catch (e) {
         logError?.(`bad daemon response: ${e}`)
-        resolve(null)
+        resolve({ kind: 'unavailable' })
       }
     })
-    sock.on('timeout', () => { sock.destroy(); resolve(null) })
-    sock.on('error', (e) => { logError?.(`connect ${sockPath} failed: ${e}`); resolve(null) })
+    sock.on('timeout', () => { sock.destroy(); resolve({ kind: 'unavailable' }) })
+    sock.on('error', (e) => { logError?.(`connect ${sockPath} failed: ${e}`); resolve({ kind: 'unavailable' }) })
   })
 }

--- a/src/permbot.ts
+++ b/src/permbot.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs'
 import * as net from 'node:net'
 import * as path from 'node:path'
 import type { IrcMessage, RoostIrcClient } from './irc-client.js'
-import { CHAT_KEYWORDS, type PermBotKind } from './permbot-socket.js'
+import { CHAT_KEYWORDS, describeNickReject, type PermBotKind } from './permbot-socket.js'
 
 // ---- Types ------------------------------------------------------------------
 
@@ -81,10 +81,23 @@ export function startPermbot(
   const queue: QueueEntry[] = []
   let inFlight: InFlight | null = null
   let shuttingDown = false
+  // Set when the permbot's IRC link permanently fails to register (432, etc.).
+  // Holds the deny reason. While set, every request is rejected immediately
+  // rather than queued against a connection that will never deliver. Cleared
+  // only if a later 'registered' fires — defensive; a 432-wedged client never
+  // reaches a second 001, so recovery is operator respawn, not auto-heal.
+  let unreachable: string | null = null
 
   function respond(socket: net.Socket, payload: object): void {
     try { socket.write(JSON.stringify(payload) + '\n') } catch { /* ignore */ }
     socket.destroy()
+  }
+
+  // Loud failure goes to BOTH stderr (captured by the tmux session) and
+  // permbot.log so an operator greps it from either surface.
+  function logLoud(msg: string): void {
+    process.stderr.write(`roost-irc[${nick}]: ${msg}\n`)
+    log(msg)
   }
 
   function maybeDispatch(): void {
@@ -185,6 +198,12 @@ export function startPermbot(
       }
       const kind: PermBotKind = req.kind
 
+      if (unreachable !== null) {
+        log(`request rejected (unreachable): kind=${kind} replyTarget=${replyTarget}`)
+        respond(socket, { error: unreachable, unreachable: true })
+        return
+      }
+
       log(`queued request: kind=${kind} replyTarget=${replyTarget} ${JSON.stringify(req)}`)
       queue.push({ socket, summary, timeout, kind, replyTarget, channel })
       maybeDispatch()
@@ -241,15 +260,36 @@ export function startPermbot(
   client.on('system', (kind, content) => {
     const detail = typeof content === 'string' ? content : ''
     if (kind === 'registered') {
+      if (unreachable !== null) {
+        unreachable = null
+        logLoud('IRC registration recovered — clearing unreachable state')
+      }
       log('registered with IRC (001 received)')
     } else if (kind === 'registration-failed') {
-      log('FATAL nick registration failure, shutting down')
-      stop()
+      // Fail loud + fail closed: the IRC link will never deliver, so reject
+      // everything now instead of letting the hook wait out its socket timeout
+      // with no connection. The socket server stays up so the cause reaches
+      // the hook (and the operator's log) — we do NOT stop()/unlink here.
+      const failContent = typeof content === 'object' && content !== null ? content : {}
+      unreachable = `permbot unreachable: ${describeNickReject(failContent)}`
+      logLoud(`FATAL ${unreachable}`)
+      if (inFlight !== null) {
+        clearTimeout(inFlight.timer)
+        clearTimeout(inFlight.nudgeTimer)
+        respond(inFlight.socket, { error: unreachable, unreachable: true })
+        inFlight = null
+      }
+      for (const e of queue) respond(e.socket, { error: unreachable, unreachable: true })
+      queue.length = 0
     } else if (kind === 'disconnected') {
       // The unix socket stays open while IRC reconnects; in-flight requests time
       // out as usual. The hook's askDaemon falls back only if the socket itself
-      // is gone, which it isn't during a transient drop.
-      log('IRC connection lost — waiting for auto-reconnect')
+      // is gone, which it isn't during a transient drop. But a never-registered
+      // client (432) won't auto-reconnect, so don't claim it will — that's the
+      // log line that masked the original incident.
+      log(unreachable !== null
+        ? 'IRC connection closed after registration failure — no auto-reconnect (see FATAL above)'
+        : 'IRC connection lost — waiting for auto-reconnect')
     } else if (kind === 'reconnected') {
       log(`IRC reconnected${detail ? ': ' + detail : ''}`)
     } else if (kind === 'reconnecting') {

--- a/src/permission-prompt.ts
+++ b/src/permission-prompt.ts
@@ -3,7 +3,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { checkOwnership } from './owner-gate.js'
-import { socketRoundtrip } from './permbot-socket.js'
+import { socketRoundtrip, describeNickReject, type DaemonResponse } from './permbot-socket.js'
 
 const WORKER      = process.env['ROOST_IRC_NICK'] ?? 'unknown'
 const SOCK_PATH   = process.env['ROOST_PERM_SOCK'] ?? ''
@@ -165,7 +165,7 @@ export function resolveTranscriptPath(transcriptPath: string, agentId: string): 
 
 // ---- Socket round-trip to permbot daemon ------------------------------------
 
-export async function askDaemon(summary: string): Promise<string | null> {
+export async function askDaemon(summary: string): Promise<DaemonResponse> {
   const req: Record<string, unknown> = { summary, timeout: SOCKET_SAFETY_TIMEOUT, kind: 'permission' }
   if (PERM_TARGET) req['replyTarget'] = PERM_TARGET
   return socketRoundtrip(SOCK_PATH, req, (msg) => { process.stderr.write(`perm-hook[${WORKER}]: ${msg}\n`) })
@@ -232,7 +232,11 @@ export async function sendFallbackDm(summary: string, reason: string): Promise<v
         if (flushTimer) clearTimeout(flushTimer)
         finish()
       } else if (kind === 'registration-failed') {
-        flog('registration failed')
+        // The DM can't deliver on an unregistered nick, but name the cause so
+        // it's greppable rather than a bare "registration failed". pnotify's
+        // nick is longer than the permbot's, so it hits 432 even more readily.
+        const detail = typeof content === 'object' && content !== null ? content : {}
+        flog(`registration rejected — ${describeNickReject(detail)}`)
         clearTimeout(regTimer)
         if (flushTimer) clearTimeout(flushTimer)
         finish()
@@ -281,17 +285,25 @@ if (import.meta.main) {
   }
   const summary = summaryLines.join('\n')
 
-  const reply = await askDaemon(summary)
-  if (reply === null) {
+  const res = await askDaemon(summary)
+  if (res.kind === 'unreachable') {
+    // Fail closed: the permbot is up but its IRC link never registered, so no
+    // operator can answer. Deny with the cause instead of hanging at a terminal
+    // prompt nobody is watching. Skip the fallback DM — pnotify's nick would hit
+    // the same registration failure.
+    process.stderr.write(`perm-hook[${WORKER}]: ${res.cause}\n`)
+    emit('deny', res.cause)
+  }
+  if (res.kind !== 'reply') {
     await sendFallbackDm(summary, 'permbot unavailable / timed out')
     emit('ask', 'permbot unavailable / timed out; falling back to terminal')
   }
 
-  const parts = reply!.trim().split(/\s+/, 2)
+  const parts = res.reply.trim().split(/\s+/, 2)
   const norm = (parts[0] ?? '').toLowerCase()
   const msg  = parts[1] ?? ''
   if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) emit('allow', msg || 'operator approved via IRC')
   if (['n', 'no', 'deny', 'block'].includes(norm)) emit('deny', msg || 'operator denied via IRC')
-  await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(reply)}`)
-  emit('ask', `unrecognized reply ${JSON.stringify(reply)}; falling back to terminal`)
+  await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(res.reply)}`)
+  emit('ask', `unrecognized reply ${JSON.stringify(res.reply)}; falling back to terminal`)
 }

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -15,7 +15,7 @@
 // queue, nudge logic, and operator UX stay in one place.
 
 import { checkOwnership } from './owner-gate.js'
-import { socketRoundtrip } from './permbot-socket.js'
+import { socketRoundtrip, type DaemonResponse } from './permbot-socket.js'
 import {
   summarize,
   extractIntent,
@@ -142,7 +142,7 @@ function emit(decision: 'allow' | 'deny' | 'ask', reason = ''): never {
 
 // ---- Socket round-trip ------------------------------------------------------
 
-async function askDaemon(summary: string): Promise<string | null> {
+async function askDaemon(summary: string): Promise<DaemonResponse> {
   const req: Record<string, unknown> = { summary, timeout: SOCKET_SAFETY_TIMEOUT, kind: 'permission' }
   if (PERM_TARGET) req['replyTarget'] = PERM_TARGET
   return socketRoundtrip(SOCK_PATH, req, (msg) => {
@@ -193,17 +193,24 @@ if (import.meta.main) {
   }
   const summary = summaryLines.join('\n')
 
-  const reply = await askDaemon(summary)
-  if (reply === null) {
+  const res = await askDaemon(summary)
+  if (res.kind === 'unreachable') {
+    // Fail closed with the cause — the permbot is up but its IRC link never
+    // registered, so no operator can answer. No fallback DM: pnotify's nick
+    // would hit the same registration failure.
+    process.stderr.write(`pretooluse-hook[${WORKER}]: ${res.cause}\n`)
+    emit('deny', res.cause)
+  }
+  if (res.kind !== 'reply') {
     await sendFallbackDm(summary, 'permbot unavailable / timed out (PreToolUse Bash)')
     emit('ask', 'permbot unavailable / timed out; falling back to terminal')
   }
 
-  const parts = reply!.trim().split(/\s+/, 2)
+  const parts = res.reply.trim().split(/\s+/, 2)
   const norm = (parts[0] ?? '').toLowerCase()
   const msg  = parts[1] ?? ''
   if (['y', 'yes', 'allow', 'ok', 'approve'].includes(norm)) emit('allow', msg || 'operator approved via IRC')
   if (['n', 'no', 'deny', 'block'].includes(norm)) emit('deny', msg || 'operator denied via IRC')
-  await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(reply)}`)
-  emit('ask', `unrecognized reply ${JSON.stringify(reply)}; falling back to terminal`)
+  await sendFallbackDm(summary, `unrecognized reply ${JSON.stringify(res.reply)}`)
+  emit('ask', `unrecognized reply ${JSON.stringify(res.reply)}; falling back to terminal`)
 }

--- a/test/ask-question-hook.test.ts
+++ b/test/ask-question-hook.test.ts
@@ -195,6 +195,26 @@ describe('ask-question-hook subprocess', () => {
     expect(out.hookSpecificOutput.updatedInput.answers['Which framework?']).toBe('React')
   }, 10_000)
 
+  it('returns deny with the cause when the daemon reports unreachable', async () => {
+    const sockPath = makeSock('ask-hook')
+    const cause = "permbot unreachable: 432 Erroneous nickname for nick 'permbot-worker-test' (19 chars) — raise limits.nicklen in ergo.yaml"
+    const stub = startPermbotStub(sockPath, { error: cause, unreachable: true })
+    await stub.ready
+
+    const [{ stdout }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_ASK_CHANNEL: '#ask-channel',
+      }),
+      stub.done,
+    ])
+
+    const out = JSON.parse(stdout.trim()) as { hookSpecificOutput: { permissionDecision: string; permissionDecisionReason?: string } }
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain(cause)
+  }, 10_000)
+
   it('returns deny when permbot times out', async () => {
     const sockPath = makeSock('ask-hook')
     // Stub that accepts connections but never responds → triggers socket timeout

--- a/test/permbot-registration-failure.test.ts
+++ b/test/permbot-registration-failure.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'bun:test'
+import * as fs from 'node:fs'
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { startPermbot } from '../src/permbot.js'
+import { RoostIrcClientImpl } from '../src/irc-client-impl.js'
+import { startErgoDedicated, isErgoAvailable } from './helpers/ergo.js'
+import { suppressLateRejection } from './helpers/tool.js'
+import type { SystemContent, SystemKind } from '../src/irc-client.js'
+
+// The ergo test helper pins nicklen=32, so a nick longer than that is rejected
+// at registration with 432 — the exact failure mode that wedged the live
+// reviewers. 43 chars here.
+const OVERLONG_NICK = 'permbot-overlong-worker-nick-past-the-limit'
+
+function tmp(ext: string): string {
+  return path.join(os.tmpdir(), `permbot-regfail-${process.pid}-${Math.random().toString(36).slice(2)}.${ext}`)
+}
+
+function socketRoundtrip(sockPath: string, req: object): Promise<Record<string, unknown>> {
+  return suppressLateRejection(new Promise((resolve, reject) => {
+    const sock = net.createConnection(sockPath)
+    let buf = ''
+    sock.on('connect', () => sock.write(JSON.stringify(req) + '\n'))
+    sock.on('data', (d) => {
+      buf += d.toString('utf8')
+      if (buf.includes('\n')) {
+        try { resolve(JSON.parse(buf.split('\n')[0])) } catch (e) { reject(e) }
+        sock.destroy()
+      }
+    })
+    sock.on('error', reject)
+  }))
+}
+
+async function waitFor<T>(predicate: () => T | undefined, deadlineMs: number, errMsg: string): Promise<T> {
+  const start = Date.now()
+  while (true) {
+    const v = predicate()
+    if (v !== undefined) return v
+    if (Date.now() - start > deadlineMs) throw new Error(errMsg)
+    await new Promise<void>(res => setTimeout(res, 50))
+  }
+}
+
+describe.if(isErgoAvailable())('permbot IRC registration failure (real ergo, 432)', () => {
+  it('over-long nick → 432 → registration-failed{code,nick,reason} → unreachable deny + greppable nicklen hint', async () => {
+    const dedicated = await startErgoDedicated()
+    if (!dedicated) return
+
+    const logFile = tmp('log')
+    const sockPath = tmp('sock')
+    const events: Array<{ kind: SystemKind; content: SystemContent }> = []
+    let stopPermbot: (() => void) | null = null
+
+    try {
+      const client = new RoostIrcClientImpl({
+        nick: OVERLONG_NICK, autoJoin: [], historySize: 0, joinHistoryLines: 0, joinHistoryMinutes: 0,
+      })
+      client.on('system', (kind, content) => { events.push({ kind, content }) })
+
+      const { stop, ready } = startPermbot(
+        { nick: OVERLONG_NICK, sockPath, worker: 'wkr', debugLog: logFile },
+        client,
+      )
+      stopPermbot = stop
+      await ready
+
+      client.connect({
+        host: dedicated.host,
+        port: dedicated.port,
+        nick: OVERLONG_NICK,
+        username: OVERLONG_NICK,
+        gecos: 'permbot',
+        autoReconnect: false,
+      })
+
+      // The load-bearing assertion: irc-framework remaps 432 to the named event
+      // 'nick invalid' (never a bare '432'), and our client must translate that
+      // into a registration-failed system event. If this regresses, the whole
+      // fail-loud chain goes silent again.
+      const failed = await waitFor(
+        () => events.find(e => e.kind === 'registration-failed'),
+        8000,
+        'registration-failed never fired on a real 432 — event-name regression in irc-client-impl',
+      )
+      const detail = failed.content as { code?: number; nick?: string; reason?: string }
+      expect(detail.code).toBe(432)
+      expect(detail.nick).toBe(OVERLONG_NICK)
+      expect(typeof detail.reason).toBe('string')  // ergo's 432 text, e.g. "Erroneous nickname"
+      // It never reached 001, so no 'registered' — proves we caught a true
+      // registration failure, not a post-registration nick rejection.
+      expect(events.find(e => e.kind === 'registered')).toBeUndefined()
+
+      // The permbot now fails closed: any request gets the unreachable cause
+      // immediately instead of queuing against a dead IRC link for 570s.
+      const resp = await Promise.race([
+        socketRoundtrip(sockPath, { summary: 'Read /x', timeout: 30, kind: 'permission', replyTarget: 'operator' }),
+        new Promise<Record<string, unknown>>((_, rej) => setTimeout(() => rej(new Error('socket roundtrip stalled')), 3000).unref?.()),
+      ])
+      expect(resp.unreachable).toBe(true)
+      expect(String(resp.error)).toContain('432')
+      expect(String(resp.error)).toContain('nicklen')
+
+      // Greppable forensic line on disk (stderr gets the same line live).
+      const logContent = fs.readFileSync(logFile, 'utf8')
+      expect(logContent).toMatch(/FATAL permbot unreachable/)
+      expect(logContent).toMatch(/raise limits\.nicklen/)
+    } finally {
+      try { stopPermbot?.() } catch { /* ignore */ }
+      try { fs.unlinkSync(logFile) } catch { /* ignore */ }
+      try { fs.unlinkSync(sockPath) } catch { /* ignore */ }
+      await dedicated.cleanup()
+    }
+  }, 20_000)
+})

--- a/test/permbot.test.ts
+++ b/test/permbot.test.ts
@@ -374,6 +374,53 @@ describe('permbot ask-question channel routing', () => {
   })
 })
 
+describe('permbot registration failure (fail loud + fail closed)', () => {
+  it('on registration-failed: fails in-flight, queued, and future requests with the unreachable cause; keeps the socket', async () => {
+    const sockPath = tmpSock()
+    const logFile = tmpLog()
+    const { client, emitSystem } = makeMockClient()
+    const { stop, ready } = startPermbot(
+      { nick: 'permbot-test', sockPath, worker: 'wkr', debugLog: logFile },
+      client,
+    )
+    stops.push(stop)
+    await ready
+
+    const { response: inflight } = await socketSend(sockPath, { summary: 'Read /x', timeout: 30, kind: 'permission', replyTarget: 'operator' })
+    const { response: queued } = await socketSend(sockPath, { summary: 'Read /y', timeout: 30, kind: 'permission', replyTarget: 'operator' })
+    await new Promise(r => setTimeout(r, 30))
+
+    // The permbot's IRC nick is rejected at registration (e.g. exceeds nicklen).
+    const longNick = 'permbot-this-is-a-very-long-worker-nick-indeed'
+    emitSystem('registration-failed', { code: 432, nick: longNick, reason: 'Erroneous nickname' })
+
+    const [r1, r2] = await Promise.all([inflight, queued]) as Array<{ error?: string; unreachable?: boolean }>
+    for (const r of [r1, r2]) {
+      expect(r.unreachable).toBe(true)
+      expect(r.error).toContain('permbot unreachable')
+      expect(r.error).toContain('432')
+      expect(r.error).toContain('nicklen')
+      expect(r.error).toContain(`(${longNick.length} chars)`)
+      expect(r.error).toContain('respawn')
+    }
+
+    // A request arriving AFTER the failure is rejected immediately, not queued.
+    const post = await socketRoundtrip(sockPath, { summary: 'Read /z', timeout: 30, kind: 'permission', replyTarget: 'operator' }) as { unreachable?: boolean }
+    expect(post.unreachable).toBe(true)
+
+    // We did NOT stop()/unlink — the socket stays up so the cause keeps reaching the hook.
+    expect(fs.existsSync(sockPath)).toBe(true)
+
+    const logContent = fs.readFileSync(logFile, 'utf8')
+    try {
+      expect(logContent).toMatch(/FATAL permbot unreachable/)
+      expect(logContent).toMatch(/raise limits\.nicklen/)
+    } finally {
+      try { fs.unlinkSync(logFile) } catch { /* ignore */ }
+    }
+  })
+})
+
 describe('permbot lifecycle logging', () => {
   it('writes lifecycle milestones to debugLog so operator grep contract holds', async () => {
     // Issue #578 acceptance: `grep -E 'PING|PONG|reconnect|CAP|registered' permbot.log`

--- a/test/permission-prompt.test.ts
+++ b/test/permission-prompt.test.ts
@@ -267,6 +267,28 @@ describe('permission-prompt hook', () => {
     expect(out.hookSpecificOutput.decision.message).toBe('operator denied via IRC')
   }, 10_000)
 
+  it('fails closed (deny) with the cause when the daemon reports unreachable', async () => {
+    const sockPath = makeSock('perm-hook')
+    const cause = "permbot unreachable: 432 Erroneous nickname for nick 'permbot-worker-test' (19 chars) — likely exceeds the server nicklen; raise limits.nicklen in ergo.yaml if the nick exceeds it, then respawn the agent (a wedged permbot cannot self-heal)"
+    const stub = startPermbotStub(sockPath, { error: cause, unreachable: true })
+    await stub.ready
+
+    const [{ stdout }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+        // No PERM_HOST/PORT: proves the unreachable path does NOT attempt a
+        // fallback DM (which would hit the same registration failure).
+      }),
+      stub.done,
+    ])
+
+    const out = JSON.parse(stdout.trim()) as { hookSpecificOutput: { decision: { behavior: string; message?: string } } }
+    expect(out.hookSpecificOutput.decision.behavior).toBe('deny')
+    expect(out.hookSpecificOutput.decision.message).toBe(cause)
+  }, 10_000)
+
   it('emits ask when operator reply is unrecognized', async () => {
     const sockPath = makeSock('perm-hook')
     const stub = startPermbotStub(sockPath, { reply: 'maybe later' })

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -211,6 +211,27 @@ describe('pretooluse-prompt hook subprocess', () => {
     expect(out.hookSpecificOutput.permissionDecision).toBe('deny')
   }, 10_000)
 
+  it('fails closed (deny) with the cause when the daemon reports unreachable', async () => {
+    const sockPath = makeSock('pretooluse-hook')
+    const cause = "permbot unreachable: 432 Erroneous nickname for nick 'permbot-worker-test' (19 chars) — raise limits.nicklen in ergo.yaml"
+    const stub = startPermbotStub(sockPath, { error: cause, unreachable: true })
+    await stub.ready
+
+    const [{ stdout }] = await Promise.all([
+      runHook({
+        ROOST_IRC_NICK: 'worker-test',
+        ROOST_PERM_SOCK: sockPath,
+        ROOST_PERM_TARGET: 'operator',
+        // No PERM_HOST/PORT: the unreachable path must NOT attempt a fallback DM.
+      }),
+      stub.done,
+    ])
+
+    const out = JSON.parse(stdout.trim()) as { hookSpecificOutput: { permissionDecision: string; permissionDecisionReason?: string } }
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(out.hookSpecificOutput.permissionDecisionReason).toBe(cause)
+  }, 10_000)
+
   it('emits ask + falls back when operator reply is unrecognized', async () => {
     const sockPath = makeSock('pretooluse-hook')
     const stub = startPermbotStub(sockPath, { reply: 'maybe later' })


### PR DESCRIPTION
Closes #591

## Root cause (narrower than the issue framing)

The registration-failure detection was **dead code**. `irc-client-impl.ts` listened on raw numeric events `'432'/'433'/'436'`, but irc-framework remaps numerics to *named* events before emitting — 432 → `'nick invalid'`, 433 → `'nick in use'` — and never emits the bare numeric. So a too-long permbot/pnotify nick (e.g. `permbot-teak-carrot-reviewer-2006` = 33 > 32) was rejected with 432, but `registration-failed` never fired, the permbot never `stop()`'d, and hook requests queued against a dead IRC link until the 570s socket timeout. `permbot.log` masked it as "IRC connection lost — waiting for auto-reconnect". The path shipped with **zero test coverage**.

## Fix

- **`etc/ergo.yaml`**: nicklen 32 → 48 (prefix headroom for multi-repo `<project>-<slug>-reviewer-<NNNN>` nicks).
- **`irc-client-impl.ts`**: listen on `'nick invalid'`/`'nick in use'`; emit `registration-failed` with `{code,nick,reason}`. Dropped the dead `'436'` listener (irc-framework gives no event for it; single-server ergo never emits it).
- **`permbot.ts`**: on `registration-failed`, enter an *unreachable* state — keep the unix socket listening, log the cause + nicklen hint to **stderr AND permbot.log**, and answer in-flight/queued/future requests immediately with `{error,unreachable:true}`. No `stop()`/unlink, so the cause reaches the hook.
- **hooks**: `socketRoundtrip` now returns a discriminated `DaemonResponse`. `permission` + `pretooluse` **fail closed** (deny with cause) on `unreachable` and skip the pnotify fallback DM (its nick would hit the same 432); `timeout`/socket-gone keep the existing fallback+ask path unchanged. `ask-question` denies with the cause. The pnotify fallback logs the cause+hint instead of a bare "registration failed".

### Why fail-closed, scoped
Fail-closed deny only for "permbot up but IRC unregistered" — a broken permission gate should deny (not allow, not hang a headless agent at a terminal prompt). Genuine operator-timeout and socket-gone paths are untouched.

### Recovery = respawn, not auto-heal
A never-registered client can't auto-reconnect: irc-framework's reconnect gate (`connection.js`) requires `was_connected && safely_registered`, and `safely_registered` is only set on RPL_WELCOME, which a 432'd client never reaches. The deny/log cue says: raise nicklen if needed, then respawn the agent. (`clear-on-registered` is kept as cheap defensive code.)

## Tests
- `permbot.test.ts`: mock-client unit — `registration-failed` fails in-flight + queued + future requests with the cause; socket stays up; greppable log.
- `permbot-registration-failure.test.ts`: **real ergo** — 43-char nick → real 432 → `registration-failed{code,nick,reason}` → unreachable deny + nicklen-hint log. Pins the irc-framework named-event behavior so the dead-listener bug can't regress silently.
- hook tests: `unreachable` → deny-closed-with-cause in all three hooks; existing timeout/unavailable→fallback+ask paths unchanged.

All 939 tests pass; typecheck + lint clean.