### PR TITLE
bump version to 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## What's new since v0.8.5

- **Automode is now the default** — sonnet joins opus on `--permission-mode auto` (#603); associate-pm frontmatter flipped to auto per Alex's ruling
- **Bash PreToolUse hook skipped in auto/bypassPermissions mode** — perm-irc only relays when CC can block; no-op relay eliminated (#620)
- **`roost agents` command** — self-updating shipped-agent discovery; default shows installed agents, `--all` shows full roster + install path (#608)
- **Sonnet 5 + Opus 4.8 pricing** — added to src/pricing.ts (#622, #617)