### PR TITLE
add Fable model support: auto permissions + pricing table entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The commands, skills, and agents this plugin ships (`prompts/`, `agents/`, `skil
 
 ## Agent frontmatter
 
-Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatter — `auto` for opus and sonnet agents, `acceptEdits` (or `default`) for everything else (haiku, or any unrecognized model). Claude Code reads `permissionMode:` natively on project- and user-scope agents, so the wrapper deliberately does not *pass* it — the `--agent` path of `bin/roost spawn` omits `--permission-mode` entirely and relies on the frontmatter. If a new shipped agent needs a different mode, declare it in the file — don't add a special case to the wrapper.
+Every agent in `agents/` should declare `permissionMode:` in its YAML frontmatter — `auto` for fable, opus, and sonnet agents, `acceptEdits` (or `default`) for everything else (haiku, or any unrecognized model). Claude Code reads `permissionMode:` natively on project- and user-scope agents, so the wrapper deliberately does not *pass* it — the `--agent` path of `bin/roost spawn` omits `--permission-mode` entirely and relies on the frontmatter. If a new shipped agent needs a different mode, declare it in the file — don't add a special case to the wrapper.
 
 `bin/roost spawn` does locally peek at the frontmatter's `permissionMode:` value for one narrow reason: deciding whether to wire the `--perm-irc` bash PreToolUse relay, which is pointless noise under permission modes that never block on bash. That peek never reaches claude and doesn't change what's passed on the `--agent` path — it's a separate, read-only decision from the "don't parse it" rule above.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ roost status
 `spawn` accepts `-c|--channels`, `-m|--model`, `-s|--session`,
 `--mcp-config`, `-p|--prompt-file`, `--cwd`, and `--` (everything
 after forwards to claude verbatim). Default channel is `#roost`;
-default model is `opus` (Opus 4.8). Opus and sonnet default to
+default model is `opus` (Opus 4.8). Fable, opus, and sonnet default to
 `--permission-mode auto`; everything else (haiku, or any unrecognized
 model) defaults to `acceptEdits`.
 

--- a/bin/roost
+++ b/bin/roost
@@ -126,8 +126,8 @@ the user's login shell (from \$SHELL) so .bash_profile / .zprofile / ~/.config/f
 Permission mode handling splits by path. With --agent the wrapper passes
 no --permission-mode and claude code reads \`permissionMode:\` natively
 from the agent's frontmatter. With --model (or the default opus) the
-wrapper defaults to auto for opus and sonnet, acceptEdits for everything
-else (haiku, or any unrecognized model).
+wrapper defaults to auto for fable, opus, and sonnet, acceptEdits for
+everything else (haiku, or any unrecognized model).
 Explicit --permission-mode always wins. --perm-irc's bash relay reads this
 same resolved mode (peeking at agent frontmatter locally when needed) to
 skip wiring itself for modes that never block on bash — see --perm-irc below.
@@ -176,8 +176,8 @@ Options:
                              wrapper passes nothing (claude code reads
                              \`permissionMode:\` natively from the agent
                              frontmatter); with --model the wrapper defaults
-                             to auto for opus and sonnet, acceptEdits for
-                             everything else (haiku, or any unrecognized
+                             to auto for fable, opus, and sonnet, acceptEdits
+                             for everything else (haiku, or any unrecognized
                              model). Explicit --permission-mode always wins.
   --cache-ttl TTL            Prompt-cache TTL: \`5m\` or \`1h\`. Translated
                              to claude-code's env-var knobs in the spawned
@@ -800,7 +800,7 @@ cmd_spawn() {
   # code read `permissionMode:` natively from the agent's frontmatter.
   if [ -z "${permission_mode}" ] && [ -z "${agent}" ]; then
     case "${model}" in
-      *opus*|*sonnet*) permission_mode="auto" ;;
+      *fable*|*opus*|*sonnet*) permission_mode="auto" ;;
       *) permission_mode="acceptEdits" ;;
     esac
   fi

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -49,9 +49,9 @@ Defaults:
 - model: `opus`
 - permission mode: with `--agent`, the wrapper passes nothing and claude
   code reads `permissionMode:` natively from the agent frontmatter; with
-  `--model` (or the default opus), the wrapper defaults to `auto` for opus
-  and sonnet, `acceptEdits` for everything else (haiku, or any unrecognized
-  model). Explicit `--permission-mode` wins in both paths.
+  `--model` (or the default opus), the wrapper defaults to `auto` for fable,
+  opus, and sonnet, `acceptEdits` for everything else (haiku, or any
+  unrecognized model). Explicit `--permission-mode` wins in both paths.
 - cache-ttl: no wrapper default — if unset, neither env var is
   injected and claude-code's native cache behavior applies. Caller
   picks per session. Translated to claude-code's env knobs in the
@@ -71,7 +71,7 @@ The wrapper handles the `ROOST_IRC_*` env vars, the
 `--dangerously-load-development-channels server:plugin:roost:roost-irc` flag, the
 `--permission-mode` flag (with `--agent`, defers to the agent's native
 `permissionMode:` frontmatter; with `--model`, smart-defaulted: `auto` for
-opus and sonnet, `acceptEdits` for everything else (haiku, or any
+fable, opus, and sonnet, `acceptEdits` for everything else (haiku, or any
 unrecognized model); explicit `--permission-mode` wins either
 way), and the dev-channels confirmation prompt that appears on first
 launch.

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -3,7 +3,7 @@
 // to estimate cost from token counts.
 //
 // Source: https://platform.claude.com/docs/en/about-claude/pricing
-// Retrieved: 2026-06-30
+// Retrieved: 2026-07-03
 //
 // All rates are USD per 1M tokens. When Anthropic publishes new rates or a
 // model ID we don't yet recognize appears in transcripts, bump this table
@@ -35,6 +35,8 @@ export interface ModelPricing {
 }
 
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
+  // Fable 5 — higher-powered tier above Opus, priced accordingly.
+  'claude-fable-5':             { input: 10, output: 50, cache_creation_5m: 12.50, cache_creation_1h: 20,  cache_read: 1.00 },
   // Opus 4.x current generation — $5 base input. Opus 4.1 and earlier use the $15 tier.
   'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -184,6 +184,18 @@ else
 fi
 teardown
 
+# -- Test 9b: --model fable (no agent) → auto ---------------------------------
+# Fable gets auto via the model-derived default, same as opus and sonnet.
+
+setup
+out="$("${ROOST_BIN}" spawn testnick --model fable --cwd "$TDIR" 2>&1 || true)"
+if echo "$out" | grep -q "permission-mode: auto"; then
+  ok "--model fable → permission-mode: auto"
+else
+  fail "--model fable → permission-mode: auto" "out=$out"
+fi
+teardown
+
 # -- Test 10: --model opus explicit → auto -----------------------------------
 # Explicit opus also gets auto (sanity).
 


### PR DESCRIPTION
Closes #636

Fable is higher-powered than Opus, so it joins the auto permission-mode tier alongside opus and sonnet.

- `bin/roost`: model-derived default glob (`*opus*|*sonnet*` → `*fable*|*opus*|*sonnet*`) + the two `--help` prose sites
- Canonical tier-boundary wording (power-descending: "fable, opus, and sonnet") propagated verbatim to all 6 surfaces: bin/roost ×2, CLAUDE.md, README.md, SKILL.md ×2 — the `(haiku, or any unrecognized model)` parenthetical is untouched, unaffected by this change
- `src/pricing.ts`: added Fable 5 — $10 input / $50 output / $12.50 5m-cache-write / $20 1h-cache-write / $1 cache-read per MTok. Source: https://platform.claude.com/docs/en/about-claude/pricing (retrieved 2026-07-03)
- `test/spawn_test.sh`: new Test 9b, `--model fable` → `permission-mode: auto`, mirroring the existing Test 9 (sonnet)

Scope note: left the separate "bare aliases (opus, sonnet, haiku)" example list at bin/roost:149/816 untouched — different invariant (alias-vs-pinned-id pattern), not the auto-tier boundary, and not asked for in the issue.

## Test plan
- [x] `bun run lint` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bash test/spawn_test.sh` — 51 passed, 0 failed
- [x] `bun test` — 1014 passed, 0 failed