### PR TITLE
add learning from #608

### DIFF
--- a/.claude/rules/cli-skill-sync.md
+++ b/.claude/rules/cli-skill-sync.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - bin/roost
+---
+
+# CLI Skill Sync
+
+Patterns for keeping skills/roost/SKILL.md in sync with the CLI.
+
+## 2026-07-01: When you touch bin/roost, review skills/roost/SKILL.md (from #608)
+
+When you add, change, or remove a command or flag in bin/roost, read skills/roost/SKILL.md and update it to match — the skill teaches agents the CLI surface. README.md and the agent prompts in agents/ mirror the CLI too, so glance at them, but SKILL.md is the one that drifts silently, because it's not the obvious doc to update. In #608 the worker updated README and lead-pm.md on its own; only SKILL.md was missed, until human review.

--- a/.claude/rules/cli-skill-sync.md
+++ b/.claude/rules/cli-skill-sync.md
@@ -9,4 +9,4 @@ Patterns for keeping skills/roost/SKILL.md in sync with the CLI.
 
 ## 2026-07-01: When you touch bin/roost, review skills/roost/SKILL.md (from #608)
 
-When you add, change, or remove a command or flag in bin/roost, read skills/roost/SKILL.md and update it to match — the skill teaches agents the CLI surface. README.md and the agent prompts in agents/ mirror the CLI too, so glance at them, but SKILL.md is the one that drifts silently, because it's not the obvious doc to update. In #608 the worker updated README and lead-pm.md on its own; only SKILL.md was missed, until human review.
+When you add, change, or remove a command or flag in bin/roost, read skills/roost/SKILL.md and update it to match — the skill teaches agents the CLI surface. README.md and the agent prompts in agents/ mirror the CLI too, so glance at them. SKILL.md is the one that drifts silently: it's not the obvious doc to update, so it's the easiest to miss.


### PR DESCRIPTION
path-scoped learning from #608: when bin/roost is touched, review skills/roost/SKILL.md. paths: bin/roost → loads for any agent reading the CLI.