### PR TITLE
bump version to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
v0.8.5 patch release — pre-0.9 robustness.

- PR #592: permbot fails loud on IRC registration failure (432 → deny-closed with cause + nicklen hint); raises nicklen 32→48 in etc/ergo.yaml. fixes the carrot perm-swallow bug. closes #591.
- PR #593: dispatcher GH call layer degrades gracefully on transient errors — 404 retry, per-entry cooldown skip, escalating rate-limit breaker (5/10/30/60m). closes #506, #529, #590.