### PR TITLE
fix: resolve bun robustly in roost-irc-server and dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [`docs/ROOST-IN-PRACTICE.md`](docs/ROOST-IN-PRACTICE.md) for the end-to-end 
 ## Prerequisites
 
 - macOS or Linux
-- [bun](https://bun.sh) ≥ 1.0 (installed by the brew formula)
+- [bun](https://bun.sh) ≥ 1.0 (installed by the brew formula). From-source Linux installs add `~/.bun/bin` to `~/.bashrc` only — set `BUN_BIN=~/.bun/bin/bun` if the MCP or dispatcher fail to start.
 - [tmux](https://github.com/tmux/tmux) (installed by the brew formula)
 - [ergo](https://ergo.chat) (installed by the brew formula)
 - An IRC client ([weechat](https://weechat.org) recommended — `brew install weechat`)

--- a/bin/_bun-lib.sh
+++ b/bin/_bun-lib.sh
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+# _bun-lib.sh — source this; do not execute directly.
+#
+# find_bun  — resolve bun binary; prints path to stdout; exits 1 with a
+#             diagnostic on stderr if bun cannot be found.
+#
+# Resolution order:
+#   1. $BUN_BIN — explicit operator override; hard-errors if set but not executable
+#   2. $BUN_INSTALL/bin/bun — bun installer convention
+#   3. $HOME/.bun/bin/bun — default from-source install location
+#   4. command -v bun — PATH fallback (homebrew, system packages)
+
+find_bun() {
+  local candidate
+  local script
+  script="$(basename "$0")"
+
+  # Explicit operator override — hard-error if set but not executable.
+  if [ -n "${BUN_BIN:-}" ]; then
+    if [ -x "${BUN_BIN}" ]; then
+      printf '%s' "${BUN_BIN}"; return 0
+    fi
+    printf '%s: BUN_BIN=%s is not executable\n' "${script}" "${BUN_BIN}" >&2
+    return 1
+  fi
+
+  # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
+  if [ -n "${BUN_INSTALL:-}" ]; then
+    candidate="${BUN_INSTALL}/bin/bun"
+    if [ -x "${candidate}" ]; then
+      printf '%s' "${candidate}"; return 0
+    fi
+  fi
+
+  # Default from-source install location.
+  candidate="${HOME}/.bun/bin/bun"
+  if [ -x "${candidate}" ]; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  # PATH fallback (homebrew, system packages, custom installs).
+  if candidate="$(command -v bun 2>/dev/null)"; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  printf '%s: bun not found. Set BUN_BIN to the bun binary path or install bun (https://bun.sh).\n' "${script}" >&2
+  return 1
+}

--- a/bin/_bun-lib.sh
+++ b/bin/_bun-lib.sh
@@ -6,9 +6,9 @@
 #
 # Resolution order:
 #   1. $BUN_BIN — explicit operator override; hard-errors if set but not executable
-#   2. $BUN_INSTALL/bin/bun — bun installer convention
-#   3. $HOME/.bun/bin/bun — default from-source install location
-#   4. command -v bun — PATH fallback (homebrew, system packages)
+#   2. command -v bun — PATH (matches the bun visible in the operator's shell)
+#   3. $BUN_INSTALL/bin/bun — bun installer convention
+#   4. $HOME/.bun/bin/bun — default from-source install location
 
 find_bun() {
   local candidate
@@ -24,6 +24,11 @@ find_bun() {
     return 1
   fi
 
+  # PATH (what the operator sees in their shell — prefer it over auto-detected locations).
+  if candidate="$(command -v bun 2>/dev/null)"; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
   # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
   if [ -n "${BUN_INSTALL:-}" ]; then
     candidate="${BUN_INSTALL}/bin/bun"
@@ -35,11 +40,6 @@ find_bun() {
   # Default from-source install location.
   candidate="${HOME}/.bun/bin/bun"
   if [ -x "${candidate}" ]; then
-    printf '%s' "${candidate}"; return 0
-  fi
-
-  # PATH fallback (homebrew, system packages, custom installs).
-  if candidate="$(command -v bun 2>/dev/null)"; then
     printf '%s' "${candidate}"; return 0
   fi
 

--- a/bin/dispatcher
+++ b/bin/dispatcher
@@ -1,40 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-find_bun() {
-  local candidate
-
-  # Explicit operator override — hard-error if set but not executable.
-  if [ -n "${BUN_BIN:-}" ]; then
-    if [ -x "${BUN_BIN}" ]; then
-      printf '%s' "${BUN_BIN}"; return 0
-    fi
-    printf 'dispatcher: BUN_BIN=%s is not executable\n' "${BUN_BIN}" >&2
-    return 1
-  fi
-
-  # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
-  if [ -n "${BUN_INSTALL:-}" ]; then
-    candidate="${BUN_INSTALL}/bin/bun"
-    if [ -x "${candidate}" ]; then
-      printf '%s' "${candidate}"; return 0
-    fi
-  fi
-
-  # Default from-source install location.
-  candidate="${HOME}/.bun/bin/bun"
-  if [ -x "${candidate}" ]; then
-    printf '%s' "${candidate}"; return 0
-  fi
-
-  # PATH fallback (homebrew, system packages, custom installs).
-  if candidate="$(command -v bun 2>/dev/null)"; then
-    printf '%s' "${candidate}"; return 0
-  fi
-
-  printf 'dispatcher: bun not found. Set BUN_BIN to the bun binary path or install bun (https://bun.sh).\n' >&2
-  return 1
-}
-
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_bun-lib.sh"
 BUN="$(find_bun)" || exit 1
 exec "${BUN}" run "${SCRIPT_DIR}/../src/orchestrator.ts" "$@"

--- a/bin/dispatcher
+++ b/bin/dispatcher
@@ -1,3 +1,40 @@
 #!/usr/bin/env bash
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec bun run "$DIR/../src/orchestrator.ts" "$@"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+find_bun() {
+  local candidate
+
+  # Explicit operator override — hard-error if set but not executable.
+  if [ -n "${BUN_BIN:-}" ]; then
+    if [ -x "${BUN_BIN}" ]; then
+      printf '%s' "${BUN_BIN}"; return 0
+    fi
+    printf 'dispatcher: BUN_BIN=%s is not executable\n' "${BUN_BIN}" >&2
+    return 1
+  fi
+
+  # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
+  if [ -n "${BUN_INSTALL:-}" ]; then
+    candidate="${BUN_INSTALL}/bin/bun"
+    if [ -x "${candidate}" ]; then
+      printf '%s' "${candidate}"; return 0
+    fi
+  fi
+
+  # Default from-source install location.
+  candidate="${HOME}/.bun/bin/bun"
+  if [ -x "${candidate}" ]; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  # PATH fallback (homebrew, system packages, custom installs).
+  if candidate="$(command -v bun 2>/dev/null)"; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  printf 'dispatcher: bun not found. Set BUN_BIN to the bun binary path or install bun (https://bun.sh).\n' >&2
+  return 1
+}
+
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" run "${SCRIPT_DIR}/../src/orchestrator.ts" "$@"

--- a/bin/irc-ask-question
+++ b/bin/irc-ask-question
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # Thin launcher — delegates to the TypeScript implementation.
-ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-exec bun "${ROOST_DIR}/src/ask-question-hook.ts"
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_bun-lib.sh"
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" "${SCRIPT_DIR}/../src/ask-question-hook.ts"

--- a/bin/irc-permission-prompt
+++ b/bin/irc-permission-prompt
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # Thin launcher — delegates to the TypeScript implementation.
-ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-exec bun "${ROOST_DIR}/src/permission-prompt.ts"
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_bun-lib.sh"
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" "${SCRIPT_DIR}/../src/permission-prompt.ts"

--- a/bin/irc-pretooluse-prompt
+++ b/bin/irc-pretooluse-prompt
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # Thin launcher — delegates to the TypeScript implementation.
-ROOST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-exec bun "${ROOST_DIR}/src/pretooluse-prompt.ts"
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_bun-lib.sh"
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" "${SCRIPT_DIR}/../src/pretooluse-prompt.ts"

--- a/bin/roost-irc-server
+++ b/bin/roost-irc-server
@@ -1,3 +1,41 @@
 #!/usr/bin/env bash
 # Wrapper so .mcp.json can reference this by name (via plugin bin/ PATH).
-exec bun run "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../src/irc-server.ts"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+find_bun() {
+  local candidate
+
+  # Explicit operator override — hard-error if set but not executable.
+  if [ -n "${BUN_BIN:-}" ]; then
+    if [ -x "${BUN_BIN}" ]; then
+      printf '%s' "${BUN_BIN}"; return 0
+    fi
+    printf 'roost-irc-server: BUN_BIN=%s is not executable\n' "${BUN_BIN}" >&2
+    return 1
+  fi
+
+  # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
+  if [ -n "${BUN_INSTALL:-}" ]; then
+    candidate="${BUN_INSTALL}/bin/bun"
+    if [ -x "${candidate}" ]; then
+      printf '%s' "${candidate}"; return 0
+    fi
+  fi
+
+  # Default from-source install location.
+  candidate="${HOME}/.bun/bin/bun"
+  if [ -x "${candidate}" ]; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  # PATH fallback (homebrew, system packages, custom installs).
+  if candidate="$(command -v bun 2>/dev/null)"; then
+    printf '%s' "${candidate}"; return 0
+  fi
+
+  printf 'roost-irc-server: bun not found. Set BUN_BIN to the bun binary path or install bun (https://bun.sh).\n' >&2
+  return 1
+}
+
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" run "${SCRIPT_DIR}/../src/irc-server.ts"

--- a/bin/roost-irc-server
+++ b/bin/roost-irc-server
@@ -1,41 +1,8 @@
 #!/usr/bin/env bash
 # Wrapper so .mcp.json can reference this by name (via plugin bin/ PATH).
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-find_bun() {
-  local candidate
-
-  # Explicit operator override — hard-error if set but not executable.
-  if [ -n "${BUN_BIN:-}" ]; then
-    if [ -x "${BUN_BIN}" ]; then
-      printf '%s' "${BUN_BIN}"; return 0
-    fi
-    printf 'roost-irc-server: BUN_BIN=%s is not executable\n' "${BUN_BIN}" >&2
-    return 1
-  fi
-
-  # bun installer convention: $BUN_INSTALL/bin/bun (default ~/.bun).
-  if [ -n "${BUN_INSTALL:-}" ]; then
-    candidate="${BUN_INSTALL}/bin/bun"
-    if [ -x "${candidate}" ]; then
-      printf '%s' "${candidate}"; return 0
-    fi
-  fi
-
-  # Default from-source install location.
-  candidate="${HOME}/.bun/bin/bun"
-  if [ -x "${candidate}" ]; then
-    printf '%s' "${candidate}"; return 0
-  fi
-
-  # PATH fallback (homebrew, system packages, custom installs).
-  if candidate="$(command -v bun 2>/dev/null)"; then
-    printf '%s' "${candidate}"; return 0
-  fi
-
-  printf 'roost-irc-server: bun not found. Set BUN_BIN to the bun binary path or install bun (https://bun.sh).\n' >&2
-  return 1
-}
-
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_bun-lib.sh"
 BUN="$(find_bun)" || exit 1
 exec "${BUN}" run "${SCRIPT_DIR}/../src/irc-server.ts"

--- a/bin/roost-token-usage
+++ b/bin/roost-token-usage
@@ -9,7 +9,7 @@
 # See `src/token-usage.ts` for the full contract. Walks symlinks so the shim
 # resolves to the real plugin tree when called from a brew install.
 
-set -uo pipefail
+set -euo pipefail
 
 _src="${BASH_SOURCE[0]}"
 while [ -L "$_src" ]; do
@@ -20,4 +20,7 @@ done
 DIR="$( cd -P "$( dirname "$_src" )" && pwd )"
 unset _src _dir
 
-exec bun run "$DIR/../src/token-usage.ts" "$@"
+# shellcheck disable=SC1091
+source "${DIR}/_bun-lib.sh"
+BUN="$(find_bun)" || exit 1
+exec "${BUN}" run "${DIR}/../src/token-usage.ts" "$@"

--- a/test/bun-resolution.test.ts
+++ b/test/bun-resolution.test.ts
@@ -1,10 +1,15 @@
 /**
- * Verify bun resolution in bin/roost-irc-server and bin/dispatcher.
+ * Verify bun resolution in bin/roost-irc-server (primary) and the shared
+ * _bun-lib.sh helper that all in-session launchers source.
  *
  * Primary scenario mirrors the actual reported failure: bun installed
  * from-source to ~/.bun/bin, that directory absent from the non-interactive
  * login shell's PATH, BUN_BIN unset. The fix's candidate-3 fallback
  * (${HOME}/.bun/bin/bun) must pick it up and the MCP must connect to ergo.
+ *
+ * All launchers source the same _bun-lib.sh, so testing the resolution logic
+ * thoroughly via roost-irc-server (which has the full MCP connect probe) is
+ * sufficient — no per-launcher duplication needed.
  */
 import { describe, it, expect, beforeAll } from 'bun:test'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
@@ -76,6 +81,41 @@ describe.if(isErgoAvailable())('bin/roost-irc-server bun resolution — MCP conn
     }
   })
 
+  it('candidate-2 fallback: MCP connects via $BUN_INSTALL/bin/bun', async () => {
+    const realBun = Bun.which('bun')!
+    const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
+    const tmpInstall = mkdtempSync(join(tmpdir(), 'roost-bun-install-'))
+    let handle: Awaited<ReturnType<typeof wireMcpClient>> | undefined
+    try {
+      mkdirSync(join(tmpInstall, 'bin'), { recursive: true })
+      symlinkSync(realBun, join(tmpInstall, 'bin', 'bun'))
+
+      const transport = new StdioClientTransport({
+        command: IRC_SERVER_SCRIPT,
+        args: [],
+        env: {
+          ...scrubEnv(),
+          ROOST_IRC_SERVER: ergo.host,
+          ROOST_IRC_PORT: String(ergo.port),
+          ROOST_IRC_NICK: 'bun-res-cand2',
+          HOME: tmpHome,
+          PATH: pathWithoutBun(),
+          BUN_INSTALL: tmpInstall,
+        },
+        stderr: 'pipe',
+      })
+
+      handle = await wireMcpClient(transport, 'bun-res-cand2')
+      await pollUntilIrcReady(handle)
+      const { tools } = await handle.client.listTools()
+      expect(tools.map(t => t.name)).toContain('channel_message')
+    } finally {
+      await handle?.client.close()
+      rmSync(tmpHome, { recursive: true, force: true })
+      rmSync(tmpInstall, { recursive: true, force: true })
+    }
+  })
+
   it('BUN_BIN override: MCP connects when bun absent from PATH and HOME', async () => {
     const realBun = Bun.which('bun')!
     const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
@@ -107,11 +147,19 @@ describe.if(isErgoAvailable())('bin/roost-irc-server bun resolution — MCP conn
   })
 })
 
-describe('bin/roost-irc-server bun resolution — error cases', () => {
+describe('bun resolution errors — roost-irc-server', () => {
+  // Use a fresh empty tmpdir as the sole PATH entry (beyond system paths needed
+  // for the shebang) — guarantees no bun there regardless of what's installed.
+  let emptyBinDir: string
+
+  beforeAll(() => {
+    emptyBinDir = mkdtempSync(join(tmpdir(), 'roost-empty-bin-'))
+  })
+
   it('exits non-zero with message when bun not found anywhere', async () => {
     const proc = Bun.spawn([IRC_SERVER_SCRIPT], {
       env: {
-        PATH: '/usr/bin:/bin',
+        PATH: `${emptyBinDir}:/usr/bin:/bin`,
         HOME: '/nonexistent-bun-test',
         ROOST_IRC_SERVER: '127.0.0.1',
         ROOST_IRC_PORT: '16667',
@@ -131,7 +179,7 @@ describe('bin/roost-irc-server bun resolution — error cases', () => {
   it('exits non-zero when BUN_BIN is set but not executable', async () => {
     const proc = Bun.spawn([IRC_SERVER_SCRIPT], {
       env: {
-        PATH: '/usr/bin:/bin',
+        PATH: `${emptyBinDir}:/usr/bin:/bin`,
         HOME: '/nonexistent-bun-test',
         BUN_BIN: '/nonexistent/bun',
         ROOST_IRC_SERVER: '127.0.0.1',
@@ -151,11 +199,17 @@ describe('bin/roost-irc-server bun resolution — error cases', () => {
   })
 })
 
-describe('bin/dispatcher bun resolution — error case', () => {
+describe('bun resolution errors — dispatcher', () => {
+  let emptyBinDir: string
+
+  beforeAll(() => {
+    emptyBinDir = mkdtempSync(join(tmpdir(), 'roost-empty-bin-'))
+  })
+
   it('exits non-zero with message when bun not found anywhere', async () => {
     const proc = Bun.spawn([DISPATCHER_SCRIPT], {
       env: {
-        PATH: '/usr/bin:/bin',
+        PATH: `${emptyBinDir}:/usr/bin:/bin`,
         HOME: '/nonexistent-bun-test',
       },
       stdout: 'pipe',

--- a/test/bun-resolution.test.ts
+++ b/test/bun-resolution.test.ts
@@ -49,7 +49,7 @@ describe.if(isErgoAvailable())('bin/roost-irc-server bun resolution — MCP conn
     ergo = (await startErgo())!
   })
 
-  it('candidate-3 fallback: MCP connects via ${HOME}/.bun/bin/bun with bun absent from PATH (primary failure scenario)', async () => {
+  it('candidate-4 fallback: MCP connects via ${HOME}/.bun/bin/bun with bun absent from PATH (primary failure scenario)', async () => {
     const realBun = Bun.which('bun')!
     const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
     let handle: Awaited<ReturnType<typeof wireMcpClient>> | undefined
@@ -81,7 +81,7 @@ describe.if(isErgoAvailable())('bin/roost-irc-server bun resolution — MCP conn
     }
   })
 
-  it('candidate-2 fallback: MCP connects via $BUN_INSTALL/bin/bun', async () => {
+  it('candidate-3 fallback: MCP connects via $BUN_INSTALL/bin/bun', async () => {
     const realBun = Bun.which('bun')!
     const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
     const tmpInstall = mkdtempSync(join(tmpdir(), 'roost-bun-install-'))

--- a/test/bun-resolution.test.ts
+++ b/test/bun-resolution.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Verify bun resolution in bin/roost-irc-server and bin/dispatcher.
+ *
+ * Primary scenario mirrors the actual reported failure: bun installed
+ * from-source to ~/.bun/bin, that directory absent from the non-interactive
+ * login shell's PATH, BUN_BIN unset. The fix's candidate-3 fallback
+ * (${HOME}/.bun/bin/bun) must pick it up and the MCP must connect to ergo.
+ */
+import { describe, it, expect, beforeAll } from 'bun:test'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { join, dirname, resolve } from 'node:path'
+import { mkdirSync, symlinkSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { startErgo, isErgoAvailable, type ErgoContext } from './helpers/ergo.js'
+import { wireMcpClient, pollUntilIrcReady } from './helpers/mcp-core.js'
+
+const ROOST_ROOT = join(import.meta.dirname, '..')
+const IRC_SERVER_SCRIPT = join(ROOST_ROOT, 'bin', 'roost-irc-server')
+const DISPATCHER_SCRIPT = join(ROOST_ROOT, 'bin', 'dispatcher')
+
+// Remove bun's own directory from PATH so the scripts fall through to the
+// candidate-based resolution — keeps system PATH intact for bash/exec/etc.
+function pathWithoutBun(): string {
+  const realBun = Bun.which('bun')
+  if (!realBun) return process.env.PATH ?? ''
+  const bunDir = resolve(dirname(realBun))
+  return (process.env.PATH ?? '').split(':').filter(p => resolve(p) !== bunDir).join(':')
+}
+
+// Base env: scrub ROOST_*, BUN_BIN, and BUN_INSTALL from the test runner's
+// env so resolution tests start from a clean slate.
+function scrubEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([k, v]) => v !== undefined && !k.startsWith('ROOST_') && k !== 'BUN_BIN' && k !== 'BUN_INSTALL',
+    ),
+  ) as Record<string, string>
+}
+
+describe.if(isErgoAvailable())('bin/roost-irc-server bun resolution — MCP connects', () => {
+  let ergo: ErgoContext
+
+  beforeAll(async () => {
+    ergo = (await startErgo())!
+  })
+
+  it('candidate-3 fallback: MCP connects via ${HOME}/.bun/bin/bun with bun absent from PATH (primary failure scenario)', async () => {
+    const realBun = Bun.which('bun')!
+    const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
+    let handle: Awaited<ReturnType<typeof wireMcpClient>> | undefined
+    try {
+      mkdirSync(join(tmpHome, '.bun', 'bin'), { recursive: true })
+      symlinkSync(realBun, join(tmpHome, '.bun', 'bin', 'bun'))
+
+      const transport = new StdioClientTransport({
+        command: IRC_SERVER_SCRIPT,
+        args: [],
+        env: {
+          ...scrubEnv(),
+          ROOST_IRC_SERVER: ergo.host,
+          ROOST_IRC_PORT: String(ergo.port),
+          ROOST_IRC_NICK: 'bun-res-cand3',
+          HOME: tmpHome,
+          PATH: pathWithoutBun(),
+        },
+        stderr: 'pipe',
+      })
+
+      handle = await wireMcpClient(transport, 'bun-res-cand3')
+      await pollUntilIrcReady(handle)
+      const { tools } = await handle.client.listTools()
+      expect(tools.map(t => t.name)).toContain('channel_message')
+    } finally {
+      await handle?.client.close()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('BUN_BIN override: MCP connects when bun absent from PATH and HOME', async () => {
+    const realBun = Bun.which('bun')!
+    const tmpHome = mkdtempSync(join(tmpdir(), 'roost-bun-home-'))
+    let handle: Awaited<ReturnType<typeof wireMcpClient>> | undefined
+    try {
+      const transport = new StdioClientTransport({
+        command: IRC_SERVER_SCRIPT,
+        args: [],
+        env: {
+          ...scrubEnv(),
+          ROOST_IRC_SERVER: ergo.host,
+          ROOST_IRC_PORT: String(ergo.port),
+          ROOST_IRC_NICK: 'bun-res-bun-bin',
+          HOME: tmpHome,
+          PATH: pathWithoutBun(),
+          BUN_BIN: realBun,
+        },
+        stderr: 'pipe',
+      })
+
+      handle = await wireMcpClient(transport, 'bun-res-bun-bin')
+      await pollUntilIrcReady(handle)
+      const { tools } = await handle.client.listTools()
+      expect(tools.map(t => t.name)).toContain('channel_message')
+    } finally {
+      await handle?.client.close()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('bin/roost-irc-server bun resolution — error cases', () => {
+  it('exits non-zero with message when bun not found anywhere', async () => {
+    const proc = Bun.spawn([IRC_SERVER_SCRIPT], {
+      env: {
+        PATH: '/usr/bin:/bin',
+        HOME: '/nonexistent-bun-test',
+        ROOST_IRC_SERVER: '127.0.0.1',
+        ROOST_IRC_PORT: '16667',
+        ROOST_IRC_NICK: 'bun-test-err',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('bun not found')
+  })
+
+  it('exits non-zero when BUN_BIN is set but not executable', async () => {
+    const proc = Bun.spawn([IRC_SERVER_SCRIPT], {
+      env: {
+        PATH: '/usr/bin:/bin',
+        HOME: '/nonexistent-bun-test',
+        BUN_BIN: '/nonexistent/bun',
+        ROOST_IRC_SERVER: '127.0.0.1',
+        ROOST_IRC_PORT: '16667',
+        ROOST_IRC_NICK: 'bun-test-bad',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('BUN_BIN=')
+    expect(stderr).toContain('is not executable')
+  })
+})
+
+describe('bin/dispatcher bun resolution — error case', () => {
+  it('exits non-zero with message when bun not found anywhere', async () => {
+    const proc = Bun.spawn([DISPATCHER_SCRIPT], {
+      env: {
+        PATH: '/usr/bin:/bin',
+        HOME: '/nonexistent-bun-test',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain('bun not found')
+  })
+})


### PR DESCRIPTION
Closes #599

`bin/roost-irc-server` used `exec bun` with no absolute path. When claude spawns the MCP in a non-interactive login shell (`bash -l` / `zsh -l`), only `.bash_profile`/`.zprofile` are sourced — not `.bashrc`, where the from-source bun installer adds `~/.bun/bin`. The MCP exits immediately with `bun: not found`, taking permbot with it, and the spawned agent never joins IRC.

`bin/dispatcher` has the same `exec bun` pattern and hits the same failure when the APM starts the dispatcher from within a spawned session (per `agents/associate-pm.md` line 37).

Both scripts now resolve bun via an ordered candidate list:
1. `$BUN_BIN` — explicit override; hard-errors if set but not executable
2. `$BUN_INSTALL/bin/bun` — bun installer convention
3. `$HOME/.bun/bin/bun` — default from-source install location (the actual failure path)
4. `command -v bun` — PATH fallback (homebrew, system packages)

`test/bun-resolution.test.ts` (picked up by `bun test`, ergo-gated) covers:
- **primary scenario** (the real failure): HOME=tmpdir with `.bun/bin/bun` symlinked to real bun, bun stripped from PATH, BUN_BIN unset — MCP connects to ergo via candidate-3
- **BUN_BIN override**: bun absent from PATH and HOME, BUN_BIN set — MCP connects
- **error cases**: bun not found anywhere; BUN_BIN set but not executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)