### PR TITLE
Scope cd-multi-positional to a single statement

### DIFF
--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -90,8 +90,13 @@ export function classifyBash(command: string): BashMissKind | null {
 
   // CC bashMissKind: "cd-multi-positional".
   // zsh `cd OLD NEW`. Two non-flag non-operator words after cd, terminated
-  // by end-of-string or a shell operator.
-  if (new RegExp(`${CD_START}cd\\s+(?!-)[^\\s&|;<>(){}]+\\s+(?!-)[^\\s&|;<>(){}]+(?=\\s|$|[&|;<>])`).test(command)) {
+  // by end-of-string or a shell operator. Internal gaps are horizontal
+  // whitespace ([ \t], not \s): the positional char class already excludes
+  // every statement separator except newline/CR, so pinning the gaps to
+  // spaces/tabs keeps both positionals inside one statement. A multi-line
+  // script whose first line is `cd <dir>` is then not misread as a two-arg
+  // cd spanning the newline into the next command.
+  if (new RegExp(`${CD_START}cd[ \\t]+(?!-)[^\\s&|;<>(){}]+[ \\t]+(?!-)[^\\s&|;<>(){}]+(?=\\s|$|[&|;<>])`).test(command)) {
     return 'cd-multi-positional'
   }
 

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -105,6 +105,12 @@ describe('classifyBash', () => {
     expect(classifyBash('cd /path/to/worktree\necho hi\ngrep -rn x src/')).toBeNull()
   })
 
+  it('null: CRLF-separated script whose first line is a single-arg cd', () => {
+    // `\r` is a statement separator too — `[ \t]+` excludes it, so a CRLF
+    // (or bare-CR) script isn't read as a two-arg cd spanning the break.
+    expect(classifyBash('cd /path/to/worktree\r\necho hi\r\ngrep -rn x src/')).toBeNull()
+  })
+
   it('null: cd alone then a command on the next line', () => {
     // Guards the gap right after `cd`: it too is horizontal-only, so a bare
     // `cd` followed by a command on the next line is not a two-arg cd.

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -59,6 +59,12 @@ describe('classifyBash', () => {
     expect(classifyBash('cd OLD NEW')).toBe('cd-multi-positional')
   })
 
+  it('cd-multi-positional: genuine two-arg cd on a later line of a script', () => {
+    // A real `cd OLD NEW` still flags when it is not the first statement —
+    // the newline-safety fix must not swallow legitimate multi-positional cds.
+    expect(classifyBash('echo hi\ncd OLD NEW')).toBe('cd-multi-positional')
+  })
+
   it('sed-dangerous: sed -i (in-place edit)', () => {
     expect(classifyBash("sed -i 's/x/y/' file.txt")).toBe('sed-dangerous')
   })
@@ -91,6 +97,18 @@ describe('classifyBash', () => {
 
   it('null: single cd', () => {
     expect(classifyBash('cd /tmp')).toBeNull()
+  })
+
+  it('null: multi-line script whose first line is a single-arg cd', () => {
+    // The reported shape. Newline is a statement separator, not an argument
+    // gap — the next command must not be read as a second positional to cd.
+    expect(classifyBash('cd /path/to/worktree\necho hi\ngrep -rn x src/')).toBeNull()
+  })
+
+  it('null: cd alone then a command on the next line', () => {
+    // Guards the gap right after `cd`: it too is horizontal-only, so a bare
+    // `cd` followed by a command on the next line is not a two-arg cd.
+    expect(classifyBash('cd\n/a /b')).toBeNull()
   })
 
   it('null: cd with flag', () => {


### PR DESCRIPTION
Closes #598

## What

`classifyBash`'s cd-multi-positional detector used `\s+` between the two positionals, and `\s` matches `\n`. A multi-line script whose first line is `cd <dir>` got read as `cd OLD NEW` (OLD = the dir, NEW = the next line's command) → false `cd-multi-positional` flag → spurious operator prompt.

There is no newline→space flatten anywhere (the #598 body's diagnosis and both proposed fixes were off — confirmed by the #604 audit). The only flatten is `clip()` in the display path, cosmetic and downstream of classification.

## Fix

Pin the two internal gaps in the regex to horizontal whitespace `[ \t]+`. The positional char class already excludes every statement separator except newline/CR, so restricting the gaps to spaces/tabs keeps both positionals inside one statement — the "split on statement separators" fix, done in place without a separate pass. A genuine `cd OLD NEW` (including on a later line of a script) still flags.

## Scope

Surgical, per lead direction: cd-multi-positional false-flag only. The read-only fast-path and the sibling cd-compound read-only over-fire (O2 in the audit) are tracked separately as the audit's sibling-structuring work.

## Tests

- `cd /path\necho hi\ngrep ...` (the reported shape) → null
- `echo hi\ncd OLD NEW` (real two-arg on a later line) → still flags
- `cd\n/a /b` (guards the post-`cd` gap) → null
- existing `cd OLD NEW` and commit-message guards unchanged

Unit repro proves the regex. End-to-end non-auto permbot validation to follow before ready-for-review, per alex's flip-gate directive.