### PR TITLE
Add claude-sonnet-5 pricing to src/pricing.ts

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -34,6 +34,11 @@ export const PRICING: Readonly<Record<string, ModelPricing>> = {
   'claude-opus-4-5':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-5-20251101':   { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-1':            { input: 15, output: 75, cache_creation_5m: 18.75, cache_creation_1h: 30,  cache_read: 1.50 },
+  // Sonnet 5 — new generation, separate tier from Sonnet 4.x below. Introductory
+  // pricing through 2026-08-31 (this row). Standard pricing from 2026-09-01: input 3,
+  // output 15, cache_creation_5m 3.75, cache_creation_1h 6, cache_read 0.30 — flip
+  // this entry to those numbers then.
+  'claude-sonnet-5':                { input: 2,  output: 10, cache_creation_5m: 2.50,  cache_creation_1h: 4,   cache_read: 0.20 }, // exact-match: dated variants (claude-sonnet-5-YYYYMMDD) each need an explicit entry
   // Sonnet 4.x current generation (with date-stamped variant Claude Code records).
   'claude-sonnet-4-6':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
   'claude-sonnet-4-5':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -34,12 +34,12 @@ export const PRICING: Readonly<Record<string, ModelPricing>> = {
   'claude-opus-4-5':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-5-20251101':   { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-1':            { input: 15, output: 75, cache_creation_5m: 18.75, cache_creation_1h: 30,  cache_read: 1.50 },
-  // Sonnet 5 — new generation, separate tier from Sonnet 4.x below. Introductory
-  // pricing through 2026-08-31 (this row). Standard pricing from 2026-09-01: input 3,
+  // Sonnet 5 — separate pricing tier from Sonnet 4.x below. Introductory pricing
+  // through 2026-08-31 (this row). Standard pricing from 2026-09-01: input 3,
   // output 15, cache_creation_5m 3.75, cache_creation_1h 6, cache_read 0.30 — flip
   // this entry to those numbers then.
   'claude-sonnet-5':                { input: 2,  output: 10, cache_creation_5m: 2.50,  cache_creation_1h: 4,   cache_read: 0.20 }, // exact-match: dated variants (claude-sonnet-5-YYYYMMDD) each need an explicit entry
-  // Sonnet 4.x current generation (with date-stamped variant Claude Code records).
+  // Sonnet 4.x (with date-stamped variant Claude Code records).
   'claude-sonnet-4-6':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
   'claude-sonnet-4-5':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
   'claude-sonnet-4-5-20250929':     { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },


### PR DESCRIPTION
Closes #622

Adds `claude-sonnet-5` to `src/pricing.ts`, mirroring #617 (the opus-4-8 addition).

**Alias confirmed empirically**: spawned `claude --model claude-sonnet-5 -p ... --output-format json`; the `model` field in both the init event and the assistant message came back `claude-sonnet-5`, and the model self-reported the same string. Cross-checked against Anthropic's live pricing page — no dated-snapshot variant documented, consistent with what the spawn test echoed back, so no `-YYYYMMDD` row is added (same call #617 made for opus-4-8).

**Pricing** sourced live from https://platform.claude.com/docs/en/about-claude/pricing:
- Introductory (now through 2026-08-31, encoded in this entry): input $2, output $10, 5m-cache-write $2.50, 1h-cache-write $4, cache-read $0.20 (all /MTok)
- Standard (from 2026-09-01): input $3, output $15, 5m $3.75, 1h $6, read $0.30 — documented in the entry's comment so the September flip is a copy-paste, not a re-fetch

Cache multipliers are the standard 1.25x/2x/0.1x of base input, consistent with every other row in the table.

**Verified token-usage picks it up**: ran `bin/roost-token-usage report` against a synthetic transcript with `model: claude-sonnet-5` — got a real `$1.50` for 500k in / 50k out, not `$?`.

Followup needed after merge: flip intro→standard rates on 2026-09-01 (lead-pm will have the APM file this).