### PR TITLE
Degrade the GH gh-call layer gracefully on transient/expected errors

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/backoff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/backoff.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'bun:test'
+import { RateLimitBreaker, BACKOFF_SCHEDULE_MS, formatBackoffNotice, formatReadFailureNote } from '../backoff.js'
+import { WARN_COOLDOWN_MS } from '../../_rate-limit.js'
+
+const T0 = 1_000_000_000_000
+const M = 60_000
+
+describe('RateLimitBreaker', () => {
+  it('starts closed — shouldSkip false', () => {
+    const b = new RateLimitBreaker()
+    expect(b.shouldSkip(T0)).toBe(false)
+    expect(b.currentLevel).toBe(0)
+  })
+
+  it('first trip opens for 5m and returns the window', () => {
+    const b = new RateLimitBreaker()
+    expect(b.trip(T0)).toBe(5 * M)
+    expect(b.currentLevel).toBe(1)
+    expect(b.shouldSkip(T0)).toBe(true)
+    expect(b.shouldSkip(T0 + 5 * M - 1)).toBe(true)
+    expect(b.shouldSkip(T0 + 5 * M)).toBe(false)  // window elapsed
+  })
+
+  it('escalates 5 → 10 → 30 → 60, capped at 60', () => {
+    const b = new RateLimitBreaker()
+    // Trip once per elapsed window.
+    expect(b.trip(T0)).toBe(5 * M)
+    expect(b.trip(T0 + 5 * M)).toBe(10 * M)
+    expect(b.trip(T0 + 15 * M)).toBe(30 * M)
+    expect(b.trip(T0 + 45 * M)).toBe(60 * M)
+    expect(b.trip(T0 + 105 * M)).toBe(60 * M)  // capped
+    expect(b.trip(T0 + 165 * M)).toBe(60 * M)  // stays capped
+  })
+
+  it('a trip inside an open window is a no-op (concurrent trips advance once)', () => {
+    const b = new RateLimitBreaker()
+    expect(b.trip(T0)).toBe(5 * M)
+    // Same tick / still open → no advance, returns null.
+    expect(b.trip(T0)).toBeNull()
+    expect(b.trip(T0 + 1)).toBeNull()
+    expect(b.currentLevel).toBe(1)
+  })
+
+  it('reset inside an open window is a no-op (a recovered sibling cannot cancel a trip)', () => {
+    const b = new RateLimitBreaker()
+    b.trip(T0)
+    b.reset(T0 + 1)  // still inside the 5m window
+    expect(b.shouldSkip(T0 + 1)).toBe(true)
+    expect(b.currentLevel).toBe(1)
+  })
+
+  it('reset after the window closes the breaker (half-open recovery)', () => {
+    const b = new RateLimitBreaker()
+    b.trip(T0)
+    b.reset(T0 + 5 * M)  // window elapsed
+    expect(b.currentLevel).toBe(0)
+    expect(b.shouldSkip(T0 + 5 * M)).toBe(false)
+    // Next trip starts the schedule over at 5m.
+    expect(b.trip(T0 + 6 * M)).toBe(5 * M)
+  })
+
+  it('forceClose resets unconditionally (test isolation)', () => {
+    const b = new RateLimitBreaker()
+    b.trip(T0)
+    b.forceClose()
+    expect(b.currentLevel).toBe(0)
+    expect(b.shouldSkip(T0)).toBe(false)
+  })
+
+  it('schedule is 5/10/30/60 minutes', () => {
+    expect(BACKOFF_SCHEDULE_MS).toEqual([5 * M, 10 * M, 30 * M, 60 * M])
+  })
+})
+
+describe('format helpers', () => {
+  it('formatBackoffNotice renders the window in minutes', () => {
+    expect(formatBackoffNotice(5 * M)).toBe('[dispatcher] GH rate-limited, backing off 5m')
+    expect(formatBackoffNotice(60 * M)).toBe('[dispatcher] GH rate-limited, backing off 60m')
+  })
+
+  it('formatReadFailureNote hedges deleted-vs-flaking and embeds the verbatim recovery command', () => {
+    const note = formatReadFailureNote('github-new-issues', 'org/repo', 'unwatch new-issues org/repo')
+    expect(note).toBe(
+      `[dispatcher] github-new-issues: org/repo read failing (deleted/renamed or GH flaking) —` +
+      ` suppressing ${Math.round(WARN_COOLDOWN_MS / 60_000)}m; if persistent: unwatch new-issues org/repo`
+    )
+  })
+})

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, fetchRateLimit } from '../github-api.js'
+import { GhError, spawnGh, fetchRateLimit, isRateLimitError, isExpectedTransientError } from '../github-api.js'
 import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../../_rate-limit.js'
 
 function mkErr(stderr: string): GhError {
@@ -88,7 +88,28 @@ describe('spawnGh (retry-aware)', () => {
     expect(h.logs[2]).toContain('HTTP 502: Bad Gateway')
   })
 
-  it('does not retry on non-transient errors (404)', async () => {
+  it('retries a 404 (transient edge-flap) then succeeds, on the shorter base', async () => {
+    const h = harness()
+    let calls = 0
+    const out = await spawnGh(['api', '/x'], {
+      sleep: h.sleep,
+      log: h.log,
+      baseMs: 1000,
+      notFoundBaseMs: 100,
+      random: () => 0,
+      exec: async () => {
+        calls++
+        if (calls === 1) throw mkErr('gh: HTTP 404: Not Found')
+        return { ok: true }
+      },
+    })
+    expect(out).toEqual({ ok: true })
+    expect(calls).toBe(2)
+    expect(h.sleeps).toEqual([100])  // notFoundBaseMs, not baseMs
+    expect(h.logs[0]).toContain('matched=http-404')
+  })
+
+  it('exhausts a 404 after N attempts (real missing resource / sustained flap)', async () => {
     const h = harness()
     let calls = 0
     let caught: unknown = null
@@ -96,14 +117,17 @@ describe('spawnGh (retry-aware)', () => {
       await spawnGh(['api', '/x'], {
         sleep: h.sleep,
         log: h.log,
+        notFoundBaseMs: 1,
+        random: () => 0,
         exec: async () => { calls++; throw mkErr('gh: HTTP 404: Not Found') },
       })
     } catch (e) { caught = e }
-    expect(calls).toBe(1)
-    expect(h.sleeps).toEqual([])
-    expect(h.logs).toEqual([])
+    expect(calls).toBe(3)
     expect(caught).toBeInstanceOf(GhError)
-    expect((caught as GhError).attempts).toBe(1)
+    expect((caught as GhError).attempts).toBe(3)
+    // A persistent 404 is the per-entry skip class, not rate-limit.
+    expect(isExpectedTransientError(caught)).toBe(true)
+    expect(isRateLimitError(caught)).toBe(false)
   })
 
   it('treats 422 as non-transient but logs stderr verbatim', async () => {
@@ -130,7 +154,6 @@ describe('spawnGh (retry-aware)', () => {
     const cases: Array<[string, string]> = [
       ['gh: HTTP 500', 'http-5xx'],
       ['gh: HTTP 504: Gateway Timeout', 'http-5xx'],
-      ['gh: HTTP 429: rate limit', 'http-429-rate-limit'],
       ['dial tcp: i/o timeout', 'timeout'],
       ['context deadline exceeded', 'timeout'],
       ['request timed out', 'timeout'],
@@ -171,6 +194,66 @@ describe('spawnGh (retry-aware)', () => {
     } catch { /* exhausted */ }
     // i=0: 100 * 1 * 1.5 = 150; i=1: 100 * 2 * 1.5 = 300
     expect(h.sleeps).toEqual([150, 300])
+  })
+
+  it('does not retry HTTP 429 — fails fast for the breaker', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await spawnGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw mkErr('gh: HTTP 429: Too Many Requests') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(h.sleeps).toEqual([])
+    expect(isRateLimitError(caught)).toBe(true)
+    expect(h.logs[0]).toContain('rate-limited (not retried here)')
+  })
+
+  it('treats HTTP 403 with a rate-limit message as rate-limit (no retry)', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await spawnGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw mkErr('gh: HTTP 403: API rate limit exceeded for user') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(isRateLimitError(caught)).toBe(true)
+  })
+
+  it('treats an HTTP 403 secondary rate limit as rate-limit (no retry)', async () => {
+    let caught: unknown = null
+    try {
+      await spawnGh(['api', '/x'], {
+        sleep: async () => {},
+        log: () => {},
+        exec: async () => { throw mkErr('gh: HTTP 403: You have exceeded a secondary rate limit') },
+      })
+    } catch (e) { caught = e }
+    expect(isRateLimitError(caught)).toBe(true)
+  })
+
+  it('does not treat a non-rate-limit HTTP 403 as rate-limit or transient (throws once)', async () => {
+    const h = harness()
+    let calls = 0
+    let caught: unknown = null
+    try {
+      await spawnGh(['api', '/x'], {
+        sleep: h.sleep,
+        log: h.log,
+        exec: async () => { calls++; throw mkErr('gh: HTTP 403: Resource not accessible by integration') },
+      })
+    } catch (e) { caught = e }
+    expect(calls).toBe(1)
+    expect(isRateLimitError(caught)).toBe(false)
+    expect(isExpectedTransientError(caught)).toBe(false)
   })
 
   it('rethrows non-GhError immediately without classifying', async () => {

--- a/src/orchestrator/plugins/github/__tests__/resilience.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/resilience.test.ts
@@ -1,0 +1,120 @@
+// Integration coverage for the gh-call resilience layer (GhPluginBase.readEntry
+// + the shared rate-limit breaker), exercised through plugin runTicks. The four
+// readEntry outcomes — success, transient/404 skip+note, rate-limit→breaker,
+// 422/non-GhError→throw — plus the missing-repo cooldown and breaker quiet path.
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test'
+import { GitHubNewPrsPlugin, type NewPrsPluginState } from '../new-prs-plugin.js'
+import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
+import { GhClient, GhError, type GhRepoPr } from '../github-api.js'
+import { GhPluginBase } from '../base.js'
+import type { OrchestratorConfig } from '../../../config.js'
+import { stubRateLimit } from './gh-test-helpers.js'
+
+function prsConfig(): OrchestratorConfig {
+  return { project: 'proj', repo: 'org/repo', plugins: { 'github-new-prs': { watched: [{ repo: 'org/repo' }] } } }
+}
+function issuesConfig(): OrchestratorConfig {
+  return { project: 'proj', repo: 'org/repo', plugins: { 'github-new-issues': { watched: [{ repo: 'org/repo' }] } } }
+}
+function pr(n: number): GhRepoPr {
+  return { number: n, title: `PR ${n}`, html_url: `https://github.com/org/repo/pull/${n}`, labels: [], user: { login: 'ext' } }
+}
+function oneline(e: { payload: unknown }): string {
+  return (e.payload as { kind: 'oneline'; text: string }).text
+}
+function ghErr(stderr: string): GhError {
+  return new GhError(`gh failed (exit 1)\n${stderr}`, stderr, 3)
+}
+
+describe('gh-call resilience (readEntry + breaker)', () => {
+  stubRateLimit()
+  beforeEach(() => { GhPluginBase.resetBreakerForTest() })
+  afterEach(() => { GhPluginBase.resetBreakerForTest() })
+
+  it('success path: a clean read emits events normally', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockResolvedValue([pr(1), pr(2)])
+    try {
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), { repos: { 'org/repo': [1] } })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(oneline(result.taggedEvents[0]!)).toContain('org/repo#2')
+    } finally { spy.mockRestore() }
+  })
+
+  it('transient/404 past retries: skips the entry with a hedged cooldown note, preserves prev state', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    try {
+      const prev: NewPrsPluginState = { repos: { 'org/repo': [1, 2] } }
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), prev)
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = oneline(result.taggedEvents[0]!)
+      expect(text).toContain('github-new-prs: org/repo read failing (deleted/renamed or GH flaking)')
+      expect(text).toContain('unwatch new-prs org/repo')
+      // Prev state carried forward untouched — nothing lost, nothing replayed.
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2])
+    } finally { spy.mockRestore() }
+  })
+
+  it('missing-repo note is cooldown-gated — recurs only once per window per repo', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    try {
+      const plugin = new GitHubNewPrsPlugin('#proj-leads')  // same instance → shared cooldown map
+      const prev: NewPrsPluginState = { repos: { 'org/repo': [1] } }
+      const first = await plugin.runTick(prsConfig(), prev)
+      const second = await plugin.runTick(prsConfig(), first.state)
+      expect(first.taggedEvents).toHaveLength(1)
+      expect(second.taggedEvents).toHaveLength(0)  // suppressed within the window
+    } finally { spy.mockRestore() }
+  })
+
+  it('rate-limit: trips the breaker, emits a backoff notice, preserves prev state', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 429: Too Many Requests'))
+    try {
+      const prev: NewPrsPluginState = { repos: { 'org/repo': [1] } }
+      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), prev)
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(oneline(result.taggedEvents[0]!)).toBe('[dispatcher] GH rate-limited, backing off 5m')
+      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1])
+    } finally { spy.mockRestore() }
+  })
+
+  it('rate-limit quiets the next tick: breaker open → no poll, no events', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 429: Too Many Requests'))
+    try {
+      const plugin = new GitHubNewPrsPlugin('#proj-leads')
+      await plugin.runTick(prsConfig(), { repos: { 'org/repo': [1] } })
+      expect(spy).toHaveBeenCalledTimes(1)
+      const second = await plugin.runTick(prsConfig(), { repos: { 'org/repo': [1] } })
+      expect(spy).toHaveBeenCalledTimes(1)  // breaker open → did not poll again
+      expect(second.taggedEvents).toHaveLength(0)  // silent
+    } finally { spy.mockRestore() }
+  })
+
+  it('422 (real defect) is not swallowed — runTick rejects', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 422: Validation Failed'))
+    try {
+      await expect(new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), { repos: { 'org/repo': [1] } }))
+        .rejects.toThrow(GhError)
+    } finally { spy.mockRestore() }
+  })
+
+  it('non-GhError (upstream bug) is not swallowed — runTick rejects', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(new Error('bun.spawn died'))
+    try {
+      await expect(new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), { repos: { 'org/repo': [1] } }))
+        .rejects.toThrow('bun.spawn died')
+    } finally { spy.mockRestore() }
+  })
+
+  it('github-new-issues missing-repo: hedged note with the verbatim unwatch recovery', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    try {
+      const prev: NewIssuesPluginState = { repos: { 'org/repo': [1] } }
+      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(issuesConfig(), prev)
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = oneline(result.taggedEvents[0]!)
+      expect(text).toContain('github-new-issues: org/repo read failing (deleted/renamed or GH flaking)')
+      expect(text).toContain('unwatch new-issues org/repo')
+      expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1])
+    } finally { spy.mockRestore() }
+  })
+})

