### PR TITLE
pricing: normalize dated model ids before lookup

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -11,6 +11,14 @@
 // print `$?` for that nick and stderr-warn the unknown ID rather than
 // silently defaulting to a rate that could mislead in either direction.
 //
+// Claude Code often records a dated snapshot id (e.g.
+// `claude-opus-4-8-20260115`) rather than the bare alias. costFor/missCostFor
+// look up the exact id first, then fall back to the id with its trailing
+// `-YYYYMMDD` stamp stripped — so a new dated snapshot of an already-priced
+// model resolves without a manual table entry. A literal entry still wins
+// over the fallback, so a one-off pinned rate for a specific snapshot stays
+// possible.
+//
 // Cache-write tier: Anthropic bills 5-minute cache writes at 1.25x the base
 // input rate and 1-hour cache writes at 2x. The JSONL `usage.cache_creation`
 // nested object breaks these out (`ephemeral_5m_input_tokens` and
@@ -27,25 +35,22 @@ export interface ModelPricing {
 }
 
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
-  // Opus 4.x current generation — $5 base input (with date-stamped variant Claude Code records). Opus 4.1 and earlier use the $15 tier.
-  'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 }, // exact-match: dated variants (claude-opus-4-8-YYYYMMDD) each need an explicit entry
+  // Opus 4.x current generation — $5 base input. Opus 4.1 and earlier use the $15 tier.
+  'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-6':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-5':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
-  'claude-opus-4-5-20251101':   { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-1':            { input: 15, output: 75, cache_creation_5m: 18.75, cache_creation_1h: 30,  cache_read: 1.50 },
   // Sonnet 5 — separate pricing tier from Sonnet 4.x below. Introductory pricing
   // through 2026-08-31 (this row). Standard pricing from 2026-09-01: input 3,
   // output 15, cache_creation_5m 3.75, cache_creation_1h 6, cache_read 0.30 — flip
   // this entry to those numbers then.
-  'claude-sonnet-5':                { input: 2,  output: 10, cache_creation_5m: 2.50,  cache_creation_1h: 4,   cache_read: 0.20 }, // exact-match: dated variants (claude-sonnet-5-YYYYMMDD) each need an explicit entry
-  // Sonnet 4.x (with date-stamped variant Claude Code records).
+  'claude-sonnet-5':                { input: 2,  output: 10, cache_creation_5m: 2.50,  cache_creation_1h: 4,   cache_read: 0.20 },
+  // Sonnet 4.x.
   'claude-sonnet-4-6':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
   'claude-sonnet-4-5':              { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
-  'claude-sonnet-4-5-20250929':     { input: 3,  output: 15, cache_creation_5m: 3.75,  cache_creation_1h: 6,   cache_read: 0.30 },
-  // Haiku 4.5 (with date-stamped variant Claude Code records).
+  // Haiku 4.5.
   'claude-haiku-4-5':          { input: 1,  output: 5,  cache_creation_5m: 1.25,  cache_creation_1h: 2,   cache_read: 0.10 },
-  'claude-haiku-4-5-20251001': { input: 1,  output: 5,  cache_creation_5m: 1.25,  cache_creation_1h: 2,   cache_read: 0.10 },
 }
 
 // IDs that appear in transcripts but don't represent real API spend —
@@ -60,11 +65,22 @@ export interface UsageCounts {
   cache_read: number
 }
 
+// Strips a trailing `-YYYYMMDD` snapshot date stamp, e.g.
+// `claude-opus-4-8-20260115` -> `claude-opus-4-8`. Ids without a trailing
+// 8-digit group pass through unchanged.
+export function normalizeModelId(model: string): string {
+  return model.replace(/-\d{8}$/, '')
+}
+
+function lookupPricing(model: string): ModelPricing | undefined {
+  return PRICING[model] ?? PRICING[normalizeModelId(model)]
+}
+
 // Returns the USD cost for the given counts at the given model's rates, or
 // `null` if the model is unknown (caller surfaces `$?` and warns).
 export function costFor(model: string, u: UsageCounts): number | null {
   if (SKIPPED_MODELS.has(model)) return 0
-  const p = PRICING[model]
+  const p = lookupPricing(model)
   if (!p) return null
   return (
     p.input * u.input
@@ -81,7 +97,7 @@ export function costFor(model: string, u: UsageCounts): number | null {
 // premium is computed at the correct rate per tier). Returns `null` for unknown models.
 export function missCostFor(model: string, tokens5m: number, tokens1h: number): number | null {
   if (SKIPPED_MODELS.has(model)) return 0
-  const p = PRICING[model]
+  const p = lookupPricing(model)
   if (!p) return null
   return (
     (p.cache_creation_5m - p.cache_read) * tokens5m

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { PRICING, costFor, missCostFor, normalizeModelId } from '../src/pricing.js'
+import { PRICING, costFor, missCostFor, normalizeModelId, type ModelPricing } from '../src/pricing.js'
 
 const ZERO_USAGE = { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
 const SAMPLE_USAGE = { input: 1000, output: 500, cache_creation_5m: 200, cache_creation_1h: 100, cache_read: 50 }
@@ -58,17 +58,32 @@ describe('costFor / missCostFor unknown models', () => {
 })
 
 describe('exact match takes priority over the normalized fallback', () => {
-  it('an exact PRICING entry is used as-is even though it also has a dated shape', () => {
-    // claude-opus-4-1 has no trailing date stamp, so normalization is a
-    // no-op here — this just locks that the exact-match lookup path runs
-    // first and short-circuits before any fallback.
-    expect(costFor('claude-opus-4-1', SAMPLE_USAGE)).toBe(
-      (PRICING['claude-opus-4-1'].input * SAMPLE_USAGE.input
-        + PRICING['claude-opus-4-1'].output * SAMPLE_USAGE.output
-        + PRICING['claude-opus-4-1'].cache_creation_5m * SAMPLE_USAGE.cache_creation_5m
-        + PRICING['claude-opus-4-1'].cache_creation_1h * SAMPLE_USAGE.cache_creation_1h
-        + PRICING['claude-opus-4-1'].cache_read * SAMPLE_USAGE.cache_read) / 1_000_000,
-    )
+  // No shipped PRICING entry has both a dated and bare form anymore (that's
+  // exactly the duplication this PR removed), so a real divergent case has
+  // to be planted to actually exercise the `??` priority order rather than
+  // just asserting it structurally.
+  it('a literal dated entry is used over its bare alias, even when priced differently', () => {
+    const bare = 'claude-test-fixture-4-0'
+    const dated = 'claude-test-fixture-4-0-20260101'
+    const bareRate: ModelPricing = { input: 1, output: 1, cache_creation_5m: 1, cache_creation_1h: 1, cache_read: 1 }
+    const datedRate: ModelPricing = { input: 999, output: 999, cache_creation_5m: 999, cache_creation_1h: 999, cache_read: 999 }
+    const mutablePricing = PRICING as Record<string, ModelPricing>
+    mutablePricing[bare] = bareRate
+    mutablePricing[dated] = datedRate
+    try {
+      const expectedDatedCost = (
+        datedRate.input * SAMPLE_USAGE.input
+        + datedRate.output * SAMPLE_USAGE.output
+        + datedRate.cache_creation_5m * SAMPLE_USAGE.cache_creation_5m
+        + datedRate.cache_creation_1h * SAMPLE_USAGE.cache_creation_1h
+        + datedRate.cache_read * SAMPLE_USAGE.cache_read
+      ) / 1_000_000
+      expect(costFor(dated, SAMPLE_USAGE)).toBe(expectedDatedCost)
+      expect(costFor(dated, SAMPLE_USAGE)).not.toBe(costFor(bare, SAMPLE_USAGE))
+    } finally {
+      delete mutablePricing[bare]
+      delete mutablePricing[dated]
+    }
   })
 })
 

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'bun:test'
+import { PRICING, costFor, missCostFor, normalizeModelId } from '../src/pricing.js'
+
+const ZERO_USAGE = { input: 0, output: 0, cache_creation_5m: 0, cache_creation_1h: 0, cache_read: 0 }
+const SAMPLE_USAGE = { input: 1000, output: 500, cache_creation_5m: 200, cache_creation_1h: 100, cache_read: 50 }
+
+describe('normalizeModelId', () => {
+  it('strips a trailing 8-digit date stamp', () => {
+    expect(normalizeModelId('claude-opus-4-8-20260115')).toBe('claude-opus-4-8')
+  })
+
+  it('leaves ids with no trailing date stamp unchanged', () => {
+    expect(normalizeModelId('claude-opus-4-8')).toBe('claude-opus-4-8')
+  })
+
+  it('does not strip a 7-digit trailing numeric group', () => {
+    expect(normalizeModelId('claude-foo-1234567')).toBe('claude-foo-1234567')
+  })
+
+  it('does not strip a 9-digit trailing numeric group', () => {
+    expect(normalizeModelId('claude-foo-123456789')).toBe('claude-foo-123456789')
+  })
+
+  it('only strips the trailing group, not an 8-digit group in the middle', () => {
+    expect(normalizeModelId('claude-20260115-foo')).toBe('claude-20260115-foo')
+  })
+})
+
+// One case per model id we removed the redundant dated duplicate for —
+// proves each drop is safe (fallback reproduces the same price) rather than
+// assumed.
+describe('costFor resolves dated snapshot ids via fallback', () => {
+  const cases: [string, string][] = [
+    ['claude-opus-4-8', 'claude-opus-4-8-20260115'],
+    ['claude-opus-4-5', 'claude-opus-4-5-20251101'],
+    ['claude-sonnet-5', 'claude-sonnet-5-20260601'],
+    ['claude-sonnet-4-5', 'claude-sonnet-4-5-20250929'],
+    ['claude-haiku-4-5', 'claude-haiku-4-5-20251001'],
+  ]
+
+  for (const [bare, dated] of cases) {
+    it(`${dated} matches ${bare}'s price`, () => {
+      expect(costFor(dated, SAMPLE_USAGE)).toBe(costFor(bare, SAMPLE_USAGE))
+      expect(costFor(dated, SAMPLE_USAGE)).not.toBeNull()
+    })
+  }
+})
+
+describe('costFor / missCostFor unknown models', () => {
+  it('returns null for a wholly unknown model with no date stamp', () => {
+    expect(costFor('claude-mystery-9-0', ZERO_USAGE)).toBeNull()
+  })
+
+  it('returns null for an unknown model even with a trailing date stamp', () => {
+    expect(costFor('claude-mystery-9-0-20260115', ZERO_USAGE)).toBeNull()
+    expect(missCostFor('claude-mystery-9-0-20260115', 100, 100)).toBeNull()
+  })
+})
+
+describe('exact match takes priority over the normalized fallback', () => {
+  it('an exact PRICING entry is used as-is even though it also has a dated shape', () => {
+    // claude-opus-4-1 has no trailing date stamp, so normalization is a
+    // no-op here — this just locks that the exact-match lookup path runs
+    // first and short-circuits before any fallback.
+    expect(costFor('claude-opus-4-1', SAMPLE_USAGE)).toBe(
+      (PRICING['claude-opus-4-1'].input * SAMPLE_USAGE.input
+        + PRICING['claude-opus-4-1'].output * SAMPLE_USAGE.output
+        + PRICING['claude-opus-4-1'].cache_creation_5m * SAMPLE_USAGE.cache_creation_5m
+        + PRICING['claude-opus-4-1'].cache_creation_1h * SAMPLE_USAGE.cache_creation_1h
+        + PRICING['claude-opus-4-1'].cache_read * SAMPLE_USAGE.cache_read) / 1_000_000,
+    )
+  })
+})
+
+describe('missCostFor resolves dated snapshot ids via fallback', () => {
+  it('claude-sonnet-4-6-20260301 matches claude-sonnet-4-6', () => {
+    expect(missCostFor('claude-sonnet-4-6-20260301', 500, 250)).toBe(missCostFor('claude-sonnet-4-6', 500, 250))
+    expect(missCostFor('claude-sonnet-4-6-20260301', 500, 250)).not.toBeNull()
+  })
+})

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -730,6 +730,19 @@ describe('token-usage', () => {
       expect(rep.err).toContain('add to src/pricing.ts')
     })
 
+    it('dated model id (Claude Code snapshot form) prices via the bare-alias fallback, not $?', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-8-20260615', input: 1000, output: 500 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '319', 'roost-x']))
+      // Opus 4.8: 1000 × $5 + 500 × $25 = 5000 + 12500 = 17500 / 1M = $0.0175 → $0.02
+      expect(rep.out).toContain('roost-x: $0.02')
+      expect(rep.out).toMatch(/opus-4-8-20260615:.*\$0\.02/)
+      expect(rep.err).toBe('')
+    })
+
     it('exits non-zero when any nick matches zero session files', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })


### PR DESCRIPTION
Closes #615

costFor()/missCostFor() did an exact-match lookup on `message.model`, so Claude Code's dated snapshot ids (e.g. `claude-opus-4-8-20260115`) never matched the bare alias entry and silently priced as `$?`.

Adds a fallback that strips a trailing `-YYYYMMDD` stamp and retries the lookup — exact match still wins first, so a future pinned rate for a specific snapshot stays possible. Drops the three dated-entry duplicates (`opus-4-5`, `sonnet-4-5`, `haiku-4-5`) that are now redundant with the fallback — they were pure copies of the bare alias and a second copy risked silently drifting out of sync.

Tests: unit coverage for `normalizeModelId` (including the 7/9-digit trailing-numeric edge cases) and `costFor`/`missCostFor` fallback per dropped id, plus one end-to-end `report` test feeding a dated model id through the full pipeline.