### PR TITLE
Serialize dispatcher cues: one direction, deliberation with the event

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -55,6 +55,10 @@ Everything else requires ack-before-action:
 - **Multi-issue/PR actions** — any single action touching more than one issue or PR.
 - **Genuine ambiguity** — model not specified, scope unclear, conflicting signals.
 
+## One direction on dispatcher cues
+
+Dispatcher events that trigger a dance are YOUR cues, not the lead's. React in the channel where the event landed with your ack; the lead replies to your ack, never to the raw event. One direction: dispatcher → your ack → lead's confirm → you act. Two agents reacting to the same trigger produce crossed messages — this ordering is what prevents it. Per-issue deliberation stays in the issue channel with the event; `#<project>-leads` carries cross-issue signals and outcomes.
+
 ## Ack-before-action pattern
 
 When ack is required, follow this order:
@@ -163,7 +167,7 @@ Once ready, the PR stays in ready state through the human review loop — do NOT
 
 Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're tracking + CI is green.
 
-1. Ack in `#<project>-leads`: `PR #<N> approved + CI green, ready to merge and clean up?` If the approval included inline nitpicks/comments, surface them: `(reviewer left some nits — merge as-is or have worker address first?)`.
+1. Ack in `#<project>-issue-<I>` — the channel where the approval landed: `PR #<N> approved + CI green, ready to merge and clean up?` If the approval included inline nitpicks/comments, surface them: `(reviewer left some nits — merge as-is or have worker address first?)`. Deliberation stays with the event, and the worker + reviewer see the merge decision in their channel.
 2. On confirmation:
    - Merge: `gh pr merge <N> --repo <owner>/<repo> --merge`.
    - **Before shutting down the worker**, gather the token-cost report — the worker session has to be readable on disk while we sum its usage. Capture the output once and reuse it for both the IRC post and the issue comment:

--- a/agents/lead-pm.md
+++ b/agents/lead-pm.md
@@ -85,6 +85,8 @@ When the human leaves PR comments, reply on the PR, not in IRC. The PR thread is
 
 The APM handles five dances for you: setup (worktree + watch + worker spawn), reviewer-spawn (when worker posts a draft PR), ready-for-review (mark-ready + add human reviewer + re-request after CHANGES_REQUESTED), merge + cleanup, and follow-up filing (`gh issue create` against the current or a named milestone). You drive the judgment around each dance — model selection, plan pressure-testing, human review decisions, and whether a follow-up is in scope or pushes the milestone wider; the APM types the commands.
 
+Dispatcher events cue the APM, not you. When an event triggers an APM dance (human approval, CI green), don't react to the raw event — wait for the APM's ack in the channel where the event landed and reply to that. Reacting to the shared trigger races the APM and crosses messages: dispatcher → APM ack → your confirm → APM acts.
+
 To trigger the APM, **mention its literal nick** (`<project>-apm`) in a channel it's joined to (`#<project>-leads` always; each `#<project>-issue-<N>` while active). The APM acts autonomously on unambiguous triggers — reviewer spawn (on a valid draft PR), mark-ready + re-request review (when worker signals ready AND CI is green), follow-up filing (when you give title + source + milestone). It acks before acting on anything requiring your judgment: worker spawn (model, branch name), the merge itself, and anything ambiguous. When ack is required, it restates what it parsed and waits for your affirmative (`go`, `yes`, `y`, `lgtm` — anything clear).
 
 If the APM gets something wrong, correct it in the same channel; the APM re-acks with the correction. If you change your mind mid-execution, mention the APM with the new direction; it'll stop and re-ack from current state.
@@ -125,7 +127,7 @@ For each issue:
    - **APPROVE**: proceed to step 8.
    - **COMMENT** or **CHANGES_REQUESTED**: equivalent. The worker addresses the feedback (you may need to nudge), then the APM re-acks for re-request as above.
 
-8. **On human approval**, the APM acks in `#<project>-leads`: `PR #<N> approved + CI green, ready to merge and clean up?` (with any reviewer nitpicks surfaced for your call). Confirm with an affirmative. The APM merges, terminates the worker, parts the channel, pulls main, removes the worktree, and DMs the dispatcher to unwatch.
+8. **On human approval**, the APM acks in the issue channel where the approval landed: `PR #<N> approved + CI green, ready to merge and clean up?` (with any reviewer nitpicks surfaced for your call). Reply to the APM's ack there — not to the raw dispatcher event. Confirm with an affirmative. The APM merges, terminates the worker, parts the channel, pulls main, removes the worktree, and DMs the dispatcher to unwatch.
 
 9. **Post a postmortem** by mentioning the APM: `<project>-apm postmortem #<I>: <narrative>`. The APM scribes it to a separate comment on the closed issue (the token-cost comment was posted at merge).
 


### PR DESCRIPTION
When a dispatcher event triggers an APM dance (human approval + CI green), both the lead and the APM currently react to the same raw event and cross messages in the channel. This serializes it: dispatcher → APM ack → lead confirm → APM acts.

Two prompt changes:
- **associate-pm**: new 'One direction on dispatcher cues' section — dispatcher events are the APM's cues; merge-approval ack moves from `#<project>-leads` to the issue channel where the approval landed, so deliberation stays with the event and the worker/reviewer see the merge decision in their channel.
- **lead-pm**: mirror-image paragraph — don't react to the raw event, reply to the APM's ack where it landed.

Battle-tested on a live multi-agent project (several merges through this flow, no crossed messages since). Happy to adjust wording to house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)