### PR TITLE
add claude-opus-4-8 to pricing table

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -27,7 +27,7 @@ export interface ModelPricing {
 }
 
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
-  // Opus 4.x current generation — $5 base input. (Opus 4.1 and earlier use the $15 tier.)
+  // Opus 4.x current generation — $5 base input (with date-stamped variant Claude Code records). Opus 4.1 and earlier use the $15 tier.
   'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 }, // exact-match lookup: add dated variants (claude-opus-4-8-YYYYMMDD) when observed in transcripts
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-6':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -3,7 +3,7 @@
 // to estimate cost from token counts.
 //
 // Source: https://platform.claude.com/docs/en/about-claude/pricing
-// Retrieved: 2026-05-16
+// Retrieved: 2026-06-30
 //
 // All rates are USD per 1M tokens. When Anthropic publishes new rates or a
 // model ID we don't yet recognize appears in transcripts, bump this table
@@ -27,8 +27,8 @@ export interface ModelPricing {
 }
 
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
-  // Opus 4.x current generation — $5 base input (with date-stamped variant Claude Code records).
-  // (Opus 4.1 and earlier remain on the older $15 tier.)
+  // Opus 4.x current generation — $5 base input. (Opus 4.1 and earlier use the $15 tier.)
+  'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 }, // exact-match lookup: add dated variants (claude-opus-4-8-YYYYMMDD) when observed in transcripts
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-6':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-5':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -28,7 +28,7 @@ export interface ModelPricing {
 
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
   // Opus 4.x current generation — $5 base input (with date-stamped variant Claude Code records). Opus 4.1 and earlier use the $15 tier.
-  'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 }, // exact-match lookup: add dated variants (claude-opus-4-8-YYYYMMDD) when observed in transcripts
+  'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 }, // exact-match: dated variants (claude-opus-4-8-YYYYMMDD) each need an explicit entry
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-6':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-5':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },


### PR DESCRIPTION
Closes #612

Adds `claude-opus-4-8` to the Opus 4.x current-gen block in `src/pricing.ts`. All five rates confirmed from the Anthropic pricing page (retrieved 2026-06-30): \$5 input / \$25 output / \$6.25 5m-cache / \$10 1h-cache / \$0.50 cache-read.

Lookup mechanism is exact-match (`PRICING[model]`), not normalized. Transcript scan found only the bare alias; no dated variant present yet. A trailing comment on the new entry documents the gap so the next person knows to add `claude-opus-4-8-YYYYMMDD` explicitly when it shows up in transcripts.

Also bumps the retrieval date comment from 2026-05-16 to 2026-06-30 and consolidates the two-line Opus block comment into one.