### PR TITLE
route PR-scoped events to watch channel when no linked issues

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -598,6 +598,30 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
     } finally { spy.mockRestore() }
   })
 
+  it('pr_no_linked_issues note names the Linear channel as routing destination when cross-link exists but no GitHub link', async () => {
+    const warnEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues', repo: 'org/repo', pr: 25, url: 'u', title: 't',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap(), events: [warnEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25 }] },
+          'linear-issues': { watched: [{ identifier: 'C-758' }] },
+        },
+      }
+      const result = await plugin(stubFromMap({
+        'C-758': [attachment('https://github.com/org/repo/pull/25')],
+      })).runTick(cfg, { prs: {} })
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('#proj-issue-c-758')
+      expect(text).not.toContain('#proj-leads')
+    } finally { spy.mockRestore() }
+  })
+
   it('declares Linear channels in desiredChannels for every watched Linear identifier', () => {
     const cfg: OrchestratorConfig = {
       project: 'proj', repo: 'org/repo',
@@ -948,6 +972,28 @@ describe('GitHubPrsPlugin.runTick — cross-repo linked issues', () => {
       }
       const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
       expect(result.channels).toContain('#proj-bar-issue-14')
+    } finally { spy.mockRestore() }
+  })
+
+  it('single-mode: pr_added_to_watch with only foreign-repo linked issues announces routing to projectChannel, not empty', async () => {
+    const seedEv: OrchestratorEvent = {
+      kind: 'pr_added_to_watch', repo: 'org/main', pr: 25, url: 'u', title: 't',
+      linked_issues: [{ repo: 'org/other', number: 14 }],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ repo: 'org/main', linked_issues: [{ repo: 'org/other', number: 14 }] }),
+      events: [seedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/main',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('#proj-leads')
+      expect(text).not.toMatch(/routing events to\s*$/)
     } finally { spy.mockRestore() }
   })
 

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -182,7 +182,7 @@ describe('GitHubPrsPlugin.runTick', () => {
   })
 })
 
