### PR TITLE
isolate per-entry gh failures from the tick; treat 401 as transient

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/backoff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/backoff.test.ts
@@ -78,11 +78,11 @@ describe('format helpers', () => {
     expect(formatBackoffNotice(60 * M)).toBe('[dispatcher] GH rate-limited, backing off 60m')
   })
 
-  it('formatReadFailureNote hedges deleted-vs-flaking and embeds the verbatim recovery command', () => {
-    const note = formatReadFailureNote('github-new-issues', 'org/repo', 'unwatch new-issues org/repo')
+  it('formatReadFailureNote surfaces the failure reason and embeds the verbatim recovery command', () => {
+    const note = formatReadFailureNote('github-new-issues', 'org/repo', 'unwatch new-issues org/repo', 'deleted/renamed (HTTP 404)')
     expect(note).toBe(
-      `[dispatcher] github-new-issues: org/repo read failing (deleted/renamed or GH flaking) —` +
-      ` suppressing ${Math.round(WARN_COOLDOWN_MS / 60_000)}m; if persistent: unwatch new-issues org/repo`
+      `[dispatcher] github-new-issues: org/repo read failing: deleted/renamed (HTTP 404).` +
+      ` suppressing ${Math.round(WARN_COOLDOWN_MS / 60_000)}m; recover: unwatch new-issues org/repo`
     )
   })
 })

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, fetchRateLimit, isRateLimitError, isExpectedTransientError, describeReadFailure } from '../github-api.js'
+import { GhError, spawnGh, fetchRateLimit, isRateLimitError, describeReadFailure } from '../github-api.js'
 import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../../_rate-limit.js'
 
 function mkErr(stderr: string): GhError {
@@ -129,17 +129,18 @@ describe('spawnGh (retry-aware)', () => {
     expect(h.logs[0]).toContain('matched=http-401')
   })
 
-  it('a sustained 401 exhausts and is classed transient (the per-entry warn class, not rate-limit)', async () => {
+  it('a sustained 401 is retried (transient) to exhaustion, not failed fast as rate-limit', async () => {
+    let calls = 0
     let caught: unknown = null
     try {
       await spawnGh(['api', '/x'], {
         sleep: async () => {},
         log: () => {},
-        exec: async () => { throw mkErr('gh: Bad credentials (HTTP 401)') },
+        exec: async () => { calls++; throw mkErr('gh: Bad credentials (HTTP 401)') },
       })
     } catch (e) { caught = e }
-    expect(caught).toBeInstanceOf(GhError)
-    expect(isExpectedTransientError(caught)).toBe(true)
+    expect(calls).toBe(3)  // retried like any transient, not failed-fast like a rate-limit
+    expect((caught as GhError).attempts).toBe(3)
     expect(isRateLimitError(caught)).toBe(false)
   })
 
@@ -159,8 +160,7 @@ describe('spawnGh (retry-aware)', () => {
     expect(calls).toBe(3)
     expect(caught).toBeInstanceOf(GhError)
     expect((caught as GhError).attempts).toBe(3)
-    // A persistent 404 is the per-entry skip class, not rate-limit.
-    expect(isExpectedTransientError(caught)).toBe(true)
+    // A persistent 404 is retried (the per-entry skip class), not rate-limit.
     expect(isRateLimitError(caught)).toBe(false)
   })
 
@@ -274,7 +274,7 @@ describe('spawnGh (retry-aware)', () => {
     expect(isRateLimitError(caught)).toBe(true)
   })
 
-  it('does not treat a non-rate-limit HTTP 403 as rate-limit or transient (throws once)', async () => {
+  it('does not retry a non-rate-limit HTTP 403 — throws once (not transient, not rate-limit)', async () => {
     const h = harness()
     let calls = 0
     let caught: unknown = null
@@ -285,9 +285,8 @@ describe('spawnGh (retry-aware)', () => {
         exec: async () => { calls++; throw mkErr('gh: HTTP 403: Resource not accessible by integration') },
       })
     } catch (e) { caught = e }
-    expect(calls).toBe(1)
+    expect(calls).toBe(1)  // no retry → not classed transient
     expect(isRateLimitError(caught)).toBe(false)
-    expect(isExpectedTransientError(caught)).toBe(false)
   })
 
   it('rethrows non-GhError immediately without classifying', async () => {

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, fetchRateLimit, isRateLimitError, isExpectedTransientError } from '../github-api.js'
+import { GhError, spawnGh, fetchRateLimit, isRateLimitError, isExpectedTransientError, describeReadFailure } from '../github-api.js'
 import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../../_rate-limit.js'
 
 function mkErr(stderr: string): GhError {
@@ -107,6 +107,40 @@ describe('spawnGh (retry-aware)', () => {
     expect(calls).toBe(2)
     expect(h.sleeps).toEqual([100])  // notFoundBaseMs, not baseMs
     expect(h.logs[0]).toContain('matched=http-404')
+  })
+
+  it('retries a 401 (GitHub intermittently 401s a valid token) then succeeds', async () => {
+    const h = harness()
+    let calls = 0
+    const out = await spawnGh(['api', '/x'], {
+      sleep: h.sleep,
+      log: h.log,
+      baseMs: 100,
+      random: () => 0,
+      exec: async () => {
+        calls++
+        if (calls === 1) throw mkErr('gh: Bad credentials (HTTP 401)')
+        return { ok: true }
+      },
+    })
+    expect(out).toEqual({ ok: true })
+    expect(calls).toBe(2)
+    expect(h.sleeps).toEqual([100])  // baseMs (not the 404 short base) — 401 is a normal transient
+    expect(h.logs[0]).toContain('matched=http-401')
+  })
+
+  it('a sustained 401 exhausts and is classed transient (the per-entry warn class, not rate-limit)', async () => {
+    let caught: unknown = null
+    try {
+      await spawnGh(['api', '/x'], {
+        sleep: async () => {},
+        log: () => {},
+        exec: async () => { throw mkErr('gh: Bad credentials (HTTP 401)') },
+      })
+    } catch (e) { caught = e }
+    expect(caught).toBeInstanceOf(GhError)
+    expect(isExpectedTransientError(caught)).toBe(true)
+    expect(isRateLimitError(caught)).toBe(false)
   })
 
   it('exhausts a 404 after N attempts (real missing resource / sustained flap)', async () => {
@@ -270,6 +304,25 @@ describe('spawnGh (retry-aware)', () => {
     expect(calls).toBe(1)
     expect(h.sleeps).toEqual([])
     expect((caught as Error).message).toBe('bun.spawn died')
+  })
+})
+
+describe('describeReadFailure', () => {
+  it('names the operator action per status', () => {
+    expect(describeReadFailure('gh: Bad credentials (HTTP 401)')).toBe('auth rejected (HTTP 401), rotate token if it persists')
+    expect(describeReadFailure('gh: Not Found (HTTP 404)')).toBe('deleted/renamed (HTTP 404)')
+    expect(describeReadFailure('gh: Resource not accessible by integration (HTTP 403)')).toBe('permission denied (HTTP 403), check token scopes')
+    expect(describeReadFailure('gh: Validation Failed (HTTP 422)')).toBe('validation failed (HTTP 422), likely a query bug')
+  })
+
+  it('labels network/server transients as GH flaking', () => {
+    expect(describeReadFailure('gh: HTTP 503: Service Unavailable')).toBe('GH flaking (http-5xx)')
+    expect(describeReadFailure('dial tcp: i/o timeout')).toBe('GH flaking (timeout)')
+  })
+
+  it('falls back to the first stderr line for an unrecognized error', () => {
+    expect(describeReadFailure('gh: some brand new failure mode\nmore detail')).toBe('gh error: gh: some brand new failure mode')
+    expect(describeReadFailure('')).toBe('gh read failed')
   })
 })
 

--- a/src/orchestrator/plugins/github/__tests__/resilience.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/resilience.test.ts
@@ -1,14 +1,23 @@
 // Integration coverage for the gh-call resilience layer (GhPluginBase.readEntry
-// + the shared rate-limit breaker), exercised through plugin runTicks.
+// + the shared rate-limit breaker), exercised through plugin runTicks, plus a
+// direct state-machine block for readEntry's failure-threshold/throttle logic
+// (runTick reads Date.now(), so only the direct block can drive the time
+// windows).
 //
-// Block 1 (repo-feed plugins: new-prs/new-issues) — the four readEntry outcomes:
-// success, transient/404 skip+note, rate-limit→breaker, 422/non-GhError→throw,
-// plus the missing-repo cooldown and breaker quiet path.
+// Block 1 (repo-feed plugins: new-prs/new-issues) — the readEntry outcomes:
+// success, the warn-after-threshold note, the degraded-entry read throttle,
+// rate-limit→breaker, 422 isolating per-entry (no longer a whole-tick crash),
+// non-GhError→throw.
 //
 // Block 2 (per-N plugins: prs/issues) — the multi-entry skip path that block 1
 // can't reach: carrying a flapped entry's prev snapshot (and its dynamic
-// channels) forward, the cross/multi-repo recovery command, and the empty-watch
-// early-return that keeps an idle plugin from resetting a sibling's escalation.
+// channels) forward, a single 401 isolating to its entry while the sibling is
+// processed (pre-fix this crashed the whole tick), the cross/multi-repo recovery
+// command, and the empty-watch early-return.
+//
+// Block 3 — readEntry directly, with an injected clock: warn threshold, read
+// throttle, clean-probe recovery, the 401 reason path, rate-limit passthrough,
+// and the non-GhError rethrow boundary.
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test'
 import { GitHubNewPrsPlugin, type NewPrsPluginState } from '../new-prs-plugin.js'
 import { GitHubNewIssuesPlugin, type NewIssuesPluginState } from '../new-issues-plugin.js'
@@ -16,9 +25,11 @@ import { GitHubPrsPlugin } from '../prs-plugin.js'
 import { GitHubIssuesPlugin } from '../issues-plugin.js'
 import { GhClient, GhError, type GhRepoPr } from '../github-api.js'
 import { GhScraper } from '../scraper.js'
-import { GhPluginBase } from '../base.js'
-import { RateLimitBreaker } from '../backoff.js'
+import { GhPluginBase, type ReadEntryResult } from '../base.js'
+import { RateLimitBreaker, READ_FAILURE_THRESHOLD } from '../backoff.js'
+import { WARN_COOLDOWN_MS } from '../../_rate-limit.js'
 import type { OrchestratorConfig } from '../../../config.js'
+import type { PluginTickResult } from '../../../plugin.js'
 import type { PrSnap, IssueSnap, PrPluginState, IssuePluginState } from '../types.js'
 import { stubRateLimit } from './gh-test-helpers.js'
 
@@ -38,6 +49,25 @@ function ghErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1)\n${stderr}`, stderr, 3)
 }
 
+// Drive `n` runTicks on one plugin instance, threading state forward, and return
+// every tick's result. The threshold/cooldown gating lives on the instance, so
+// the same instance must see all the ticks.
+async function runTicks(
+  plugin: { runTick(c: OrchestratorConfig, s: unknown): Promise<PluginTickResult> },
+  config: OrchestratorConfig,
+  seed: unknown,
+  n: number,
+): Promise<PluginTickResult[]> {
+  const results: PluginTickResult[] = []
+  let state = seed
+  for (let i = 0; i < n; i++) {
+    const r = await plugin.runTick(config, state)
+    results.push(r)
+    state = r.state
+  }
+  return results
+}
+
 describe('gh-call resilience (readEntry + breaker)', () => {
   stubRateLimit()
   beforeEach(() => { GhPluginBase.resetBreakerForTest() })
@@ -52,29 +82,35 @@ describe('gh-call resilience (readEntry + breaker)', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('transient/404 past retries: skips the entry with a hedged cooldown note, preserves prev state', async () => {
-    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+  it('a transient flap stays silent below the threshold, then warns on the Nth consecutive failure', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: Not Found (HTTP 404)'))
     try {
-      const prev: NewPrsPluginState = { repos: { 'org/repo': [1, 2] } }
-      const result = await new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), prev)
-      expect(result.taggedEvents).toHaveLength(1)
-      const text = oneline(result.taggedEvents[0]!)
-      expect(text).toContain('github-new-prs: org/repo read failing (deleted/renamed or GH flaking)')
-      expect(text).toContain('unwatch new-prs org/repo')
-      // Prev state carried forward untouched — nothing lost, nothing replayed.
-      expect((result.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2])
+      const plugin = new GitHubNewPrsPlugin('#proj-leads')
+      const results = await runTicks(plugin, prsConfig(), { repos: { 'org/repo': [1, 2] } }, READ_FAILURE_THRESHOLD)
+      // Every tick before the last is silent — a one-off flap never pings IRC.
+      for (const r of results.slice(0, -1)) expect(r.taggedEvents).toHaveLength(0)
+      // The Nth consecutive failure warns, with the failure reason + recovery cmd.
+      const warned = results[results.length - 1]!
+      expect(warned.taggedEvents).toHaveLength(1)
+      const text = oneline(warned.taggedEvents[0]!)
+      expect(text).toContain('github-new-prs: org/repo read failing: deleted/renamed (HTTP 404)')
+      expect(text).toContain('recover: unwatch new-prs org/repo')
+      // Prev state carried forward untouched across every skipped tick.
+      expect((warned.state as NewPrsPluginState).repos['org/repo']).toEqual([1, 2])
     } finally { spy.mockRestore() }
   })
 
-  it('missing-repo note is cooldown-gated — recurs only once per window per repo', async () => {
-    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+  it('once degraded it throttles reads — stops re-reading every tick, suppresses repeat warns', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: Not Found (HTTP 404)'))
     try {
-      const plugin = new GitHubNewPrsPlugin('#proj-leads')  // same instance → shared cooldown map
-      const prev: NewPrsPluginState = { repos: { 'org/repo': [1] } }
-      const first = await plugin.runTick(prsConfig(), prev)
-      const second = await plugin.runTick(prsConfig(), first.state)
-      expect(first.taggedEvents).toHaveLength(1)
-      expect(second.taggedEvents).toHaveLength(0)  // suppressed within the window
+      const plugin = new GitHubNewPrsPlugin('#proj-leads')  // same instance → shared failure state
+      const warmup = await runTicks(plugin, prsConfig(), { repos: { 'org/repo': [1] } }, READ_FAILURE_THRESHOLD)
+      expect(spy).toHaveBeenCalledTimes(READ_FAILURE_THRESHOLD)  // read every tick up to the threshold
+      expect(warmup[warmup.length - 1]!.taggedEvents).toHaveLength(1)  // warned on the Nth
+      // Next tick: degraded entry inside the cooldown → no re-read, no repeat warn.
+      const throttled = await plugin.runTick(prsConfig(), warmup[warmup.length - 1]!.state)
+      expect(spy).toHaveBeenCalledTimes(READ_FAILURE_THRESHOLD)  // did NOT re-read
+      expect(throttled.taggedEvents).toHaveLength(0)
     } finally { spy.mockRestore() }
   })
 
@@ -101,11 +137,14 @@ describe('gh-call resilience (readEntry + breaker)', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('422 (real defect) is not swallowed — runTick rejects', async () => {
+  it('422 isolates to its entry instead of crashing the tick — warns with the query-bug reason', async () => {
     const spy = spyOn(GhClient.prototype, 'fetchRepoOpenPrs').mockRejectedValue(ghErr('gh: HTTP 422: Validation Failed'))
     try {
-      await expect(new GitHubNewPrsPlugin('#proj-leads').runTick(prsConfig(), { repos: { 'org/repo': [1] } }))
-        .rejects.toThrow(GhError)
+      const plugin = new GitHubNewPrsPlugin('#proj-leads')
+      // No throw — a 422 is now a per-entry condition, not a whole-tick crash.
+      const results = await runTicks(plugin, prsConfig(), { repos: { 'org/repo': [1] } }, READ_FAILURE_THRESHOLD)
+      const warned = results[results.length - 1]!
+      expect(oneline(warned.taggedEvents[0]!)).toContain('read failing: validation failed (HTTP 422), likely a query bug')
     } finally { spy.mockRestore() }
   })
 
@@ -117,16 +156,16 @@ describe('gh-call resilience (readEntry + breaker)', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('github-new-issues missing-repo: hedged note with the verbatim unwatch recovery', async () => {
-    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+  it('github-new-issues missing-repo: warns after the threshold with the verbatim unwatch recovery', async () => {
+    const spy = spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockRejectedValue(ghErr('gh: Not Found (HTTP 404)'))
     try {
-      const prev: NewIssuesPluginState = { repos: { 'org/repo': [1] } }
-      const result = await new GitHubNewIssuesPlugin('#proj-leads').runTick(issuesConfig(), prev)
-      expect(result.taggedEvents).toHaveLength(1)
-      const text = oneline(result.taggedEvents[0]!)
-      expect(text).toContain('github-new-issues: org/repo read failing (deleted/renamed or GH flaking)')
-      expect(text).toContain('unwatch new-issues org/repo')
-      expect((result.state as NewIssuesPluginState).repos['org/repo']).toEqual([1])
+      const plugin = new GitHubNewIssuesPlugin('#proj-leads')
+      const results = await runTicks(plugin, issuesConfig(), { repos: { 'org/repo': [1] } }, READ_FAILURE_THRESHOLD)
+      const warned = results[results.length - 1]!
+      const text = oneline(warned.taggedEvents[0]!)
+      expect(text).toContain('github-new-issues: org/repo read failing: deleted/renamed (HTTP 404)')
+      expect(text).toContain('recover: unwatch new-issues org/repo')
+      expect((warned.state as NewIssuesPluginState).repos['org/repo']).toEqual([1])
     } finally { spy.mockRestore() }
   })
 })
@@ -174,7 +213,7 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
     const prevPr1 = prSnap({ number: 1, url: 'https://github.com/org/repo/pull/1', linked_issues: [{ repo: 'org/repo', number: 42 }] })
     const prevPr2 = prSnap({ number: 2, url: 'https://github.com/org/repo/pull/2' })
     const spy = spyOn(GhScraper.prototype, 'scrapePr').mockImplementation(async (_repo: string, number: number) => {
-      if (number === 1) throw ghErr('gh: HTTP 404: Not Found')
+      if (number === 1) throw ghErr('gh: Not Found (HTTP 404)')
       return { snap: prSnap({ number: 2, url: 'https://github.com/org/repo/pull/2' }), events: [] }
     })
     try {
@@ -188,15 +227,16 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
       const plugin = new GitHubPrsPlugin('#proj-leads')
       plugin._setLinearQueryForTest(linearStub({ 'TEAM-7': ['https://github.com/org/repo/pull/1'] }))
       const prev: PrPluginState = { prs: { 'org/repo#1': prevPr1, 'org/repo#2': prevPr2 } }
-      const result = await plugin.runTick(config, prev)
+      const results = await runTicks(plugin, config, prev, READ_FAILURE_THRESHOLD)
+      const result = results[results.length - 1]!
 
-      // The flapped entry skips with a hedged note; the healthy sibling is untouched.
+      // The flapped entry warns once past the threshold; the healthy sibling is untouched.
       expect(result.taggedEvents).toHaveLength(1)
       const text = oneline(result.taggedEvents[0]!)
-      expect(text).toContain('github-prs: org/repo#1 read failing (deleted/renamed or GH flaking)')
-      expect(text).toContain('unwatch pr 1')  // single-repo → bare number, no repo suffix
+      expect(text).toContain('github-prs: org/repo#1 read failing: deleted/renamed (HTTP 404)')
+      expect(text).toContain('recover: unwatch pr 1')  // single-repo → bare number, no repo suffix
 
-      // prevPr1 carried forward verbatim — a flap doesn't drop the snapshot.
+      // prevPr1 carried forward verbatim on every tick — a flap doesn't drop the snapshot.
       const state = result.state as PrPluginState
       expect(state.prs['org/repo#1']).toEqual(prevPr1)
       expect(state.prs['org/repo#2']).toBeDefined()
@@ -210,10 +250,34 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
     } finally { spy.mockRestore() }
   })
 
-  it('issues transient skip: carries the flapped issue forward, emits the hedged note', async () => {
+  it('a single 401 isolates to its entry: the sibling is processed and the tick never throws', async () => {
+    // Pre-fix, scrapePr throwing 401 propagated out of readEntry → runOneTick's
+    // Promise.all rejected → the whole tick (every plugin) was lost. Now the 401
+    // entry skips and the healthy sibling still produces state.
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockImplementation(async (_repo: string, number: number) => {
+      if (number === 1) throw ghErr('gh: Bad credentials (HTTP 401)')
+      return { snap: prSnap({ number: 2, title: 'P2-fresh' }), events: [] }
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 1 }, { number: 2 }] } },
+      }
+      const prevPr1 = prSnap({ number: 1 })
+      const prev: PrPluginState = { prs: { 'org/repo#1': prevPr1, 'org/repo#2': prSnap({ number: 2, title: 'P2-stale' }) } }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(config, prev)
+      // First 401 tick is silent (below threshold) but did NOT throw.
+      expect(result.taggedEvents).toHaveLength(0)
+      const state = result.state as PrPluginState
+      expect(state.prs['org/repo#1']).toEqual(prevPr1)            // failed entry carried forward
+      expect(state.prs['org/repo#2']!.title).toBe('P2-fresh')    // sibling freshly processed
+    } finally { spy.mockRestore() }
+  })
+
+  it('issues transient skip: carries the flapped issue forward, warns after the threshold', async () => {
     const prevIssue1 = issueSnap({ number: 1 })
     const spy = spyOn(GhScraper.prototype, 'scrapeIssue').mockImplementation(async (_repo: string, number: number) => {
-      if (number === 1) throw ghErr('gh: HTTP 404: Not Found')
+      if (number === 1) throw ghErr('gh: Not Found (HTTP 404)')
       return { snap: issueSnap({ number: 2 }), events: [] }
     })
     try {
@@ -222,12 +286,13 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
         plugins: { 'github-issues': { watched: [{ number: 1 }, { number: 2 }] } },
       }
       const prev: IssuePluginState = { issues: { 'org/repo#1': prevIssue1, 'org/repo#2': issueSnap({ number: 2 }) } }
-      const result = await new GitHubIssuesPlugin('#proj-leads').runTick(config, prev)
+      const results = await runTicks(new GitHubIssuesPlugin('#proj-leads'), config, prev, READ_FAILURE_THRESHOLD)
+      const result = results[results.length - 1]!
 
       expect(result.taggedEvents).toHaveLength(1)
       const text = oneline(result.taggedEvents[0]!)
-      expect(text).toContain('github-issues: org/repo#1 read failing (deleted/renamed or GH flaking)')
-      expect(text).toContain('unwatch 1')
+      expect(text).toContain('github-issues: org/repo#1 read failing: deleted/renamed (HTTP 404)')
+      expect(text).toContain('recover: unwatch 1')
       expect((result.state as IssuePluginState).issues['org/repo#1']).toEqual(prevIssue1)
     } finally { spy.mockRestore() }
   })
@@ -235,23 +300,23 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
   it('cross/multi-repo skip note qualifies the recovery command with the repo', async () => {
     // Multi-repo (no config.repo): bare `unwatch pr <N>` / `unwatch <N>` would hit
     // bareError, so the note must carry the repo (mirrors formatEntryLabel).
-    const prsSpy = spyOn(GhScraper.prototype, 'scrapePr').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    const prsSpy = spyOn(GhScraper.prototype, 'scrapePr').mockRejectedValue(ghErr('gh: Not Found (HTTP 404)'))
     try {
       const config: OrchestratorConfig = {
         project: 'proj', plugins: { 'github-prs': { watched: [{ number: 5, repo: 'org/other' }] } },
       }
-      const result = await new GitHubPrsPlugin('#proj-leads').runTick(config, { prs: {} })
-      expect(oneline(result.taggedEvents[0]!)).toContain('unwatch pr 5 org/other')
+      const results = await runTicks(new GitHubPrsPlugin('#proj-leads'), config, { prs: {} }, READ_FAILURE_THRESHOLD)
+      expect(oneline(results[results.length - 1]!.taggedEvents[0]!)).toContain('recover: unwatch pr 5 org/other')
     } finally { prsSpy.mockRestore() }
 
     GhPluginBase.resetBreakerForTest()
-    const issuesSpy = spyOn(GhScraper.prototype, 'scrapeIssue').mockRejectedValue(ghErr('gh: HTTP 404: Not Found'))
+    const issuesSpy = spyOn(GhScraper.prototype, 'scrapeIssue').mockRejectedValue(ghErr('gh: Not Found (HTTP 404)'))
     try {
       const config: OrchestratorConfig = {
         project: 'proj', plugins: { 'github-issues': { watched: [{ number: 8, repo: 'org/other' }] } },
       }
-      const result = await new GitHubIssuesPlugin('#proj-leads').runTick(config, { issues: {} })
-      expect(oneline(result.taggedEvents[0]!)).toContain('unwatch 8 org/other')
+      const results = await runTicks(new GitHubIssuesPlugin('#proj-leads'), config, { issues: {} }, READ_FAILURE_THRESHOLD)
+      expect(oneline(results[results.length - 1]!.taggedEvents[0]!)).toContain('recover: unwatch 8 org/other')
     } finally { issuesSpy.mockRestore() }
   })
 
@@ -281,5 +346,92 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
         expect(resetSpy).toHaveBeenCalled()
       } finally { okSpy.mockRestore() }
     } finally { resetSpy.mockRestore() }
+  })
+})
+
+// readEntry exposes a protected state machine that runTick can't drive across
+// time (runTick stamps its own Date.now()). A minimal concrete plugin surfaces
+// it so these can inject the clock and pin the threshold/throttle/recovery edges.
+class ReadEntryProbe extends GhPluginBase {
+  readonly name = 'probe'
+  desiredChannels(): string[] { return [] }
+  async runTick(): Promise<PluginTickResult> { return { state: null, taggedEvents: [], channels: [] } }
+  call<T>(key: string, body: () => Promise<T>, now: number): Promise<ReadEntryResult<T>> {
+    return this.readEntry(key, ['#probe'], 'unwatch probe', body, now)
+  }
+}
+
+describe('readEntry failure-threshold state machine (direct, injected clock)', () => {
+  const T0 = 1_700_000_000_000
+
+  function probe(): ReadEntryProbe { return new ReadEntryProbe('#probe', () => {}) }
+  function failBody(stderr: string): () => Promise<never> {
+    return async () => { throw new GhError(`gh failed\n${stderr}`, stderr, 3) }
+  }
+  function isSilentSkip(r: ReadEntryResult<unknown>): boolean {
+    return !r.ok && !r.rateLimited && r.events.length === 0
+  }
+  function noteText(r: ReadEntryResult<unknown>): string {
+    if (r.ok || r.rateLimited) throw new Error('expected a per-entry note result')
+    expect(r.events).toHaveLength(1)
+    return (r.events[0]!.payload as { kind: 'oneline'; text: string }).text
+  }
+
+  it('stays silent below the threshold, then warns on the Nth consecutive failure', async () => {
+    const p = probe()
+    const body = failBody('gh: Not Found (HTTP 404)')
+    for (let i = 1; i < READ_FAILURE_THRESHOLD; i++) {
+      expect(isSilentSkip(await p.call('k', body, T0 + i))).toBe(true)
+    }
+    const text = noteText(await p.call('k', body, T0 + READ_FAILURE_THRESHOLD))
+    expect(text).toContain('read failing: deleted/renamed (HTTP 404)')
+    expect(text).toContain('recover: unwatch probe')
+  })
+
+  it('throttles a degraded entry: skips body() within the cooldown, probes after it', async () => {
+    const p = probe()
+    let calls = 0
+    const body = async (): Promise<never> => { calls++; throw new GhError('gh failed\nHTTP 404', 'HTTP 404', 3) }
+    for (let i = 1; i <= READ_FAILURE_THRESHOLD; i++) await p.call('k', body, T0 + i)
+    expect(calls).toBe(READ_FAILURE_THRESHOLD)  // read every tick up to the threshold
+    // Inside the cooldown → throttled: body untouched, silent.
+    const throttled = await p.call('k', body, T0 + READ_FAILURE_THRESHOLD + 1)
+    expect(calls).toBe(READ_FAILURE_THRESHOLD)
+    expect(isSilentSkip(throttled)).toBe(true)
+    // Past the cooldown → a single probe runs and re-warns.
+    const probed = await p.call('k', body, T0 + READ_FAILURE_THRESHOLD + WARN_COOLDOWN_MS + 1)
+    expect(calls).toBe(READ_FAILURE_THRESHOLD + 1)
+    expect(noteText(probed)).toContain('read failing')
+  })
+
+  it('a clean probe clears the failure state — the count restarts from the next failure', async () => {
+    const p = probe()
+    const fail = failBody('gh: Not Found (HTTP 404)')
+    for (let i = 1; i <= READ_FAILURE_THRESHOLD; i++) await p.call('k', fail, T0 + i)  // degraded + warned
+    // Past the cooldown the probe succeeds → state cleared, entry recovers.
+    const ok = await p.call('k', async () => 'value', T0 + WARN_COOLDOWN_MS + 10)
+    expect(ok).toEqual({ ok: true, value: 'value' })
+    // A fresh failure is consecutive #1 again → silent until the threshold.
+    expect(isSilentSkip(await p.call('k', fail, T0 + WARN_COOLDOWN_MS + 11))).toBe(true)
+  })
+
+  it('surfaces the 401 reason once past the threshold (the #602 path)', async () => {
+    const p = probe()
+    const body = failBody('gh: Bad credentials (HTTP 401)')
+    for (let i = 1; i < READ_FAILURE_THRESHOLD; i++) expect(isSilentSkip(await p.call('k', body, T0 + i))).toBe(true)
+    expect(noteText(await p.call('k', body, T0 + READ_FAILURE_THRESHOLD)))
+      .toContain('auth rejected (HTTP 401), rotate token if it persists')
+  })
+
+  it('rate-limit returns the breaker signal and does not advance the failure count', async () => {
+    const p = probe()
+    expect(await p.call('k', failBody('gh: HTTP 429: Too Many Requests'), T0)).toEqual({ ok: false, rateLimited: true })
+    // The 429 didn't count — a following transient failure is consecutive #1, silent.
+    expect(isSilentSkip(await p.call('k', failBody('gh: HTTP 503'), T0 + 1))).toBe(true)
+  })
+
+  it('a non-GhError (real infra/code bug) is rethrown — it must crash the tick', async () => {
+    const p = probe()
+    await expect(p.call('k', async () => { throw new Error('bun.spawn died') }, T0)).rejects.toThrow('bun.spawn died')
   })
 })

--- a/src/orchestrator/plugins/github/backoff.ts
+++ b/src/orchestrator/plugins/github/backoff.ts
@@ -10,6 +10,14 @@ import { WARN_COOLDOWN_MS } from '../_rate-limit.js'
 // Escalating backoff windows, capped at the last. One step per open window.
 export const BACKOFF_SCHEDULE_MS: ReadonlyArray<number> = [5, 10, 30, 60].map(m => m * 60_000)
 
+// Consecutive failed ticks on one watched entry before readEntry treats it as
+// likely-dead rather than flapping. Gates two behaviors off the same count:
+// the IRC warn note (don't ping on a one-off flap) and read throttling (stop
+// re-reading a dead entry every tick). 3 ticks ≈ ~9 failed gh attempts (each
+// tick retries in-call), which a transient flap clears well inside — so only a
+// sustained failure crosses it. See GhPluginBase.readEntry.
+export const READ_FAILURE_THRESHOLD = 3
+
 export class RateLimitBreaker {
   private level = 0   // 0 = closed; N = number of escalations applied
   private until = 0   // unix ms; polling is allowed again when now >= until
@@ -58,16 +66,13 @@ export function formatBackoffNotice(windowMs: number): string {
   return `[dispatcher] GH rate-limited, backing off ${Math.round(windowMs / 60_000)}m`
 }
 
-// Cooldown-gated note for an entry whose read keeps failing after retries. HTTP
-// 404 can't tell a deleted/renamed repo from an upstream edge-flap, so the
-// wording hedges; recurrence is the persistence signal (a real deletion keeps
-// warning every window, a one-off flap warns once). `recoveryCmd` is the exact
-// dispatcher DM an operator types to stop watching — pulled verbatim from the
-// owning plugin's help text.
-export function formatReadFailureNote(pluginName: string, key: string, recoveryCmd: string): string {
+// Cooldown-gated note for an entry whose read keeps failing past the
+// consecutive-failure threshold. `reason` (from describeReadFailure) names the
+// distinguishing action — rotate token (401), unwatch a dead repo (404), or
+// ride out a GH flake — so the reader doesn't have to dig the dispatcher log.
+// `recoveryCmd` is the exact dispatcher DM an operator types to stop watching,
+// pulled verbatim from the owning plugin's help text.
+export function formatReadFailureNote(pluginName: string, key: string, recoveryCmd: string, reason: string): string {
   const mins = Math.round(WARN_COOLDOWN_MS / 60_000)
-  return (
-    `[dispatcher] ${pluginName}: ${key} read failing (deleted/renamed or GH flaking) —` +
-    ` suppressing ${mins}m; if persistent: ${recoveryCmd}`
-  )
+  return `[dispatcher] ${pluginName}: ${key} read failing: ${reason}. suppressing ${mins}m; recover: ${recoveryCmd}`
 }

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -5,9 +5,9 @@ import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, type PluginTickResult, type TaggedEvent } from '../../plugin.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { tryClaimPerN, type PerNCommand } from '../grammar.js'
-import { GhClient, GhError, fetchRateLimit, isExpectedTransientError, isRateLimitError } from './github-api.js'
+import { GhClient, GhError, describeReadFailure, fetchRateLimit, isRateLimitError } from './github-api.js'
 import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
-import { RateLimitBreaker, formatBackoffNotice } from './backoff.js'
+import { RateLimitBreaker, READ_FAILURE_THRESHOLD, formatBackoffNotice, formatReadFailureNote } from './backoff.js'
 
 // Per-entry read outcome. `readEntry` never throws the expected gh-error
 // classes — it returns one of these so a caller's Promise.all over entries
@@ -32,9 +32,12 @@ export abstract class GhPluginBase extends BasePlugin {
   // so a rate-limit on any of them should quiet all of them.
   private static readonly _breaker = new RateLimitBreaker()
 
-  // Per-entry skip-note cooldown (per instance — a per-watcher signal, unlike
+  // Per-entry read-failure state (per instance — a per-watcher signal, unlike
   // the cross-instance rate-limit warn cooldown). Keyed by the entry's read key.
-  private _skipWarnedAt = new Map<string, number>()
+  //   consecutive — failing ticks in a row; reset to 0 on any clean read.
+  //   warnedAt    — last time the IRC note fired (cooldown gate against spam).
+  //   lastReadAt  — last time we actually attempted the read (throttle gate).
+  private _readFailures = new Map<string, { consecutive: number; warnedAt: number; lastReadAt: number }>()
 
   // Last channel set this plugin returned from a clean tick — replayed while the
   // breaker is open so a multi-minute backoff doesn't PART the watched channels.
@@ -95,29 +98,58 @@ export abstract class GhPluginBase extends BasePlugin {
   }
 
   // Run one watched entry's read. Returns a discriminated result instead of
-  // throwing the expected gh-error classes:
-  //   - success                       → { ok: true, value }
-  //   - rate-limit                    → { ok: false, rateLimited: true }  (caller trips the breaker)
-  //   - 404 / transient past retries  → { ok: false, rateLimited: false, events } (cooldown-gated note, skip entry)
-  //   - 422 / non-GhError             → re-thrown (a real defect surfaces as dispatcher_error)
-  // `noteText` is the cooldown-gated message; `noteChannels` route it.
+  // throwing, so one bad entry never aborts the tick's Promise.all (which would
+  // drop every sibling plugin's work — the dispatcher runs all runTicks together):
+  //   - success      → { ok: true, value }  (clears the entry's failure state)
+  //   - rate-limit   → { ok: false, rateLimited: true }  (caller trips the breaker)
+  //   - any GhError  → { ok: false, rateLimited: false, events } (skip the entry, warn)
+  //   - non-GhError  → re-thrown (a real infra/code bug, e.g. a spawn crash — fail loud)
+  // A watched entry erroring is a per-entry condition (401/404/403/422/network);
+  // only a genuine non-GhError defect should take the whole tick down.
+  //
+  // A per-entry consecutive-failure count drives two threshold behaviors off the
+  // one signal (see READ_FAILURE_THRESHOLD):
+  //   warn   — the IRC note fires only once the entry has failed THRESHOLD ticks
+  //            in a row, so a one-off flap (404/401/5xx that clears next tick)
+  //            never pings the channel. Past the threshold it repeats per cooldown.
+  //   throttle — once past the threshold the entry is likely dead, not flapping,
+  //            so we stop re-reading it every tick (each read is ~3 in-call gh
+  //            retries); we probe once per cooldown instead. A clean probe resets
+  //            the count and the entry recovers to every-tick reads.
+  // WARN_COOLDOWN_MS does double duty here: the warn-repeat gate and the probe
+  // cadence are the same window, so a degraded entry's note and re-probe align.
+  // `recoveryCmd` is the verbatim dispatcher DM to stop watching; `noteChannels`
+  // route the note. readEntry builds the note (it holds the error → the reason).
   protected async readEntry<T>(
     cooldownKey: string,
     noteChannels: string[],
-    noteText: string,
+    recoveryCmd: string,
     body: () => Promise<T>,
     now = Date.now(),
   ): Promise<ReadEntryResult<T>> {
+    // Throttle: a degraded entry probes once per cooldown, not every tick.
+    const st = this._readFailures.get(cooldownKey)
+    if (st && st.consecutive >= READ_FAILURE_THRESHOLD && now - st.lastReadAt < WARN_COOLDOWN_MS) {
+      return { ok: false, rateLimited: false, events: [] }
+    }
     try {
-      return { ok: true, value: await body() }
+      const value = await body()
+      this._readFailures.delete(cooldownKey)  // clean read → not failing
+      return { ok: true, value }
     } catch (e) {
       if (!(e instanceof GhError)) throw e
       if (isRateLimitError(e)) return { ok: false, rateLimited: true }
-      if (!isExpectedTransientError(e)) throw e
-      this.log(`[${this.name}] read failing for ${cooldownKey}: ${e.message}\n`)
-      const last = this._skipWarnedAt.get(cooldownKey) ?? 0
-      if (now - last <= WARN_COOLDOWN_MS) return { ok: false, rateLimited: false, events: [] }
-      this._skipWarnedAt.set(cooldownKey, now)
+      const fail = st ?? { consecutive: 0, warnedAt: 0, lastReadAt: 0 }
+      fail.consecutive += 1
+      fail.lastReadAt = now
+      this._readFailures.set(cooldownKey, fail)
+      this.log(`[${this.name}] read failing for ${cooldownKey} (${fail.consecutive} in a row): ${e.message}\n`)
+      // Below threshold: a flap, stay silent. Past it: warn, then cooldown-gate.
+      if (fail.consecutive < READ_FAILURE_THRESHOLD) return { ok: false, rateLimited: false, events: [] }
+      const warnedRecently = fail.warnedAt !== 0 && now - fail.warnedAt <= WARN_COOLDOWN_MS
+      if (warnedRecently) return { ok: false, rateLimited: false, events: [] }
+      fail.warnedAt = now
+      const noteText = formatReadFailureNote(this.name, cooldownKey, recoveryCmd, describeReadFailure(e.stderr))
       return {
         ok: false,
         rateLimited: false,

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -145,8 +145,10 @@ export abstract class GhPluginBase extends BasePlugin {
       this._readFailures.set(cooldownKey, fail)
       this.log(`[${this.name}] read failing for ${cooldownKey} (${fail.consecutive} in a row): ${e.message}\n`)
       // Below threshold: a flap, stay silent. Past it: warn, then cooldown-gate.
+      // The `<` matches the throttle gate above so warn + re-probe share one
+      // window exactly — at the boundary tick the entry both re-reads and re-warns.
       if (fail.consecutive < READ_FAILURE_THRESHOLD) return { ok: false, rateLimited: false, events: [] }
-      const warnedRecently = fail.warnedAt !== 0 && now - fail.warnedAt <= WARN_COOLDOWN_MS
+      const warnedRecently = fail.warnedAt !== 0 && now - fail.warnedAt < WARN_COOLDOWN_MS
       if (warnedRecently) return { ok: false, rateLimited: false, events: [] }
       fail.warnedAt = now
       const noteText = formatReadFailureNote(this.name, cooldownKey, recoveryCmd, describeReadFailure(e.stderr))

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -21,7 +21,6 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import type { GhCommit } from './github-api.js'
 import { GhPluginBase } from './base.js'
-import { formatReadFailureNote } from './backoff.js'
 
 export interface CommitWatchEntry {
   repo: string
@@ -193,7 +192,7 @@ export class GitHubCommitsPlugin extends GhPluginBase {
       const r = await this.readEntry(
         key,
         channels,
-        formatReadFailureNote(this.name, key, `unwatch ${formatRepoSpec(entry.repo, entry.branch, entry.path)}`),
+        `unwatch ${formatRepoSpec(entry.repo, entry.branch, entry.path)}`,
         () => this.client.fetchRepoCommits(entry.repo, branch, entry.path, PER_PAGE),
         now,
       )

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -69,13 +69,6 @@ export function isRateLimitError(e: unknown): boolean {
   return e instanceof GhError && isRateLimitStderr(e.stderr)
 }
 
-// Expected/transient gh error class the per-entry readEntry path skips with a
-// cooldown-gated note (vs failing the whole tick): a 404 that survived its
-// retries, or any network/server transient that exhausted its retries.
-export function isExpectedTransientError(e: unknown): boolean {
-  return e instanceof GhError && (HTTP_404.test(e.stderr) || classifyTransient(e.stderr) != null)
-}
-
 export class GhError extends Error {
   readonly stderr: string
   readonly attempts: number

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -6,8 +6,15 @@ import type { RateLimitInfo } from '../_rate-limit.js'
 // owns the backoff schedule); 404 retries on a shorter base since an upstream
 // edge-flap clears on the next request, not after server recovery. 422 throws
 // on first attempt, logged verbatim so a 422-as-race shows in dispatcher logs.
+//
+// 401 (`gh: Bad credentials (HTTP 401)`) is here because GitHub intermittently
+// 401s a valid token — an internal auth service hiccup the API facade surfaces
+// as 401, cleared by the next request. We retry it like any transient rather
+// than crash the tick; a genuinely-revoked token still surfaces via the
+// per-entry consecutive-failure warn note (it just persists past the threshold).
 const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
   { re: /HTTP 5\d\d/i, label: 'http-5xx' },
+  { re: /HTTP 401/i, label: 'http-401' },
   { re: /\btimed out\b/i, label: 'timeout' },
   { re: /\bcontext deadline exceeded\b/i, label: 'timeout' },
   { re: /\bi\/o timeout\b/i, label: 'timeout' },
@@ -21,6 +28,7 @@ const TRANSIENT_PATTERNS: { re: RegExp; label: string }[] = [
 const HTTP_422 = /HTTP 422/i
 const HTTP_404 = /HTTP 404/i
 const HTTP_403 = /HTTP 403/i
+const HTTP_401 = /HTTP 401/i
 const HTTP_429 = /HTTP 429/i
 const RATE_LIMIT_MSG = /rate limit|secondary rate/i
 
@@ -29,6 +37,23 @@ function classifyTransient(stderr: string): string | null {
     if (re.test(stderr)) return label
   }
   return null
+}
+
+// Short operator-facing reason for a read that keeps failing, derived from gh
+// stderr. Surfaces the distinguishing *action* so a reader doesn't have to dig
+// the dispatcher log: rotate the token (401), unwatch a dead repo (404), fix
+// token scopes (403), file a query bug (422), or ride out a GitHub flake.
+// Called only after the rate-limit branch, so a 403 here is the permission kind,
+// not a rate-limit 403. Fed into the cooldown-gated warn note.
+export function describeReadFailure(stderr: string): string {
+  if (HTTP_401.test(stderr)) return 'auth rejected (HTTP 401), rotate token if it persists'
+  if (HTTP_404.test(stderr)) return 'deleted/renamed (HTTP 404)'
+  if (HTTP_403.test(stderr)) return 'permission denied (HTTP 403), check token scopes'
+  if (HTTP_422.test(stderr)) return 'validation failed (HTTP 422), likely a query bug'
+  const label = classifyTransient(stderr)
+  if (label) return `GH flaking (${label})`
+  const firstLine = stderr.split('\n').map(s => s.trim()).find(Boolean)
+  return firstLine ? `gh error: ${firstLine}` : 'gh read failed'
 }
 
 // Rate-limit = HTTP 429, or HTTP 403 carrying a rate-limit message (primary or

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -3,7 +3,6 @@ import { resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, issueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
-import { formatReadFailureNote } from './backoff.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
@@ -53,7 +52,7 @@ export class GitHubIssuesPlugin extends GhBase {
       const r = await this.readEntry(
         key,
         [projectChannel],
-        formatReadFailureNote(this.name, key, `unwatch ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`),
+        `unwatch ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`,
         () => scraper.scrapeIssue(repo, number, prevIssue),
         now,
       )

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -16,7 +16,6 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import { labelNames, type GhRepoIssue } from './github-api.js'
 import { GhPluginBase } from './base.js'
-import { formatReadFailureNote } from './backoff.js'
 
 export interface NewIssuesWatchEntry {
   repo: string
@@ -160,7 +159,7 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
       const r = await this.readEntry(
         repo,
         announcementChannels,
-        formatReadFailureNote(this.name, repo, `unwatch new-issues ${repo}`),
+        `unwatch new-issues ${repo}`,
         () => this.client.fetchRepoOpenIssues(repo),
         now,
       )

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -20,7 +20,6 @@ import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_share
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import { labelNames, type GhRepoPr } from './github-api.js'
 import { GhPluginBase } from './base.js'
-import { formatReadFailureNote } from './backoff.js'
 
 export interface NewPrsWatchEntry {
   repo: string
@@ -165,7 +164,7 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
       const r = await this.readEntry(
         repo,
         announcementChannels,
-        formatReadFailureNote(this.name, repo, `unwatch new-prs ${repo}`),
+        `unwatch new-prs ${repo}`,
         () => this.client.fetchRepoOpenPrs(repo),
         now,
       )

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -3,7 +3,6 @@ import { resolveRepoEntry } from '../../config.js'
 import { channelSlug, defaultProject, isMultiRepo, issueChannel, linearIssueChannel, resolveProjectChannel } from '../../naming.js'
 import type { PluginLogger, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { GhBase } from './base.js'
-import { formatReadFailureNote } from './backoff.js'
 import { GhScraper } from './scraper.js'
 import { formatPayload } from './format.js'
 import { shouldPush, type OrchestratorEvent } from './diff.js'
@@ -183,7 +182,7 @@ export class GitHubPrsPlugin extends GhBase {
       const r = await this.readEntry(
         key,
         [projectChannel],
-        formatReadFailureNote(this.name, key, `unwatch pr ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`),
+        `unwatch pr ${number}${repo !== defaultRepo ? ` ${repo}` : ''}`,
         () => scraper.scrapePr(repo, number, prevPr),
         now,
       )


### PR DESCRIPTION
Closes #602
Closes #595

## Headline: a single watched-entry error crashed the whole tick

`runOneTick` runs every plugin's `runTick` in one `Promise.all` (`src/orchestrator.ts:98`). One rejection rejects the whole thing — so a single watched entry's gh error dropped **every** plugin's events and state for that tick (no `writeState`, no event dispatch).

A 401 hit this regularly. GitHub intermittently 401s a **valid** token (an internal auth-service hiccup the API facade surfaces as `gh: Bad credentials (HTTP 401)`), and `spawnGh` re-threw it as an unhandled `GhError`. From the sdks dispatcher log — same token, healthy budget, recovers next tick:

```
orchestrator[daemon]: tick failed: GhError: ... gh api repos/GoCarrot/teak-ios/issues/151/comments...
gh: Bad credentials (HTTP 401)
orchestrator[daemon]: tick clean, 0 events in 1.6s     ← next tick fine, 4954/5000 budget
```

401 (#602) was just one trigger. The real fix is the boundary: **a watched entry erroring is a per-entry condition; only a genuine non-GhError defect should take the tick down.**

## What changed

`readEntry` now returns a per-entry result for **any** `GhError` (rate-limit still trips the breaker; non-GhError — a real spawn/code bug — still re-throws and crashes loud). A per-entry consecutive-failure count drives two thresholds off one signal (`READ_FAILURE_THRESHOLD = 3`):

- **warn after 3 consecutive failures** — a one-off flap never pings IRC. ⚠️ **Behavior change:** this defers the first warn to the 3rd consecutive failure for **all** transients (404/network included), not just 401. A single-tick blip that used to warn immediately is now silent; only a sustained failure warns. Intentional — net less channel noise.
- **throttle once degraded** (#595) — stop re-reading a likely-dead entry every tick (a 404 dead repo was 3 in-call retries every tick forever); probe once per cooldown instead. A clean probe clears the state and the entry recovers to every-tick reads. A real flap clears before reaching 3, so it keeps its fast in-call retries.

Supporting:
- `401` added to `TRANSIENT_PATTERNS` so `spawnGh` retries it in-call too (verified the real string matches `/HTTP 401/i`).
- The warn note now names the operator **action** (`describeReadFailure`): rotate token (401) / unwatch dead repo (404) / fix scopes (403) / query bug (422) / ride out a flake — instead of one generic hedge.
- `WARN_COOLDOWN_MS` does double duty (warn-repeat gate + probe cadence) so a degraded entry's note and re-probe align. Noted in-code.
- Note construction centralized into `readEntry` (it holds the error → the reason); dropped the duplicated `formatReadFailureNote` call from all 5 call sites.

## §#486 completeness

The failure mode is "single-entry error crashes the tick," so the fix covers it uniformly, not just 401. 5xx/429/403-rate-limit/timeout/dns/conn/EOF were already transient; 401 was the only gap. 403-scope and 422 previously re-threw (crash) — now isolated per-entry too. A systematic 422 (query bug) still hits every entry → N notes → impossible to miss, and the daemon log keeps the verbatim detail; only a per-entry race gets isolated.

## Tests

- `readEntry` state machine direct (injected clock): warn threshold, read throttle, clean-probe recovery, the 401 reason path, rate-limit passthrough, non-GhError rethrow boundary.
- Integration (through runTick): warn-after-3, degraded-entry throttle (read-count), 422 isolating instead of crashing, a single 401 isolating while the sibling is processed and the tick survives, new note wording.
- `describeReadFailure` per-status + fallback; a 401 in-call retry test.

`bun test` 978 pass / 0 fail, lint + typecheck clean.
