### PR TITLE
fix ircd-down hint: correct binary dir and working dir

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -610,7 +610,7 @@ require_ircd() {
   if ! (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "error: no IRC daemon listening on ${IRC_HOST}:${IRC_PORT}" >&2
     echo "  start ergo with:" >&2
-    echo "    cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\"" >&2
+    echo "    mkdir -p ~/roost-ircd/logs && cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\"" >&2
     exit 2
   fi
 }
@@ -1132,7 +1132,7 @@ cmd_status() {
   if (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "ircd: up on ${IRC_HOST}:${IRC_PORT}"
   else
-    echo "ircd: DOWN (start: cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\")"
+    echo "ircd: DOWN (start: mkdir -p ~/roost-ircd/logs && cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\")"
   fi
   local count
   count="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -c "^${SESSION_PREFIX}")" || count=0

--- a/bin/roost
+++ b/bin/roost
@@ -610,7 +610,7 @@ require_ircd() {
   if ! (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "error: no IRC daemon listening on ${IRC_HOST}:${IRC_PORT}" >&2
     echo "  start ergo with:" >&2
-    echo "    cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml" >&2
+    echo "    cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\"" >&2
     exit 2
   fi
 }
@@ -1132,7 +1132,7 @@ cmd_status() {
   if (echo > /dev/tcp/"${IRC_HOST}"/"${IRC_PORT}") 2>/dev/null; then
     echo "ircd: up on ${IRC_HOST}:${IRC_PORT}"
   else
-    echo "ircd: DOWN (start: cd ${ROOST_DIR}/var/ergo && ./ergo run --conf ${ROOST_DIR}/etc/ergo.yaml)"
+    echo "ircd: DOWN (start: cd ~/roost-ircd && \"${ROOST_DIR}/var/ergo-bin/ergo\" run --conf \"${ROOST_DIR}/etc/ergo.yaml\")"
   fi
   local count
   count="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -c "^${SESSION_PREFIX}")" || count=0


### PR DESCRIPTION
Closes #600

Two spots in `bin/roost` (lines 613 and 1135) emitted a start hint pointing at `var/ergo` — a directory that doesn't exist. The fix updates both to the real paths.

What changed:
- `var/ergo` → `var/ergo-bin/ergo` (where `bin/install-ergo` actually puts the binary)
- `cd <bin-dir> && ./ergo` → `cd ~/roost-ircd && "<abs-path>/ergo"` — ergo's relative datastore/log paths need the operator's ircd working dir, not the bin dir; `~/roost-ircd` is the documented convention (README §2)

Both lines are byte-identical per §#422.