-describe('GitHubPrsPlugin.runTick — routing when no linked issues (#576)', () => {
+describe('GitHubPrsPlugin.runTick — routing when no linked issues', () => {
   stubRateLimit()
 
   it('routes PR event to defaultChannel when no linked issues and no entry channels (resolveChannels empty/empty fallback)', async () => {
@@ -247,7 +247,7 @@ describe('GitHubPrsPlugin.runTick — routing when no linked issues (#576)', () 
   })
 })
 
-describe('GitHubPrsPlugin.runTick — pr_no_linked_issues notification (#601)', () => {
+describe('GitHubPrsPlugin.runTick — pr_no_linked_issues notification', () => {
   stubRateLimit()
 
   it('emits note to project channel naming the routing destination when no entry channels', async () => {

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -182,6 +182,140 @@ describe('GitHubPrsPlugin.runTick', () => {
   })
 })
 
+describe('GitHubPrsPlugin.runTick — routing when no linked issues (#576)', () => {
+  stubRateLimit()
+
+  it('routes PR event to defaultChannel when no linked issues and no entry channels (resolveChannels empty/empty fallback)', async () => {
+    const ciEv: OrchestratorEvent = {
+      kind: 'ci_transitioned',
+      repo: 'org/repo', pr: 25, url: 'u',
+      from: 'PENDING', to: 'SUCCESS', head_oid: 'abc', linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [ciEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes PR review event to entry channels when no linked issues but entry channels specified', async () => {
+    const reviewEv: OrchestratorEvent = {
+      kind: 'pr_review_submitted',
+      repo: 'org/repo', pr: 25, url: 'u',
+      review_id: 1, review_url: 'ru', author: 'alice', state: 'APPROVED',
+      body: '', body_preview: '', is_worker_reply: false, linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [reviewEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25, channels: ['#proj-issue-576'] }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-576'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes PR CI event to entry channels when no linked issues but entry channels specified', async () => {
+    const ciEv: OrchestratorEvent = {
+      kind: 'ci_transitioned',
+      repo: 'org/repo', pr: 25, url: 'u',
+      from: 'PENDING', to: 'FAILURE', head_oid: 'abc', linked_issues: [],
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [ciEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25, channels: ['#proj-issue-576'] }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-576'])
+    } finally { spy.mockRestore() }
+  })
+})
+
+describe('GitHubPrsPlugin.runTick — pr_no_linked_issues notification (#601)', () => {
+  stubRateLimit()
+
+  it('emits note to project channel naming the routing destination when no entry channels', async () => {
+    const noLinkedEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues',
+      repo: 'org/repo', pr: 25, url: 'https://example.com/p/25', title: 'P',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [noLinkedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25 }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('org/repo#25')
+      expect(text).toContain('#proj-leads')
+      expect(text).not.toContain('won\'t be routed')
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits confirmation to project channel when entry channels specified', async () => {
+    const noLinkedEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues',
+      repo: 'org/repo', pr: 25, url: 'u', title: 'P',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [noLinkedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25, channels: ['#proj-issue-576'] }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      const text = (result.taggedEvents[0]?.payload as { kind: 'oneline'; text: string }).text
+      expect(text).toContain('org/repo#25')
+      expect(text).toContain('#proj-issue-576')
+      expect(text).not.toContain('won\'t be routed')
+    } finally { spy.mockRestore() }
+  })
+
+  it('routes notification to project channel only, not to entry channels', async () => {
+    const noLinkedEv: OrchestratorEvent = {
+      kind: 'pr_no_linked_issues',
+      repo: 'org/repo', pr: 25, url: 'u', title: 'P',
+    } as OrchestratorEvent
+    const spy = spyOn(GhScraper.prototype, 'scrapePr').mockResolvedValue({
+      snap: fakePrSnap({ linked_issues: [] }), events: [noLinkedEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: { 'github-prs': { watched: [{ number: 25, channels: ['#some-channel'] }] } },
+      }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-leads'])
+      expect(result.taggedEvents[0]?.channels).not.toContain('#some-channel')
+    } finally { spy.mockRestore() }
+  })
+})
+
 describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
   stubRateLimit()
 
@@ -267,7 +401,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
         'C-758': [attachment('https://github.com/org/repo/pull/25')],
       })).runTick(cfg, { prs: {} })
       expect(result.taggedEvents).toHaveLength(1)
-      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#proj-issue-25', '#proj-issue-c-758'])
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-c-758'])
       expect(result.channels).toContain('#proj-issue-c-758')
     } finally { spy.mockRestore() }
   })
@@ -292,7 +426,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
       }
       const result = await plugin(queryFn).runTick(cfg, { prs: {} })
       expect(calls).toBe(0)
-      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj'])
       expect(result.channels).not.toContain('#proj-issue-c-758')
     } finally { spy.mockRestore() }
   })
@@ -325,7 +459,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
       attached = false
       const tick2 = await p.runTick(cfg, tick1.state)
       expect(tick2.taggedEvents[0]?.channels).not.toContain('#proj-issue-c-758')
-      expect(tick2.taggedEvents[0]?.channels).toContain('#proj-issue-25')
+      expect(tick2.taggedEvents[0]?.channels).toEqual(['#proj'])
     } finally { spy.mockRestore() }
   })
 
@@ -412,7 +546,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
         'C-2': [attachment('https://github.com/org/repo/pull/25')],
       })).runTick(cfg, { prs: {} })
       expect(result.taggedEvents[0]?.channels.sort()).toEqual([
-        '#proj-issue-25', '#proj-issue-c-1', '#proj-issue-c-2',
+        '#proj-issue-c-1', '#proj-issue-c-2',
       ])
     } finally { spy.mockRestore() }
   })
@@ -498,7 +632,7 @@ describe('GitHubPrsPlugin.runTick — Linear attachment cross-link', () => {
         },
       }
       const result = await plugin(async () => { throw new Error('linear down') }).runTick(cfg, { prs: {} })
-      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj'])
     } finally { spy.mockRestore() }
   })
 })
