### PR TITLE
add learning from #622

### DIFF
--- a/.claude/learnings/lead-pm.md
+++ b/.claude/learnings/lead-pm.md
@@ -54,6 +54,10 @@ When a symptom could plausibly be caused by two in-flight fixes (one direct, one
 
 Frame live-probe gating as milestone-savings, not pre-flip overhead. When a worker (or you) treats the probe as optional polish, the gate stops firing — but the catch (a rewrite from scratch) costs far less than shipping a query that 400s on every tick. #495's Linear schema bug and #519's zsh extended_glob bug were both caught this way; neither would have surfaced from mocked tests.
 
+## 2026-06-30: A comment documenting a future-required change is a hope, not a trigger (from #622)
+
+A comment documenting a future-required change is a hope, not a trigger. When you encode a value that's correct-now but has a known future change date (e.g. a model's intro-pricing window that flips to standard on a fixed date), file a committed followup to make the change — don't lean on an in-code comment to remind someone. The comment documents WHY; the followup ensures it actually happens.
+
 ## 2026-06-30: Anchor audit/investigation findings to the tool's mission before grading severity (from #604)
 
 Before grading how serious an audit or investigation finding is, ask what the tool is FOR — importance is relative to the mission, not how alarming the finding looks in isolation. perm-irc is a parity relay (relay iff Claude Code blocks), not a safety tool, so "the classifier doesn't catch rm -rf" was off-mission — yet it got graded the "more serious" finding and sharpened further. Alex's mission re-anchor inverted the priority: the scary under-fire was parity working as intended, and the boring over-fire was the whole bug. Pressure-test at plan time: "what is this tool for, and are we framing findings against that mission?" Sibling to §449/§591 (verify behavior empirically) — this one is "frame findings against mission."

--- a/.claude/learnings/worker.md
+++ b/.claude/learnings/worker.md
@@ -38,6 +38,10 @@ When splitting connect-time timers into stages (registration → ready → flush
 
 macOS tmp_cleaner runs daily at midnight, wiping files with atime+mtime+ctime all >3d (verified via `/System/Library/LaunchDaemons/com.apple.tmp_cleaner.plist` + `strings /usr/libexec/tmp_cleaner`). Long-running sessions that don't touch a /tmp file for 3+ days will lose it. For any path re-used across days (shim, lock, socket, log), prefer a brew-symlink-stable or absolute-clone-stable location. Only use /tmp for transient single-session state.
 
+## 2026-06-30: A comment documenting a future-required change is a hope, not a trigger (from #622)
+
+A comment documenting a future-required change is a hope, not a trigger. When you encode a value that's correct-now but has a known future change date (e.g. a model's intro-pricing window that flips to standard on a fixed date), file a committed followup to make the change — don't lean on an in-code comment to remind someone. The comment documents WHY; the followup ensures it actually happens.
+
 ## 2026-06-30: Anchor audit/investigation findings to the tool's mission before grading severity (from #604)
 
 Before grading how serious an audit or investigation finding is, ask what the tool is FOR — importance is relative to the mission, not how alarming the finding looks in isolation. perm-irc is a parity relay (relay iff Claude Code blocks), not a safety tool, so "the classifier doesn't catch rm -rf" was off-mission — yet it got graded the "more serious" finding and sharpened further. Alex's mission re-anchor inverted the priority: the scary under-fire was parity working as intended, and the boring over-fire was the whole bug. Pressure-test at plan time: "what is this tool for, and are we framing findings against that mission?" Sibling to §449/§591 (verify behavior empirically) — this one is "frame findings against mission."


### PR DESCRIPTION
audience-scoped learning from the #622 postmortem: a comment documenting a future-required change is a hope, not a trigger. verbatim in lead-pm.md and worker.md.