### PR TITLE
Reconcile per-tick IRC membership against config-static plugin channels

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -317,4 +317,6 @@ async function main(): Promise<void> {
   }
 }
 
-main()
+if (import.meta.main) {
+  main()
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -57,6 +57,20 @@ function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChan
   return [...chans].sort()
 }
 
+// Per-tick membership target: plugins' config-static channels (desiredChannels)
+// unioned with this tick's dynamic channels (result.channels). Plugins that
+// only join at boot (e.g. github-new-issues) return `channels: []` from every
+// runTick, so without the desiredChannels half a tick-dynamic sibling losing
+// interest in a channel would part it out from under a config-static plugin.
+export function reconcileDesiredChannels(
+  plugins: Plugin[],
+  config: OrchestratorConfig,
+  projectChannel: string,
+  resultChannels: string[],
+): string[] {
+  return [...new Set<string>([...bootChannels(plugins, config, projectChannel), ...resultChannels])].sort()
+}
+
 // IRC client shape shared by daemon and --dispatch-irc.
 function newIrcClient(nick: string, channels: string[]): RoostIrcClientImpl {
   return new RoostIrcClientImpl({
@@ -205,7 +219,7 @@ async function runDaemon(stateDir: string): Promise<void> {
 
     // Reconcile IRC membership against plugins' desired set, then snapshot.
     // On reconcile failure, re-query so the snapshot reflects reality.
-    const desired = new Set<string>([projectChannel, ...result.channels])
+    const desired = new Set<string>(reconcileDesiredChannels(plugins, config, projectChannel, result.channels))
     let joined: string[] | null = null
     try {
       for (const ch of (await client.whoisChannels()) ?? []) {

--- a/src/orchestrator/__tests__/reconcile-desired-channels.test.ts
+++ b/src/orchestrator/__tests__/reconcile-desired-channels.test.ts
@@ -4,7 +4,7 @@ import { GitHubNewIssuesPlugin } from '../plugins/github/new-issues-plugin.js'
 import { GitHubPrsPlugin } from '../plugins/github/prs-plugin.js'
 import type { OrchestratorConfig } from '../config.js'
 
-// github-new-issues is the config-static plugin from #665: it always returns
+// github-new-issues is a config-static plugin: it always returns
 // `channels: []` from runTick and relies entirely on desiredChannels for
 // membership. github-prs is the tick-dynamic plugin whose runTick channels
 // can legitimately drop a channel between ticks (e.g. a linked issue closes).
@@ -25,7 +25,7 @@ describe('reconcileDesiredChannels', () => {
     const cfg = config()
 
     // github-new-issues always returns channels: [] from runTick — simulate
-    // exactly that (the #665 repro: no tick-dynamic plugin naming #homelab).
+    // exactly that (no tick-dynamic plugin naming #homelab).
     const result = reconcileDesiredChannels(plugins, cfg, '#proj-leads', [])
 
     expect(result).toEqual(['#homelab', '#proj-leads'])

--- a/src/orchestrator/__tests__/reconcile-desired-channels.test.ts
+++ b/src/orchestrator/__tests__/reconcile-desired-channels.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test'
+import { reconcileDesiredChannels } from '../../orchestrator.js'
+import { GitHubNewIssuesPlugin } from '../plugins/github/new-issues-plugin.js'
+import { GitHubPrsPlugin } from '../plugins/github/prs-plugin.js'
+import type { OrchestratorConfig } from '../config.js'
+
+// github-new-issues is the config-static plugin from #665: it always returns
+// `channels: []` from runTick and relies entirely on desiredChannels for
+// membership. github-prs is the tick-dynamic plugin whose runTick channels
+// can legitimately drop a channel between ticks (e.g. a linked issue closes).
+function config(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    project: 'proj',
+    repo: 'org/repo',
+    plugins: {
+      'github-new-issues': { watched: [{ repo: 'org/repo', channels: ['#homelab'] }] },
+    },
+    ...overrides,
+  }
+}
+
+describe('reconcileDesiredChannels', () => {
+  it('retains a config-static plugin channel even when this tick reported no dynamic channels', () => {
+    const plugins = [new GitHubNewIssuesPlugin('#proj-leads')]
+    const cfg = config()
+
+    // github-new-issues always returns channels: [] from runTick — simulate
+    // exactly that (the #665 repro: no tick-dynamic plugin naming #homelab).
+    const result = reconcileDesiredChannels(plugins, cfg, '#proj-leads', [])
+
+    expect(result).toEqual(['#homelab', '#proj-leads'])
+  })
+
+  it('does not retain a dynamic channel this tick no longer names', () => {
+    const plugins = [new GitHubNewIssuesPlugin('#proj-leads'), new GitHubPrsPlugin('#proj-leads')]
+    const cfg = config()
+
+    // Previous tick, github-prs named #issue-42 (e.g. a linked issue). This
+    // tick it doesn't (the linked issue closed) — #issue-42 must be parted,
+    // not retained forever just because it once appeared.
+    const stale = reconcileDesiredChannels(plugins, cfg, '#proj-leads', ['#issue-42'])
+    expect(stale).toContain('#issue-42')
+
+    const current = reconcileDesiredChannels(plugins, cfg, '#proj-leads', [])
+    expect(current).not.toContain('#issue-42')
+    expect(current).toEqual(['#homelab', '#proj-leads'])
+  })
+})


### PR DESCRIPTION
Closes #665

Per-tick reconcile (`orchestrator.ts`'s daemon loop) only unioned `projectChannel` with `result.channels`. Plugins whose membership is config-static — `github-new-issues`, `github-new-prs`, `linear-new-issues` — always return `channels: []` from `runTick` and rely on `desiredChannels()` joining at boot. So once no tick-dynamic plugin (e.g. `github-prs`) named a config-static plugin's channel, the daemon would part it, silently dropping that plugin's future events (`say()` to a channel it's not in has no delivery ack, and plugin state still marks the event seen).

Fix: reconcile against `bootChannels(plugins, config, projectChannel) ∪ result.channels` every tick — matching what boot (line 137) and the tick-failure fallback (line 203) already did. Extracted as `reconcileDesiredChannels()` so it's unit-testable without standing up a full daemon loop.

Test covers both directions with real plugin instances (not stubs): a config-static channel persists across a tick that reports no dynamic channels, and a dynamic channel from a prior tick is correctly dropped when it's no longer named.

Belt-and-braces hardening ideas from the issue (join-before-say in `dispatchTaggedEvents`, surfacing delivery failure on `say` to a non-joined channel) are deliberately out of scope here — flagged to the team as possible followups.