@@ -767,8 +901,8 @@ describe('GitHubPrsPlugin.runTick — cross-repo linked issues', () => {
         plugins: { 'github-prs': { watched: [{ number: 25 }] } },
       }
       const result = await new GitHubPrsPlugin('#proj', (m) => { logs.push(m) }).runTick(cfg, { prs: {} })
-      // Foreign repo dropped → falls back to the PR's own issue channel.
-      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-issue-25'])
+      // Foreign repo dropped → all linked issues dropped → falls back to defaultChannel.
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj'])
       // The cross-repo channel must not appear in the desired-channel set.
       expect(result.channels).not.toContain('#proj-issue-14')
       // Operator-visible stderr warning naming both sides + the remediation.

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -108,10 +108,6 @@ export function formatEvent(event: OrchestratorEvent): string {
     return `Issue ${tag} BACKLOG: ${ev.comment_count ?? 0} comments existed before watch — scan manually: ${event.url ?? ''}`
   }
 
-  if (kind === 'pr_no_linked_issues') {
-    return `PR ${tag} has no linked issues — routing events to project channel. Add Closes #<issue> (or Fixes/Resolves) or specify #channels at watch time: ${event.url ?? ''}`
-  }
-
   if (kind === 'dispatcher_error') {
     const ev = event as SeedEvent
     const tb = (ev.stderr ?? '').trim().split('\n')

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -109,7 +109,7 @@ export function formatEvent(event: OrchestratorEvent): string {
   }
 
   if (kind === 'pr_no_linked_issues') {
-    return `WARN PR ${tag} has no linked issues — events won't be routed. Add Closes #<issue> (or Fixes/Resolves) to the PR body: ${event.url ?? ''}`
+    return `PR ${tag} has no linked issues — routing events to project channel. Add Closes #<issue> (or Fixes/Resolves) or specify #channels at watch time: ${event.url ?? ''}`
   }
 
   if (kind === 'dispatcher_error') {

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -247,8 +247,12 @@ export class GitHubPrsPlugin extends GhBase {
         if (event.kind === 'pr_no_linked_issues') {
           // Notification to project channel only — distinct from review/CI event
           // routing, which reaches the watch channel via resolveChannels below.
-          const text = entryChannels.length
-            ? `routing PR ${key} events → ${entryChannels.join(' ')} (no linked issue)`
+          // Derive the routing destination from the same resolveChannels result
+          // the events use, so the note stays accurate when Linear cross-links exist.
+          const actualChannels = this.resolveChannels(linearChannels, entryChannels)
+          const nonProjectChannels = actualChannels.filter(ch => ch !== projectChannel)
+          const text = nonProjectChannels.length
+            ? `routing PR ${key} events → ${nonProjectChannels.join(' ')} (no linked issue)`
             : `PR ${key} has no linked issues — routing events to ${projectChannel}. Add Closes #<issue> (or Fixes/Resolves) or specify #channels at watch time: ${event.url ?? ''}`
           taggedEvents.push({ channels: [projectChannel], payload: { kind: 'oneline', text } })
           continue
@@ -263,9 +267,10 @@ export class GitHubPrsPlugin extends GhBase {
               GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels),
               entryChannels
             ).filter(ch => ch !== projectChannel)
+            const routingStr = routingChannels.length ? routingChannels.join(', ') : projectChannel
             taggedEvents.push({
               channels: [projectChannel],
-              payload: { kind: 'oneline', text: `now watching PR ${key} — routing events to ${routingChannels.join(', ')}` },
+              payload: { kind: 'oneline', text: `now watching PR ${key} — routing events to ${routingStr}` },
             })
           }
           continue

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -98,10 +98,10 @@ export class GitHubPrsPlugin extends GhBase {
   }
 
   // Channels for a PR event: linked-issue channels (each slugged per its own
-  // repo), project channel for no-linked-issues warnings, PR channel fallback.
-  // Linear channels (PRs cross-linked to Linear issues via attachments) are
-  // additive — appended to the github routing for every event with a `pr`
-  // number except the `pr_no_linked_issues` warning, which stays project-only.
+  // repo), or Linear channels when no GitHub issues are linked. Returns []
+  // when both are absent so resolveChannels falls back to entryChannels or
+  // defaultChannel. pr_no_linked_issues is handled inline in runTick and
+  // never reaches this function.
   private static prEventChannels(
     config: OrchestratorConfig,
     project: string,
@@ -112,14 +112,15 @@ export class GitHubPrsPlugin extends GhBase {
     linearChannels: string[],
   ): string[] {
     if (event.pr == null) return []
-    if (event.kind === 'pr_no_linked_issues') return [projectChannel]
     if (routable.length) {
       return [
         ...routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo))),
         ...linearChannels,
       ]
     }
-    return [issueChannel(project, event.pr, channelSlug(config, prRepo)), ...linearChannels]
+    // No GitHub linked issues: route to Linear channels when present; otherwise
+    // return [] so resolveChannels falls back to entryChannels or defaultChannel.
+    return linearChannels
   }
 
   // Stderr-only — operator-visible in daemon.log without IRC noise.
@@ -243,6 +244,15 @@ export class GitHubPrsPlugin extends GhBase {
         snap.warned_drops_for_oid = snap.head_oid
       }
       for (const event of events) {
+        if (event.kind === 'pr_no_linked_issues') {
+          // Notification to project channel only — distinct from review/CI event
+          // routing, which reaches the watch channel via resolveChannels below.
+          const text = entryChannels.length
+            ? `routing PR ${key} events → ${entryChannels.join(' ')} (no linked issue)`
+            : `PR ${key} has no linked issues — routing events to ${projectChannel}. Add Closes #<issue> (or Fixes/Resolves) or specify #channels at watch time: ${event.url ?? ''}`
+          taggedEvents.push({ channels: [projectChannel], payload: { kind: 'oneline', text } })
+          continue
+        }
         if (event.kind === 'pr_added_to_watch') {
           const linked = event.linked_issues ?? []
           // Suppress only when there are neither github linked-issues nor


### PR DESCRIPTION
Closes #576
Closes #601

## What

Two routing bugs in `GitHubPrsPlugin` when a watched PR has no linked issues:

**#576** — review/CI/comment events routed to `#proj-issue-<prNum>` (a derived channel nobody watches for maint PRs) instead of the watch channel.

**#601** — `pr_no_linked_issues` emitted a misleading WARN ("events won't be routed") even when an explicit channel was specified at watch time.

## How

`prEventChannels`: drop the `#proj-issue-<prNum>` fallback. Returning `[]` when no GitHub linked issues and no Linear cross-links exist lets `resolveChannels` fall through to `entryChannels` (channels declared at `watch pr N #chan`) or `defaultChannel` (#proj-leads). All PR-scoped events now reach the watch channel regardless of linked-issue state.

`pr_no_linked_issues`: intercepted before the generic `formatPayload` path. With explicit entry channels → confirmation "routing PR X events → #chan (no linked issue)" to project channel only. Without → accurate note naming the actual routing destination. Both cases route to `[projectChannel]` only — kept separate from review/CI routing (comment in code).

Two load-bearing tests pinned: `resolveChannels([],[])` → `[defaultChannel]` (via the CI-event-routes-to-defaultChannel test) and `watch pr N` with no linked issues → events land in leads.

## Scope notes

**Supersedes #601's "warning unchanged"**: after #576, the no-explicit case routes to leads. The old "events won't be routed" would be false, so the no-explicit message is updated too. The "warning unchanged" criterion rested on the pre-#576 premise that the fallback was a spurious PR-derived channel.

**#243 interplay**: the additive concern from #243 doesn't reach `pr_no_linked_issues` — that event only fires when there are no linked issues at all, so there is no issue-channel routing for an explicit channel to be additive to. Suppressing the warning (and emitting a confirmation instead) is correct in this case.

**`#proj-issue-<prNum>` dropped from Linear-only routing too** (reviewer: this was always spurious — PR number ≠ issue number; Linear channel is the real destination).

**Single-mode foreign-repo drop fallback** now goes to `defaultChannel` instead of `#proj-issue-<prNum>`. Correct — the dropped link means no routable destination.