### PR TITLE
Add seenBy to inbound channel messages

### DIFF
--- a/src/irc-server.ts
+++ b/src/irc-server.ts
@@ -209,7 +209,7 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
       // for to attribute a session JSONL to its roost nick. Centralized in
       // src/mcp-banner.ts so the producer (here) and the consumer can't
       // drift. Passive variant above uses a different wording on purpose.
-      instructions: `roost IRC MCP. ${mcpConnectionLine(NICK)}. This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message responses include a [#channel seen by: nick1, nick2, ...] line when members are present — anyone not in this list did not see your message. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}. IMPORTANT: ${REPLY_REMINDER}`,
+      instructions: `roost IRC MCP. ${mcpConnectionLine(NICK)}. This MCP is a plain IRCv3 client — there is no special pipeline between it and any other component. Every message that arrives in a channel (from another agent, a human, or a bot) reaches you identically, as a normal IRC channel message. Outbound: use channel_message, direct_message, channel_join, channel_leave, channel_who, channel_history, channel_list, channel_ack. channel_message supports multiline — long messages are sent as IRCv3 draft/multiline batches. Inbound: IRC traffic arrives as <channel> events. Regular messages carry event="message"; membership events (join/leave/nick) carry the corresponding event= value. All carry sender, channel, isDirect, ts, and seq. event="message" events carry mention="true" when your nick appears in the body or it's a DM. Channel messages (not DMs) also carry seenBy="nick1, nick2" — the channel's current member list, so you can tell who else already has the message and skip restating it — omitted when no members are cached. After compaction a special event with event=unread-summary lists channels with pending unread messages — check those channels. channel_message responses include a [#channel seen by: nick1, nick2, ...] line when members are present — anyone not in this list did not see your message. channel_message, direct_message, channel_list, and channel_ack responses include a trailing 'unread:' block listing other channels with pending messages. channel_history returns historical <channel> elements with historical="true"; parse them the same way as live events. Auto-joined: ${AUTO_JOIN.join(', ') || '(none)'}. IMPORTANT: ${REPLY_REMINDER}`,
     },
   )
 
@@ -254,6 +254,12 @@ export function createMcpServer(client: RoostIrcClient, config: ClientConfig, op
     }
     if (meta.historical) r.historical = 'true'
     if (wireMention({ mention: meta.mention, isDirect: msg.isDirect })) r.mention = 'true'
+    // Mirrors handleSay's seen-by hint (below) on the inbound side — same "current
+    // NAMES snapshot" semantics, not a delivery receipt. DMs are 1:1 and skip it.
+    if (!msg.isDirect) {
+      const users = client.getUsers(msg.channel)
+      if (users.length > 0) r.seenBy = users.join(', ')
+    }
     return r
   }
 

--- a/src/wire-meta.ts
+++ b/src/wire-meta.ts
@@ -24,6 +24,7 @@ export interface WireMessageMeta {
   chunkCount?: string
   historical?: 'true'
   mention?: 'true'
+  seenBy?: string
 }
 
 export interface WireReminderMeta {

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -38,6 +38,24 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     expect(Number(n3.meta.seq)).toBeGreaterThan(Number(n2.meta.seq))
   })
 
