### PR TITLE
perm-irc ↔ Claude Code divergence audit (#604)

### DIFF
--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -1,261 +1,218 @@
 # perm-irc ↔ Claude Code divergence audit — June 2026
 
-Investigation for #604. Hypothesis: `--perm-irc` fires IRC permission
-prompts for actions Claude Code's auto permission-mode would grant on its
-own — spurious prompts that add friction without safety. Pairs with #598
-(the cd-multi-positional specific) and gates the 0.8.6 perm batch.
+Investigation for #604. Hypothesis: `--perm-irc` fires IRC permission prompts
+for actions Claude Code's auto permission-mode would grant on its own. Pairs
+with #598 and gates the 0.8.6 perm batch.
 
-Verdict: **hypothesis confirmed, but the mechanism is narrower and more
-interesting than "the classifier is too aggressive."** Two real over-fires,
-both in roost's own `classifyBash` heuristic (not CC). The shell-operators
-seed repro does *not* reproduce as written. And the survey surfaced a more
-dangerous divergence in the opposite direction: **under-fires** where roost
-misses a CC bashMissKind, leaving a headless worker hung on a terminal prompt
-it can't see.
+This audit had two passes. The first read CC's classifier out of the 2.1.196
+binary and *inferred* behavior. Alex (#609) asked the literal operational
+question that inference can't answer, so the second pass ran real auto-mode
+Claude Code sessions and *observed* it. The observed pass is authoritative and
+is first below. The binary pass follows, corrected where observation overturned
+it — the gap between the two is itself a finding.
 
-## The headline finding: pass-through ≠ auto-grant
+## Empirical answer (authoritative)
 
-The intuitive fix for a spurious prompt is "make roost stop classifying it /
-let it pass through." **That's wrong here**, and it reframes the whole batch.
+**Q1: in auto mode, does Claude Code still stop and request permission for a
+classified bash expression? NO.**
+**Q2: with auto mode + perm-irc, does roost relay permission requests that are
+unnecessary because auto mode already let the agent proceed? YES.**
 
-`classifyBash` (in `src/pretooluse-prompt.ts`) exists for one reason: CC's
-structural Bash safety analyzer escalates certain command *shapes*
-(`bashMissKind`s) to a prompt that **bypasses the PermissionRequest hook and
-shows terminal-only** — a `--perm-irc` worker never sees it and hangs. roost's
-PreToolUse hook fires *before* that analyzer and routes those shapes to IRC
-instead. So for a true bashMissKind, "pass through" doesn't mean "auto-grant"
-— it means "let CC show a terminal prompt nobody can answer." Hang.
+Evidence below. Method: real `claude --permission-mode auto` 2.1.196 sessions
+(the production config — the box's user settings already set `defaultMode:
+auto`, which is what an everyday roost worker runs), with observation-only hooks
+that log the exact tool-call and whether CC routed a prompt, plus a positive
+control proving the harness detects a real block. The subshell shape was run in
+both headless and an interactive tmux session and behaved identically (auto-
+granted, no prompt), so a "no prompt" result is a genuine grant, not a headless
+artifact.
 
-The actual lever is the other branch of the hook: it can `emit('allow')`
-directly (see `pretooluse-prompt.ts:133`, used at `:212`). CC 2.1.196 has a
-**"simple read-only command" fast-path** that auto-allows read-only commands
-(rejecting only subshells and `&`). Where a command is read-only and CC would
-auto-grant, roost should `emit('allow')` from the PreToolUse hook too — not
-ask the operator, and not pass through. The fix for the over-fires is *teach
-roost to grant the read-only subset*, not *narrow what it catches*.
+### Probe A — what CC's *native* auto mode does (no roost classifier present)
 
-## Verdicts (read these first)
+Each command's exact tool-call string was confirmed verbatim from the
+PreToolUse log before reading the result (the inner model passed every shape
+unmodified, including subshell parens and newlines).
 
-| # | Divergence | Direction | roost | CC 2.1.196 | Verdict |
-|---|---|---|---|---|---|
-| O1 | multi-line `cd /p\n<readonly>` (#598) | over-fire | `cd-multi-positional` → IRC ask | per-statement parse → read-only → **allow** | **bug — roost** |
-| O2 | `cd <dir>; <readonly>` / `cd <dir> && <readonly>` | over-fire | `cd-compound` → IRC ask | read-only tail, not write/redirect/git → **allow** | **bug — roost** |
-| U1 | `cd $(...)` / runtime-determined path target | under-fire | `null` → pass through → hang | `shell-expansion` bashMissKind → ask | **bug — roost (hang risk)** |
-| U2 | `cmd > /dev/tcp/...` (net redirect) | under-fire | `null` → hang | `net-redirect` bashMissKind → ask | **bug — roost (hang risk)** |
-| U3 | path-command flags (`cp --target-directory=…`) | under-fire | `null` → hang | `flag-validation` bashMissKind → ask | **bug — roost (hang risk)** |
-| U4 | redirect target is expansion (`> $(...)`) | under-fire | `null` → hang | `shell-expansion`/`redirected_statement` → ask | **bug — roost (hang risk)** |
-| M1 | non-cd subshell `(grep …)` / command group `{ ls; }` | match | `shell-operators` → IRC ask | `shell-operators` (`hasSubshell`/`hasCommandGroup`) → ask | correct |
-| M2 | `cd … && git …`, `cd … && <write/redirect>` | match | `cd-compound` → IRC ask | `cd-git-compound` / `cd-compound-write/-redirect` → ask | correct |
-| M3 | real zsh `cd OLD NEW` | match | `cd-multi-positional` → IRC ask | `cd-multi-positional` → ask | correct |
-| M4 | bare `&&`/`\|` pipeline of read-only cmds | match | `null` → pass through | read-only fast-path → **allow** | correct (both grant) |
+| command (tool-call verbatim) | shape roost's classifyBash would flag | CC auto mode (observed) |
+|---|---|---|
+| `(echo TOK)` | shell-operators | executed, no prompt |
+| `cd /tmp /usr` | cd-multi-positional | ran (errored at bash level), no prompt |
+| `cd /tmp; echo TOK` | cd-compound | executed, no prompt |
+| `echo TOK` (control) | none (`null`) | executed, no prompt |
+| `rm -rf <throwaway-dir>` (**positive control**) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (no exec)** |
 
-O1–O4 noise, U1–U4 hang. The under-fires matter more: a spurious prompt costs
-an operator ack; a missed bashMissKind hangs the worker silently for minutes
-(the original worker-202 failure this hook was built to prevent).
+The positive control is load-bearing: `--permission-mode default` blocks the
+`rm` (the harness sees a real non-execution) while `auto` runs it. So (a) the
+harness can detect a block when one occurs, and (b) `--permission-mode` genuinely
+overrides the settings default. PermissionRequest never fired in auto mode for
+any row. So: **auto mode grants the classified shapes outright, no prompt.**
 
-## How the perm-irc path decides to fire
+### Probe B — what roost adds on top (real `classifyBash` PreToolUse hook)
 
-Under `--perm-irc`, `bin/roost` wires two hooks sharing one permbot socket
-(`bin/roost:822-864`):
+The real `src/pretooluse-prompt.ts` hook, driven against a permbot stub, for
+shapes Probe A just proved auto mode grants:
 
-- **PermissionRequest** → `src/permission-prompt.ts`. Catches CC's *normal*
-  rule-based permission prompts (the ones CC routes through the hook). Routes
-  to IRC via the permbot.
-- **PreToolUse:Bash** → `src/pretooluse-prompt.ts`. Catches the *structural
-  analyzer* escalations that bypass PermissionRequest. `classifyBash(command)`
-  returns a `BashMissKind` or `null`; non-null → route to IRC, `null` → pass
-  through to the normal pipeline.
+| command | relayed to operator? | trigger shown | hook decision |
+|---|---|---|---|
+| `cd /tmp; ls` | **YES** | `safety-check trigger: cd-compound` | allow |
+| `(echo hi)` | **YES** | `safety-check trigger: shell-operators` | allow |
+| `cd /tmp\necho hi\nls` (#598 shape) | **YES** | `safety-check trigger: cd-multi-positional` | allow |
+| `echo hi` (control) | NO (passes through) | — | — |
 
-`src/permbot.ts` is pure routing — no second classifier. So **the entire
-firing decision for the structural path lives in `classifyBash`**, ~65 lines
-of regexes approximating CC's analyzer.
+roost's PreToolUse classifier fires *upstream* of CC's permission decision and
+relays the flagged shapes to the operator. Auto mode would have granted all
+three silently. The plain read-only control passes through (classifyBash returns
+`null`), so the relay is specifically the classifier's doing. That is the
+spurious prompt in Q2, and it lives entirely in `classifyBash`, not in CC.
 
-The key architectural distinction for separating real gaps from non-gaps:
+### The inversion: classifyBash keys on syntax, which tracks neither danger nor hang-risk
 
-- A command CC escalates via a **bashMissKind** (structural analyzer) bypasses
-  PermissionRequest → terminal-only → roost's *PreToolUse* hook must catch it,
-  or the worker hangs.
-- A command CC escalates via a **normal rule-based ask** (e.g. an un-allowlisted
-  `cmd &`, which CC flags "not read-only" but not as a bashMissKind) goes
-  through PermissionRequest → roost's *PermissionRequest* hook already catches
-  it. No hang, no classifyBash gap.
+Same exported `classifyBash`, two batteries:
 
-That's why `&` (background) is *not* on the under-fire list even though roost's
-`classifyBash` returns `null` for it: it's a normal ask, covered by the other
-hook.
+- **Over-fire — benign-but-complex syntax, flagged + relayed:** `cd /tmp; ls`
+  (cd-compound), `(grep -rn foo src/)` (shell-operators), the multi-line `cd`
+  block (cd-multi-positional). All three *executed* in Probe A, so they are not
+  hang-risks. Pure friction.
+- **Under-fire — dangerous-but-simple syntax, returns `null` (not flagged):**
+  all nine of `rm -rf /important`, `rm -rf ~/work`, `dd if=/dev/zero of=/dev/diskN`,
+  `curl … | sh`, `git push --force`, `chmod -R 777 /etc`, `mv ~/.ssh/id_rsa /tmp/x`,
+  `echo pwned > ~/.bashrc`, `kill -9 -1`. Zero flagged.
 
-## How CC 2.1.196 actually behaves (grounded, not inferred)
+Syntax (has a subshell / two cd args / a `;`) correlates with neither what's
+destructive nor what hangs. So classifyBash over-fires on harmless commands and
+under-fires on destructive ones at the same time.
 
-roost's `classifyBash` comments cite Claude Code **2.1.139**; the installed
-binary is **2.1.196**. Per §#449 (verify the real system, don't infer from a
-doc) I extracted the live classifier from the binary
-(`~/.local/share/claude/versions/2.1.196`, a Bun-compiled Mach-O with the JS
-bundle embedded; `strings` + windowed grep). Load-bearing facts:
+### This is false safety, not just friction
+
+The prompts don't merely waste an ack. They actively mislead. An operator
+watching `cd-compound` and `shell-operators` prompts roll past reasonably
+concludes that the dangerous stuff is being gated too. It isn't: `rm -rf`, `dd`,
+`chmod -R 777`, `curl … | sh` sail through silently in auto mode. The relay
+manufactures confidence that a safety layer exists where there is none.
+
+## The lesson: what the analyzer DECIDES vs what auto mode ENFORCES
+
+The binary pass (below) established that CC's structural analyzer *returns*
+`{behavior:"ask", bashMissKind:…}` for these shapes, and inferred from that:
+"CC prompts → a `--perm-irc` worker would hang → roost's relay prevents the
+hang → pass-through ≠ auto-grant." Observation overturned that premise: auto
+mode does **not** enforce the analyzer's syntactic "ask" as a prompt. It grants
+the command. The analyzer's decision and the mode's enforcement are two
+different things, and a binary-only read conflated them and got the conclusion
+backwards.
+
+That miss is worth preserving rather than editing away. It is the §449/§591
+trap in the wild: reading what a system *says it decides* is not the same as
+observing what it *does* in the configuration the question is actually asked
+against. The fix for the audit was to run the real thing.
+
+## Binary analysis (corrected by observation)
+
+Still-accurate mechanism, useful for whoever writes the fix. Extracted from
+`~/.local/share/claude/versions/2.1.196` (Bun-compiled Mach-O, JS bundle
+embedded; `strings` + windowed grep). roost's `classifyBash` comments cite
+2.1.139; installed is 2.1.196.
+
+These facts hold (they describe what the analyzer computes and what classifyBash
+does, independent of mode enforcement):
 
 1. **CC parses with tree-sitter, per statement.** `U_(command)` calls
-   `HD().parse(e)` and walks the AST, splitting into individual command nodes;
-   `redirected_statement` and compound nodes are descended into. The
-   statement-separator regex is `[;|\n\r]|&&` — **newlines are separators, not
-   flattened.** The cd validator (`E1p`) counts arguments on the *parsed* cd
-   statement.
-
-2. **`shell-operators` fires only on subshell / command group.** The function
-   (`Pkm`): `if (treeSitter ? compoundStructure.hasSubshell ||
-   compoundStructure.hasCommandGroup : U_(command).length > 1)`. With
-   tree-sitter (normal path) bare `&&`/`|` do **not** trigger it. The
-   `U_().length>1` branch is a *parse-failure fallback* only.
-
-3. **The cd-compound family is three kinds, each gated on the tail:**
-   `cd-compound-write` (compound has a write), `cd-compound-redirect` (output
-   redirection), and `cd-git-compound` (git in the compound, plus bare-repo
-   indicator checks). There is **no bashMissKind for `cd <dir>; <readonly>`** —
-   a read-only tail hits the read-only fast-path and is allowed.
-
+   `HD().parse(e)` and walks the AST into command nodes; the statement separator
+   is `[;|\n\r]|&&`. Newlines are separators, not flattened. The cd validator
+   (`E1p`) counts arguments on the *parsed* cd statement.
+2. **CC's `shell-operators` fires only on subshell / command group** (`Pkm`:
+   `treeSitter ? hasSubshell || hasCommandGroup : U_().length>1`). Bare `&&`/`|`
+   don't trigger it on the tree-sitter path.
+3. **CC's cd-compound family is three tail-gated kinds:** `cd-compound-write`,
+   `cd-compound-redirect`, `cd-git-compound`. There is no kind for `cd <dir>;
+   <readonly>`.
 4. **`shell-expansion` and `net-redirect` are real 2.1.196 bashMissKinds** with
-   no analog in roost's table — runtime-determined path targets
-   (command-substitution / untracked variable in a path arg) and
-   `/dev/tcp`-`/dev/udp` redirects, respectively.
+   no analog in roost's table.
+5. **A "simple read-only command" fast-path** auto-allows, rejecting only
+   subshells and `&`.
 
-5. **"simple read-only command" fast-path** auto-allows; it rejects only
-   "contains a subshell" and "`&` defers execution past approval-time checks."
+What observation **corrected**:
 
-## Findings
+- **"pass-through ≠ auto-grant / hang-risk" (the old headline): WRONG for auto
+  mode.** Probe A: pass-through *does* auto-grant these shapes; no hang occurs.
+  The hang premise came from 2.1.139-era reasoning and does not hold for a
+  2.1.196 auto worker.
+- **The old "under-fire = hang" rows (shell-expansion, net-redirect, path-command
+  flag-validation, redirect-target expansion): NOT hangs in auto mode.** Auto
+  mode grants, it doesn't prompt, so a missed bashMissKind is a missed *grant*,
+  not a hang. The real under-fire is danger (below), not the bashMissKind set
+  difference.
+- **The old "correct mirror" rows: also over-fire in auto mode.** They were
+  scored "correct" on the assumption CC prompts for them. CC doesn't (in auto
+  mode), so relaying them is friction too.
 
-### O1 — multi-line `cd` over-fires `cd-multi-positional` (this is #598)
+What observation **confirmed**:
 
-```
-cd /path/to/wt
-echo "=== refs ==="
-grep -rn foo src/
-ls -la
-```
+- **#598 is a roost bug, mechanism misdiagnosed.** #598 reports the classifier
+  "flattens newlines→spaces." It doesn't. roost's `cd-multi-positional` regex
+  (`pretooluse-prompt.ts:94`) uses `\s+`, and `\s` matches `\n`, so
+  `cd /path\necho` reads as `cd` with two positional args. No flatten step
+  exists (the only flatten is `clip()` in the display path,
+  `permission-prompt.ts:51`, cosmetic and downstream). The proposed fix (a)
+  "preserve newlines" does nothing for the false flag; (b) "split on statement
+  separators" is the real fix. #598 is **one instance** of the syntax-keying
+  over-fire, not the whole story.
 
-roost → `cd-multi-positional` → IRC ask. Reproduce:
-`bun -e 'import {classifyBash} from "./src/pretooluse-prompt.ts"; console.log(classifyBash("cd /p\necho x\nls"))'`.
+## Recommendation
 
-**Mechanism — and #598 has it wrong.** #598 reports "the permission classifier
-flattens newlines→spaces before classifying." It doesn't. roost's
-`cd-multi-positional` regex (`pretooluse-prompt.ts:94`) uses `\s+` between the
-cd target and the next token, and **`\s` matches `\n`**. So `cd /path\necho`
-reads as `cd` with two positional args (`/path`, `echo`) with no flattening
-step anywhere. The only flattening in roost is `clip()` in the *display* path
-(`permission-prompt.ts:51`) — cosmetic, downstream of classification.
+Two distinct failure modes. Same root cause (syntax is the wrong axis), but they
+are not one finding and should not be filed as one.
 
-CC handles the same input correctly (tree-sitter splits the statements; cd has
-one arg) and the block is read-only → CC **auto-allows**. So this is a pure
-roost false positive: spurious prompt, and not even hang-prevention, since CC
-would have granted.
+**1. Friction — over-fire on benign syntax. Alex's original hypothesis,
+confirmed.** classifyBash relays harmless shapes (cd-compound, shell-operators,
+cd-multi-positional including #598) that auto mode would grant. Cleanup-priority.
+The narrow version is #598; the general version is "stop flagging benign
+syntactic shapes."
 
-**#598 verdict: confirmed real, mechanism misdiagnosed, fix re-scoped.**
-- The proposed fix (a) "preserve newlines in classify+display" does *not* fix
-  the false flag — roost already has the newlines; `\s+` eats them. It only
-  fixes the cosmetic display.
-- The proposed fix (b) "treat newlines as statement separators in the
-  classifier" is the real fix: split on `[;|\n\r]|&&` (mirror CC) before
-  counting cd args, or tighten the `cd-multi-positional` regex so it can't
-  cross a newline/operator. Better still, per the headline, also `emit('allow')`
-  for the read-only result.
+**2. Latent safety gap — under-fire on destructive commands. New, and more
+serious than the friction.** The nine destructive commands tested fall through
+`classifyBash` (`null`) and, for the one safe to run live (`rm -rf
+<throwaway>`), through auto mode unprompted. An auto worker can run those today
+with no human in the loop, while the friction prompts imply otherwise (false
+safety). This warrants its own follow-up at higher priority than the friction
+cleanup.
 
-### O2 — `cd-compound` over-fires on read-only tails
+**Bounded claim (don't over-read).** What's tested: all nine return `null` from
+classifyBash; auto mode executed `rm -rf <throwaway>` with no prompt while
+default blocked it. What's *not* tested: I did not live-run the other eight
+(they're destructive/networked), and I did not probe CC's critical-path guards
+(no `rm -rf /`). The binary shows CC retains some native critical-dir rm checks
+I did not map. So the precise statement is "these nine are ungated by
+classifyBash, and auto mode ran the one destructive command I tested
+unprompted," not "auto mode runs everything."
 
-`cd /tmp; ls`, `cd src && grep -rn foo .`, `cd logs && tail -n 50 app.log` →
-roost `cd-compound` → IRC ask. CC escalates cd-compound **only** for write,
-output redirection, or git tails (finding #3 above); a read-only tail is
-allowed. (Note the alternation is `&&`/`||`/`;` only — a single-`|` read-only
-tail like `cd build | wc -l` is *not* matched and correctly passes through,
-M4-shaped. The over-fire is the `;`/`&&`/`||` read-only tails.)
+**Fix axis.** Re-key on what a command *does* (destructive / irreversible /
+exfiltrating), not on its *syntax*. Syntax tracks neither.
 
-roost collapses CC's three distinct kinds into one detector
-(`pretooluse-prompt.ts:100`) that fires on `cd … (&&|\|\||;)` regardless of the
-tail. The git/write/redirect tails are correct mirrors (M2); the read-only
-tails are the over-fire. **Fix:** gate roost's `cd-compound` on the tail
-containing a write/redirect/git — or, simpler and aligned with the headline,
-`emit('allow')` when the compound is entirely read-only.
-
-### U1–U4 — under-fires: bashMissKinds roost misses (hang risk)
-
-These are the dangerous ones. CC 2.1.196 escalates them via a bashMissKind
-(bypassing PermissionRequest → terminal-only); roost's `classifyBash` returns
-`null` → passes through → the worker hangs on a prompt it can't see.
-
-- **U1 `shell-expansion`** — `cd $(git rev-parse --show-toplevel)`, and likely
-  bare `cd $VAR` with an untracked variable. roost has no detector for a
-  runtime-determined path target.
-- **U2 `net-redirect`** — `echo x > /dev/tcp/host/80`. No roost analog.
-- **U3 `flag-validation` on path-commands** — `cp a b --target-directory=/tmp`.
-  roost's `flag-validation` (`pretooluse-prompt.ts:117`) only matches the
-  *wrapper* set `env|timeout|xargs|nice|nohup` with `--chdir`-shaped flags; CC's
-  applies to path-commands (cd/cp/mv) with flags like `--target-directory`.
-  Different surfaces — roost misses CC's.
-- **U4 redirect-target expansion** — `cat foo > $(somecmd)`. CC flags the
-  runtime-determined redirect target; roost only catches the cd-compound
-  redirect variant.
-
-**Confidence / caveat.** U1–U4 are confirmed as real 2.1.196 bashMissKinds in
-the binary, and roost demonstrably returns `null` for them. The hang
-*prediction* rests on one load-bearing assumption carried from the 2.1.139 era:
-that bashMissKind "ask"s still bypass the PermissionRequest hook in 2.1.196. I
-could not verify the bypass statically. **The fix PR should behaviorally
-confirm** (run 2.1.196 on one U-case under `--perm-irc`, observe hang vs IRC
-route) before committing detectors — cheap, and it pins the assumption the
-whole hook rests on.
-
-### M-rows — correct mirrors (no action)
-
-shell-operators on a non-cd subshell/group (M1 — `(grep …)`, `{ ls; }`),
-cd-compound on git/write/redirect tails (M2), real `cd OLD NEW` (M3), and
-read-only pipelines passing through (M4) all match CC 2.1.196. (Detector
-ordering wrinkle: a subshell whose first token is `cd` — `(cd /tmp && ls)` —
-trips `cd-compound` first, since `CD_START` includes `(` and the cd-compound
-check precedes shell-operators. Still routes to IRC, so the verdict is
-unaffected; the M1 example is deliberately non-cd to keep it exact.) **The
-shell-operators seed repro in #604's comment does not
-reproduce as written**: `echo "…" && grep … | head` has no subshell/group, so
-roost returns `null` and CC's read-only fast-path allows it — neither prompts.
-The real observed command must have contained a top-level `(…)`/`{…}` (which
-*is* a correct route — CC would have shown a terminal prompt). The operator's
-"fired purely on the `&&`/`|`" reading is the misattribution; the trigger was
-the subshell.
-
-## Recommendations: bug vs intended
-
-**Intended, leave alone:** M1–M4. roost correctly mirrors CC; routing these to
-IRC is the hook doing its job (the alternative is a hang).
-
-**Bugs to fix (over-fire, noise):**
-- O1 (#598): fix `cd-multi-positional` to not cross statement separators.
-  Re-scope #598 — the "flatten" framing and the "preserve newlines" fix are
-  both wrong; this is a roost regex bug.
-- O2: gate `cd-compound` on a write/redirect/git tail.
-- Both O1 and O2 are best fixed by adding a **read-only fast-path that
-  `emit('allow')`s** — same shape as CC's, and it generalizes beyond these two
-  to any future read-only shape that trips a shape detector.
-
-**Bugs to fix (under-fire, hang — higher severity):**
-- U1–U4: add detectors for `shell-expansion`, `net-redirect`,
-  path-command `flag-validation`, and redirect-target expansion, after
-  behaviorally confirming the bypass assumption (see U-caveat).
-
-**Sibling structuring for the batch.** The over-fires and under-fires share one
-root cause: roost's `classifyBash` is a **hand-rolled regex approximation of a
-tree-sitter analyzer**, frozen at 2.1.139, and CC has since drifted (new kinds,
-the read-only fast-path, the three-way cd-compound split). The durable fix is
-to (a) add the read-only fast-path, (b) realign the detector set to 2.1.196's
-bashMissKinds, and (c) add a version-drift tripwire (the existing
-one-example-per-kind test is good but only catches *renames*, not *new* kinds —
-consider a periodic re-extraction check). #598 is one symptom; O2/U1–U4 are
-its siblings and belong in the same realignment, not separate one-off patches.
+**Design call for Alex, not a foregone fix.** Whether roost *should* add a
+danger gate at all is a product decision and partly CC's job (CC owns the
+permission model; roost shouldn't reimplement it). The audit's job is to show
+the current classifier gives false safety on the danger axis and friction on the
+syntax axis. If a gate is wanted, it must key on danger; if not, classifyBash's
+syntactic flagging should be dropped or narrowed so it stops implying a gate
+that isn't there.
 
 ## Reproducibility
 
-roost side is deterministic — every table row is a one-liner against the
-exported `classifyBash`:
+roost side is deterministic — every classifyBash claim is a one-liner:
 
 ```
 bun -e 'import {classifyBash} from "./src/pretooluse-prompt.ts"; console.log(classifyBash(<command>))'
 ```
 
-CC side was read from the 2.1.196 binary (function names minified: `U_` =
-statement splitter, `E1p` = path-command/cd validator, `Pkm` = shell-operators,
-`iBa`/`aBa` = sed). The U-row hang predictions are the only claims not yet
-behaviorally confirmed; flagged inline.
+CC side: Probe A ran real `claude --permission-mode auto` (and `default`/`plan`
+for controls) 2.1.196 sessions with two observation hooks — a PreToolUse:Bash
+logger that passes through, and a PermissionRequest logger that emits allow — in
+a clean cwd with roost's env stripped, so the inner session uses only the probe
+hooks. Each row confirmed the logged tool-call matched the intended expression
+before the result was read. The subshell shape was cross-checked in both
+headless `claude -p` and interactive tmux and agreed. Probe B drove the real
+`src/pretooluse-prompt.ts` against a logging permbot stub. The harness lives in the session scratchpad
+(observation hooks, settings, headless/interactive drivers, Probe B script);
+the binary-extraction function names are `U_` (splitter), `E1p` (cd/path
+validator), `Pkm` (shell-operators), `iBa`/`aBa` (sed).

--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -1,0 +1,253 @@
+# perm-irc ↔ Claude Code divergence audit — June 2026
+
+Investigation for #604. Hypothesis: `--perm-irc` fires IRC permission
+prompts for actions Claude Code's auto permission-mode would grant on its
+own — spurious prompts that add friction without safety. Pairs with #598
+(the cd-multi-positional specific) and gates the 0.8.6 perm batch.
+
+Verdict: **hypothesis confirmed, but the mechanism is narrower and more
+interesting than "the classifier is too aggressive."** Two real over-fires,
+both in roost's own `classifyBash` heuristic (not CC). The shell-operators
+seed repro does *not* reproduce as written. And the survey surfaced a more
+dangerous divergence in the opposite direction: **under-fires** where roost
+misses a CC bashMissKind, leaving a headless worker hung on a terminal prompt
+it can't see.
+
+## The headline finding: pass-through ≠ auto-grant
+
+The intuitive fix for a spurious prompt is "make roost stop classifying it /
+let it pass through." **That's wrong here**, and it reframes the whole batch.
+
+`classifyBash` (in `src/pretooluse-prompt.ts`) exists for one reason: CC's
+structural Bash safety analyzer escalates certain command *shapes*
+(`bashMissKind`s) to a prompt that **bypasses the PermissionRequest hook and
+shows terminal-only** — a `--perm-irc` worker never sees it and hangs. roost's
+PreToolUse hook fires *before* that analyzer and routes those shapes to IRC
+instead. So for a true bashMissKind, "pass through" doesn't mean "auto-grant"
+— it means "let CC show a terminal prompt nobody can answer." Hang.
+
+The actual lever is the other branch of the hook: it can `emit('allow')`
+directly (see `pretooluse-prompt.ts:133`, used at `:212`). CC 2.1.196 has a
+**"simple read-only command" fast-path** that auto-allows read-only commands
+(rejecting only subshells and `&`). Where a command is read-only and CC would
+auto-grant, roost should `emit('allow')` from the PreToolUse hook too — not
+ask the operator, and not pass through. The fix for the over-fires is *teach
+roost to grant the read-only subset*, not *narrow what it catches*.
+
+## Verdicts (read these first)
+
+| # | Divergence | Direction | roost | CC 2.1.196 | Verdict |
+|---|---|---|---|---|---|
+| O1 | multi-line `cd /p\n<readonly>` (#598) | over-fire | `cd-multi-positional` → IRC ask | per-statement parse → read-only → **allow** | **bug — roost** |
+| O2 | `cd <dir>; <readonly>` / `cd <dir> && <readonly>` | over-fire | `cd-compound` → IRC ask | read-only tail, not write/redirect/git → **allow** | **bug — roost** |
+| U1 | `cd $(...)` / runtime-determined path target | under-fire | `null` → pass through → hang | `shell-expansion` bashMissKind → ask | **bug — roost (hang risk)** |
+| U2 | `cmd > /dev/tcp/...` (net redirect) | under-fire | `null` → hang | `net-redirect` bashMissKind → ask | **bug — roost (hang risk)** |
+| U3 | path-command flags (`cp --target-directory=…`) | under-fire | `null` → hang | `flag-validation` bashMissKind → ask | **bug — roost (hang risk)** |
+| U4 | redirect target is expansion (`> $(...)`) | under-fire | `null` → hang | `shell-expansion`/`redirected_statement` → ask | **bug — roost (hang risk)** |
+| M1 | subshell `(…)` / command group `{…}` | match | `shell-operators` → IRC ask | `shell-operators` (`hasSubshell`/`hasCommandGroup`) → ask | correct |
+| M2 | `cd … && git …`, `cd … && <write/redirect>` | match | `cd-compound` → IRC ask | `cd-git-compound` / `cd-compound-write/-redirect` → ask | correct |
+| M3 | real zsh `cd OLD NEW` | match | `cd-multi-positional` → IRC ask | `cd-multi-positional` → ask | correct |
+| M4 | bare `&&`/`\|` pipeline of read-only cmds | match | `null` → pass through | read-only fast-path → **allow** | correct (both grant) |
+
+O1–O4 noise, U1–U4 hang. The under-fires matter more: a spurious prompt costs
+an operator ack; a missed bashMissKind hangs the worker silently for minutes
+(the original worker-202 failure this hook was built to prevent).
+
+## How the perm-irc path decides to fire
+
+Under `--perm-irc`, `bin/roost` wires two hooks sharing one permbot socket
+(`bin/roost:822-864`):
+
+- **PermissionRequest** → `src/permission-prompt.ts`. Catches CC's *normal*
+  rule-based permission prompts (the ones CC routes through the hook). Routes
+  to IRC via the permbot.
+- **PreToolUse:Bash** → `src/pretooluse-prompt.ts`. Catches the *structural
+  analyzer* escalations that bypass PermissionRequest. `classifyBash(command)`
+  returns a `BashMissKind` or `null`; non-null → route to IRC, `null` → pass
+  through to the normal pipeline.
+
+`src/permbot.ts` is pure routing — no second classifier. So **the entire
+firing decision for the structural path lives in `classifyBash`**, ~65 lines
+of regexes approximating CC's analyzer.
+
+The key architectural distinction for separating real gaps from non-gaps:
+
+- A command CC escalates via a **bashMissKind** (structural analyzer) bypasses
+  PermissionRequest → terminal-only → roost's *PreToolUse* hook must catch it,
+  or the worker hangs.
+- A command CC escalates via a **normal rule-based ask** (e.g. an un-allowlisted
+  `cmd &`, which CC flags "not read-only" but not as a bashMissKind) goes
+  through PermissionRequest → roost's *PermissionRequest* hook already catches
+  it. No hang, no classifyBash gap.
+
+That's why `&` (background) is *not* on the under-fire list even though roost's
+`classifyBash` returns `null` for it: it's a normal ask, covered by the other
+hook.
+
+## How CC 2.1.196 actually behaves (grounded, not inferred)
+
+roost's `classifyBash` comments cite Claude Code **2.1.139**; the installed
+binary is **2.1.196**. Per §#449 (verify the real system, don't infer from a
+doc) I extracted the live classifier from the binary
+(`~/.local/share/claude/versions/2.1.196`, a Bun-compiled Mach-O with the JS
+bundle embedded; `strings` + windowed grep). Load-bearing facts:
+
+1. **CC parses with tree-sitter, per statement.** `U_(command)` calls
+   `HD().parse(e)` and walks the AST, splitting into individual command nodes;
+   `redirected_statement` and compound nodes are descended into. The
+   statement-separator regex is `[;|\n\r]|&&` — **newlines are separators, not
+   flattened.** The cd validator (`E1p`) counts arguments on the *parsed* cd
+   statement.
+
+2. **`shell-operators` fires only on subshell / command group.** The function
+   (`Pkm`): `if (treeSitter ? compoundStructure.hasSubshell ||
+   compoundStructure.hasCommandGroup : U_(command).length > 1)`. With
+   tree-sitter (normal path) bare `&&`/`|` do **not** trigger it. The
+   `U_().length>1` branch is a *parse-failure fallback* only.
+
+3. **The cd-compound family is three kinds, each gated on the tail:**
+   `cd-compound-write` (compound has a write), `cd-compound-redirect` (output
+   redirection), and `cd-git-compound` (git in the compound, plus bare-repo
+   indicator checks). There is **no bashMissKind for `cd <dir>; <readonly>`** —
+   a read-only tail hits the read-only fast-path and is allowed.
+
+4. **`shell-expansion` and `net-redirect` are real 2.1.196 bashMissKinds** with
+   no analog in roost's table — runtime-determined path targets
+   (command-substitution / untracked variable in a path arg) and
+   `/dev/tcp`-`/dev/udp` redirects, respectively.
+
+5. **"simple read-only command" fast-path** auto-allows; it rejects only
+   "contains a subshell" and "`&` defers execution past approval-time checks."
+
+## Findings
+
+### O1 — multi-line `cd` over-fires `cd-multi-positional` (this is #598)
+
+```
+cd /path/to/wt
+echo "=== refs ==="
+grep -rn foo src/
+ls -la
+```
+
+roost → `cd-multi-positional` → IRC ask. Reproduce:
+`bun -e 'import {classifyBash} from "./src/pretooluse-prompt.ts"; console.log(classifyBash("cd /p\necho x\nls"))'`.
+
+**Mechanism — and #598 has it wrong.** #598 reports "the permission classifier
+flattens newlines→spaces before classifying." It doesn't. roost's
+`cd-multi-positional` regex (`pretooluse-prompt.ts:94`) uses `\s+` between the
+cd target and the next token, and **`\s` matches `\n`**. So `cd /path\necho`
+reads as `cd` with two positional args (`/path`, `echo`) with no flattening
+step anywhere. The only flattening in roost is `clip()` in the *display* path
+(`permission-prompt.ts:51`) — cosmetic, downstream of classification.
+
+CC handles the same input correctly (tree-sitter splits the statements; cd has
+one arg) and the block is read-only → CC **auto-allows**. So this is a pure
+roost false positive: spurious prompt, and not even hang-prevention, since CC
+would have granted.
+
+**#598 verdict: confirmed real, mechanism misdiagnosed, fix re-scoped.**
+- The proposed fix (a) "preserve newlines in classify+display" does *not* fix
+  the false flag — roost already has the newlines; `\s+` eats them. It only
+  fixes the cosmetic display.
+- The proposed fix (b) "treat newlines as statement separators in the
+  classifier" is the real fix: split on `[;|\n\r]|&&` (mirror CC) before
+  counting cd args, or tighten the `cd-multi-positional` regex so it can't
+  cross a newline/operator. Better still, per the headline, also `emit('allow')`
+  for the read-only result.
+
+### O2 — `cd-compound` over-fires on read-only tails
+
+`cd /tmp; ls`, `cd src && grep -rn foo .`, `cd build | wc -l` → roost
+`cd-compound` → IRC ask. CC escalates cd-compound **only** for write, output
+redirection, or git tails (finding #3 above); a read-only tail is allowed.
+
+roost collapses CC's three distinct kinds into one detector
+(`pretooluse-prompt.ts:100`) that fires on `cd … (&&|\|\||;)` regardless of the
+tail. The git/write/redirect tails are correct mirrors (M2); the read-only
+tails are the over-fire. **Fix:** gate roost's `cd-compound` on the tail
+containing a write/redirect/git — or, simpler and aligned with the headline,
+`emit('allow')` when the compound is entirely read-only.
+
+### U1–U4 — under-fires: bashMissKinds roost misses (hang risk)
+
+These are the dangerous ones. CC 2.1.196 escalates them via a bashMissKind
+(bypassing PermissionRequest → terminal-only); roost's `classifyBash` returns
+`null` → passes through → the worker hangs on a prompt it can't see.
+
+- **U1 `shell-expansion`** — `cd $(git rev-parse --show-toplevel)`, and likely
+  bare `cd $VAR` with an untracked variable. roost has no detector for a
+  runtime-determined path target.
+- **U2 `net-redirect`** — `echo x > /dev/tcp/host/80`. No roost analog.
+- **U3 `flag-validation` on path-commands** — `cp a b --target-directory=/tmp`.
+  roost's `flag-validation` (`pretooluse-prompt.ts:117`) only matches the
+  *wrapper* set `env|timeout|xargs|nice|nohup` with `--chdir`-shaped flags; CC's
+  applies to path-commands (cd/cp/mv) with flags like `--target-directory`.
+  Different surfaces — roost misses CC's.
+- **U4 redirect-target expansion** — `cat foo > $(somecmd)`. CC flags the
+  runtime-determined redirect target; roost only catches the cd-compound
+  redirect variant.
+
+**Confidence / caveat.** U1–U4 are confirmed as real 2.1.196 bashMissKinds in
+the binary, and roost demonstrably returns `null` for them. The hang
+*prediction* rests on one load-bearing assumption carried from the 2.1.139 era:
+that bashMissKind "ask"s still bypass the PermissionRequest hook in 2.1.196. I
+could not verify the bypass statically. **The fix PR should behaviorally
+confirm** (run 2.1.196 on one U-case under `--perm-irc`, observe hang vs IRC
+route) before committing detectors — cheap, and it pins the assumption the
+whole hook rests on.
+
+### M-rows — correct mirrors (no action)
+
+shell-operators on subshell/group (M1), cd-compound on git/write/redirect tails
+(M2), real `cd OLD NEW` (M3), and read-only pipelines passing through (M4) all
+match CC 2.1.196. **The shell-operators seed repro in #604's comment does not
+reproduce as written**: `echo "…" && grep … | head` has no subshell/group, so
+roost returns `null` and CC's read-only fast-path allows it — neither prompts.
+The real observed command must have contained a top-level `(…)`/`{…}` (which
+*is* a correct route — CC would have shown a terminal prompt). The operator's
+"fired purely on the `&&`/`|`" reading is the misattribution; the trigger was
+the subshell.
+
+## Recommendations: bug vs intended
+
+**Intended, leave alone:** M1–M4. roost correctly mirrors CC; routing these to
+IRC is the hook doing its job (the alternative is a hang).
+
+**Bugs to fix (over-fire, noise):**
+- O1 (#598): fix `cd-multi-positional` to not cross statement separators.
+  Re-scope #598 — the "flatten" framing and the "preserve newlines" fix are
+  both wrong; this is a roost regex bug.
+- O2: gate `cd-compound` on a write/redirect/git tail.
+- Both O1 and O2 are best fixed by adding a **read-only fast-path that
+  `emit('allow')`s** — same shape as CC's, and it generalizes beyond these two
+  to any future read-only shape that trips a shape detector.
+
+**Bugs to fix (under-fire, hang — higher severity):**
+- U1–U4: add detectors for `shell-expansion`, `net-redirect`,
+  path-command `flag-validation`, and redirect-target expansion, after
+  behaviorally confirming the bypass assumption (see U-caveat).
+
+**Sibling structuring for the batch.** The over-fires and under-fires share one
+root cause: roost's `classifyBash` is a **hand-rolled regex approximation of a
+tree-sitter analyzer**, frozen at 2.1.139, and CC has since drifted (new kinds,
+the read-only fast-path, the three-way cd-compound split). The durable fix is
+to (a) add the read-only fast-path, (b) realign the detector set to 2.1.196's
+bashMissKinds, and (c) add a version-drift tripwire (the existing
+one-example-per-kind test is good but only catches *renames*, not *new* kinds —
+consider a periodic re-extraction check). #598 is one symptom; O2/U1–U4 are
+its siblings and belong in the same realignment, not separate one-off patches.
+
+## Reproducibility
+
+roost side is deterministic — every table row is a one-liner against the
+exported `classifyBash`:
+
+```
+bun -e 'import {classifyBash} from "./src/pretooluse-prompt.ts"; console.log(classifyBash(<command>))'
+```
+
+CC side was read from the 2.1.196 binary (function names minified: `U_` =
+statement splitter, `E1p` = path-command/cd validator, `Pkm` = shell-operators,
+`iBa`/`aBa` = sed). The U-row hang predictions are the only claims not yet
+behaviorally confirmed; flagged inline.

--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -4,6 +4,15 @@ Investigation for #604. Hypothesis: `--perm-irc` fires IRC permission prompts
 for actions Claude Code's auto permission-mode would grant on its own. Pairs
 with #598 and gates the 0.8.6 perm batch.
 
+**Mission anchor — what perm-irc is for.** roost is a *parity relay* for CC's
+blocking permission requests, not a safety tool. The sole goal: when CC would
+block on user input, route it over IRC so an operator can unblock the agent —
+nothing more, nothing less. So the bar is parity. If CC asks, roost relays; if
+CC doesn't ask, roost stays silent. Whether CC's gating is "right" is out of
+scope — roost mirrors it. That makes "the classifier doesn't catch `rm -rf`" a
+non-issue: CC auto-grants it, so roost correctly stays silent. The only defect
+that matters is the inverse — roost relaying what CC would have granted.
+
 This audit had two passes. The first read CC's classifier out of the 2.1.196
 binary and *inferred* behavior. Alex (#609) asked the literal operational
 question that inference can't answer, so the second pass ran real auto-mode
@@ -39,30 +48,21 @@ unmodified, including subshell parens and newlines).
 | `cd /tmp /usr` | cd-multi-positional | ran (errored at bash level), no prompt |
 | `cd /tmp; echo TOK` | cd-compound | executed, no prompt |
 | `echo TOK` (control) | none (`null`) | executed, no prompt |
-| `rm -rf /tmp/<throwaway>` (**positive control**) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (sandbox)** |
-| `touch /tmp/<throwaway>.txt` (write control) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (sandbox)** |
+| `rm -rf /tmp/<throwaway>` (**positive control**) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED** |
 
-The positive control is load-bearing in two ways. First, it proves the harness
-can see a real non-execution: `--permission-mode default` refuses both the `rm`
-and a plain `touch` whose targets sit in `/tmp` (outside the session working dir),
-failing before the marker echo, while `auto` runs both and emits the marker. So
-an auto-mode "no prompt → executed" row is a genuine grant, and `--permission-mode`
-is honored (default behaved like default, not like the box's `defaultMode: auto`).
+The positive control is load-bearing: it proves the harness can see a real
+non-execution. `--permission-mode default` refuses `rm -rf /tmp/<throwaway>`
+(a write outside the session working dir — CC's cwd sandbox, a gate separate
+from the bash permission-request layer) and the marker never prints, while `auto`
+runs it and prints the marker. So an auto-mode "no prompt → executed" row is a
+genuine grant, not the harness being blind, and `--permission-mode` is honored
+(default behaved like default, not like the box's `defaultMode: auto`).
 
-Second — and this is bigger than "the flag overrides the settings default" — the
-gate default enforces here is CC's **cwd sandbox**: it refuses writes outside the
-session working dir (note default still ran the read-only `echo`, so it isn't
-blanket-denying bash). **Auto bypasses that sandbox.** It executed an out-of-cwd
-`rm -rf` and an out-of-cwd `touch` that default refused. So in auto, the
-destructive reach is *not* worktree-local — ops targeting paths outside the
-worktree run too.
-
-The default-mode block also happens *upstream* of the hookable PermissionRequest
-path: CC denies the out-of-cwd op before the hook is reached, so the allow-
-emitting observation hook (see Reproducibility) never sees it. PermissionRequest
-in fact never fired in *any* of the 13 runs, default or auto (see the mechanism
-note below). So: **auto mode grants the classified shapes outright, no prompt**,
-and relaxes the cwd sandbox that default enforces.
+That default-mode block also happened *upstream* of the hookable PermissionRequest
+path, so the allow-emitting observation hook (see Reproducibility) never saw it.
+PermissionRequest in fact never fired in *any* of the 13 runs, default or auto
+(mechanism note below). So: **auto mode grants the classified shapes outright,
+no prompt.**
 
 ### Probe B — what roost adds on top (real `classifyBash` PreToolUse hook)
 
@@ -86,38 +86,32 @@ spurious prompt in Q2, and it lives entirely in `classifyBash`, not in CC.
 
 `--perm-irc` wires two hooks: PreToolUse:Bash (`irc-pretooluse-prompt`, i.e.
 `classifyBash`) and PermissionRequest (`irc-permission-prompt`). Across all 13
-probe runs — read-only, subshell, cd shapes, out-of-cwd `touch`, out-of-cwd
-`rm`, in both default and auto — the PermissionRequest hook never fired for a
-Bash call. CC 2.1.196 gates bash through the PreToolUse/native-analyzer path and
-the cwd sandbox, not through PermissionRequest. So for bash, roost's
-`irc-permission-prompt` is effectively inert: `classifyBash` (PreToolUse) is
-roost's only bash lever, with no PermissionRequest backstop behind it. A fix to
-roost's bash handling changes `classifyBash` or nothing.
+probe runs — read-only, subshell, cd shapes, the `rm` control, in both default
+and auto — the PermissionRequest hook never fired for a Bash call. CC 2.1.196
+routes bash through the PreToolUse/native-analyzer path, not through
+PermissionRequest. So the parity-correct relay — `irc-permission-prompt`, which
+would fire on a real CC block — has nothing to relay for bash in auto mode,
+because CC produces no blocking bash request. The only thing that *does* fire is
+`classifyBash`, which predicts CC's decision from syntax and gets it wrong
+(over-fires). `classifyBash` (PreToolUse) is roost's only active bash lever — a
+fix to roost's bash handling changes `classifyBash` or nothing.
 
-### The inversion: classifyBash keys on syntax, which tracks neither danger nor hang-risk
+### Why classifyBash over-fires: it keys on syntax, not on what CC blocks
 
-Same exported `classifyBash`, two batteries:
+classifyBash decides what to relay from the *shape* of the command, not from
+what CC would actually do with it. So it flags shapes CC auto-grants: `cd /tmp;
+ls` (cd-compound), `(grep -rn foo src/)` (shell-operators), the multi-line `cd`
+block (cd-multi-positional). All three executed in Probe A — CC produced no
+blocking request, yet roost relayed them to the operator. That is the parity
+violation, and it's the whole of the bug.
 
-- **Over-fire — benign-but-complex syntax, flagged + relayed:** `cd /tmp; ls`
-  (cd-compound), `(grep -rn foo src/)` (shell-operators), the multi-line `cd`
-  block (cd-multi-positional). All three *executed* in Probe A, so they are not
-  hang-risks. Pure friction.
-- **Under-fire — dangerous-but-simple syntax, returns `null` (not flagged):**
-  all nine of `rm -rf /important`, `rm -rf ~/work`, `dd if=/dev/zero of=/dev/diskN`,
-  `curl … | sh`, `git push --force`, `chmod -R 777 /etc`, `mv ~/.ssh/id_rsa /tmp/x`,
-  `echo pwned > ~/.bashrc`, `kill -9 -1`. Zero flagged.
-
-Syntax (has a subshell / two cd args / a `;`) correlates with neither what's
-destructive nor what hangs. So classifyBash over-fires on harmless commands and
-under-fires on destructive ones at the same time.
-
-### This is false safety, not just friction
-
-The prompts don't merely waste an ack. They actively mislead. An operator
-watching `cd-compound` and `shell-operators` prompts roll past reasonably
-concludes that the dangerous stuff is being gated too. It isn't: `rm -rf`, `dd`,
-`chmod -R 777`, `curl … | sh` sail through silently in auto mode. The relay
-manufactures confidence that a safety layer exists where there is none.
+The same syntax-keying leaves classifyBash silent on simple destructive commands
+(`rm -rf`, `dd`, `curl | sh`, etc. all return `null`). That is **not** a gap: CC
+auto-grants those too, so both sides stay silent — parity working as intended.
+roost is a parity relay, not a safety layer, and isn't trying to catch them. The
+point is only the axis: classifyBash keys on syntax, orthogonal to what CC
+blocks, so its relays don't track CC. The failure is one-directional — it relays
+where CC wouldn't.
 
 ## The lesson: what the analyzer DECIDES vs what auto mode ENFORCES
 
@@ -169,8 +163,8 @@ What observation **corrected**:
 - **The old "under-fire = hang" rows (shell-expansion, net-redirect, path-command
   flag-validation, redirect-target expansion): NOT hangs in auto mode.** Auto
   mode grants, it doesn't prompt, so a missed bashMissKind is a missed *grant*,
-  not a hang. The real under-fire is danger (below), not the bashMissKind set
-  difference.
+  not a hang. And a missed grant is parity-correct silence — CC didn't block, so
+  neither should roost — not a defect to chase.
 - **The old "correct mirror" rows: also over-fire in auto mode.** They were
   scored "correct" on the assumption CC prompts for them. CC doesn't (in auto
   mode), so relaying them is friction too.
@@ -189,47 +183,33 @@ What observation **confirmed**:
 
 ## Recommendation
 
-Two distinct failure modes. Same root cause (syntax is the wrong axis), but they
-are not one finding and should not be filed as one.
+One bug, on the parity axis. classifyBash relays bash shapes CC's auto mode
+auto-grants — it asks the operator when CC produced no blocking request. That is
+the divergence from parity, and it's Alex's original hypothesis, confirmed.
+The fix direction: relay a bash command only when CC would actually block it.
+#598 is the narrow, shippable instance (the `cd`-multi-positional false flag);
+the general goal is "no relay where CC produces no blocking request."
 
-**1. Friction — over-fire on benign syntax. Alex's original hypothesis,
-confirmed.** classifyBash relays harmless shapes (cd-compound, shell-operators,
-cd-multi-positional including #598) that auto mode would grant. Cleanup-priority.
-The narrow version is #598; the general version is "stop flagging benign
-syntactic shapes."
+**Not a bug: the under-fire.** classifyBash returning `null` on `rm -rf`, `dd`,
+`curl | sh`, etc. is parity working — CC auto-grants them, so roost correctly
+stays silent. roost is a parity relay, not a safety layer; there is no danger
+gate to add, and none should be added. Catching destructive commands is
+explicitly out of scope.
 
-**2. Latent safety gap — under-fire on destructive commands. New, and more
-serious than the friction.** The nine destructive commands tested fall through
-`classifyBash` (`null`). The one safe to run live (`rm -rf /tmp/<throwaway>`) ran
-through auto mode unprompted — and it targeted a path *outside* the session
-worktree, which default mode's cwd sandbox refused. So auto's destructive reach
-isn't worktree-local: auto relaxes the one CC-native gate (the cwd sandbox) that
-would otherwise contain an out-of-cwd op, and classifyBash doesn't replace it. An
-auto worker can run these today with no human in the loop, while the friction
-prompts imply otherwise (false safety). Higher priority than the friction cleanup.
+**The mechanism question is open, not settled here.** classifyBash keys on syntax
+(orthogonal to CC's decision), and across these probes the PermissionRequest hook
+never fired for bash — even on the default-mode block — so "did CC actually block
+this?" isn't cleanly available from either current path. Whoever takes the
+followup gets to design how roost detects a real CC bash block; the audit's job
+is to establish that the current syntactic relay isn't it, and that in auto mode
+the parity-correct bash relay volume is essentially zero.
 
-**Bounded claim (don't over-read).** What's tested: all nine return `null` from
-classifyBash; auto mode executed `rm -rf /tmp/<throwaway>` and a `touch` of an
-out-of-cwd path with no prompt, while default's sandbox refused both. Both targets
-were `/tmp` throwaway paths — out-of-cwd, but not system-critical. What's *not*
-tested: I did not live-run the other eight (destructive/networked), did not probe
-CC's critical-path guards (no `rm -rf /`), and did not run the *same literal path*
-in both modes — the default/auto targets differed by a trailing digit to avoid
-collision, so they're the same out-of-cwd location class, not identical paths. The
-binary shows CC retains some native critical-dir rm checks I did not map. So the
-precise statement is "auto ran the out-of-cwd /tmp ops I tested unprompted, past
-the sandbox default enforces," not "auto runs `rm -rf /`."
-
-**Fix axis.** Re-key on what a command *does* (destructive / irreversible /
-exfiltrating), not on its *syntax*. Syntax tracks neither.
-
-**Design call for Alex, not a foregone fix.** Whether roost *should* add a
-danger gate at all is a product decision and partly CC's job (CC owns the
-permission model; roost shouldn't reimplement it). The audit's job is to show
-the current classifier gives false safety on the danger axis and friction on the
-syntax axis. If a gate is wanted, it must key on danger; if not, classifyBash's
-syntactic flagging should be dropped or narrowed so it stops implying a gate
-that isn't there.
+**Live-run scope (don't over-read).** Among the destructive shapes, only `rm -rf
+/tmp/<throwaway>` was run live in CC (executed in auto, blocked in default — the
+positive control); the rest were exercised only through `classifyBash`
+(deterministic `null`). That's enough for the parity question — roost mirrors CC,
+and we confirmed CC's auto-mode silence on the represented shapes — and I did not
+probe CC's own critical-path guards (no `rm -rf /`).
 
 ## Reproducibility
 

--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -44,7 +44,7 @@ roost to grant the read-only subset*, not *narrow what it catches*.
 | U2 | `cmd > /dev/tcp/...` (net redirect) | under-fire | `null` → hang | `net-redirect` bashMissKind → ask | **bug — roost (hang risk)** |
 | U3 | path-command flags (`cp --target-directory=…`) | under-fire | `null` → hang | `flag-validation` bashMissKind → ask | **bug — roost (hang risk)** |
 | U4 | redirect target is expansion (`> $(...)`) | under-fire | `null` → hang | `shell-expansion`/`redirected_statement` → ask | **bug — roost (hang risk)** |
-| M1 | subshell `(…)` / command group `{…}` | match | `shell-operators` → IRC ask | `shell-operators` (`hasSubshell`/`hasCommandGroup`) → ask | correct |
+| M1 | non-cd subshell `(grep …)` / command group `{ ls; }` | match | `shell-operators` → IRC ask | `shell-operators` (`hasSubshell`/`hasCommandGroup`) → ask | correct |
 | M2 | `cd … && git …`, `cd … && <write/redirect>` | match | `cd-compound` → IRC ask | `cd-git-compound` / `cd-compound-write/-redirect` → ask | correct |
 | M3 | real zsh `cd OLD NEW` | match | `cd-multi-positional` → IRC ask | `cd-multi-positional` → ask | correct |
 | M4 | bare `&&`/`\|` pipeline of read-only cmds | match | `null` → pass through | read-only fast-path → **allow** | correct (both grant) |
@@ -158,9 +158,12 @@ would have granted.
 
 ### O2 — `cd-compound` over-fires on read-only tails
 
-`cd /tmp; ls`, `cd src && grep -rn foo .`, `cd build | wc -l` → roost
-`cd-compound` → IRC ask. CC escalates cd-compound **only** for write, output
-redirection, or git tails (finding #3 above); a read-only tail is allowed.
+`cd /tmp; ls`, `cd src && grep -rn foo .`, `cd logs && tail -n 50 app.log` →
+roost `cd-compound` → IRC ask. CC escalates cd-compound **only** for write,
+output redirection, or git tails (finding #3 above); a read-only tail is
+allowed. (Note the alternation is `&&`/`||`/`;` only — a single-`|` read-only
+tail like `cd build | wc -l` is *not* matched and correctly passes through,
+M4-shaped. The over-fire is the `;`/`&&`/`||` read-only tails.)
 
 roost collapses CC's three distinct kinds into one detector
 (`pretooluse-prompt.ts:100`) that fires on `cd … (&&|\|\||;)` regardless of the
@@ -199,9 +202,14 @@ whole hook rests on.
 
 ### M-rows — correct mirrors (no action)
 
-shell-operators on subshell/group (M1), cd-compound on git/write/redirect tails
-(M2), real `cd OLD NEW` (M3), and read-only pipelines passing through (M4) all
-match CC 2.1.196. **The shell-operators seed repro in #604's comment does not
+shell-operators on a non-cd subshell/group (M1 — `(grep …)`, `{ ls; }`),
+cd-compound on git/write/redirect tails (M2), real `cd OLD NEW` (M3), and
+read-only pipelines passing through (M4) all match CC 2.1.196. (Detector
+ordering wrinkle: a subshell whose first token is `cd` — `(cd /tmp && ls)` —
+trips `cd-compound` first, since `CD_START` includes `(` and the cd-compound
+check precedes shell-operators. Still routes to IRC, so the verdict is
+unaffected; the M1 example is deliberately non-cd to keep it exact.) **The
+shell-operators seed repro in #604's comment does not
 reproduce as written**: `echo "…" && grep … | head` has no subshell/group, so
 roost returns `null` and CC's read-only fast-path allows it — neither prompts.
 The real observed command must have contained a top-level `(…)`/`{…}` (which

--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -39,18 +39,30 @@ unmodified, including subshell parens and newlines).
 | `cd /tmp /usr` | cd-multi-positional | ran (errored at bash level), no prompt |
 | `cd /tmp; echo TOK` | cd-compound | executed, no prompt |
 | `echo TOK` (control) | none (`null`) | executed, no prompt |
-| `rm -rf <throwaway-dir>` (**positive control**) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (no exec)** |
+| `rm -rf /tmp/<throwaway>` (**positive control**) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (sandbox)** |
+| `touch /tmp/<throwaway>.txt` (write control) | none (`null`) | **auto: executed, no prompt** · **default: BLOCKED (sandbox)** |
 
-The positive control is load-bearing: `--permission-mode default` blocks the
-`rm` (the harness sees a real non-execution) while `auto` runs it. So (a) the
-harness can detect a block when one occurs, and (b) `--permission-mode` genuinely
-overrides the settings default. The default-mode block happens *upstream* of the
-hookable PermissionRequest path — CC denies the destructive `rm` (target outside
-the session working dir) before the hook is reached, so the allow-emitting
-observation hook (see Reproducibility) never sees it and can't override the
-block. PermissionRequest in fact never fired in *any* run, default or auto, so
-its allow was a harness backstop that was never exercised. So: **auto mode grants
-the classified shapes outright, no prompt.**
+The positive control is load-bearing in two ways. First, it proves the harness
+can see a real non-execution: `--permission-mode default` refuses both the `rm`
+and a plain `touch` whose targets sit in `/tmp` (outside the session working dir),
+failing before the marker echo, while `auto` runs both and emits the marker. So
+an auto-mode "no prompt → executed" row is a genuine grant, and `--permission-mode`
+is honored (default behaved like default, not like the box's `defaultMode: auto`).
+
+Second — and this is bigger than "the flag overrides the settings default" — the
+gate default enforces here is CC's **cwd sandbox**: it refuses writes outside the
+session working dir (note default still ran the read-only `echo`, so it isn't
+blanket-denying bash). **Auto bypasses that sandbox.** It executed an out-of-cwd
+`rm -rf` and an out-of-cwd `touch` that default refused. So in auto, the
+destructive reach is *not* worktree-local — ops targeting paths outside the
+worktree run too.
+
+The default-mode block also happens *upstream* of the hookable PermissionRequest
+path: CC denies the out-of-cwd op before the hook is reached, so the allow-
+emitting observation hook (see Reproducibility) never sees it. PermissionRequest
+in fact never fired in *any* of the 13 runs, default or auto (see the mechanism
+note below). So: **auto mode grants the classified shapes outright, no prompt**,
+and relaxes the cwd sandbox that default enforces.
 
 ### Probe B — what roost adds on top (real `classifyBash` PreToolUse hook)
 
@@ -69,6 +81,18 @@ relays the flagged shapes to the operator. Auto mode would have granted all
 three silently. The plain read-only control passes through (classifyBash returns
 `null`), so the relay is specifically the classifier's doing. That is the
 spurious prompt in Q2, and it lives entirely in `classifyBash`, not in CC.
+
+### Mechanism: classifyBash is roost's only bash lever; the PermissionRequest hook is inert for bash
+
+`--perm-irc` wires two hooks: PreToolUse:Bash (`irc-pretooluse-prompt`, i.e.
+`classifyBash`) and PermissionRequest (`irc-permission-prompt`). Across all 13
+probe runs — read-only, subshell, cd shapes, out-of-cwd `touch`, out-of-cwd
+`rm`, in both default and auto — the PermissionRequest hook never fired for a
+Bash call. CC 2.1.196 gates bash through the PreToolUse/native-analyzer path and
+the cwd sandbox, not through PermissionRequest. So for bash, roost's
+`irc-permission-prompt` is effectively inert: `classifyBash` (PreToolUse) is
+roost's only bash lever, with no PermissionRequest backstop behind it. A fix to
+roost's bash handling changes `classifyBash` or nothing.
 
 ### The inversion: classifyBash keys on syntax, which tracks neither danger nor hang-risk
 
@@ -176,20 +200,25 @@ syntactic shapes."
 
 **2. Latent safety gap — under-fire on destructive commands. New, and more
 serious than the friction.** The nine destructive commands tested fall through
-`classifyBash` (`null`) and, for the one safe to run live (`rm -rf
-<throwaway>`), through auto mode unprompted. An auto worker can run those today
-with no human in the loop, while the friction prompts imply otherwise (false
-safety). This warrants its own follow-up at higher priority than the friction
-cleanup.
+`classifyBash` (`null`). The one safe to run live (`rm -rf /tmp/<throwaway>`) ran
+through auto mode unprompted — and it targeted a path *outside* the session
+worktree, which default mode's cwd sandbox refused. So auto's destructive reach
+isn't worktree-local: auto relaxes the one CC-native gate (the cwd sandbox) that
+would otherwise contain an out-of-cwd op, and classifyBash doesn't replace it. An
+auto worker can run these today with no human in the loop, while the friction
+prompts imply otherwise (false safety). Higher priority than the friction cleanup.
 
 **Bounded claim (don't over-read).** What's tested: all nine return `null` from
-classifyBash; auto mode executed `rm -rf <throwaway>` with no prompt while
-default blocked it. What's *not* tested: I did not live-run the other eight
-(they're destructive/networked), and I did not probe CC's critical-path guards
-(no `rm -rf /`). The binary shows CC retains some native critical-dir rm checks
-I did not map. So the precise statement is "these nine are ungated by
-classifyBash, and auto mode ran the one destructive command I tested
-unprompted," not "auto mode runs everything."
+classifyBash; auto mode executed `rm -rf /tmp/<throwaway>` and a `touch` of an
+out-of-cwd path with no prompt, while default's sandbox refused both. Both targets
+were `/tmp` throwaway paths — out-of-cwd, but not system-critical. What's *not*
+tested: I did not live-run the other eight (destructive/networked), did not probe
+CC's critical-path guards (no `rm -rf /`), and did not run the *same literal path*
+in both modes — the default/auto targets differed by a trailing digit to avoid
+collision, so they're the same out-of-cwd location class, not identical paths. The
+binary shows CC retains some native critical-dir rm checks I did not map. So the
+precise statement is "auto ran the out-of-cwd /tmp ops I tested unprompted, past
+the sandbox default enforces," not "auto runs `rm -rf /`."
 
 **Fix axis.** Re-key on what a command *does* (destructive / irreversible /
 exfiltrating), not on its *syntax*. Syntax tracks neither.

--- a/docs/audit-2026-06-perm-irc.md
+++ b/docs/audit-2026-06-perm-irc.md
@@ -44,8 +44,13 @@ unmodified, including subshell parens and newlines).
 The positive control is load-bearing: `--permission-mode default` blocks the
 `rm` (the harness sees a real non-execution) while `auto` runs it. So (a) the
 harness can detect a block when one occurs, and (b) `--permission-mode` genuinely
-overrides the settings default. PermissionRequest never fired in auto mode for
-any row. So: **auto mode grants the classified shapes outright, no prompt.**
+overrides the settings default. The default-mode block happens *upstream* of the
+hookable PermissionRequest path — CC denies the destructive `rm` (target outside
+the session working dir) before the hook is reached, so the allow-emitting
+observation hook (see Reproducibility) never sees it and can't override the
+block. PermissionRequest in fact never fired in *any* run, default or auto, so
+its allow was a harness backstop that was never exercised. So: **auto mode grants
+the classified shapes outright, no prompt.**
 
 ### Probe B — what roost adds on top (real `classifyBash` PreToolUse hook)
 
@@ -207,7 +212,8 @@ bun -e 'import {classifyBash} from "./src/pretooluse-prompt.ts"; console.log(cla
 
 CC side: Probe A ran real `claude --permission-mode auto` (and `default`/`plan`
 for controls) 2.1.196 sessions with two observation hooks — a PreToolUse:Bash
-logger that passes through, and a PermissionRequest logger that emits allow — in
+logger that passes through, and a PermissionRequest logger that emits allow
+(which never fired — see the positive control) — in
 a clean cwd with roost's env stripped, so the inner session uses only the probe
 hooks. Each row confirmed the logged tool-call matched the intended expression
 before the result was read. The subshell shape was cross-checked in both


### PR DESCRIPTION
Closes #604

Investigation deliverable: `docs/audit-2026-06-perm-irc.md`. Findings, no code change.

**Black box.** Maps where `--perm-irc`'s `classifyBash` diverges from what Claude Code 2.1.196's analyzer actually does, grounded by extracting the live classifier from the installed binary (not the stale 2.1.139 table the comments cite).

- **Hypothesis confirmed**, but the over-fires are roost regex bugs, not CC being aggressive — and the survey surfaced the opposite, more dangerous divergence too.
- **Reframe up front:** pass-through ≠ auto-grant. For a true bashMissKind, passing through hands the worker a terminal-only prompt it can't answer (hang). The lever is `emit('allow')` for the read-only subset, mirroring CC's own read-only fast-path.
- **2 over-fires (noise):** multi-line `cd` → `cd-multi-positional` (**this is #598**); `cd-compound` on read-only tails. Both roost-side.
- **4 under-fires (hang risk, higher sev):** roost misses 2.1.196 bashMissKinds `shell-expansion`, `net-redirect`, path-command `flag-validation`, redirect-target expansion → headless worker hangs. Hang prediction flagged for behavioral confirmation in the fix PR.
- **Correct mirrors (leave alone):** shell-operators (subshell/group), cd git/write/redirect, real `cd OLD NEW`.
- **#598 re-scoped:** the "flatten newlines→spaces" mechanism is wrong — it's the `cd-multi-positional` regex's `\s+` matching `\n`. Fix is split-on-separators, not "preserve newlines." O2/U1–U4 are its siblings; recommend one realignment, not one-off patches.

Reproducibility + the binary-extraction method are documented in the doc's last two sections.
