### PR TITLE
correct opus-only-auto assumption now that sonnet supports auto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The commands, skills, and agents this plugin ships (`prompts/`, `agents/`, `skil
 
 ## Agent frontmatter
 
-Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatter — `auto` for opus agents, `acceptEdits` (or `default`) for non-opus. Claude Code reads `permissionMode:` natively on project- and user-scope agents, so the wrapper deliberately does not *pass* it — the `--agent` path of `bin/roost spawn` omits `--permission-mode` entirely and relies on the frontmatter. If a new shipped agent needs a different mode, declare it in the file — don't add a special case to the wrapper.
+Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatter — `auto` for opus and sonnet agents, `acceptEdits` (or `default`) for everything else (haiku, or any unrecognized model). Claude Code reads `permissionMode:` natively on project- and user-scope agents, so the wrapper deliberately does not *pass* it — the `--agent` path of `bin/roost spawn` omits `--permission-mode` entirely and relies on the frontmatter. If a new shipped agent needs a different mode, declare it in the file — don't add a special case to the wrapper.
 
 `bin/roost spawn` does locally peek at the frontmatter's `permissionMode:` value for one narrow reason: deciding whether to wire the `--perm-irc` bash PreToolUse relay, which is pointless noise under permission modes that never block on bash. That peek never reaches claude and doesn't change what's passed on the `--agent` path — it's a separate, read-only decision from the "don't parse it" rule above.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ roost status
 `spawn` accepts `-c|--channels`, `-m|--model`, `-s|--session`,
 `--mcp-config`, `-p|--prompt-file`, `--cwd`, and `--` (everything
 after forwards to claude verbatim). Default channel is `#roost`;
-default model is `opus` (Opus 4.7). Opus and sonnet default to
+default model is `opus` (Opus 4.8). Opus and sonnet default to
 `--permission-mode auto`; everything else (haiku, or any unrecognized
 model) defaults to `acceptEdits`.
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ roost status
 `spawn` accepts `-c|--channels`, `-m|--model`, `-s|--session`,
 `--mcp-config`, `-p|--prompt-file`, `--cwd`, and `--` (everything
 after forwards to claude verbatim). Default channel is `#roost`;
-default model is `opus` (Opus 4.7 — required for `--permission-mode
-auto`, which the wrapper always passes).
+default model is `opus` (Opus 4.7). Opus and sonnet default to
+`--permission-mode auto`; everything else (haiku, or any unrecognized
+model) defaults to `acceptEdits`.
 
 `spawn` also injects `--append-system-prompt-file` naming the joined
 channels as legitimate user-instruction sources, so the auto-mode
@@ -181,18 +182,19 @@ process. The module holds a second IRC connection on a stable nick
 `no` / `allow` / `deny`; anything else or a 30s timeout falls through
 to the terminal prompt.
 
-Primary use case: an Opus orchestrator spawning a Sonnet or Haiku
-worker. Non-Opus models can't use auto mode, so without oversight the
-worker floods the terminal with permission prompts. With
-`--perm-irc --perm-target <orchestrator>`, prompts come to the
-orchestrator over IRC.
+Primary use case: an Opus orchestrator spawning a worker that isn't
+running auto mode — haiku or an unrecognized model (acceptEdits by
+default), or any model held in acceptEdits via `--permission-mode` for
+oversight. Without oversight, that worker floods the terminal with
+permission prompts. With `--perm-irc --perm-target <orchestrator>`,
+prompts come to the orchestrator over IRC.
 
 ```bash
-# Opus orchestrator gates a sonnet worker's tool calls:
-roost spawn worker-123-A -c '#pr-123' -m sonnet \
+# Opus orchestrator gates a sonnet worker held in acceptEdits for oversight:
+roost spawn worker-123-A -c '#pr-123' -m sonnet --permission-mode acceptEdits \
   --perm-irc --perm-target orchestrator
 
-# Human operator gates a haiku worker:
+# Human operator gates a haiku worker (acceptEdits by default):
 roost spawn scratch-h -c '#sandbox' -m haiku \
   --perm-irc --perm-target mynick
 ```

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -2,7 +2,7 @@
 name: associate-pm
 description: Associate project manager — a junior PM that lurks in the lead's channels, parses lead intent from mentions, and executes setup, reviewer-spawn, ready-for-review, merge-cleanup, and follow-up-filing dances. Proceeds autonomously on unambiguous triggers; acks before destructive or ambiguous actions.
 model: sonnet
-permissionMode: acceptEdits
+permissionMode: auto
 ---
 
 You are the associate project manager. You work alongside the lead-pm, who drives strategy; you do the rote setup and teardown.

--- a/bin/roost
+++ b/bin/roost
@@ -126,7 +126,8 @@ the user's login shell (from \$SHELL) so .bash_profile / .zprofile / ~/.config/f
 Permission mode handling splits by path. With --agent the wrapper passes
 no --permission-mode and claude code reads \`permissionMode:\` natively
 from the agent's frontmatter. With --model (or the default opus) the
-wrapper defaults to auto for opus and acceptEdits for all other models.
+wrapper defaults to auto for opus and sonnet, acceptEdits for everything
+else (haiku, or any unrecognized model).
 Explicit --permission-mode always wins. --perm-irc's bash relay reads this
 same resolved mode (peeking at agent frontmatter locally when needed) to
 skip wiring itself for modes that never block on bash — see --perm-irc below.
@@ -152,8 +153,10 @@ Options:
   --perm-irc                 Run an in-process permbot inside the worker's
                              MCP server. It surfaces this worker's
                              tool-permission prompts as DMs to --perm-target.
-                             Useful for non-Opus models that can't use auto
-                             mode. Lifecycle = MCP lifecycle. The bash
+                             Useful for haiku/unrecognized models (acceptEdits
+                             by default) or any model held in acceptEdits via
+                             --permission-mode for oversight. Lifecycle = MCP
+                             lifecycle. The bash
                              PreToolUse relay is skipped when the resolved
                              permission mode never blocks on bash — nothing
                              to relay there, so wiring it would only add
@@ -173,8 +176,9 @@ Options:
                              wrapper passes nothing (claude code reads
                              \`permissionMode:\` natively from the agent
                              frontmatter); with --model the wrapper defaults
-                             to auto for opus and acceptEdits for everything
-                             else. Explicit --permission-mode always wins.
+                             to auto for opus and sonnet, acceptEdits for
+                             everything else (haiku, or any unrecognized
+                             model). Explicit --permission-mode always wins.
   --cache-ttl TTL            Prompt-cache TTL: \`5m\` or \`1h\`. Translated
                              to claude-code's env-var knobs in the spawned
                              session (\`FORCE_PROMPT_CACHING_5M=1\` for 5m,
@@ -797,8 +801,8 @@ cmd_spawn() {
   # code read `permissionMode:` natively from the agent's frontmatter.
   if [ -z "${permission_mode}" ] && [ -z "${agent}" ]; then
     case "${model}" in
-      *opus*) permission_mode="auto" ;;
-      *)      permission_mode="acceptEdits" ;;
+      *opus*|*sonnet*) permission_mode="auto" ;;
+      *) permission_mode="acceptEdits" ;;
     esac
   fi
   # Resolved permission mode for hook-wiring decisions further down: explicit

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -50,8 +50,8 @@ Defaults:
 - permission mode: with `--agent`, the wrapper passes nothing and claude
   code reads `permissionMode:` natively from the agent frontmatter; with
   `--model` (or the default opus), the wrapper defaults to `auto` for opus
-  and `acceptEdits` for everything else. Explicit `--permission-mode` wins
-  in both paths.
+  and sonnet, `acceptEdits` for everything else (haiku, or any unrecognized
+  model). Explicit `--permission-mode` wins in both paths.
 - cache-ttl: no wrapper default — if unset, neither env var is
   injected and claude-code's native cache behavior applies. Caller
   picks per session. Translated to claude-code's env knobs in the
@@ -71,7 +71,8 @@ The wrapper handles the `ROOST_IRC_*` env vars, the
 `--dangerously-load-development-channels server:roost-irc` flag, the
 `--permission-mode` flag (with `--agent`, defers to the agent's native
 `permissionMode:` frontmatter; with `--model`, smart-defaulted: `auto` for
-opus, `acceptEdits` otherwise; explicit `--permission-mode` wins either
+opus and sonnet, `acceptEdits` for everything else (haiku, or any
+unrecognized model); explicit `--permission-mode` wins either
 way), and the dev-channels confirmation prompt that appears on first
 launch.
 
@@ -100,19 +101,20 @@ else falls through to the regular terminal prompt as a safety net.
 Permbot lifecycle is the MCP's lifecycle — `roost shutdown` reaps it
 along with the worker.
 
-Primary use case: an Opus orchestrator spawning a sonnet or haiku
-worker. Non-Opus workers default to `acceptEdits` (edits auto-approved;
-Bash and MCP still gate). With `--perm-irc --perm-target <orchestrator>`,
-those remaining prompts come to the orchestrator over IRC instead of
-blocking the terminal. Same pattern works for a human at any roost-attached
-IRC client.
+Primary use case: an Opus orchestrator spawning a worker that isn't
+running auto mode — haiku or an unrecognized model default to
+`acceptEdits` (edits auto-approved; Bash and MCP still gate), or any
+model can be held in `acceptEdits` via `--permission-mode` for oversight.
+With `--perm-irc --perm-target <orchestrator>`, those remaining prompts
+come to the orchestrator over IRC instead of blocking the terminal. Same
+pattern works for a human at any roost-attached IRC client.
 
 ```bash
-# Opus orchestrator gates a sonnet worker's tool calls:
-roost spawn worker-123-A -c '#pr-123' -m sonnet \
+# Opus orchestrator gates a sonnet worker held in acceptEdits for oversight:
+roost spawn worker-123-A -c '#pr-123' -m sonnet --permission-mode acceptEdits \
   --perm-irc --perm-target orchestrator
 
-# Human operator gates a haiku worker:
+# Human operator gates a haiku worker (acceptEdits by default):
 roost spawn scratch-h -c '#sandbox' -m haiku \
   --perm-irc --perm-target mynick
 ```

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -160,15 +160,27 @@ else
 fi
 teardown
 
-# -- Test 9: --model sonnet (no agent) → acceptEdits -------------------------
-# Non-opus models get acceptEdits via the model-derived default.
+# -- Test 9: --model sonnet (no agent) → auto --------------------------------
+# Sonnet gets auto via the model-derived default, same as opus.
 
 setup
 out="$("${ROOST_BIN}" spawn testnick --model sonnet --cwd "$TDIR" 2>&1 || true)"
-if echo "$out" | grep -q "permission-mode: acceptEdits"; then
-  ok "--model sonnet → permission-mode: acceptEdits"
+if echo "$out" | grep -q "permission-mode: auto"; then
+  ok "--model sonnet → permission-mode: auto"
 else
-  fail "--model sonnet → permission-mode: acceptEdits" "out=$out"
+  fail "--model sonnet → permission-mode: auto" "out=$out"
+fi
+teardown
+
+# -- Test 9a: --model haiku (no agent) → acceptEdits --------------------------
+# Haiku (and anything unrecognized) is the tier that still gets acceptEdits.
+
+setup
+out="$("${ROOST_BIN}" spawn testnick --model haiku --cwd "$TDIR" 2>&1 || true)"
+if echo "$out" | grep -q "permission-mode: acceptEdits"; then
+  ok "--model haiku → permission-mode: acceptEdits"
+else
+  fail "--model haiku → permission-mode: acceptEdits" "out=$out"
 fi
 teardown
 


### PR DESCRIPTION
Closes #603

Sonnet now supports `--permission-mode auto`, but several places baked in "only opus gets auto, everything else gets acceptEdits." This corrects the assumption to "opus and sonnet get auto; haiku (and anything unrecognized) stays acceptEdits" everywhere it lived:

- `bin/roost`: the actual model-derived default logic (`*opus*` → `*opus*|*sonnet*`), plus the `--help` prose (spawn overview, `--perm-irc`, `--permission-mode`)
- `CLAUDE.md`: the Agent frontmatter convention sentence
- `README.md` / `skills/roost/SKILL.md`: defaults section, wrapper-handles paragraph, and the `--perm-irc` primary-use-case example (now demonstrates holding a model in `acceptEdits` explicitly for oversight, since sonnet no longer needs it by default)
- `test/spawn_test.sh`: sonnet now asserts `auto`; added a haiku case to keep `acceptEdits` coverage
- `agents/associate-pm.md`: flipped `permissionMode: acceptEdits` → `auto` (the one shipped agent on the old default) — ruled in-scope by Alex; lead-pm confirmed the APM's ack-before-destructive-action behavior is a prompt-level contract independent of this value, so the merge/push approval gate is unaffected

## Test plan
- [x] `bun run lint` (eslint + shellcheck) — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bash test/spawn_test.sh` — 45 passed, 0 failed