+  // Join-history auto-replay path (issue #626) — distinct from the live-push and
+  // channel_history-tool paths tested elsewhere; confirms seenBy is populated even
+  // though the message arrives via emitAutoReplayBatch rather than the live handler.
+  it('pre-join historical replay carries seenBy with both nicks', async () => {
+    const peer = await connectPeer(ergo, 'ip-hist-seen-peer1')
+    const mcp = await startMcpInProcess(ergo, 'ip-hist-seen-mcp1')
+
+    await peer.joinChannel('#ip-hist-seenby1')
+    peer.say('#ip-hist-seenby1', 'seenby-before-join')
+    await sleep(200)
+
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-hist-seenby1' } })
+
+    const n = await mcp.waitForNotification(messagePredicate({ historical: true, content: 'seenby-before-join' }))
+    expect(n.meta.seenBy).toContain('ip-hist-seen-mcp1')
+    expect(n.meta.seenBy).toContain('ip-hist-seen-peer1')
+  })
+
   it('messages sent while parted arrive as historical on rejoin', async () => {
     const peer = await connectPeer(ergo, 'ip-hist-peer2')
     const mcp = await startMcpInProcess(ergo, 'ip-hist-mcp2')

--- a/test/chathistory.test.ts
+++ b/test/chathistory.test.ts
@@ -38,9 +38,9 @@ describe.if(isErgoAvailable())('chathistory backfill', () => {
     expect(Number(n3.meta.seq)).toBeGreaterThan(Number(n2.meta.seq))
   })
 
-  // Join-history auto-replay path (issue #626) — distinct from the live-push and
-  // channel_history-tool paths tested elsewhere; confirms seenBy is populated even
-  // though the message arrives via emitAutoReplayBatch rather than the live handler.
+  // Join-history auto-replay path — distinct from the live-push and channel_history-tool
+  // paths tested elsewhere; confirms seenBy is populated even though the message arrives
+  // via emitAutoReplayBatch rather than the live handler.
   it('pre-join historical replay carries seenBy with both nicks', async () => {
     const peer = await connectPeer(ergo, 'ip-hist-seen-peer1')
     const mcp = await startMcpInProcess(ergo, 'ip-hist-seen-mcp1')

--- a/test/inbound.test.ts
+++ b/test/inbound.test.ts
@@ -264,8 +264,10 @@ describe.if(isErgoAvailable())('inbound notifications', () => {
     peer.say('#ip-in-seen1', 'seen by test')
     const n = await mcp.waitForNotification(messagePredicate({ channel: '#ip-in-seen1', content: 'seen by test' }))
 
-    expect(n.meta.seenBy).toContain('ip-in-seen1')
-    expect(n.meta.seenBy).toContain('ip-in-seen1-peer')
+    // exact match, not toContain — ip-in-seen1 is a prefix of ip-in-seen1-peer,
+    // so a substring check on the shorter nick is subsumed by the longer one
+    // and wouldn't independently catch the agent's own nick going missing.
+    expect(n.meta.seenBy).toBe('ip-in-seen1, ip-in-seen1-peer')
   })
 
   it('peer→DM has no seenBy attribute', async () => {

--- a/test/inbound.test.ts
+++ b/test/inbound.test.ts
@@ -251,4 +251,30 @@ describe.if(isErgoAvailable())('inbound notifications', () => {
 
     expect(n.meta.mention).toBe('true')
   })
+
+  // ---- seenBy attribute (issue #626) ----------------------------------------
+
+  it('peer→channel message carries seenBy with both nicks', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-seen1')
+    const peer = await connectPeer(ergo, 'ip-in-seen1-peer')
+    await mcp.client.callTool({ name: 'channel_join', arguments: { channel: '#ip-in-seen1' } })
+    await peer.joinChannel('#ip-in-seen1')
+    await mcp.waitForNotification(eventPredicate('join', { channel: '#ip-in-seen1', sender: 'ip-in-seen1-peer' }))
+
+    peer.say('#ip-in-seen1', 'seen by test')
+    const n = await mcp.waitForNotification(messagePredicate({ channel: '#ip-in-seen1', content: 'seen by test' }))
+
+    expect(n.meta.seenBy).toContain('ip-in-seen1')
+    expect(n.meta.seenBy).toContain('ip-in-seen1-peer')
+  })
+
+  it('peer→DM has no seenBy attribute', async () => {
+    const mcp = await startMcpInProcess(ergo, 'ip-in-seen2')
+    const peer = await connectPeer(ergo, 'ip-in-seen2-peer')
+
+    peer.say('ip-in-seen2', 'dm no seenby')
+    const n = await mcp.waitForNotification(messagePredicate({ isDirect: true, content: 'dm no seenby' }))
+
+    expect(n.meta.seenBy).toBeUndefined()
+  })
 })

--- a/test/inbound.test.ts
+++ b/test/inbound.test.ts
@@ -252,7 +252,7 @@ describe.if(isErgoAvailable())('inbound notifications', () => {
     expect(n.meta.mention).toBe('true')
   })
 
-  // ---- seenBy attribute (issue #626) ----------------------------------------
+  // ---- seenBy attribute -------------------------------------------------------
 
   it('peer→channel message carries seenBy with both nicks', async () => {
     const mcp = await startMcpInProcess(ergo, 'ip-in-seen1')

--- a/test/irc-server.test.ts
+++ b/test/irc-server.test.ts
@@ -183,6 +183,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     expect(text).toContain('historical="true"')
     expect(text).toContain('>shape-test-msg<')
     expect(text).not.toContain('mention="true"')
+    expect(text).toContain('seenBy="ip-histshape1, ip-histshape1-peer"')
   })
 
   it('channel_history emits mention="true" for DMs', async () => {
@@ -196,6 +197,7 @@ describe.if(isErgoAvailable())('irc-server MCP tools', () => {
     const text = toolText(hist)
     expect(text).toContain('isDirect="true"')
     expect(text).toContain('mention="true"')
+    expect(text).not.toContain('seenBy')
   })
 
   it('channel_history emits mention="true" for nick mention in channel', async () => {


### PR DESCRIPTION
Closes #626

Incoming channel messages now carry a `seenBy` attribute (current channel member list), mirroring the seen-by hint outgoing `channel_message` replies already give (`handleSay`). Agents seeing another agent's message in a group channel can tell who else already has it, instead of assuming they need to restate it.

`buildMessageMeta` is the single builder shared by the live push path, the join-history auto-replay path, and `channel_history`'s synthesized `<channel>` tags — so all three surface `seenBy` uniformly from one change. DMs are 1:1 and skip it, same as the outgoing convention. Historical/replayed messages get a *current*-membership snapshot (not membership at original send time) — same approximation the outgoing hint already makes.

Also updated the MCP `instructions` contract string to document the new attribute.

## Test plan
- [x] `bun run lint` / `bun run typecheck` clean
- [x] New tests: live channel message carries seenBy with both nicks; DM has no seenBy; join-history replay path carries seenBy (run 3x standalone to rule out a NAMES-vs-batch-ordering race); channel_history tool's synthesized tag carries seenBy
- [x] Full suite: 995 pass, 0 fail