### PR TITLE
Estimate api time from assistant span when turn_duration rows are absent

### DIFF
--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -6,6 +6,9 @@
 //     opus-4-7:    7.4k in / 63.4k out / 17.5M cache_r / 644.6k cache_w  ($14.38, miss: 128.3k ($1.42) [tools_changed 16.2k ($0.18) · system_changed 112.1k ($1.24)])
 //     sonnet-4-6:  1.2k in /  2.4k out /  300k cache_r /   8.5k cache_w  ($0.42)
 //
+// A leading `~` on the api figure (e.g. `~3m44s api`) marks an estimate —
+// see scanFile's api-time note for when and why we fall back to one.
+//
 // Sessions are matched by the MCP banner produced by src/mcp-banner.ts —
 // every roost-spawned session writes `You are connected to IRC as nick
 // "<nick>"` into its MCP instructions payload, which lands verbatim (with
@@ -21,9 +24,11 @@
 //
 //   report <stateDir> <issue> <nick>...
 //     For each nick: walk all matching session transcripts, sum per-model
-//     token usage + API duration (from `system/turn_duration` rows), pull
-//     wall duration from the first/last in-scope turn timestamps, and
-//     price each model via src/pricing.ts. If a snapshot exists for
+//     token usage + API duration (from `system/turn_duration` rows, or —
+//     when a transcript has none — an estimate from its assistant-row
+//     timestamp span, rendered with a leading `~`), pull wall duration from
+//     the first/last in-scope turn timestamps, and price each model via
+//     src/pricing.ts. If a snapshot exists for
 //     <issue>+<nick>, only turns with `timestamp > snapshot_at` count;
 //     otherwise the full cumulative is reported (which matches per-issue
 //     for ephemeral nicks like workers/reviewers that live one issue).
