### PR TITLE
Drop stale GhScraper comment refs

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts
@@ -25,7 +25,7 @@ function baseConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorCo
 }
 
 // Plugin owns its GhClient; intercept fetch at the prototype seam — same shape
-// the sibling plugin tests use for scrapeIssue/scrapePr.
+// the sibling plugin tests use for fetchPrsBatch/fetchIssuesBatch.
 function stubFetch(response: GhRepoIssue[]) {
   return spyOn(GhClient.prototype, 'fetchRepoOpenIssues').mockResolvedValue(response)
 }

--- a/src/orchestrator/plugins/linear/scraper.ts
+++ b/src/orchestrator/plugins/linear/scraper.ts
@@ -71,10 +71,9 @@ export function isLinearNotFoundError(e: unknown): boolean {
   )
 }
 
-// Per-tick handle. Constructor takes the client so tests can inject a mock
-// (mirrors `GhScraper(client, agentLogins)`). The client argument is typed
-// against the minimal `LinearGraphqlSurface` so unit tests don't have to
-// stand up a full `LinearClient` instance.
+// Per-tick handle. Constructor takes the client so tests can inject a mock.
+// The client argument is typed against the minimal `LinearGraphqlSurface` so
+// unit tests don't have to stand up a full `LinearClient` instance.
 export class LinearScraper {
   constructor(private readonly client: LinearGraphqlSurface) {}
 


### PR DESCRIPTION
Closes #660

Two comments in files the batch-GraphQL rewrite (#613/#616) never touched still referenced the deleted `GhScraper`:

- `src/orchestrator/plugins/linear/scraper.ts` — dropped the `(mirrors GhScraper(client, agentLogins))` parenthetical; the "tests can inject a mock" point stands on its own.
- `src/orchestrator/plugins/github/__tests__/new-issues-plugin.test.ts` — reworded the "same shape ... for scrapeIssue/scrapePr" comment to name the sibling tests' actual current stub seam, `fetchPrsBatch`/`fetchIssuesBatch`.

Comment-only, zero runtime/behavior change. Did not touch `LinearScraper.scrapeIssue` or its live refs (Linear-side, unrelated) per the issue's guardrail.