--- a/src/orchestrator/plugins/github/__tests__/resilience.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/resilience.test.ts
@@ -1,13 +1,25 @@
 // Integration coverage for the gh-call resilience layer (GhPluginBase.readEntry
-// + the shared rate-limit breaker), exercised through plugin runTicks. The four
-// readEntry outcomes — success, transient/404 skip+note, rate-limit→breaker,
-// 422/non-GhError→throw — plus the missing-repo cooldown and breaker quiet path.
+// + the shared rate-limit breaker), exercised through plugin runTicks.
+//
+// Block 1 (repo-feed plugins: new-prs/new-issues) — the four readEntry outcomes:
+// success, transient/404 skip+note, rate-limit→breaker, 422/non-GhError→throw,
+// plus the missing-repo cooldown and breaker quiet path.
+//
+// Block 2 (per-N plugins: prs/issues) — the multi-entry skip path that block 1
+// can't reach: carrying a flapped entry's prev snapshot (and its dynamic
+// channels) forward, the cross/multi-repo recovery command, and the empty-watch
+// early-return that keeps an idle plugin from resetting a sibling's escalation.
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test'
 import { GitHubNewPrsPlugin, type NewPrsPluginState } from '../new-prs-plugin.js'
 import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
+import { GitHubPrsPlugin } from '../prs-plugin.js'
+import { GitHubIssuesPlugin } from '../issues-plugin.js'
 import { GhClient, GhError, type GhRepoPr } from '../github-api.js'