@@ -60,6 +65,10 @@ interface NickReport {
   // Value: miss token counts split by creation tier (from the same row's cache_creation block).
   missByModel: Map<string, Map<string, MissCounts>>
   apiDurationMs: number
+  // True when any contributing transcript lacked `turn_duration` rows and we
+  // estimated its api time from the assistant-row timestamp span instead.
+  // Renders the nick's api figure with a leading `~`.
+  apiDurationEstimated: boolean
   wallFirst?: string
   wallLast?: string
   // Number of contributing JSONL transcript files (parent + each subagent file
@@ -82,6 +91,7 @@ function emptyReport(): NickReport {
     byModel: new Map(),
     missByModel: new Map(),
     apiDurationMs: 0,
+    apiDurationEstimated: false,
     transcripts: 0,
     unknownModels: new Set(),
     files: [],
@@ -213,6 +223,9 @@ interface ScanResult {
   byModel: Map<string, UsageCounts>
   missByModel: Map<string, Map<string, MissCounts>>
   apiDurationMs: number
+  // True when this file had no `turn_duration` rows and apiDurationMs was
+  // estimated from the assistant-row timestamp span (see scanFile's api-time note).
+  apiDurationEstimated: boolean
   wallFirst?: string
   wallLast?: string
   unknownModels: Set<string>
@@ -237,10 +250,32 @@ interface ScanResult {
 // compaction. It carries preTokens/postTokens + durationMs but no per-
 // field usage block — the summary API call itself isn't logged. We
 // aggregate the markers so the gap is visible, without pricing it.
+//
+// API-time note: Claude Code writes a `turn_duration` row only when a turn
+// completes and control returns to the prompt. An agent that runs a single
+// turn and exits at the end of it (a reviewer: spawn → review → exit)
+// terminates before that row is flushed, so its transcript carries zero
+// turn_duration rows and the summed api time is a misleading 0s. When a file
+// has no turn_duration rows at all, we estimate its api time from the span of
+// its assistant-usage timestamps instead, and flag it (`apiDurationEstimated`)
+// so the report marks the figure with a leading `~`. The span is the same
+// quantity turn_duration measures — busy wall-time across the turn, tool exec
+// included — because a single-turn agent never idles. Presence of even one
+// turn_duration row (in-window) suppresses the estimate, so a forked/resumed
+// transcript whose turn_durations dedup away against another file does not
+// double-count: its rows are still "seen," just billed to the file that got
+// there first.
 function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<string>, seenCompactUuids: Set<string>, sinceTs?: string, countSidechain = false): ScanResult {
   const byModel = new Map<string, UsageCounts>()
   const missByModel = new Map<string, Map<string, MissCounts>>()
-  let apiDurationMs = 0
+  let measuredApiMs = 0
+  // Whether any in-window turn_duration row was present (counted or deduped).
+  // Its presence — not its contribution — is what suppresses the span estimate.
+  let sawTurnDuration = false
+  // First/last timestamps of contributing assistant-usage rows, for the
+  // span estimate used when the file has no turn_duration rows.
+  let assistantFirst: string | undefined
+  let assistantLast: string | undefined
   let wallFirst: string | undefined
   let wallLast: string | undefined
   const unknownModels = new Set<string>()
@@ -302,7 +337,11 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
         if (costFor(row.message.model, tokens) === null) {
           unknownModels.add(row.message.model)
         }
-        if (ts) trackLocal(ts)
+        if (ts) {
+          trackLocal(ts)
+          if (!assistantFirst || ts < assistantFirst) assistantFirst = ts
+          if (!assistantLast || ts > assistantLast) assistantLast = ts
+        }
         contributed = true
       }
 
@@ -340,11 +379,15 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
     // Dedup by uuid so forked/resumed transcripts don't re-add the same
     // turn; within a single file these uuids are already unique.
     if (row.type === 'system' && row.subtype === 'turn_duration' && typeof row.durationMs === 'number') {
+      // Set before the dedup check: a turn_duration row that dedups away
+      // still proves this session's turns were recorded, so it must suppress
+      // the span estimate here (the file that counted it owns the time).
+      sawTurnDuration = true
       if (row.uuid) {
         if (seenTurnUuids.has(row.uuid)) continue
         seenTurnUuids.add(row.uuid)
       }
-      apiDurationMs += row.durationMs
+      measuredApiMs += row.durationMs
       if (ts) trackLocal(ts)
       contributed = true
       continue
@@ -368,7 +411,18 @@ function scanFile(text: string, seenRequestIds: Set<string>, seenTurnUuids: Set<
       continue
     }
   }
-  return { byModel, missByModel, apiDurationMs, wallFirst, wallLast, unknownModels, contributed, compactions }
+  // No turn_duration rows but real assistant work → estimate api time from
+  // the assistant-usage span (see this function's api-time note). Otherwise
+  // trust the measured sum.
+  let apiDurationMs = measuredApiMs
+  let apiDurationEstimated = false
+  if (!sawTurnDuration && assistantFirst && assistantLast) {
+    const span = Date.parse(assistantLast) - Date.parse(assistantFirst)
+    apiDurationMs = span > 0 ? span : 0
+    apiDurationEstimated = true
+  }
+
+  return { byModel, missByModel, apiDurationMs, apiDurationEstimated, wallFirst, wallLast, unknownModels, contributed, compactions }
 }
 
 export async function collectForNick(
@@ -401,6 +455,7 @@ export async function collectForNick(
     for (const [m, u] of result.byModel) addToUsageMap(report.byModel, m, u)
     addToMissMap(report.missByModel, result.missByModel)
     report.apiDurationMs += result.apiDurationMs
+    if (result.apiDurationEstimated) report.apiDurationEstimated = true
     if (result.wallFirst) trackTs(report, result.wallFirst)
     if (result.wallLast) trackTs(report, result.wallLast)
     for (const m of result.unknownModels) report.unknownModels.add(m)
@@ -423,6 +478,7 @@ export async function collectForNick(
       for (const [m, u] of subResult.byModel) addToUsageMap(report.byModel, m, u)
       addToMissMap(report.missByModel, subResult.missByModel)
       report.apiDurationMs += subResult.apiDurationMs
+      if (subResult.apiDurationEstimated) report.apiDurationEstimated = true
       if (subResult.wallFirst) trackTs(report, subResult.wallFirst)
       if (subResult.wallLast) trackTs(report, subResult.wallLast)
       for (const m of subResult.unknownModels) report.unknownModels.add(m)
@@ -533,7 +589,9 @@ function formatNick(nick: string, r: NickReport): string {
   const missPart = totalMissCost === null || totalMissCost > 0
     ? ` (${fmtDollars(totalMissCost)} miss)`
     : ''
-  const head = `${nick}: ${fmtDollars(totalCost)}${missPart} · ${fmtDuration(r.apiDurationMs)} api / ${fmtDuration(wallMs)} wall`
+  // Leading `~` marks an estimated api figure — see scanFile's api-time note.
+  const apiStr = `${r.apiDurationEstimated ? '~' : ''}${fmtDuration(r.apiDurationMs)}`
+  const head = `${nick}: ${fmtDollars(totalCost)}${missPart} · ${apiStr} api / ${fmtDuration(wallMs)} wall`
   // Compaction is its own line — surface what the JSONL gives us (pre/post
   // context size, total wall) and explicitly call out that the API call's
   // input/output isn't captured. See scanFile's "Known gaps" comment.

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -258,9 +258,12 @@ interface ScanResult {
 // turn_duration rows and the summed api time is a misleading 0s. When a file
 // has no turn_duration rows at all, we estimate its api time from the span of
 // its assistant-usage timestamps instead, and flag it (`apiDurationEstimated`)
-// so the report marks the figure with a leading `~`. The span is the same
-// quantity turn_duration measures — busy wall-time across the turn, tool exec
-// included — because a single-turn agent never idles. Presence of even one
+// so the report marks the figure with a leading `~`. The span measures the
+// same thing turn_duration does — busy wall-time across the turn, tool exec
+// included, not per-token latency — because a single-turn agent never idles.
+// It runs slightly low: the span starts at the first response, so it omits
+// that response's own prompt→first-token latency. Fine for a `~` figure.
+// Presence of even one
 // turn_duration row (in-window) suppresses the estimate, so a forked/resumed
 // transcript whose turn_durations dedup away against another file does not
 // double-count: its rows are still "seen," just billed to the file that got

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -811,6 +811,24 @@ describe('token-usage', () => {
       expect(rep.out).not.toContain('~')
     })
 
+    it('marks a mixed measured+estimated nick with ~ on the combined figure', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // One measured session (1m turn_duration) and one estimated session
+      // (no turn_duration, 3m44s assistant span). The combined figure sums to
+      // 4m44s and — because any estimated file taints the total — carries `~`.
+      await writeSessionFile(d, 'measured.jsonl', 'roost-mix', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, apiDurationMs: 60_000 },
+      ])
+      await writeSessionFile(d, 'estimated.jsonl', 'roost-mix', [
+        { ts: '2026-05-16T11:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_1' },
+        { ts: '2026-05-16T11:03:44Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_2' },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '394', 'roost-mix']))
+      expect(rep.result).toBe(0)
+      expect(rep.out).toContain('~4m44s api')
+    })
+
     it('per-model line shows cache_w_5m and cache_w_1h as separate columns', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -384,6 +384,92 @@ describe('token-usage', () => {
       expect(r.apiDurationMs).toBe(4000)
     })
 
+    it('estimates api time from the assistant-row span when a file has no turn_duration rows', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Reviewer shape: real assistant usage, no turn_duration companions
+      // (the session exits at the end of its single turn before the row flushes).
+      await writeSessionFile(d, 's.jsonl', 'roost-reviewer-1', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_1' },
+        { ts: '2026-05-16T10:01:30Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_2' },
+        { ts: '2026-05-16T10:03:44Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_3' },
+      ])
+      const r = await collectForNick('roost-reviewer-1', projects)
+      // span 10:00:00 → 10:03:44 = 3m44s = 224_000 ms.
+      expect(r.apiDurationMs).toBe(224_000)
+      expect(r.apiDurationEstimated).toBe(true)
+    })
+
+    it('keeps the measured sum (no estimate) when turn_duration rows are present', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Two 5-minute-apart turns, each with a short turn_duration. The measured
+      // sum (5s) is nothing like the 5m assistant span — proves we take the sum.
+      await writeSessionFile(d, 's.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, apiDurationMs: 4000 },
+        { ts: '2026-05-16T10:05:00Z', model: 'claude-opus-4-7', input: 10, output: 5, apiDurationMs: 1000 },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      expect(r.apiDurationMs).toBe(5000)
+      expect(r.apiDurationEstimated).toBe(false)
+    })
+
+    it('estimates a forked no-turn_duration transcript once, not per file', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Realistic reviewer fork: both files carry the same turns (shared
+      // requestIds). The second file's assistant rows dedup away, so only the
+      // first file's span is estimated — no double-count.
+      const turns = [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_1' },
+        { ts: '2026-05-16T10:03:44Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_2' },
+      ]
+      await writeSessionFile(d, 'fork-a.jsonl', 'roost-x', turns)
+      await writeSessionFile(d, 'fork-b.jsonl', 'roost-x', turns)
+      const r = await collectForNick('roost-x', projects)
+      expect(r.apiDurationMs).toBe(224_000)
+      expect(r.apiDurationEstimated).toBe(true)
+    })
+
+    it('a re-logged turn_duration suppresses a file\'s span estimate (defensive, no double-count)', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Pathological shape: both files re-log the same turn_duration (shared
+      // uuid) but carry distinct fresh assistant spans. The deduped
+      // turn_duration must still suppress the second file's span estimate, so
+      // a measured 4s never gets a 10m guess stacked on top — regardless of
+      // scan order (both files hold the marker, both spans are equal).
+      await writeSessionFile(d, 'fork-a.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_a1', apiDurationMs: 4000, turnUuid: 'turn_shared' },
+        { ts: '2026-05-16T10:10:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_a2' },
+      ])
+      await writeSessionFile(d, 'fork-b.jsonl', 'roost-x', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_b1', apiDurationMs: 4000, turnUuid: 'turn_shared' },
+        { ts: '2026-05-16T10:10:00Z', model: 'claude-opus-4-7', input: 1, output: 1, requestId: 'req_b2' },
+      ])
+      const r = await collectForNick('roost-x', projects)
+      expect(r.apiDurationMs).toBe(4000)
+      expect(r.apiDurationEstimated).toBe(false)
+    })
+
+    it('estimates a subagent file with no turn_duration and marks the parent nick estimated', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // Parent has a measured turn; subagent runs turns but emits no
+      // turn_duration → its span is estimated and the nick figure is marked.
+      const parent = await writeSessionFile(d, 's.jsonl', 'roost-worker-99', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 100, output: 50, apiDurationMs: 2000 },
+      ])
+      await writeSubagentFile(parent, 'aaa7777777777777a', [
+        { ts: '2026-05-16T10:01:00Z', model: 'claude-haiku-4-5-20251001', input: 200, output: 75, requestId: 'req_s1' },
+        { ts: '2026-05-16T10:02:00Z', model: 'claude-haiku-4-5-20251001', input: 50, output: 25, requestId: 'req_s2' },
+      ])
+      const r = await collectForNick('roost-worker-99', projects)
+      // Parent measured 2s + subagent span 1m (10:01 → 10:02) = 62_000 ms.
+      expect(r.apiDurationMs).toBe(62_000)
+      expect(r.apiDurationEstimated).toBe(true)
+    })
+
     it('bills subagent transcripts under a matched parent to the parent nick', async () => {
       const d = join(projects, '-p')
       await mkdir(d, { recursive: true })
@@ -698,6 +784,31 @@ describe('token-usage', () => {
       expect(rep.out).toContain('($2.25)')
       // Wall: 10:00 → 10:30 = 30m. API: 60+30 = 90s = 1m30s.
       expect(rep.out).toContain('1m30s api / 30m00s wall')
+    })
+
+    it('marks an estimated api figure with a leading ~', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      // No turn_duration rows → api estimated from the 3m44s assistant span.
+      await writeSessionFile(d, 's.jsonl', 'roost-reviewer-7', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_1' },
+        { ts: '2026-05-16T10:03:44Z', model: 'claude-opus-4-7', input: 10, output: 100, requestId: 'req_2' },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '394', 'roost-reviewer-7']))
+      expect(rep.result).toBe(0)
+      expect(rep.out).toContain('~3m44s api / 3m44s wall')
+    })
+
+    it('leaves a measured api figure unmarked (no ~)', async () => {
+      const d = join(projects, '-p')
+      await mkdir(d, { recursive: true })
+      await writeSessionFile(d, 's.jsonl', 'roost-worker-7', [
+        { ts: '2026-05-16T10:00:00Z', model: 'claude-opus-4-7', input: 10, output: 5, apiDurationMs: 90_000 },
+      ])
+      const rep = await capture(() => main(['report', stateDir, '394', 'roost-worker-7']))
+      expect(rep.result).toBe(0)
+      expect(rep.out).toContain('1m30s api')
+      expect(rep.out).not.toContain('~')
     })
 
     it('per-model line shows cache_w_5m and cache_w_1h as separate columns', async () => {


### PR DESCRIPTION
Closes #394

## Root cause

`roost-token-usage` derives api time entirely by summing `system/turn_duration`
rows. Claude Code writes those rows only at **turn completion** — when control
returns to the interactive prompt. A reviewer runs a single turn (spawn →
review → exit) and terminates at the end of that turn *before* the row is
flushed, so its transcript carries **zero** turn_duration rows and api time
reports a misleading `0s` while wall spans minutes of real work.

Confirmed empirically across five reviewers (639/642/644/645/647): 0
turn_duration rows each, same Claude Code version / entrypoint / mode as
workers. Workers, lead-pm, and apm complete turns and idle between IRC
messages, so they accumulate turn_duration normally. No reviewer row carries
any `durationMs` / `ttftMs` / result field — the timing is **structurally
absent** from the transcript, not mis-parsed. So the fix can't parse
differently; it synthesizes a fallback.

## Fix

When a transcript file has no turn_duration rows, estimate its api time from
the span of its assistant-usage timestamps, and render the nick's api figure
with a leading `~` (e.g. `~3m44s api`). For a single-turn agent that never
idles, that span is the *same quantity* turn_duration measures — busy
wall-time across the turn, tool execution included — so it's an honest
estimate, not a fudge. The `~` makes it self-documenting.

Scoping: the fallback fires only for files with **zero** turn_duration rows.
The measured path is untouched, so workers/lead/apm and long-lived agents that
lose only their in-flight final turn are unaffected. Presence of even one
in-window turn_duration row suppresses the estimate, so a forked/resumed
transcript whose rows dedup away doesn't double-count.

Verified against real transcripts:
```
roost-reviewer-639: ... · ~3m44s api / 3m44s wall   (was 0s api / 3m44s wall)
roost-worker-620:   ... · 53m12s api / 3h03m wall    (measured, no ~)
```

## Follow-up (not in this PR)

Instrumenting real api/wall at spawn time (harness-level) would give measured
numbers for short-lived agents instead of an estimate — a separate,
cross-cutting concern. Lead is filing it separately.