### PR TITLE
Harden the roost agents discovery mechanism

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -924,6 +924,11 @@ cmd_spawn() {
   esac
   if [ "${perm_irc}" -eq 1 ] && [ "${_skip_bash_hook}" -eq 0 ]; then
     pretooluse_entries+=("{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec irc-pretooluse-prompt\"}]}")
+  elif [ "${perm_irc}" -eq 1 ] && [ "${_skip_bash_hook}" -eq 1 ]; then
+    # Otherwise an operator who passed --perm-irc expecting bash prompts sees
+    # none and has no way to tell "resolved mode never blocks on bash" apart
+    # from "something's broken".
+    echo "  bash permission relay: skipped — ${hook_perm_mode} never blocks on bash"
   fi
   if [ "${ask_routing}" -eq 1 ]; then
     pretooluse_entries+=("{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"${ROOST_BIN} hook-exec irc-ask-question\"}]}")

--- a/bin/roost
+++ b/bin/roost
@@ -1123,13 +1123,50 @@ cmd_spawn() {
   echo "  shutdown with: roost shutdown ${nick}"
 }
 
-# Read the single-line `description:` from an agent file's YAML frontmatter.
-# Prints nothing if there's no frontmatter description.
+# Read the `description:` from an agent file's YAML frontmatter and fold it
+# to one line for roster display. Handles both plain scalars
+# (`description: text`) and YAML block scalars (`description: >` folded or
+# `description: |` literal, with optional chomp/indent indicators) — a block
+# scalar's continuation lines are joined with spaces rather than printing the
+# bare `>`/`|`. Prints nothing if there's no frontmatter description.
 _agent_description() {
   awk '
-    /^---[[:space:]]*$/ { fence++; next }
-    fence == 1 && /^description:[[:space:]]*/ { sub(/^description:[[:space:]]*/, ""); print; exit }
-    fence >= 2 { exit }
+    {
+      if (in_block) {
+        if ($0 ~ /^---[[:space:]]*$/) { exit }
+        if (block_indent < 0) {
+          if ($0 ~ /^[[:space:]]*$/) { next }
+          line = $0
+          sub(/^[[:space:]]*/, "", line)
+          block_indent = length($0) - length(line)
+        }
+        indent = 0
+        while (substr($0, indent + 1, 1) == " ") indent++
+        if (indent < block_indent) { exit }
+        content = substr($0, block_indent + 1)
+        result = (result == "" ? content : result " " content)
+        next
+      }
+      if ($0 ~ /^---[[:space:]]*$/) {
+        fence++
+        if (fence >= 2) exit
+        next
+      }
+      if (fence == 1 && $0 ~ /^description:[[:space:]]*/) {
+        val = $0
+        sub(/^description:[[:space:]]*/, "", val)
+        if (val ~ /^[>|][0-9]*[+-]?[[:space:]]*$/) {
+          in_block = 1
+          block_indent = -1
+          result = ""
+          next
+        }
+        print val
+        exit
+      }
+      if (fence >= 2) exit
+    }
+    END { if (in_block && result != "") print result }
   ' "$1"
 }
 

--- a/bin/roost
+++ b/bin/roost
@@ -753,25 +753,24 @@ cmd_spawn() {
     # claude searches .claude/agents/ recursively by filename.
     # plugin-tree agents (${ROOST_DIR}/agents/) are NOT searched by claude; operators
     # must run `roost init` to copy/symlink them into <cwd>/.claude/agents/.
-    local _agent_found=0
-    local _search_root
-    for _search_root in "${cwd}/.claude/agents" "${HOME}/.claude/agents"; do
-      if [ -d "${_search_root}" ]; then
-        _agent_path="$(find -L "${_search_root}" -name "${agent}.md" -type f 2>/dev/null | head -1)"
-        if [ -n "${_agent_path}" ]; then
-          _agent_found=1
-          break
-        fi
+    # _resolvable_agents is the single search impl: this lookup, the not-found
+    # error's "available agents" list, and `roost agents` all read the same
+    # computation, so they can't disagree about what --agent accepts.
+    local _resolvable _an _as _ap
+    _resolvable="$(_resolvable_agents "${cwd}")"
+    while IFS=$'\t' read -r _an _as _ap; do
+      [ -n "${_an}" ] || continue
+      if [ "${_an}" = "${agent}" ]; then
+        _agent_path="${_ap}"
+        break
       fi
-    done
-    if [ "${_agent_found}" -eq 0 ]; then
+    done <<< "${_resolvable}"
+    if [ -z "${_agent_path}" ]; then
       echo "error: agent '${agent}' not found; searched:" >&2
       printf '  %s/.claude/agents/**/%s.md\n' "${cwd}" "${agent}" >&2
       printf '  %s/.claude/agents/**/%s.md\n' "${HOME}" "${agent}" >&2
-      # Same resolver set 'roost agents' lists, so the two never disagree about
-      # what --agent accepts.
       local _avail
-      _avail="$(_resolvable_agents "${cwd}" | cut -f1 | paste -sd' ' -)"
+      _avail="$(printf '%s' "${_resolvable}" | cut -f1 | paste -sd' ' -)"
       if [ -n "${_avail}" ]; then
         echo "available agents: ${_avail}" >&2
       else
@@ -1146,10 +1145,14 @@ _shipped_agents() {
   done
 }
 
-# Emit "name<TAB>scope" for every agent `roost spawn --agent` would resolve
-# from a given working dir, mirroring the resolver in cmd_spawn: project
-# .claude/agents shadows user ~/.claude/agents, deduped by basename. This is
-# exactly the spawnable set — the not-found error lists the same computation.
+# Emit "name<TAB>scope<TAB>path" for every agent `roost spawn --agent` can
+# resolve from a given working dir: project .claude/agents shadows user
+# ~/.claude/agents, deduped by basename. This IS the resolver — cmd_spawn's
+# --agent lookup, the not-found error's "available agents" list, and `roost
+# agents` all read this one computation, so they can't drift from each other.
+# Within a root, duplicate basenames in different subdirs tie-break on sorted
+# path (deterministic); across roots, project always shadows user regardless
+# of path, via loop order below.
 _resolvable_agents() {
   local _cwd="$1"
   local _root _scope _f _name
@@ -1162,7 +1165,7 @@ _resolvable_agents() {
       _name="$(basename "${_f}" .md)"
       case "${_seen}" in *" ${_name} "*) continue ;; esac
       _seen="${_seen}${_name} "
-      printf '%s\t%s\n' "${_name}" "${_scope}"
+      printf '%s\t%s\t%s\n' "${_name}" "${_scope}" "${_f}"
     done < <(find -L "${_root}" -name '*.md' -type f 2>/dev/null | sort)
   done
 }
@@ -1210,7 +1213,7 @@ cmd_agents() {
     while IFS=$'\t' read -r _rn _; do
       [ "${#_rn}" -gt "${_rw}" ] && _rw="${#_rn}"
     done <<< "${resolvable}"
-    while IFS=$'\t' read -r _rn _rs; do
+    while IFS=$'\t' read -r _rn _rs _; do
       printf '  %-*s  (%s)\n' "${_rw}" "${_rn}" "${_rs}"
     done <<< "${resolvable}"
   elif [ "${show_all}" -eq 1 ]; then

--- a/bin/roost
+++ b/bin/roost
@@ -958,6 +958,8 @@ cmd_spawn() {
   # suppresses the failure-cleanup trap, so spawn_test.sh can read the files
   # written above after a preflight failure exits the spawn. Prod operators
   # never set this — the success path prints "data dir: ..." after tmux comes up.
+  # This does not stop the spawn: on the success path, tmux and claude still
+  # start for real — tests must tear those sessions down themselves.
   if [ "${ROOST_SPAWN_KEEP_DATA_DIR:-0}" = "1" ]; then
     echo "  data dir (preflight): ${ROOST_DATA_DIR}"
   else

--- a/test/agents_test.sh
+++ b/test/agents_test.sh
@@ -155,6 +155,34 @@ else
   fail "--help prints agents usage documenting --all" "out=$out"
 fi
 
+# -- Test 9: _agent_description folds YAML block scalars into one clean line ---
+# `_shipped_agents` (backing `roost agents --all`) only reads from the real
+# ${ROOST_DIR}/agents tree, so a folded-description regression can't be
+# exercised through the CLI without editing shipped agent files. bin/roost
+# guards its dispatch table behind `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`,
+# so sourcing it in an isolated `bash -c` subprocess to call the helper
+# directly is safe — no dispatch runs, nothing leaks into this test's shell.
+
+setup
+printf -- '---\ndescription: >\n  A folded description\n  spanning multiple\n  source lines.\n---\nbody\n' > "$TDIR/folded.md"
+printf -- '---\ndescription: |\n  Line one.\n  Line two.\n---\nbody\n' > "$TDIR/literal.md"
+printf -- '---\ndescription: single line desc\n---\nbody\n' > "$TDIR/single.md"
+printf -- '---\nname: nodesc\n---\nbody\n' > "$TDIR/nodesc.md"
+folded_out="$(bash -c 'source "'"${ROOST_BIN}"'"; _agent_description "$1"' _ "$TDIR/folded.md")"
+literal_out="$(bash -c 'source "'"${ROOST_BIN}"'"; _agent_description "$1"' _ "$TDIR/literal.md")"
+single_out="$(bash -c 'source "'"${ROOST_BIN}"'"; _agent_description "$1"' _ "$TDIR/single.md")"
+nodesc_out="$(bash -c 'source "'"${ROOST_BIN}"'"; _agent_description "$1"' _ "$TDIR/nodesc.md")"
+if [ "$folded_out" = "A folded description spanning multiple source lines." ] \
+    && [ "$literal_out" = "Line one. Line two." ] \
+    && [ "$single_out" = "single line desc" ] \
+    && [ "$nodesc_out" = "" ]; then
+  ok "_agent_description: folds block scalars, leaves single-line/no-description behavior unchanged"
+else
+  fail "_agent_description: folds block scalars, leaves single-line/no-description behavior unchanged" \
+    "folded=[$folded_out] literal=[$literal_out] single=[$single_out] nodesc=[$nodesc_out]"
+fi
+teardown
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -751,7 +751,63 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
-# -- Test 38: duplicate basename in two subdirs of the same root resolves ------
+# -- Test 38: --perm-irc + auto (skip-set) → skip diagnostic printed -----------
+# An operator who passes --perm-irc expecting bash prompts gets none on the
+# skip path with no explanation. A one-line diagnostic closes that gap.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if echo "$out" | grep -qF "bash permission relay: skipped — auto never blocks on bash"; then
+  ok "--perm-irc + auto: skip diagnostic printed with resolved mode"
+else
+  fail "--perm-irc + auto: skip diagnostic printed with resolved mode" "out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 39: --perm-irc + bypassPermissions (skip-set) → diagnostic names it --
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --permission-mode bypassPermissions --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if echo "$out" | grep -qF "bash permission relay: skipped — bypassPermissions never blocks on bash"; then
+  ok "--perm-irc + bypassPermissions: skip diagnostic names the resolved mode"
+else
+  fail "--perm-irc + bypassPermissions: skip diagnostic names the resolved mode" "out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 40: --perm-irc + acceptEdits (relay wired) → no skip diagnostic ------
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --permission-mode acceptEdits --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if ! echo "$out" | grep -q "bash permission relay: skipped"; then
+  ok "--perm-irc + acceptEdits: no skip diagnostic (relay is wired)"
+else
+  fail "--perm-irc + acceptEdits: no skip diagnostic (relay is wired)" "out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 41: no --perm-irc → no skip diagnostic even in skip-set mode ---------
+# Scope check: the diagnostic is scoped to --perm-irc sessions — without a
+# relay to begin with, there's nothing to explain the absence of.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+if ! echo "$out" | grep -q "bash permission relay: skipped"; then
+  ok "no --perm-irc: no skip diagnostic even though default mode is auto"
+else
+  fail "no --perm-irc: no skip diagnostic even though default mode is auto" "out=$out"
+fi
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 42: duplicate basename in two subdirs of the same root resolves ------
 # deterministically to the sorted-first path ------------------------------------
 # #629: the --agent resolver moved off `find | head -1` (nondeterministic) onto
 # _resolvable_agents' sorted output. Two files sharing a basename in different

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -751,6 +751,40 @@ fi
 [ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
+# -- Test 38: duplicate basename in two subdirs of the same root resolves ------
+# deterministically to the sorted-first path ------------------------------------
+# #629: the --agent resolver moved off `find | head -1` (nondeterministic) onto
+# _resolvable_agents' sorted output. Two files sharing a basename in different
+# subdirs of the same scope must resolve to the same, stable winner every time.
+# Raw spawn output isn't diffable across runs (it embeds a fresh mktemp path
+# each time), so the signal is which file's frontmatter got read: give the
+# sorted-first file (a/dupe.md) permissionMode:auto and the sorted-last file
+# (z/dupe.md) permissionMode:acceptEdits, then check the --perm-irc bash-hook
+# skip decision — driven by whichever file the resolver actually opened —
+# agrees across two independent invocations.
+
+setup
+mkdir -p "$TDIR/.claude/agents/a" "$TDIR/.claude/agents/z"
+printf -- '---\ndescription: winner (a sorts first)\npermissionMode: auto\n---\nbody\n' > "$TDIR/.claude/agents/a/dupe.md"
+printf -- '---\ndescription: loser (z sorts last)\npermissionMode: acceptEdits\n---\nbody\n' > "$TDIR/.claude/agents/z/dupe.md"
+out1="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --agent dupe --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+data_dir1="$(echo "$out1" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+tmux kill-session -t "roost-testnick" 2>/dev/null || true
+out2="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --agent dupe --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+data_dir2="$(echo "$out2" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if [ -n "$data_dir1" ] && [ -f "$data_dir1/roost-settings.json" ] \
+    && [ -n "$data_dir2" ] && [ -f "$data_dir2/roost-settings.json" ] \
+    && ! grep -qF '"matcher":"Bash"' "$data_dir1/roost-settings.json" \
+    && ! grep -qF '"matcher":"Bash"' "$data_dir2/roost-settings.json"; then
+  ok "duplicate basename in same scope: resolves deterministically (sorted-first file's frontmatter wins) across repeated calls"
+else
+  fail "duplicate basename in same scope: resolves deterministically (sorted-first file's frontmatter wins) across repeated calls" \
+    "data_dir1=$data_dir1 settings1=$(cat "$data_dir1/roost-settings.json" 2>/dev/null) data_dir2=$data_dir2 settings2=$(cat "$data_dir2/roost-settings.json" 2>/dev/null)"
+fi
+[ -n "$data_dir1" ] && rm -rf "$data_dir1"
+[ -n "$data_dir2" ] && rm -rf "$data_dir2"
+teardown
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -754,9 +754,11 @@ teardown
 # -- Test 38: --perm-irc + auto (skip-set) → skip diagnostic printed -----------
 # An operator who passes --perm-irc expecting bash prompts gets none on the
 # skip path with no explanation. A one-line diagnostic closes that gap.
+# Pinned to an explicit --permission-mode so this keeps exercising the skip
+# path even if the bare-spawn model/mode default ever moves off auto.
 
 setup
-out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --permission-mode auto --perm-irc --perm-target opnick --cwd "$TDIR" 2>&1 || true)"
 data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 if echo "$out" | grep -qF "bash permission relay: skipped — auto never blocks on bash"; then
   ok "--perm-irc + auto: skip diagnostic printed with resolved mode"
@@ -809,7 +811,7 @@ teardown
 
 # -- Test 42: duplicate basename in two subdirs of the same root resolves ------
 # deterministically to the sorted-first path ------------------------------------
-# #629: the --agent resolver moved off `find | head -1` (nondeterministic) onto
+# The --agent resolver moved off `find | head -1` (nondeterministic) onto
 # _resolvable_agents' sorted output. Two files sharing a basename in different
 # subdirs of the same scope must resolve to the same, stable winner every time.
 # Raw spawn output isn't diffable across runs (it embeds a fresh mktemp path


### PR DESCRIPTION
Closes #629
Closes #630

Two low-severity #608 followups, combined since they're both small bin/roost robustness fixes.

- **Unify the --agent resolver**: `cmd_spawn`'s real `--agent` lookup was a third parallel copy of `_resolvable_agents`' search rules. Routed it through `_resolvable_agents` instead (now emits the file path as a 3rd column), so the roster, the not-found error, and the actual resolver read one search impl. Also makes duplicate-basename resolution deterministic (was `find | head -1`, now sorted).
- **Fold YAML block-scalar descriptions**: `_agent_description` only read single-line `description: text`. An agent using `description: >` or `description: |` block-scalar frontmatter printed a bare `>`/`|` in `roost agents --all`. The awk parser now folds block-scalar continuation lines into one line.
- **Signal the --perm-irc bash-relay skip**: when the resolved permission mode never blocks on bash (auto, bypassPermissions), the relay is intentionally left unwired — but an operator passing `--perm-irc` saw no bash prompts and no explanation. Added a one-line echo naming the resolved mode.

Tests: `test/spawn_test.sh` (+5: skip-diagnostic present/absent, duplicate-basename determinism) and `test/agents_test.sh` (+1: block-scalar folding, via sourcing bin/roost to call `_agent_description` directly since the real shipped-agents tree can't otherwise exercise a block-scalar fixture). Full suites green, lint/typecheck clean.