+import { GhScraper } from '../scraper.js'
 import { GhPluginBase } from '../base.js'
+import { RateLimitBreaker } from '../backoff.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import type { PrSnap, IssueSnap, PrPluginState, IssuePluginState } from '../types.js'
 import { stubRateLimit } from './gh-test-helpers.js'
 
 function prsConfig(): OrchestratorConfig {
@@ -116,5 +128,158 @@ describe('gh-call resilience (readEntry + breaker)', () => {
       expect(text).toContain('unwatch new-issues org/repo')
       expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1])
     } finally { spy.mockRestore() }
+  })
+})
+
+function prSnap(overrides: Partial<PrSnap> = {}): PrSnap {
+  return {
+    repo: 'org/repo', number: 1, title: 'P', url: 'https://github.com/org/repo/pull/1',
+    head_ref: 'feat/x', head_oid: 'abc', is_draft: false, merged: false,
+    state: 'OPEN', labels: [], ci_state: null, linked_issues: [],
+    seen_review_comment_ids: [], seen_conversation_comment_ids: [], seen_review_ids: [],
+    ...overrides,
+  }
+}
+function issueSnap(overrides: Partial<IssueSnap> = {}): IssueSnap {
+  return {
+    repo: 'org/repo', number: 1, title: 'I', url: 'https://github.com/org/repo/issues/1',
+    state: 'open', labels: [], seen_comment_ids: [], ...overrides,
+  }
+}
+
+// Minimal Linear attachment query stub (mirrors plugin.test.ts) — maps a Linear
+// identifier to the PR URLs it's attached to, so the resolver cross-links a
+// watched PR to its Linear channel.
+type Attachment = { id: string; sourceType: string | null; url: string | null }
+type IssueNode = { identifier: string; attachments: { nodes: Attachment[] } | null }
+type QueryFn = (teamKey: string, numbers: number[]) => Promise<{ nodes: IssueNode[]; hasNextPage: boolean }>
+function linearStub(byId: Record<string, string[]>): QueryFn {
+  return async (team, numbers) => {
+    const nodes: IssueNode[] = []
+    for (const n of numbers) {
+      const id = `${team}-${n}`
+      const urls = byId[id]
+      if (urls) nodes.push({ identifier: id, attachments: { nodes: urls.map(u => ({ id: `att-${u}`, sourceType: 'github', url: u })) } })
+    }
+    return { nodes, hasNextPage: false }
+  }
+}
+
+describe('gh-call resilience — per-N skip path (issues/prs)', () => {
+  stubRateLimit()
+  beforeEach(() => { GhPluginBase.resetBreakerForTest() })
+  afterEach(() => { GhPluginBase.resetBreakerForTest() })
+
+  it('prs transient skip: carries the flapped PR forward and re-adds its dynamic channels', async () => {
+    const prevPr1 = prSnap({ number: 1, url: 'https://github.com/org/repo/pull/1', linked_issues: [{ repo: 'org/repo', number: 42 }] })
+    const prevPr2 = prSnap({ number: 2, url: 'https://github.com/org/repo/pull/2' })
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockImplementation(async (_repo: string, number: number) => {
+      if (number === 1) throw ghErr('gh: HTTP 404: Not Found')
+      return { snap: prSnap({ number: 2, url: 'https://github.com/org/repo/pull/2' }), events: [] }
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 1 }, { number: 2 }] },
+          'linear-issues': { watched: [{ identifier: 'TEAM-7' }] },
+        },
+      }
+      const plugin = new GitHubPrsPlugin('#proj-leads')
+      plugin._setLinearQueryForTest(linearStub({ 'TEAM-7': ['https://github.com/org/repo/pull/1'] }))
+      const prev: PrPluginState = { prs: { 'org/repo#1': prevPr1, 'org/repo#2': prevPr2 } }
+      const result = await plugin.runTick(config, prev)
+
+      // The flapped entry skips with a hedged note; the healthy sibling is untouched.
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = oneline(result.taggedEvents[0]!)
+      expect(text).toContain('github-prs: org/repo#1 read failing (deleted/renamed or GH flaking)')
+      expect(text).toContain('unwatch pr 1')  // single-repo → bare number, no repo suffix
+
+      // prevPr1 carried forward verbatim — a flap doesn't drop the snapshot.
+      const state = result.state as PrPluginState
+      expect(state.prs['org/repo#1']).toEqual(prevPr1)
+      expect(state.prs['org/repo#2']).toBeDefined()
+      // Linked-issue channel re-added — desiredChannels does NOT carry #42 (it's a
+      // dynamic closure target, not a watched entry), so this pins the re-add.
+      expect(result.channels).toContain('#proj-issue-42')
+      // Linear cross-link channel is also present (the carry-forward re-add runs;
+      // desiredChannels seeds watched Linear channels too, so this asserts
+      // membership rather than isolating the re-add).
+      expect(result.channels).toContain('#proj-issue-team-7')
+    } finally { spy.mockRestore() }
+  })
+
+  it('issues transient skip: carries the flapped issue forward, emits the hedged note', async () => {
+    const prevIssue1 = issueSnap({ number: 1 })
+    const spy = spyOn(GhScraper.prototype, 'scrapeIssue').mockImplementation(async (_repo: string, number: number) => {
+      if (number === 1) throw ghErr('gh: HTTP 404: Not Found')
+      return { snap: issueSnap({ number: 2 }), events: [] }
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-issues': { watched: [{ number: 1 }, { number: 2 }] } },
+      }
+      const prev: IssuePluginState = { issues: { 'org/repo#1': prevIssue1, 'org/repo#2': issueSnap({ number: 2 }) } }
+      const result = await new GitHubIssuesPlugin('#proj-leads').runTick(config, prev)
+
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = oneline(result.taggedEvents[0]!)
+      expect(text).toContain('github-issues: org/repo#1 read failing (deleted/renamed or GH flaking)')
+      expect(text).toContain('unwatch 1')
+      expect((result.state as IssuePluginState).issues['org/repo#1']).toEqual(prevIssue1)
+    } finally { spy.mockRestore() }
+  })
+
+  it('cross/multi-repo skip note qualifies the recovery command with the repo', async () => {
+    // Multi-repo (no config.repo): bare `unwatch pr <N>` / `unwatch <N>` would hit
+    // bareError, so the note must carry the repo (mirrors formatEntryLabel).
+    const prsSpy = spyOn(GhScraper.prototype, 'scrapePr').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj', plugins: { 'github-prs': { watched: [{ number: 5, repo: 'org/other' }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(config, { prs: {} })
+      expect(oneline(result.taggedEvents[0]!)).toContain('unwatch pr 5 org/other')
+    } finally { prsSpy.mockRestore() }
+
+    GhPluginBase.resetBreakerForTest()
+    const issuesSpy = spyOn(GhScraper.prototype, 'scrapeIssue').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj', plugins: { 'github-issues': { watched: [{ number: 8, repo: 'org/other' }] } },
+      }
+      const result = await new GitHubIssuesPlugin('#proj-leads').runTick(config, { issues: {} })
+      expect(oneline(result.taggedEvents[0]!)).toContain('unwatch 8 org/other')
+    } finally { issuesSpy.mockRestore() }
+  })
+
+  it('empty watch list returns before the breaker block — an idle plugin never resets the breaker', async () => {
+    const resetSpy = spyOn(RateLimitBreaker.prototype, 'reset')
+    try {
+      const emptyPrs: OrchestratorConfig = { project: 'proj', repo: 'org/repo', plugins: { 'github-prs': { watched: [] } } }
+      const prsResult = await new GitHubPrsPlugin('#proj-leads').runTick(emptyPrs, { prs: {} })
+      expect(prsResult.taggedEvents).toHaveLength(0)
+      expect(prsResult.channels).toEqual([])
+
+      const emptyIssues: OrchestratorConfig = { project: 'proj', repo: 'org/repo', plugins: { 'github-issues': { watched: [] } } }
+      const issuesResult = await new GitHubIssuesPlugin('#proj-leads').runTick(emptyIssues, { issues: {} })
+      expect(issuesResult.taggedEvents).toHaveLength(0)
+      expect(issuesResult.channels).toEqual([])
+
+      // Neither idle plugin touched the breaker — at half-open this is what keeps
+      // an empty sibling from clearing an in-flight escalation back to 5m.
+      expect(resetSpy).not.toHaveBeenCalled()
+
+      // Positive control: a non-empty clean tick *does* reset, proving the spy
+      // works and that the empty-watch early-return is what suppresses it.
+      const okSpy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({ snap: prSnap({ number: 1 }), events: [] })
+      try {
+        const cfg: OrchestratorConfig = { project: 'proj', repo: 'org/repo', plugins: { 'github-prs': { watched: [{ number: 1 }] } } }
+        await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: { 'org/repo#1': prSnap({ number: 1 }) } })
+        expect(resetSpy).toHaveBeenCalled()
+      } finally { okSpy.mockRestore() }
+    } finally { resetSpy.mockRestore() }
   })
 })

