### PR TITLE
bump version to 0.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump for the 0.8.7 release.

Since v0.8.6:
- Dispatcher batch-GraphQL rewrite — one query/tick, kills the secondary-rate-limit storm (#613/#616)
- Fable model support — auto permissions + pricing table (#636)
- bin/roost agent-resolver unification (#629/#630)
- perm-irc parity/classifier fix (#598/#639)
- Inbound seen-by attribute, pricing normalize-dated-ids, reviewer hardening, §555 stale-comment cleanup