### PR TITLE
feat: roost agents — self-updating discovery for shipped agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,8 @@ jobs:
       - name: Shell tests — spawn
         run: bash test/spawn_test.sh
 
+      - name: Shell tests — agents
+        run: bash test/agents_test.sh
+
       - name: Shell tests — compact-hook
         run: bash test/compact-hook_test.sh

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ roost spawn myproject-lead-pm \
 
 See [`docs/ROOST-IN-PRACTICE.md`](docs/ROOST-IN-PRACTICE.md) for the end-to-end walkthrough.
 
-Roost ships more agents than lead-pm — each is a `roost spawn --agent <name>`
+Roost ships more agents than lead-pm — each is a `roost spawn <nick> --agent <name>`
 target. `roost agents` lists the ones installed in your project; `roost agents
 --all` also shows what roost ships but you haven't installed yet, and how to
 pull them in.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ roost spawn myproject-lead-pm \
 See [`docs/ROOST-IN-PRACTICE.md`](docs/ROOST-IN-PRACTICE.md) for the end-to-end walkthrough.
 
 Roost ships more agents than lead-pm — each is a `roost spawn --agent <name>`
-target. Run `roost agents` to see the full set with descriptions, plus which
-are installed in your project (and how to pull in any that aren't). The list
-comes straight from the plugin tree, so new agents show up on their own.
+target. `roost agents` lists the ones installed in your project; `roost agents
+--all` also shows what roost ships but you haven't installed yet, and how to
+pull them in.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ roost spawn myproject-lead-pm \
 
 See [`docs/ROOST-IN-PRACTICE.md`](docs/ROOST-IN-PRACTICE.md) for the end-to-end walkthrough.
 
+Roost ships more agents than lead-pm — each is a `roost spawn --agent <name>`
+target. Run `roost agents` to see the full set with descriptions, plus which
+are installed in your project (and how to pull in any that aren't). The list
+comes straight from the plugin tree, so new agents show up on their own.
+
 ## Prerequisites
 
 - macOS or Linux

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -65,6 +65,8 @@ Pass the same `<human>` / `<gh-login>` values you parsed from your own initial p
 
 See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — what to pass with `--cache-ttl`, `--steer-compact`, and `--ask-irc` for each agent class.
 
+Run `roost agents` to see every agent roost ships — each is a `--agent` target for `roost spawn`. The roster reads straight from the plugin tree, so don't rely on this prompt to enumerate agents; check `roost agents` for what's actually available (and how to install any that aren't yet copied into the project).
+
 ## Working In Channels
 
 **IRC replies only**: your text output isn't surfaced in the channel — use channel_message / direct_message. (Full reminder in MCP instructions.)

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -65,7 +65,7 @@ Pass the same `<human>` / `<gh-login>` values you parsed from your own initial p
 
 See `roost spawn --help` ("Agent class guidance") for the role→flag heuristic — what to pass with `--cache-ttl`, `--steer-compact`, and `--ask-irc` for each agent class.
 
-Run `roost agents` to see every agent roost ships — each is a `--agent` target for `roost spawn`. The roster reads straight from the plugin tree, so don't rely on this prompt to enumerate agents; check `roost agents` for what's actually available (and how to install any that aren't yet copied into the project).
+Run `roost agents` to see which agents you can spawn right now — the `--agent` targets for `roost spawn`, your hire list. Add `--all` to also see what roost ships but isn't installed here yet, plus how to install it. Check `roost agents` rather than relying on this prompt to enumerate agents; it reads what's actually on disk.
 
 ## Working In Channels
 

--- a/bin/roost
+++ b/bin/roost
@@ -45,6 +45,7 @@ Usage: roost <command> [args]
 Commands:
   init                     Bootstrap config, .gitignore, and copy prompts.
   spawn <nick> [options]   Bring up a Claude session on the roost.
+  agents                   List shipped agents and what 'spawn --agent' resolves.
   shutdown <nick>          Kill the tmux session for that nick.
   list                     Show all roost-prefixed tmux sessions.
   attach <nick>            tmux attach to that nick's session.
@@ -252,6 +253,26 @@ Examples:
     --cwd ~/Dev/myproject \\
     --prompt-file /tmp/handoff.md \\
     -- --chrome --system-prompt ' '
+EOF
+}
+
+usage_agents() {
+  cat <<EOF
+Usage: roost agents [--cwd PATH]
+
+List the agents roost ships and the agents 'roost spawn --agent' can resolve
+from here. Two sections:
+
+  Shipped with roost   Every agent under the plugin's agents/ tree (name +
+                       description). A newly shipped agent shows here before
+                       'roost init' copies it into a project.
+
+  Spawnable here       What 'roost spawn --agent <name>' resolves from
+                       <cwd>/.claude/agents and ~/.claude/agents — the set spawn
+                       actually accepts.
+
+A shipped agent missing from the spawnable set is flagged with the command to
+install it. --cwd PATH inspects another project (default: current directory).
 EOF
 }
 
@@ -741,6 +762,15 @@ cmd_spawn() {
       echo "error: agent '${agent}' not found; searched:" >&2
       printf '  %s/.claude/agents/**/%s.md\n' "${cwd}" "${agent}" >&2
       printf '  %s/.claude/agents/**/%s.md\n' "${HOME}" "${agent}" >&2
+      # Same resolver set 'roost agents' lists, so the two never disagree about
+      # what --agent accepts.
+      local _avail
+      _avail="$(_resolvable_agents "${cwd}" | cut -f1 | paste -sd' ' -)"
+      if [ -n "${_avail}" ]; then
+        echo "available agents: ${_avail}" >&2
+      else
+        echo "no agents installed — run 'roost init' to copy the shipped set, or 'roost agents' to see what ships" >&2
+      fi
       exit 1
     fi
   fi
@@ -1049,6 +1079,110 @@ cmd_spawn() {
   echo "  shutdown with: roost shutdown ${nick}"
 }
 
+# Read the single-line `description:` from an agent file's YAML frontmatter.
+# Prints nothing if there's no frontmatter description.
+_agent_description() {
+  awk '
+    /^---[[:space:]]*$/ { fence++; next }
+    fence == 1 && /^description:[[:space:]]*/ { sub(/^description:[[:space:]]*/, ""); print; exit }
+    fence >= 2 { exit }
+  ' "$1"
+}
+
+# Emit "name<TAB>description" for every agent roost ships (the plugin tree).
+# The discovery surface: a newly shipped agent appears here before `roost init`
+# copies it into a project.
+_shipped_agents() {
+  local _f _name
+  for _f in "${ROOST_DIR}/agents"/*.md; do
+    [ -f "${_f}" ] || continue
+    _name="$(basename "${_f}" .md)"
+    printf '%s\t%s\n' "${_name}" "$(_agent_description "${_f}")"
+  done
+}
+
+# Emit "name<TAB>scope" for every agent `roost spawn --agent` would resolve
+# from a given working dir, mirroring the resolver in cmd_spawn: project
+# .claude/agents shadows user ~/.claude/agents, deduped by basename. This is
+# exactly the spawnable set — the not-found error lists the same computation.
+_resolvable_agents() {
+  local _cwd="$1"
+  local _root _scope _f _name
+  local _seen=" "
+  for _root in "${_cwd}/.claude/agents" "${HOME}/.claude/agents"; do
+    [ -d "${_root}" ] || continue
+    if [ "${_root}" = "${HOME}/.claude/agents" ]; then _scope="user"; else _scope="project"; fi
+    while IFS= read -r _f; do
+      [ -n "${_f}" ] || continue
+      _name="$(basename "${_f}" .md)"
+      case "${_seen}" in *" ${_name} "*) continue ;; esac
+      _seen="${_seen}${_name} "
+      printf '%s\t%s\n' "${_name}" "${_scope}"
+    done < <(find -L "${_root}" -name '*.md' -type f 2>/dev/null | sort)
+  done
+}
+
+cmd_agents() {
+  local cwd="${PWD}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --cwd)     cwd="${2:?roost agents: --cwd requires a path}"; shift 2 ;;
+      -h|--help) usage_agents; exit 0 ;;
+      *) echo "error: roost agents: unknown option: $1" >&2; usage_agents; exit 1 ;;
+    esac
+  done
+
+  local shipped resolvable resolved_names
+  shipped="$(_shipped_agents)"
+  resolvable="$(_resolvable_agents "${cwd}")"
+  resolved_names="$(printf '%s' "${resolvable}" | cut -f1)"
+
+  # Section 1: the shipped roster — the discovery answer.
+  echo "Shipped with roost (${ROOST_DIR}/agents):"
+  echo
+  if [ -n "${shipped}" ]; then
+    local _w=0 _n _d
+    while IFS=$'\t' read -r _n _; do
+      [ "${#_n}" -gt "${_w}" ] && _w="${#_n}"
+    done <<< "${shipped}"
+    while IFS=$'\t' read -r _n _d; do
+      printf '  %-*s  %s\n' "${_w}" "${_n}" "${_d}"
+    done <<< "${shipped}"
+  else
+    echo "  (none)"
+  fi
+
+  # Section 2: what `roost spawn --agent` resolves from here. listing ==
+  # spawnable, and a shipped-but-not-installed agent gets the install command.
+  echo
+  echo "Spawnable here (roost spawn --agent <name>) — resolved from .claude/agents/:"
+  echo
+  if [ -n "${resolvable}" ]; then
+    local _rw=0 _rn _rs
+    while IFS=$'\t' read -r _rn _; do
+      [ "${#_rn}" -gt "${_rw}" ] && _rw="${#_rn}"
+    done <<< "${resolvable}"
+    while IFS=$'\t' read -r _rn _rs; do
+      printf '  %-*s  (%s)\n' "${_rw}" "${_rn}" "${_rs}"
+    done <<< "${resolvable}"
+
+    local _missing="" _sn
+    while IFS=$'\t' read -r _sn _; do
+      case $'\n'"${resolved_names}"$'\n' in
+        *$'\n'"${_sn}"$'\n'*) ;;
+        *) _missing="${_missing}${_sn} " ;;
+      esac
+    done <<< "${shipped}"
+    if [ -n "${_missing}" ]; then
+      echo
+      echo "Shipped but not installed here: ${_missing% }"
+      echo "  → run 'roost init --force-agents' to copy them into .claude/agents/."
+    fi
+  else
+    echo "  (none installed — run 'roost init' to copy the shipped agents)"
+  fi
+}
+
 cmd_shutdown() {
   if [ "$#" -lt 1 ]; then
     echo "error: shutdown requires a nick" >&2
@@ -1198,6 +1332,7 @@ case "${1:-}" in
     case "${cmd}" in
       init)      usage_init ;;
       spawn)     usage_spawn ;;
+      agents)    usage_agents ;;
       shutdown)  usage_shutdown ;;
       list)      usage_list ;;
       attach)    usage_attach ;;
@@ -1214,6 +1349,7 @@ esac
 case "${cmd}" in
   init)      cmd_init "$@" ;;
   spawn)     cmd_spawn "$@" ;;
+  agents)    cmd_agents "$@" ;;
   shutdown)  cmd_shutdown "$@" ;;
   list)      cmd_list "$@" ;;
   attach)    cmd_attach "$@" ;;

--- a/bin/roost
+++ b/bin/roost
@@ -45,7 +45,7 @@ Usage: roost <command> [args]
 Commands:
   init                     Bootstrap config, .gitignore, and copy prompts.
   spawn <nick> [options]   Bring up a Claude session on the roost.
-  agents                   List shipped agents and what 'spawn --agent' resolves.
+  agents [--all]           List installed agents ('spawn --agent' targets); --all adds what ships.
   shutdown <nick>          Kill the tmux session for that nick.
   list                     Show all roost-prefixed tmux sessions.
   attach <nick>            tmux attach to that nick's session.
@@ -258,21 +258,16 @@ EOF
 
 usage_agents() {
   cat <<EOF
-Usage: roost agents [--cwd PATH]
+Usage: roost agents [--all] [--cwd PATH]
 
-List the agents roost ships and the agents 'roost spawn --agent' can resolve
-from here. Two sections:
+List the agents you can spawn with 'roost spawn --agent' — by default just the
+ones installed here, resolved from <cwd>/.claude/agents and ~/.claude/agents and
+scope-tagged. The clean "who can I hire right now" list.
 
-  Shipped with roost   Every agent under the plugin's agents/ tree (name +
-                       description). A newly shipped agent shows here before
-                       'roost init' copies it into a project.
-
-  Spawnable here       What 'roost spawn --agent <name>' resolves from
-                       <cwd>/.claude/agents and ~/.claude/agents — the set spawn
-                       actually accepts.
-
-A shipped agent missing from the spawnable set is flagged with the command to
-install it. --cwd PATH inspects another project (default: current directory).
+  --all       Also list every agent roost ships (the plugin's agents/ tree, with
+              descriptions), and flag any that ship but aren't installed here,
+              with the command to install them. The discovery/bootstrap view.
+  --cwd PATH  Resolve against another project (default: current directory).
 EOF
 }
 
@@ -1123,38 +1118,41 @@ _resolvable_agents() {
 }
 
 cmd_agents() {
-  local cwd="${PWD}"
+  local cwd="${PWD}" show_all=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
+      --all)     show_all=1; shift ;;
       --cwd)     cwd="${2:?roost agents: --cwd requires a path}"; shift 2 ;;
       -h|--help) usage_agents; exit 0 ;;
       *) echo "error: roost agents: unknown option: $1" >&2; usage_agents; exit 1 ;;
     esac
   done
 
-  local shipped resolvable resolved_names
-  shipped="$(_shipped_agents)"
+  local resolvable shipped=""
   resolvable="$(_resolvable_agents "${cwd}")"
-  resolved_names="$(printf '%s' "${resolvable}" | cut -f1)"
+  [ "${show_all}" -eq 1 ] && shipped="$(_shipped_agents)"
 
-  # Section 1: the shipped roster — the discovery answer.
-  echo "Shipped with roost (${ROOST_DIR}/agents):"
-  echo
-  if [ -n "${shipped}" ]; then
-    local _w=0 _n _d
-    while IFS=$'\t' read -r _n _; do
-      [ "${#_n}" -gt "${_w}" ] && _w="${#_n}"
-    done <<< "${shipped}"
-    while IFS=$'\t' read -r _n _d; do
-      printf '  %-*s  %s\n' "${_w}" "${_n}" "${_d}"
-    done <<< "${shipped}"
-  else
-    echo "  (none)"
+  # --all opens with the shipped roster — the discovery/bootstrap view.
+  if [ "${show_all}" -eq 1 ]; then
+    echo "Shipped with roost (${ROOST_DIR}/agents):"
+    echo
+    if [ -n "${shipped}" ]; then
+      local _w=0 _n _d
+      while IFS=$'\t' read -r _n _; do
+        [ "${#_n}" -gt "${_w}" ] && _w="${#_n}"
+      done <<< "${shipped}"
+      while IFS=$'\t' read -r _n _d; do
+        printf '  %-*s  %s\n' "${_w}" "${_n}" "${_d}"
+      done <<< "${shipped}"
+    else
+      echo "  (none)"
+    fi
+    echo
   fi
 
-  # Section 2: what `roost spawn --agent` resolves from here. listing ==
-  # spawnable, and a shipped-but-not-installed agent gets the install command.
-  echo
+  # Default view: the clean "agents to hire" list — exactly what
+  # `roost spawn --agent` resolves from here (same helper the not-found error
+  # reads, so the two can't drift).
   echo "Spawnable here (roost spawn --agent <name>) — resolved from .claude/agents/:"
   echo
   if [ -n "${resolvable}" ]; then
@@ -1165,8 +1163,18 @@ cmd_agents() {
     while IFS=$'\t' read -r _rn _rs; do
       printf '  %-*s  (%s)\n' "${_rw}" "${_rn}" "${_rs}"
     done <<< "${resolvable}"
+  elif [ "${show_all}" -eq 1 ]; then
+    echo "  (none installed — run 'roost init' to copy the shipped agents above)"
+  else
+    echo "  (none installed — run 'roost init' to copy the shipped agents, or 'roost agents --all' to see what ships)"
+  fi
 
-    local _missing="" _sn
+  # --all closes with reconciliation: shipped agents present in the roster but
+  # absent from the resolver set here, with the command to install them. Only
+  # meaningful when some are installed — the all-empty case is covered above.
+  if [ "${show_all}" -eq 1 ] && [ -n "${resolvable}" ]; then
+    local resolved_names _missing="" _sn
+    resolved_names="$(printf '%s' "${resolvable}" | cut -f1)"
     while IFS=$'\t' read -r _sn _; do
       case $'\n'"${resolved_names}"$'\n' in
         *$'\n'"${_sn}"$'\n'*) ;;
@@ -1178,8 +1186,6 @@ cmd_agents() {
       echo "Shipped but not installed here: ${_missing% }"
       echo "  → run 'roost init --force-agents' to copy them into .claude/agents/."
     fi
-  else
-    echo "  (none installed — run 'roost init' to copy the shipped agents)"
   fi
 }
 

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -81,7 +81,7 @@ claude flag the wrapper doesn't otherwise know about.
 
 ## Spawnable agents (roost agents)
 
-`roost spawn --agent NAME` runs a session as that named agent. `roost agents`
+`roost spawn <nick> --agent NAME` runs a session as that named agent. `roost agents`
 lists the `NAME`s available:
 
 - **`roost agents`** — the agents installed here: what you can spawn right now.

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -81,18 +81,13 @@ claude flag the wrapper doesn't otherwise know about.
 
 ## Spawnable agents (roost agents)
 
-`roost spawn --agent NAME` runs a session as a named agent — loading its
-definition and locking model + permission mode from the agent's frontmatter.
-`roost agents` shows the `NAME`s you can hire:
+`roost spawn --agent NAME` runs a session as that named agent. `roost agents`
+lists the `NAME`s available:
 
-- **`roost agents`** — the agents installed here (resolved from
-  `.claude/agents/`), scope-tagged. The "who can I spawn right now" list.
-- **`roost agents --all`** — also the full roster roost ships, flagging any
-  that ship but aren't installed here plus how to install them
-  (`roost init --force-agents`). Reach for this to spot a newly shipped agent.
-
-Shipped agents land in `.claude/agents/` via `roost init`, and `roost agents`
-reads that directory — so a new one shows up without editing this skill.
+- **`roost agents`** — the agents installed here: what you can spawn right now.
+- **`roost agents --all`** — also everything roost ships, flagging what isn't
+  installed here yet and how to install it (`roost init --force-agents`). Use
+  this to find a newly shipped agent.
 
 ## IRC permission oversight (--perm-irc)
 

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -29,12 +29,13 @@ a tool surface.
 ## Command surface
 
 ```bash
-roost spawn <nick> [-c CHANS] [-m MODEL] [-s SESSION] [--mcp-config PATH] \
+roost spawn <nick> [-c CHANS] [-m MODEL] [--agent NAME] [-s SESSION] [--mcp-config PATH] \
                    [--cwd PATH] [--prompt PROMPT] \
                    [--permission-mode MODE] [--cache-ttl 5m|1h] \
                    [--steer-compact] \
                    [--perm-irc --perm-target NICK] \
                    [--ask-irc CHANNEL --ask-target NICK]
+roost agents [--all]
 roost shutdown <nick>
 roost list
 roost attach <nick>
@@ -77,6 +78,21 @@ launch.
 Anything passed after `--` is forwarded verbatim to claude — use this
 for `--chrome`, `--system-prompt`, `--thinking-display`, or any other
 claude flag the wrapper doesn't otherwise know about.
+
+## Spawnable agents (roost agents)
+
+`roost spawn --agent NAME` runs a session as a named agent — loading its
+definition and locking model + permission mode from the agent's frontmatter.
+`roost agents` shows the `NAME`s you can hire:
+
+- **`roost agents`** — the agents installed here (resolved from
+  `.claude/agents/`), scope-tagged. The "who can I spawn right now" list.
+- **`roost agents --all`** — also the full roster roost ships, flagging any
+  that ship but aren't installed here plus how to install them
+  (`roost init --force-agents`). Reach for this to spot a newly shipped agent.
+
+Shipped agents land in `.claude/agents/` via `roost init`, and `roost agents`
+reads that directory — so a new one shows up without editing this skill.
 
 ## IRC permission oversight (--perm-irc)
 

--- a/test/agents_test.sh
+++ b/test/agents_test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Tests for `roost agents` — the self-updating agent roster. Plain bash, no bats.
+# Run: bash test/agents_test.sh
+set -uo pipefail
+
+ROOST_BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/bin/roost"
+REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+PASS=0
+FAIL=0
+TDIR=""
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
+
+setup() {
+  TDIR="$(mktemp -d /tmp/roost-agents-test-XXXXXXXX)"
+  trap 'rm -rf "$TDIR"' EXIT
+}
+
+teardown() {
+  rm -rf "$TDIR"
+  tmux kill-session -t "roost-testnick" 2>/dev/null || true
+  trap - EXIT
+  TDIR=""
+}
+
+# -- Test 1: shipped section lists the plugin-tree agents with descriptions ----
+# ROOST_DIR resolves to this repo, so the shipped roster reads from ./agents.
+# A newly added agent flows in here automatically — that's the whole mechanism.
+
+setup
+mkdir -p "$TDIR/empty"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/empty" 2>&1)"
+if echo "$out" | grep -q "Shipped with roost" \
+    && echo "$out" | grep -q "lead-pm" \
+    && echo "$out" | grep -q "associate-pm" \
+    && echo "$out" | grep -q "Lead project manager"; then
+  ok "shipped section lists lead-pm + associate-pm with descriptions"
+else
+  fail "shipped section lists lead-pm + associate-pm with descriptions" "out=$out"
+fi
+teardown
+
+# -- Test 2: nothing installed → spawnable section says so + points at init -----
+
+setup
+mkdir -p "$TDIR/empty"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/empty" 2>&1)"
+if echo "$out" | grep -q "Spawnable here" \
+    && echo "$out" | grep -q "none installed" \
+    && echo "$out" | grep -q "roost init"; then
+  ok "nothing installed: spawnable section empty, points at roost init"
+else
+  fail "nothing installed: spawnable section empty, points at roost init" "out=$out"
+fi
+teardown
+
+# -- Test 3: partial install → reconciliation flags the missing shipped agent --
+# Only lead-pm installed. associate-pm ships but isn't here, so it's flagged
+# with the exact install command.
+
+setup
+mkdir -p "$TDIR/proj/.claude/agents"
+cp "$REPO/agents/lead-pm.md" "$TDIR/proj/.claude/agents/"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/proj" 2>&1)"
+if echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
+    && echo "$out" | grep -q "Shipped but not installed here: associate-pm" \
+    && echo "$out" | grep -q "roost init --force-agents"; then
+  ok "partial install: lead-pm spawnable (project), associate-pm flagged for install"
+else
+  fail "partial install: lead-pm spawnable (project), associate-pm flagged for install" "out=$out"
+fi
+teardown
+
+# -- Test 4: project shadows user; user-only agent tagged (user) ---------------
+# Mirrors the spawn resolver: project .claude/agents wins over ~/.claude/agents
+# by basename. lead-pm lives in both → shown once as (project); associate-pm
+# only in user scope → (user). Both installed → no reconciliation line.
+
+setup
+mkdir -p "$TDIR/proj/.claude/agents" "$TDIR/fakehome/.claude/agents"
+cp "$REPO/agents/lead-pm.md" "$TDIR/proj/.claude/agents/"
+cp "$REPO/agents/lead-pm.md" "$TDIR/fakehome/.claude/agents/"
+cp "$REPO/agents/associate-pm.md" "$TDIR/fakehome/.claude/agents/"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/proj" 2>&1)"
+if echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
+    && echo "$out" | grep -qE 'associate-pm[[:space:]]+\(user\)' \
+    && ! echo "$out" | grep -qE 'lead-pm[[:space:]]+\(user\)' \
+    && ! echo "$out" | grep -q "Shipped but not installed here"; then
+  ok "project shadows user; user-only agent tagged (user); no reconciliation"
+else
+  fail "project shadows user; user-only agent tagged (user); no reconciliation" "out=$out"
+fi
+teardown
+
+# -- Test 5: `roost agents` and the spawn not-found error agree on the set -----
+# The consistency invariant: both surfaces list exactly what --agent resolves.
+
+setup
+mkdir -p "$TDIR/proj/.claude/agents"
+cp "$REPO/agents/lead-pm.md" "$TDIR/proj/.claude/agents/"
+cp "$REPO/agents/associate-pm.md" "$TDIR/proj/.claude/agents/"
+agents_out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/proj" 2>&1)"
+spawn_err="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" spawn testnick --agent nope --cwd "$TDIR/proj" 2>&1)"
+avail="$(echo "$spawn_err" | sed -n 's/^available agents: //p')"
+if echo "$avail" | grep -q "lead-pm" \
+    && echo "$avail" | grep -q "associate-pm" \
+    && echo "$agents_out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
+    && echo "$agents_out" | grep -qE 'associate-pm[[:space:]]+\(project\)'; then
+  ok "consistency: not-found 'available agents' matches 'roost agents' spawnable set"
+else
+  fail "consistency: not-found 'available agents' matches 'roost agents' spawnable set" "avail=$avail agents_out=$agents_out"
+fi
+teardown
+
+# -- Test 6: unknown option exits non-zero with a clear message ----------------
+
+setup
+err="$("${ROOST_BIN}" agents --bogus 2>&1)"; exit_code=$?
+if [ "$exit_code" -ne 0 ] && echo "$err" | grep -q "unknown option"; then
+  ok "unknown option: exits non-zero with clear message"
+else
+  fail "unknown option: exits non-zero with clear message" "exit=$exit_code err=$err"
+fi
+teardown
+
+# -- Test 7: --help prints the agents usage -----------------------------------
+
+out="$("${ROOST_BIN}" agents --help 2>&1)"
+if echo "$out" | grep -q "Usage: roost agents"; then
+  ok "--help prints agents usage"
+else
+  fail "--help prints agents usage" "out=$out"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/test/agents_test.sh
+++ b/test/agents_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Tests for `roost agents` — the self-updating agent roster. Plain bash, no bats.
+# Default = clean installed/spawnable list; --all = shipped roster + reconciliation.
 # Run: bash test/agents_test.sh
 set -uo pipefail
 
@@ -24,58 +25,80 @@ teardown() {
   TDIR=""
 }
 
-# -- Test 1: shipped section lists the plugin-tree agents with descriptions ----
-# ROOST_DIR resolves to this repo, so the shipped roster reads from ./agents.
-# A newly added agent flows in here automatically — that's the whole mechanism.
-
-setup
-mkdir -p "$TDIR/empty"
-out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/empty" 2>&1)"
-if echo "$out" | grep -q "Shipped with roost" \
-    && echo "$out" | grep -q "lead-pm" \
-    && echo "$out" | grep -q "associate-pm" \
-    && echo "$out" | grep -q "Lead project manager"; then
-  ok "shipped section lists lead-pm + associate-pm with descriptions"
-else
-  fail "shipped section lists lead-pm + associate-pm with descriptions" "out=$out"
-fi
-teardown
-
-# -- Test 2: nothing installed → spawnable section says so + points at init -----
-
-setup
-mkdir -p "$TDIR/empty"
-out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/empty" 2>&1)"
-if echo "$out" | grep -q "Spawnable here" \
-    && echo "$out" | grep -q "none installed" \
-    && echo "$out" | grep -q "roost init"; then
-  ok "nothing installed: spawnable section empty, points at roost init"
-else
-  fail "nothing installed: spawnable section empty, points at roost init" "out=$out"
-fi
-teardown
-
-# -- Test 3: partial install → reconciliation flags the missing shipped agent --
-# Only lead-pm installed. associate-pm ships but isn't here, so it's flagged
-# with the exact install command.
+# -- Test 1: default lists only spawnable — no roster, reconciliation, or desc --
+# The clean "agents to hire" list. lead-pm is installed; associate-pm ships but
+# isn't installed — the default must NOT mention it or the shipped roster.
 
 setup
 mkdir -p "$TDIR/proj/.claude/agents"
 cp "$REPO/agents/lead-pm.md" "$TDIR/proj/.claude/agents/"
 out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/proj" 2>&1)"
-if echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
-    && echo "$out" | grep -q "Shipped but not installed here: associate-pm" \
-    && echo "$out" | grep -q "roost init --force-agents"; then
-  ok "partial install: lead-pm spawnable (project), associate-pm flagged for install"
+if echo "$out" | grep -q "Spawnable here" \
+    && echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
+    && ! echo "$out" | grep -q "Shipped with roost" \
+    && ! echo "$out" | grep -q "Shipped but not installed" \
+    && ! echo "$out" | grep -q "associate-pm" \
+    && ! echo "$out" | grep -q "Lead project manager"; then
+  ok "default: only spawnable list, no roster/reconciliation/descriptions"
 else
-  fail "partial install: lead-pm spawnable (project), associate-pm flagged for install" "out=$out"
+  fail "default: only spawnable list, no roster/reconciliation/descriptions" "out=$out"
 fi
 teardown
 
-# -- Test 4: project shadows user; user-only agent tagged (user) ---------------
+# -- Test 2: --all shows shipped roster (with descriptions) + reconciliation ----
+
+setup
+mkdir -p "$TDIR/proj/.claude/agents"
+cp "$REPO/agents/lead-pm.md" "$TDIR/proj/.claude/agents/"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --all --cwd "$TDIR/proj" 2>&1)"
+if echo "$out" | grep -q "Shipped with roost" \
+    && echo "$out" | grep -q "associate-pm" \
+    && echo "$out" | grep -q "Lead project manager" \
+    && echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
+    && echo "$out" | grep -q "Shipped but not installed here: associate-pm" \
+    && echo "$out" | grep -q "roost init --force-agents"; then
+  ok "--all: shipped roster with descriptions + reconciliation for the missing one"
+else
+  fail "--all: shipped roster with descriptions + reconciliation for the missing one" "out=$out"
+fi
+teardown
+
+# -- Test 3: default with nothing installed → empty-state pointer --------------
+# A bare empty list reads as "broken", so the empty case (only) carries a
+# one-line pointer to roost init / roost agents --all.
+
+setup
+mkdir -p "$TDIR/empty"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/empty" 2>&1)"
+if echo "$out" | grep -q "none installed" \
+    && echo "$out" | grep -q "roost init" \
+    && echo "$out" | grep -q "roost agents --all" \
+    && ! echo "$out" | grep -q "Shipped with roost"; then
+  ok "default, none installed: empty-state points at roost init / roost agents --all"
+else
+  fail "default, none installed: empty-state points at roost init / roost agents --all" "out=$out"
+fi
+teardown
+
+# -- Test 4: --all with nothing installed → roster shown, empty-state refs above -
+
+setup
+mkdir -p "$TDIR/empty"
+out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --all --cwd "$TDIR/empty" 2>&1)"
+if echo "$out" | grep -q "Shipped with roost" \
+    && echo "$out" | grep -q "lead-pm" \
+    && echo "$out" | grep -q "none installed" \
+    && echo "$out" | grep -q "shipped agents above"; then
+  ok "--all, none installed: roster shown, empty-state references the roster above"
+else
+  fail "--all, none installed: roster shown, empty-state references the roster above" "out=$out"
+fi
+teardown
+
+# -- Test 5: default — project shadows user; user-only agent tagged (user) ------
 # Mirrors the spawn resolver: project .claude/agents wins over ~/.claude/agents
 # by basename. lead-pm lives in both → shown once as (project); associate-pm
-# only in user scope → (user). Both installed → no reconciliation line.
+# only in user scope → (user).
 
 setup
 mkdir -p "$TDIR/proj/.claude/agents" "$TDIR/fakehome/.claude/agents"
@@ -85,16 +108,15 @@ cp "$REPO/agents/associate-pm.md" "$TDIR/fakehome/.claude/agents/"
 out="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" agents --cwd "$TDIR/proj" 2>&1)"
 if echo "$out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
     && echo "$out" | grep -qE 'associate-pm[[:space:]]+\(user\)' \
-    && ! echo "$out" | grep -qE 'lead-pm[[:space:]]+\(user\)' \
-    && ! echo "$out" | grep -q "Shipped but not installed here"; then
-  ok "project shadows user; user-only agent tagged (user); no reconciliation"
+    && ! echo "$out" | grep -qE 'lead-pm[[:space:]]+\(user\)'; then
+  ok "default: project shadows user; user-only agent tagged (user)"
 else
-  fail "project shadows user; user-only agent tagged (user); no reconciliation" "out=$out"
+  fail "default: project shadows user; user-only agent tagged (user)" "out=$out"
 fi
 teardown
 
-# -- Test 5: `roost agents` and the spawn not-found error agree on the set -----
-# The consistency invariant: both surfaces list exactly what --agent resolves.
+# -- Test 6: default spawnable set == spawn not-found 'available agents' --------
+# The consistency invariant: both read _resolvable_agents, so they can't drift.
 
 setup
 mkdir -p "$TDIR/proj/.claude/agents"
@@ -107,13 +129,13 @@ if echo "$avail" | grep -q "lead-pm" \
     && echo "$avail" | grep -q "associate-pm" \
     && echo "$agents_out" | grep -qE 'lead-pm[[:space:]]+\(project\)' \
     && echo "$agents_out" | grep -qE 'associate-pm[[:space:]]+\(project\)'; then
-  ok "consistency: not-found 'available agents' matches 'roost agents' spawnable set"
+  ok "consistency: not-found 'available agents' matches default spawnable set"
 else
-  fail "consistency: not-found 'available agents' matches 'roost agents' spawnable set" "avail=$avail agents_out=$agents_out"
+  fail "consistency: not-found 'available agents' matches default spawnable set" "avail=$avail agents_out=$agents_out"
 fi
 teardown
 
-# -- Test 6: unknown option exits non-zero with a clear message ----------------
+# -- Test 7: unknown option exits non-zero with a clear message ----------------
 
 setup
 err="$("${ROOST_BIN}" agents --bogus 2>&1)"; exit_code=$?
@@ -124,13 +146,13 @@ else
 fi
 teardown
 
-# -- Test 7: --help prints the agents usage -----------------------------------
+# -- Test 8: --help prints the agents usage (documenting --all) ----------------
 
 out="$("${ROOST_BIN}" agents --help 2>&1)"
-if echo "$out" | grep -q "Usage: roost agents"; then
-  ok "--help prints agents usage"
+if echo "$out" | grep -q "Usage: roost agents" && echo "$out" | grep -q -- "--all"; then
+  ok "--help prints agents usage documenting --all"
 else
-  fail "--help prints agents usage" "out=$out"
+  fail "--help prints agents usage documenting --all" "out=$out"
 fi
 
 echo ""

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -104,6 +104,37 @@ else
 fi
 teardown
 
+# -- Test 6a: not-found error lists the resolvable agents as available ---------
+# The error surfaces what --agent *would* accept — same set 'roost agents'
+# lists, so the two can't disagree. HOME override keeps the real
+# ~/.claude/agents out of the list.
+
+setup
+mkdir -p "$TDIR/.claude/agents"
+printf -- '---\ndescription: an installed one\n---\nbody\n' > "$TDIR/.claude/agents/installedone.md"
+err="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" spawn testnick --agent nope --cwd "$TDIR" 2>&1)"; exit_code=$?
+if [ "$exit_code" -ne 0 ] \
+    && echo "$err" | grep -q "available agents:" \
+    && echo "$err" | grep -q "installedone"; then
+  ok "missing agent: error lists installed agents as available"
+else
+  fail "missing agent: error lists installed agents as available" "exit=$exit_code err=$err"
+fi
+teardown
+
+# -- Test 6b: not-found error with nothing installed hints at init/agents ------
+
+setup
+err="$(HOME="$TDIR/fakehome" "${ROOST_BIN}" spawn testnick --agent nope --cwd "$TDIR" 2>&1)"; exit_code=$?
+if [ "$exit_code" -ne 0 ] \
+    && echo "$err" | grep -q "no agents installed" \
+    && echo "$err" | grep -q "roost agents"; then
+  ok "missing agent, none installed: error hints roost init / roost agents"
+else
+  fail "missing agent, none installed: error hints roost init / roost agents" "exit=$exit_code err=$err"
+fi
+teardown
+
 # -- Test 7: explicit --permission-mode is echoed verbatim -------------------
 # The flag is passed through to claude as-is and shown in the spawn echo.
 


### PR DESCRIPTION
Closes #608

Shipped agents in `agents/` were invisible on the normal bootstrap — claude only auto-loads `.claude/agents/`, and operators read README + lead-pm, not ARCHITECTURE. A new shipped agent only became known if someone hand-patched a pointer. This swaps per-agent pointer maintenance for one mechanism.

**`roost agents`** — two sections:
- **Shipped with roost** — the plugin `agents/` roster (name + description), discovered at runtime, so a new agent shows up on its own.
- **Spawnable here** — exactly what `roost spawn --agent` resolves from `<cwd>/.claude/agents` + `~/.claude/agents`, scope-tagged. A shipped agent missing from this set is flagged with the exact install command (`roost init --force-agents`).

**Consistency invariant:** `roost agents`' spawnable section and the `spawn --agent` not-found error are both backed by one shared helper (`_resolvable_agents`), so the roster and the error message can't drift. (The real spawn resolver in `cmd_spawn` is still a separate parallel copy of the same two-root search — identical today, but not structurally bound to the helper. Routing it through `_resolvable_agents` is a clean followup, deferred to avoid contending with in-flight work on the same function.)

**Pointers:** README and `lead-pm.md` each gain one durable pointer at `roost agents` — no edits needed when the agent set changes. That's the anti-per-agent-maintenance property the issue asked for.

**Scope note:** the command is scope-agnostic by construction — it lists whatever `agents/*.md` exists at runtime (today `lead-pm` + `associate-pm`). Triage (punted to 0.9.0) is hardcoded nowhere and will appear on its own when it lands.

**Tests:** new `test/agents_test.sh` (wired into CI) covers both sections, the reconciliation line, and the not-found↔roster consistency invariant; `spawn_test.sh` gains coverage for the enriched not-found error. `bun run lint` (incl. `shellcheck bin/*`) green; both shell suites pass (agents 7/7, spawn 34/34). No `src/` change.