--- a/src/orchestrator/plugins/github/backoff.ts
+++ b/src/orchestrator/plugins/github/backoff.ts
@@ -1,0 +1,73 @@
+// Reactive GH rate-limit circuit breaker. One instance is shared across every
+// GH plugin (they poll one shared GH budget), held as a class-static on
+// GhPluginBase. Once a tick surfaces a rate-limit error the breaker opens for an
+// escalating window so the dispatcher goes quiet instead of re-firing the same
+// error every tick. It recovers (level → 0) on the first clean tick after the
+// window elapses (half-open trial).
+
+import { WARN_COOLDOWN_MS } from '../_rate-limit.js'
+
+// Escalating backoff windows, capped at the last. One step per open window.
+export const BACKOFF_SCHEDULE_MS: ReadonlyArray<number> = [5, 10, 30, 60].map(m => m * 60_000)
+
+export class RateLimitBreaker {
+  private level = 0   // 0 = closed; N = number of escalations applied
+  private until = 0   // unix ms; polling is allowed again when now >= until
+
+  // True while inside an open window — callers skip polling entirely.
+  shouldSkip(now: number): boolean {
+    return this.level > 0 && now < this.until
+  }
+
+  // Open (or escalate) the breaker. Advances at most once per window: all GH
+  // plugins rate-limit together within a tick, so the first trip sets `until`
+  // in the future and concurrent trips this tick see now < until and no-op.
+  // Returns the new window (ms) when it actually advanced, else null.
+  trip(now: number): number | null {
+    if (this.level > 0 && now < this.until) return null
+    const idx = Math.min(this.level, BACKOFF_SCHEDULE_MS.length - 1)
+    const window = BACKOFF_SCHEDULE_MS[idx]
+    this.level = Math.min(this.level + 1, BACKOFF_SCHEDULE_MS.length)
+    this.until = now + window
+    return window
+  }
+
+  // Close the breaker after a clean tick. No-ops inside an active window so a
+  // sibling plugin that recovered can't cancel a trip from the same tick —
+  // first writer wins either way, and the next tick stabilizes.
+  reset(now: number): void {
+    if (this.level > 0 && now < this.until) return
+    this.level = 0
+    this.until = 0
+  }
+
+  // Unconditional close — test-only, so a class-static breaker doesn't leak
+  // trip state across cases.
+  forceClose(): void {
+    this.level = 0
+    this.until = 0
+  }
+
+  // Test/observability accessors.
+  get currentLevel(): number { return this.level }
+  get openUntil(): number { return this.until }
+}
+
+// One-line notice posted when the breaker opens or escalates.
+export function formatBackoffNotice(windowMs: number): string {
+  return `[dispatcher] GH rate-limited, backing off ${Math.round(windowMs / 60_000)}m`
+}
+
+// Cooldown-gated note for an entry whose read keeps failing after retries. HTTP
+// 404 can't tell a deleted/renamed repo from an upstream edge-flap, so the
+// wording hedges; recurrence is the persistence signal (a real deletion keeps
+// warning every window, a one-off flap warns once). `recoveryCmd` is the exact
+// dispatcher DM an operator types to stop watching — pulled verbatim from the
+// owning plugin's help text.
+export function formatReadFailureNote(pluginName: string, key: string, recoveryCmd: string): string {
+  const mins = Math.round(WARN_COOLDOWN_MS / 60_000)
+  return (
+    `[dispatcher] ${pluginName}: ${key} read failing (deleted/renamed or GH flaking) —` +
+    ` suppressing ${mins}m; if persistent: ${recoveryCmd}`
+  )
+}

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -2,11 +2,20 @@ import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig, WatchedEntry } from '../../config.js'
 import { assertEntryRepoMode, resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
-import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, type TaggedEvent } from '../../plugin.js'
+import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, type PluginTickResult, type TaggedEvent } from '../../plugin.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { tryClaimPerN, type PerNCommand } from '../grammar.js'
-import { GhClient, fetchRateLimit } from './github-api.js'
-import { observeRateLimitFromInfo, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
+import { GhClient, GhError, fetchRateLimit, isExpectedTransientError, isRateLimitError } from './github-api.js'
+import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
+import { RateLimitBreaker, formatBackoffNotice } from './backoff.js'
+
+// Per-entry read outcome. `readEntry` never throws the expected gh-error
+// classes — it returns one of these so a caller's Promise.all over entries
+// never abandons sibling reads (bun late-rejection footgun) on the first error.
+export type ReadEntryResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; rateLimited: true }
+  | { ok: false; rateLimited: false; events: TaggedEvent[] }
 
 // Shared base for plugins needing GhClient. GhBase extends this for watch-list
 // scaffolding; non-watching plugins (e.g. GitHubNewIssuesPlugin) extend directly.
@@ -19,6 +28,18 @@ export abstract class GhPluginBase extends BasePlugin {
   // Cross-instance cooldown handle — one warning per 10 min total.
   private static readonly _statics: RateLimitStatics = { warnedAt: null }
 
+  // One breaker shared across every GH plugin — they poll one shared GH budget,
+  // so a rate-limit on any of them should quiet all of them.
+  private static readonly _breaker = new RateLimitBreaker()
+
+  // Per-entry skip-note cooldown (per instance — a per-watcher signal, unlike
+  // the cross-instance rate-limit warn cooldown). Keyed by the entry's read key.
+  private _skipWarnedAt = new Map<string, number>()
+
+  // Last channel set this plugin returned from a clean tick — replayed while the
+  // breaker is open so a multi-minute backoff doesn't PART the watched channels.
+  private _lastChannels: string[] = []
+
   constructor(defaultChannel: string, log: PluginLogger = defaultPluginLogger) {
     super(defaultChannel)
     this.log = log
@@ -27,6 +48,82 @@ export abstract class GhPluginBase extends BasePlugin {
 
   protected agentLogins(config: OrchestratorConfig): Set<string> {
     return new Set(config.agent_logins ?? [])
+  }
+
+  // Test-only: reset the shared breaker between cases. The breaker is a
+  // class-static, so trip state would otherwise leak across tests.
+  static resetBreakerForTest(): void {
+    GhPluginBase._breaker.forceClose()
+  }
+
+  // ---- gh-call resilience (rate-limit breaker + per-entry transient skip) ---
+
+  // True while the breaker is open — callers return `breakerSkipResult` and skip
+  // all polling for the tick.
+  protected breakerOpen(now: number): boolean {
+    return GhPluginBase._breaker.shouldSkip(now)
+  }
+
+  // Silent skip while the breaker is open: preserve state, replay last channels.
+  protected breakerSkipResult(prevState: unknown, config: OrchestratorConfig): PluginTickResult {
+    return { state: prevState, taggedEvents: [], channels: this.skipChannels(config) }
+  }
+
+  // A rate-limit surfaced this tick: open/escalate the breaker, emit one notice
+  // when it actually advanced, preserve state and channels.
+  protected breakerTripResult(now: number, prevState: unknown, projectChannel: string, config: OrchestratorConfig): PluginTickResult {
+    const window = GhPluginBase._breaker.trip(now)
+    const taggedEvents: TaggedEvent[] = window != null
+      ? [{ channels: [projectChannel], payload: { kind: 'oneline', text: formatBackoffNotice(window) } }]
+      : []
+    return { state: prevState, taggedEvents, channels: this.skipChannels(config) }
+  }
+
+  // Close the breaker after a clean tick (half-open recovery).
+  protected breakerReset(now: number): void {
+    GhPluginBase._breaker.reset(now)
+  }
+
+  // Record the channels a clean tick is returning, for breaker-open replay.
+  protected rememberChannels(channels: string[]): string[] {
+    this._lastChannels = channels
+    return channels
+  }
+
+  private skipChannels(config: OrchestratorConfig): string[] {
+    return this._lastChannels.length ? this._lastChannels : this.desiredChannels(config)
+  }
+
+  // Run one watched entry's read. Returns a discriminated result instead of
+  // throwing the expected gh-error classes:
+  //   - success                       → { ok: true, value }
+  //   - rate-limit                    → { ok: false, rateLimited: true }  (caller trips the breaker)
+  //   - 404 / transient past retries  → { ok: false, rateLimited: false, events } (cooldown-gated note, skip entry)
+  //   - 422 / non-GhError             → re-thrown (a real defect surfaces as dispatcher_error)
+  // `noteText` is the cooldown-gated message; `noteChannels` route it.
+  protected async readEntry<T>(
+    cooldownKey: string,
+    noteChannels: string[],
+    noteText: string,
+    body: () => Promise<T>,
+    now = Date.now(),
+  ): Promise<ReadEntryResult<T>> {
+    try {
+      return { ok: true, value: await body() }
+    } catch (e) {
+      if (!(e instanceof GhError)) throw e
+      if (isRateLimitError(e)) return { ok: false, rateLimited: true }
+      if (!isExpectedTransientError(e)) throw e
+      this.log(`[${this.name}] read failing for ${cooldownKey}: ${e.message}\n`)
+      const last = this._skipWarnedAt.get(cooldownKey) ?? 0
+      if (now - last <= WARN_COOLDOWN_MS) return { ok: false, rateLimited: false, events: [] }
+      this._skipWarnedAt.set(cooldownKey, now)
+      return {
+        ok: false,
+        rateLimited: false,
+        events: [{ channels: [...noteChannels], payload: { kind: 'oneline', text: noteText } }],
+      }
+    }
   }
 
   // End-of-tick: log current GH rate budget and emit an IRC warning to the

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -21,6 +21,7 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import type { GhCommit } from './github-api.js'
 import { GhPluginBase } from './base.js'
+import { formatReadFailureNote } from './backoff.js'
 
 export interface CommitWatchEntry {
   repo: string
@@ -179,6 +180,9 @@ export class GitHubCommitsPlugin extends GhPluginBase {
       return { state, taggedEvents, channels: [] }
     }
 
+    const now = Date.now()
+    if (this.breakerOpen(now)) return this.breakerSkipResult(prevState ?? { commits: {} }, config)
+
     // Sequential — typical configs have <5 entries; serializing keeps WARN
     // log lines next to the entry they're about.
     for (const entry of watched) {
@@ -186,13 +190,20 @@ export class GitHubCommitsPlugin extends GhPluginBase {
       const branch = entry.branch ?? DEFAULT_BRANCH
       const channels = entry.channels?.length ? [...entry.channels] : [projectChannel]
 
-      let commits: GhCommit[]
-      try {
-        commits = await this.client.fetchRepoCommits(entry.repo, branch, entry.path, PER_PAGE)
-      } catch (e) {
-        this.log(`github-commits: fetch failed for ${key}: ${e}\n`)
+      const r = await this.readEntry(
+        key,
+        channels,
+        formatReadFailureNote(this.name, key, `unwatch ${formatRepoSpec(entry.repo, entry.branch, entry.path)}`),
+        () => this.client.fetchRepoCommits(entry.repo, branch, entry.path, PER_PAGE),
+        now,
+      )
+      // Rate-limit discards this tick's partial work and preserves prev state.
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { commits: {} }, projectChannel, config)
+      if (!r.ok) {
+        taggedEvents.push(...r.events)
         continue
       }
+      const commits = r.value
 
       if (commits.length === 0) continue
       const newest = commits[0]
@@ -237,7 +248,8 @@ export class GitHubCommitsPlugin extends GhPluginBase {
       state.commits[key] = { last_sha: newest.sha }
     }
 
+    this.breakerReset(now)
     taggedEvents.push(...await this.observeRateLimit(projectChannel))
-    return { state, taggedEvents, channels: this.desiredChannels(config) }
+    return { state, taggedEvents, channels: this.rememberChannels(this.desiredChannels(config)) }
   }
 }

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -1,11 +1,13 @@
 import type { PluginLogger } from '../../plugin.js'
 import type { RateLimitInfo } from '../_rate-limit.js'
 
-// Stderr patterns we retry on. 404/401/422/etc. throw on first attempt; 422
-// is logged verbatim in spawnGh so a 422-as-race shows in dispatcher logs.
+// Stderr patterns we retry on (network/server transients). Rate-limit and 404
+// are handled separately below — rate-limit fails fast (the caller's breaker
+// owns the backoff schedule); 404 retries on a shorter base since an upstream
+// edge-flap clears on the next request, not after server recovery. 422 throws
+// on first attempt, logged verbatim so a 422-as-race shows in dispatcher logs.
 const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
   { re: /HTTP 5\d\d/i, label: 'http-5xx' },
-  { re: /HTTP 429/i, label: 'http-429-rate-limit' },
   { re: /\btimed out\b/i, label: 'timeout' },
   { re: /\bcontext deadline exceeded\b/i, label: 'timeout' },
   { re: /\bi\/o timeout\b/i, label: 'timeout' },
@@ -17,12 +19,36 @@ const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
 ]
 
 const HTTP_422 = /HTTP 422/i
+const HTTP_404 = /HTTP 404/i
+const HTTP_403 = /HTTP 403/i
+const HTTP_429 = /HTTP 429/i
+const RATE_LIMIT_MSG = /rate limit|secondary rate/i
 
 function classifyTransient(stderr: string): string | null {
   for (const { re, label } of TRANSIENT_PATTERNS) {
     if (re.test(stderr)) return label
   }
   return null
+}
+
+// Rate-limit = HTTP 429, or HTTP 403 carrying a rate-limit message (primary or
+// secondary). A 403 without that message is a real permission error and is left
+// to throw. Retrying a rate-limit in-loop just burns the budget we're limited
+// on, so spawnGh fails fast and the caller's breaker applies the backoff.
+function isRateLimitStderr(stderr: string): boolean {
+  if (HTTP_429.test(stderr)) return true
+  return HTTP_403.test(stderr) && RATE_LIMIT_MSG.test(stderr)
+}
+
+export function isRateLimitError(e: unknown): boolean {
+  return e instanceof GhError && isRateLimitStderr(e.stderr)
+}
+
+// Expected/transient gh error class the per-entry readEntry path skips with a
+// cooldown-gated note (vs failing the whole tick): a 404 that survived its
+// retries, or any network/server transient that exhausted its retries.
+export function isExpectedTransientError(e: unknown): boolean {
+  return e instanceof GhError && (HTTP_404.test(e.stderr) || classifyTransient(e.stderr) != null)
 }
 
 export class GhError extends Error {
@@ -67,6 +93,7 @@ export interface SpawnDeps {
   sleep?: (ms: number) => Promise<void>
   attempts?: number          // total tries; default 3
   baseMs?: number            // first backoff; default 1000
+  notFoundBaseMs?: number    // first backoff for 404 retries; default 250
   jitterFraction?: number    // backoff *= 1 + random()*jitterFraction; default 0.5
   random?: () => number      // 0..1; default Math.random
   exec?: (args: string[]) => Promise<unknown>  // default runGhOnce
@@ -79,6 +106,7 @@ export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown>
   const log = deps.log
   const totalAttempts = deps.attempts ?? 3
   const baseMs = deps.baseMs ?? 1000
+  const notFoundBaseMs = deps.notFoundBaseMs ?? 250
   const jitterFraction = deps.jitterFraction ?? 0.5
   const random = deps.random ?? Math.random
   const exec = deps.exec ?? runGhOnce
@@ -90,18 +118,25 @@ export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown>
     } catch (e) {
       // Non-GhError = upstream contract bug (missing gh, spawn crash) — bypass retry.
       if (!(e instanceof GhError)) throw e
+      // Rate-limit fails fast — retrying burns the budget we're limited on. The
+      // caller's breaker owns the minutes-scale backoff.
+      if (isRateLimitStderr(e.stderr)) {
+        log(`gh-retry: ${cmd} rate-limited (not retried here) — stderr verbatim:\n${e.stderr}\n`)
+        throw e
+      }
       if (HTTP_422.test(e.stderr)) {
         log(`gh-retry: ${cmd} HTTP 422 (non-transient) — stderr verbatim:\n${e.stderr}\n`)
         throw e
       }
-      const matched = classifyTransient(e.stderr)
+      const is404 = HTTP_404.test(e.stderr)
+      const matched = is404 ? 'http-404' : classifyTransient(e.stderr)
       if (!matched) throw e
       const attemptNum = i + 1
       if (attemptNum >= totalAttempts) {
         log(`gh-retry: ${cmd} exhausted ${totalAttempts} attempts (matched=${matched}) — stderr verbatim:\n${e.stderr}\n`)
         throw new GhError(`${e.message}\n(after ${totalAttempts} retries)`, e.stderr, totalAttempts)
       }
-      const backoff = Math.round(baseMs * Math.pow(2, i) * (1 + random() * jitterFraction))
+      const backoff = Math.round((is404 ? notFoundBaseMs : baseMs) * Math.pow(2, i) * (1 + random() * jitterFraction))
       log(`gh-retry: ${cmd} attempt ${attemptNum}/${totalAttempts} matched=${matched}, backoff ${backoff}ms before next try\n`)
       await sleep(backoff)
     }

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -3,6 +3,7 @@ import { resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, issueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
+import { formatReadFailureNote } from './backoff.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
@@ -32,21 +33,46 @@ export class GitHubIssuesPlugin extends GhBase {
     const agentLogins = this.agentLogins(config)
 
     const prev = prevState as IssuePluginState | null
+    const now = Date.now()
+    if (this.breakerOpen(now)) return this.breakerSkipResult(prevState ?? { issues: {} }, config)
+
     const scraper = new GhScraper(this.client, agentLogins)
 
     // Scrape in parallel — entries are independent. Preserve config order.
     // prevIssue: undefined = seed; null = new entry; IssueSnap = normal diff.
+    // readEntry returns a discriminated result instead of throwing, so a
+    // rate-limit on one entry doesn't abandon its siblings mid-flight.
     const scraped = await Promise.all(watched.map(async entry => {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevIssue: IssueSnap | null | undefined = prev === null ? undefined : (prev.issues[key] ?? null)
-      const { snap, events } = await scraper.scrapeIssue(repo, number, prevIssue)
-      return { key, snap, events, entryChannels }
+      const r = await this.readEntry(
+        key,
+        [projectChannel],
+        formatReadFailureNote(this.name, key, `unwatch ${number}`),
+        () => scraper.scrapeIssue(repo, number, prevIssue),
+        now,
+      )
+      return { key, prevIssue, entryChannels, r }
     }))
+
+    // Any rate-limit → back off the whole tick; discard partial work, preserve prev.
+    if (scraped.some(s => !s.r.ok && s.r.rateLimited)) {
+      return this.breakerTripResult(now, prevState ?? { issues: {} }, projectChannel, config)
+    }
+    this.breakerReset(now)
 
     const curState: IssuePluginState = { issues: {} }
     const taggedEvents: TaggedEvent[] = []
-    for (const { key, snap, events, entryChannels } of scraped) {
+    for (const { key, prevIssue, entryChannels, r } of scraped) {
+      if (!r.ok) {
+        if (r.rateLimited) continue  // unreachable: any rate-limit returned above; narrows the type
+        // Transient skip: carry the prev snapshot forward, emit the cooldown note.
+        if (prevIssue) curState.issues[key] = prevIssue
+        taggedEvents.push(...r.events)
+        continue
+      }
+      const { snap, events } = r.value
       curState.issues[key] = snap
       const slug = channelSlug(config, snap.repo)
       for (const event of events) {
@@ -70,6 +96,6 @@ export class GitHubIssuesPlugin extends GhBase {
     }
 
     taggedEvents.push(...await this.observeRateLimit(projectChannel))
-    return { state: curState, taggedEvents, channels: this.desiredChannels(config) }
+    return { state: curState, taggedEvents, channels: this.rememberChannels(this.desiredChannels(config)) }
   }
 }

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -30,6 +30,10 @@ export class GitHubIssuesPlugin extends GhBase {
     const projectChannel = resolveProjectChannel(config)
     const defaultRepo = config.repo
     const watched = this.watched(config)
+    // Nothing to poll: return before the breaker block. An idle plugin must not
+    // reset the shared breaker — at half-open it would clear a sibling's
+    // in-flight escalation every tick and pin the backoff at its first window.
+    if (!watched.length) return { state: prevState ?? { issues: {} }, taggedEvents: [], channels: [] }
     const agentLogins = this.agentLogins(config)
 
     const prev = prevState as IssuePluginState | null
@@ -49,7 +53,7 @@ export class GitHubIssuesPlugin extends GhBase {
       const r = await this.readEntry(
         key,
         [projectChannel],
-        formatReadFailureNote(this.name, key, `unwatch ${number}`),
+        formatReadFailureNote(this.name, key, `unwatch ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`),
         () => scraper.scrapeIssue(repo, number, prevIssue),
         now,
       )

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -201,7 +201,11 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
     this.breakerReset(now)
     const state: NewIssuesPluginState = { repos: nextRepos }
     taggedEvents.push(...await this.observeRateLimit(projectChannel))
-    return { state, taggedEvents, channels: this.rememberChannels([]) }
+    // [] (not rememberChannels): membership is config-static (per-entry channels
+    // join at boot, project channel unioned by the orchestrator), so there's
+    // nothing dynamic to replay — skipChannels falls back to desiredChannels
+    // while the breaker is open.
+    return { state, taggedEvents, channels: [] }
   }
 }
 

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -16,6 +16,7 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import { labelNames, type GhRepoIssue } from './github-api.js'
 import { GhPluginBase } from './base.js'
+import { formatReadFailureNote } from './backoff.js'
 
 export interface NewIssuesWatchEntry {
   repo: string
@@ -138,6 +139,10 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
     const watchEntries = slice.watched ?? []
     if (!watchEntries.length) return { state: prevState ?? { repos: {} }, taggedEvents: [], channels: [] }
 
+    const projectChannel = resolveProjectChannel(config)
+    const now = Date.now()
+    if (this.breakerOpen(now)) return this.breakerSkipResult(prevState ?? { repos: {} }, config)
+
     // Re-seed cleanly from older shapes (no `repos` key).
     const prev = (prevState != null && typeof prevState === 'object' && 'repos' in prevState)
       ? prevState as NewIssuesPluginState
@@ -150,9 +155,23 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
       const { repo, channels } = entry
       const announcementChannels = channels?.length
         ? [...channels]
-        : [resolveProjectChannel(config)]
+        : [projectChannel]
 
-      const issues = await this.client.fetchRepoOpenIssues(repo)
+      const r = await this.readEntry(
+        repo,
+        announcementChannels,
+        formatReadFailureNote(this.name, repo, `unwatch new-issues ${repo}`),
+        () => this.client.fetchRepoOpenIssues(repo),
+        now,
+      )
+      // Rate-limit discards this tick's partial work and preserves prev state —
+      // the next clean tick re-reads and announces what's genuinely new.
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config)
+      if (!r.ok) {
+        taggedEvents.push(...r.events)
+        continue
+      }
+      const issues = r.value
       const currentNumbers = issues
         .map(i => i.number)
         .filter((n): n is number => n != null)
@@ -179,9 +198,10 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
       nextRepos[repo] = [...seen].sort((a, b) => a - b)
     }
 
+    this.breakerReset(now)
     const state: NewIssuesPluginState = { repos: nextRepos }
-    taggedEvents.push(...await this.observeRateLimit(resolveProjectChannel(config)))
-    return { state, taggedEvents, channels: [] }
+    taggedEvents.push(...await this.observeRateLimit(projectChannel))
+    return { state, taggedEvents, channels: this.rememberChannels([]) }
   }
 }
 

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -213,7 +213,11 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
     this.breakerReset(now)
     const state: NewPrsPluginState = { repos: nextRepos }
     taggedEvents.push(...await this.observeRateLimit(projectChannel))
-    return { state, taggedEvents, channels: this.rememberChannels([]) }
+    // [] (not rememberChannels): membership is config-static (per-entry channels
+    // join at boot, project channel unioned by the orchestrator), so there's
+    // nothing dynamic to replay — skipChannels falls back to desiredChannels
+    // while the breaker is open.
+    return { state, taggedEvents, channels: [] }
   }
 }
 

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -20,6 +20,7 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import { labelNames, type GhRepoPr } from './github-api.js'
 import { GhPluginBase } from './base.js'
+import { formatReadFailureNote } from './backoff.js'
 
 export interface NewPrsWatchEntry {
   repo: string
@@ -142,6 +143,10 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
     const watchEntries = slice.watched ?? []
     if (!watchEntries.length) return { state: prevState ?? { repos: {} }, taggedEvents: [], channels: [] }
 
+    const projectChannel = resolveProjectChannel(config)
+    const now = Date.now()
+    if (this.breakerOpen(now)) return this.breakerSkipResult(prevState ?? { repos: {} }, config)
+
     // Re-seed cleanly from older shapes (no `repos` key).
     const prev = (prevState != null && typeof prevState === 'object' && 'repos' in prevState)
       ? prevState as NewPrsPluginState
@@ -155,9 +160,23 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
       const { repo, channels } = entry
       const announcementChannels = channels?.length
         ? [...channels]
-        : [resolveProjectChannel(config)]
+        : [projectChannel]
 
-      const prs = await this.client.fetchRepoOpenPrs(repo)
+      const r = await this.readEntry(
+        repo,
+        announcementChannels,
+        formatReadFailureNote(this.name, repo, `unwatch new-prs ${repo}`),
+        () => this.client.fetchRepoOpenPrs(repo),
+        now,
+      )
+      // Rate-limit discards this tick's partial work and preserves prev state —
+      // the next clean tick re-reads and announces what's genuinely new.
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config)
+      if (!r.ok) {
+        taggedEvents.push(...r.events)
+        continue
+      }
+      const prs = r.value
 
       // All open PR numbers go into state — prevents replay if agent_logins changes.
       const currentNumbers = prs
@@ -191,9 +210,10 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
       nextRepos[repo] = [...seen].sort((a, b) => a - b)
     }
 
+    this.breakerReset(now)
     const state: NewPrsPluginState = { repos: nextRepos }
-    taggedEvents.push(...await this.observeRateLimit(resolveProjectChannel(config)))
-    return { state, taggedEvents, channels: [] }
+    taggedEvents.push(...await this.observeRateLimit(projectChannel))
+    return { state, taggedEvents, channels: this.rememberChannels([]) }
   }
 }
 

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -3,6 +3,7 @@ import { resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, isMultiRepo, issueChannel, linearIssueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginLogger, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
+import { formatReadFailureNote } from './backoff.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
@@ -162,17 +163,34 @@ export class GitHubPrsPlugin extends GhBase {
     const agentLogins = this.agentLogins(config)
 
     const prev = prevState as PrPluginState | null
+    const now = Date.now()
+    if (this.breakerOpen(now)) return this.breakerSkipResult(prevState ?? { prs: {} }, config)
+
     const scraper = new GhScraper(this.client, agentLogins)
 
     // Scrape in parallel — entries are independent. Preserve config order.
     // prevPr: undefined = seed; null = new entry; PrSnap = normal diff.
+    // readEntry returns a discriminated result instead of throwing, so a
+    // rate-limit on one entry doesn't abandon its siblings mid-flight.
     const scraped = await Promise.all(watched.map(async entry => {
       const { repo, number, channels: entryChannels } = resolveRepoEntry(entry, defaultRepo)
       const key = `${repo}#${number}`
       const prevPr: PrSnap | null | undefined = prev === null ? undefined : (prev.prs[key] ?? null)
-      const { snap, events } = await scraper.scrapePr(repo, number, prevPr)
-      return { key, snap, events, entryChannels }
+      const r = await this.readEntry(
+        key,
+        [projectChannel],
+        formatReadFailureNote(this.name, key, `unwatch pr ${number}`),
+        () => scraper.scrapePr(repo, number, prevPr),
+        now,
+      )
+      return { key, prevPr, entryChannels, r }
     }))
+
+    // Any rate-limit → back off the whole tick; discard partial work, preserve prev.
+    if (scraped.some(s => !s.r.ok && s.r.rateLimited)) {
+      return this.breakerTripResult(now, prevState ?? { prs: {} }, projectChannel, config)
+    }
+    this.breakerReset(now)
 
     // Cross-link lookup: one batched Linear query per tick, gated on a
     // non-empty linear-issues watch set. Empty-watched is the load-bearing
@@ -187,7 +205,22 @@ export class GitHubPrsPlugin extends GhBase {
     // Static (config) + dynamic (linked-issues from scrape). Each linked-issue
     // channel is slugged against its own repo (closures can cross repos).
     const channels = new Set<string>(this.desiredChannels(config))
-    for (const { key, snap, events, entryChannels } of scraped) {
+    for (const { key, prevPr, entryChannels, r } of scraped) {
+      if (!r.ok) {
+        if (r.rateLimited) continue  // unreachable: any rate-limit returned above; narrows the type
+        // Transient skip: carry the prev snapshot forward and re-add its dynamic
+        // linked-issue/Linear channels so a flap doesn't PART them (the PR's own
+        // #issue-N is already in desiredChannels). Emit the cooldown note.
+        if (prevPr) {
+          curState.prs[key] = prevPr
+          const { routable } = GitHubPrsPlugin.partitionLinked(config, prevPr.repo, prevPr.linked_issues ?? [])
+          for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+          for (const ident of linkMap.get(prKey(prevPr.repo, prevPr.number)) ?? []) channels.add(linearIssueChannel(project, ident))
+        }
+        taggedEvents.push(...r.events)
+        continue
+      }
+      const { snap, events } = r.value
       curState.prs[key] = snap
       const { routable, dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
       for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
@@ -233,6 +266,6 @@ export class GitHubPrsPlugin extends GhBase {
     }
 
     taggedEvents.push(...await this.observeRateLimit(projectChannel))
-    return { state: curState, taggedEvents, channels: [...channels] }
+    return { state: curState, taggedEvents, channels: this.rememberChannels([...channels]) }
   }
 }

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -160,6 +160,10 @@ export class GitHubPrsPlugin extends GhBase {
     const projectChannel = resolveProjectChannel(config)
     const defaultRepo = config.repo
     const watched = this.watched(config)
+    // Nothing to poll: return before the breaker block. An idle plugin must not
+    // reset the shared breaker — at half-open it would clear a sibling's
+    // in-flight escalation every tick and pin the backoff at its first window.
+    if (!watched.length) return { state: prevState ?? { prs: {} }, taggedEvents: [], channels: [] }
     const agentLogins = this.agentLogins(config)
 
     const prev = prevState as PrPluginState | null
@@ -179,7 +183,7 @@ export class GitHubPrsPlugin extends GhBase {
       const r = await this.readEntry(
         key,
         [projectChannel],
-        formatReadFailureNote(this.name, key, `unwatch pr ${number}`),
+        formatReadFailureNote(this.name, key, `unwatch pr ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`),
         () => scraper.scrapePr(repo, number, prevPr),
         now,
       )


### PR DESCRIPTION
Closes #506
Closes #529
Closes #590

## Summary

The dispatcher's GH polling layer crashed the whole tick and re-fired `[dispatcher_error]` every 60s on transient/expected GH errors. This gives the three transient classes a non-flooding path each:

- **brief blip → retry.** HTTP 404 joins the `spawnGh` retry set on a shorter backoff base (an edge-flap clears on the next request, not after server recovery). The retry also disambiguates: a transient 404 succeeds on retry; a real one (deleted/renamed repo) falls through. (#590)
- **sustained flap → per-entry cooldown-gated skip.** New `GhPluginBase.readEntry` wraps every watched-entry read across all five GH plugins, returning a discriminated result instead of throwing. A 404/transient past retries skips just that entry (prev snapshot carried forward) and emits one hedged note per entry per 10m; sibling entries keep their events. (#529 + #590)
- **rate-limit → shared circuit breaker.** 429 and 403-with-rate-limit no longer retry in `spawnGh` (that just burns the budget we're limited on); they trip a class-static breaker that quiets all GH polling for an escalating 5/10/30/60m window and emits one backoff notice per escalation. (#506)

422 and non-GhError still throw — real defects keep surfacing as `[dispatcher_error]`. `readEntry` returns (not throws) the expected classes so the prs/issues `Promise.all` over entries never abandons a sibling read on the first error (bun 1.2.20 late-rejection footgun).

**On #529 hedging:** HTTP 404 can't distinguish a deleted repo from an edge-flap (confirmed by the live ~50-65% flap during this work), so the note hedges ("deleted/renamed or GH flaking") and recurrence is the persistence signal — a real deletion keeps warning every window, a one-off warns once. This is a justified deviation from Linear #516's confident "renamed or deleted" wording (Linear's GraphQL team-node absence is unambiguous; HTTP 404 isn't). Recovery commands are pulled verbatim from each plugin's own help text.

## Test plan

- [x] `bun run typecheck` + `bun run lint` clean
- [x] `bun test` — 957 pass, 0 fail
- [x] spawnGh: 404 retries-then-succeeds on shorter base, 404 exhausts, 429/403-rate-limit not retried + classified, 403-non-rate-limit throws once
- [x] breaker state machine: 5/10/30/60 escalation + cap, concurrent-trip and recovered-sibling-reset guards, half-open recovery
- [x] readEntry through plugin runTicks: success / transient-skip+hedged-note / rate-limit→breaker-notice + next-tick-quiet / 422→throws / non-GhError→throws / missing-repo cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)