### PR TITLE
Add read-only fast-path to classifyBash

### DIFF
--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -84,6 +84,13 @@ const ARITH_WITH_VARS = /\$\(\([^)]*[a-zA-Z_][^)]*\)\)/ // CC: "too-complex"
 // write vectors) are rejected structurally in isSimpleReadOnly. (`file -C`,
 // `tree -o`, `sort -o` are why those aren't here — the scan is by write
 // capability, not by whether the command "feels" read-only.)
+//
+// This is a best-effort hand-scan, NOT a flag-exhaustive safety boundary. If an
+// obscure write flag on a listed command slips through, the failure mode is
+// bounded: the fast-path returns null (defer), CC-default still gates the write
+// at its own prompt, and — since the prompt is unanswerable in a worker — the
+// worker hangs. Recoverable and operator-visible, not silent destruction. That
+// bound is what makes the name-level scan acceptable over a full safeFlags port.
 const READ_ONLY = new Set([
   'ls', 'cat', 'head', 'tail', 'wc', 'grep', 'egrep', 'fgrep', 'rg',
   'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -66,24 +66,31 @@ const TOP_CMD_GROUP   = /(?:^|[\s;&|`])\{\s/            // CC: "shell-operators"
 const ARITH_WITH_VARS = /\$\(\([^)]*[a-zA-Z_][^)]*\)\)/ // CC: "too-complex"
 
 // Command words the read-only fast-path treats as candidates. Membership rule:
-// a command is listed only if it has *no mutating form under any flag or
-// argument* — because the fast-path bites in default/acceptEdits mode (auto
-// never blocks bash), where CC's own analyzer gates a mutating command with an
-// input-wait TUI prompt that a --perm-irc worker can't answer. A name-level
-// list can't gate on flags, so any command with a write form (`find -delete`,
-// `sort -o`, `date -s`, `hostname NAME`) is left out entirely rather than
-// half-covered — otherwise the fast-path would drop the relay CC-default needs,
-// and the worker would hang on the prompt. Empirically confirmed against a live
-// 2.1.217 default-mode TUI: read-only shapes here grant silently; the excluded
-// mutating forms raise "…executes commands or modifies files… Do you want to
-// proceed?" and wait. `git` is gated further to read-only subcommands below.
+// a command is listed only if it writes *nothing to the filesystem under any
+// flag or positional argument* (stdout / exit status only). This matters
+// because the fast-path bites in default/acceptEdits mode (auto never blocks
+// bash), where CC's own analyzer gates a filesystem-mutating command with an
+// input-wait TUI prompt a --perm-irc worker can't answer — so accepting one
+// would drop the relay CC-default needs and hang the worker. Empirically
+// confirmed against a live 2.1.217 default-mode TUI: read-only shapes here
+// grant silently; a mutating form raises "…executes commands or modifies
+// files… Do you want to proceed?" and waits.
+//
+// A name-level list can't gate on flags, so every command below was scanned for
+// a write form and the ones that have one are left out entirely rather than
+// half-covered: `find -delete`/`-exec`, `sort -o`, `date -s`, `hostname NAME`,
+// `uniq IN OUT`, `xxd IN OUT`, `tree -o FILE`. `git` is gated further to
+// read-only subcommands below. Command substitution and redirection (other
+// write vectors) are rejected structurally in isSimpleReadOnly. (`file -C`,
+// `tree -o`, `sort -o` are why those aren't here — the scan is by write
+// capability, not by whether the command "feels" read-only.)
 const READ_ONLY = new Set([
   'ls', 'cat', 'head', 'tail', 'wc', 'grep', 'egrep', 'fgrep', 'rg',
   'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',
-  'file', 'stat', 'tree', 'basename', 'dirname', 'realpath', 'readlink',
+  'stat', 'basename', 'dirname', 'realpath', 'readlink',
   'whoami', 'id', 'groups', 'uname', 'tty', 'locale',
-  'true', 'false', 'test', 'uniq', 'cut', 'tr', 'comm', 'cmp',
-  'diff', 'column', 'tac', 'nl', 'od', 'xxd', 'seq', 'du', 'df', 'ps',
+  'true', 'false', 'test', 'cut', 'tr', 'comm', 'cmp',
+  'diff', 'column', 'tac', 'nl', 'od', 'seq', 'du', 'df', 'ps',
   'printenv', 'sha1sum', 'sha256sum', 'sha512sum', 'md5sum', 'git',
 ])
 

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -65,19 +65,24 @@ const TOP_SUBSHELL    = /(?:^|[\s;&|`])\((?!\s*\))/     // CC: "shell-operators"
 const TOP_CMD_GROUP   = /(?:^|[\s;&|`])\{\s/            // CC: "shell-operators" (command group)
 const ARITH_WITH_VARS = /\$\(\([^)]*[a-zA-Z_][^)]*\)\)/ // CC: "too-complex"
 
-// Command words the read-only fast-path treats as candidates. This is NOT a
-// safety allowlist — a name-level list can't prove non-mutation (`find
-// /tmp -delete`, `find . -exec rm {} +` are in here). What makes passing them
-// safe is the monotonic invariant, not the list: isSimpleReadOnly only ever
-// returns null (drops a relay), and CC auto-grants these shapes anyway, so an
-// accept can never diverge from parity. The list just scopes *which*
-// would-be-relayed shapes get dropped — its floor is O2 (`cd <dir>; <cmd>`).
+// Command words the read-only fast-path treats as candidates. Membership rule:
+// a command is listed only if it has *no mutating form under any flag or
+// argument* — because the fast-path bites in default/acceptEdits mode (auto
+// never blocks bash), where CC's own analyzer gates a mutating command with an
+// input-wait TUI prompt that a --perm-irc worker can't answer. A name-level
+// list can't gate on flags, so any command with a write form (`find -delete`,
+// `sort -o`, `date -s`, `hostname NAME`) is left out entirely rather than
+// half-covered — otherwise the fast-path would drop the relay CC-default needs,
+// and the worker would hang on the prompt. Empirically confirmed against a live
+// 2.1.217 default-mode TUI: read-only shapes here grant silently; the excluded
+// mutating forms raise "…executes commands or modifies files… Do you want to
+// proceed?" and wait. `git` is gated further to read-only subcommands below.
 const READ_ONLY = new Set([
   'ls', 'cat', 'head', 'tail', 'wc', 'grep', 'egrep', 'fgrep', 'rg',
-  'find', 'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',
+  'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',
   'file', 'stat', 'tree', 'basename', 'dirname', 'realpath', 'readlink',
-  'date', 'whoami', 'id', 'groups', 'uname', 'hostname', 'tty', 'locale',
-  'true', 'false', 'test', 'sort', 'uniq', 'cut', 'tr', 'comm', 'cmp',
+  'whoami', 'id', 'groups', 'uname', 'tty', 'locale',
+  'true', 'false', 'test', 'uniq', 'cut', 'tr', 'comm', 'cmp',
   'diff', 'column', 'tac', 'nl', 'od', 'xxd', 'seq', 'du', 'df', 'ps',
   'printenv', 'sha1sum', 'sha256sum', 'sha512sum', 'md5sum', 'git',
 ])
@@ -95,13 +100,15 @@ const GIT_READONLY = new Set([
 
 /**
  * True if the command matches Claude Code's read-only fast-path — every
- * statement a read-only command, with no subshell, background `&`, redirection,
- * process substitution, variable arithmetic, second cd, multi-positional cd, or
- * cd-into-git. Safe to return null on a true not because the allowlist proves
- * non-mutation (it doesn't — see READ_ONLY) but because the fast-path is
- * monotonic: it only drops relays, and CC auto-grants these shapes regardless.
- * A false means "can't prove the fast-path shape", and the command falls
- * through to the bashMissKind checks unchanged.
+ * statement a read-only command (see READ_ONLY / GIT_READONLY), with no
+ * subshell, background `&`, redirection, process substitution, variable
+ * arithmetic, second cd, multi-positional cd, or cd-into-git. A true is safe to
+ * return null on because the accept set is a strict subset of what CC-default
+ * grants (allowlist restricted to commands with no mutating form; the
+ * structural gates below reject every shape CC-default would prompt on), so a
+ * dropped relay can never leave a worker hanging on a prompt CC would raise. A
+ * false means "can't prove the fast-path shape", and the command falls through
+ * to the bashMissKind checks unchanged.
  */
 function isSimpleReadOnly(command: string): boolean {
   // Structural disqualifiers. Any of these means CC's fast-path declines, so
@@ -114,6 +121,11 @@ function isSimpleReadOnly(command: string): boolean {
   if (TOP_CMD_GROUP.test(command)) return false
   if (/(?<!&)&(?!&)/.test(command)) return false     // background &
   if (ARITH_WITH_VARS.test(command)) return false
+  // Command substitution runs an inner command the allowlist never sees
+  // (`echo $(rm -rf x)`, `` echo `rm -rf x` ``). The word-level check would
+  // pass on the outer `echo` and miss it, so decline outright — `$((` arith is
+  // caught above, everything else with `$(` or a backtick can't be vetted.
+  if (/\$\(/.test(command) || command.includes('`')) return false
 
   const statements = command.split(/&&|\|\||[;|\n\r]/)
   let cdCount = 0

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -54,6 +54,83 @@ export type BashMissKind =
   | 'flag-validation'       // CC: "flag-validation"
   | 'too-complex'           // CC: "too-complex"
 
+// Claude Code's "simple read-only command" fast-path: commands whose every
+// statement is a read-only command with no way to mutate state or escape
+// static validation. CC auto-grants these outright, so relaying them to the
+// operator is a parity violation (they never produce a blocking request). The
+// allowlist is a general read-only unix set plus `git` gated to its read-only
+// subcommands. Deliberately conservative — a command that isn't provably in
+// this set just falls through to the bashMissKind checks, so membership only
+// ever *drops* a relay, never adds one.
+const READ_ONLY = new Set([
+  'ls', 'cat', 'head', 'tail', 'wc', 'grep', 'egrep', 'fgrep', 'rg',
+  'find', 'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',
+  'file', 'stat', 'tree', 'basename', 'dirname', 'realpath', 'readlink',
+  'date', 'whoami', 'id', 'groups', 'uname', 'hostname', 'tty', 'locale',
+  'true', 'false', 'test', 'sort', 'uniq', 'cut', 'tr', 'comm', 'cmp',
+  'diff', 'column', 'tac', 'nl', 'od', 'xxd', 'seq', 'du', 'df', 'ps',
+  'printenv', 'sha1sum', 'sha256sum', 'sha512sum', 'md5sum', 'git',
+])
+
+// git subcommands that never mutate regardless of flags. `git` sits in
+// READ_ONLY only as a gate — the subcommand must land here or the fast-path
+// declines. Mutating-capable subcommands (branch/tag/remote/config/…) are
+// left out so a flag like `git branch -d` can't slip through.
+const GIT_READONLY = new Set([
+  'status', 'log', 'diff', 'show', 'blame', 'reflog', 'ls-files',
+  'rev-parse', 'rev-list', 'describe', 'cat-file', 'for-each-ref',
+  'shortlog', 'grep', 'whatchanged', 'ls-tree', 'ls-remote', 'show-ref',
+  'symbolic-ref', 'var', 'help', 'version',
+])
+
+/**
+ * True if the command matches Claude Code's read-only fast-path — every
+ * statement a read-only command, with no subshell, background `&`, redirection,
+ * process substitution, variable arithmetic, second cd, multi-positional cd, or
+ * cd-into-git. An `true` here is a strict subset of what CC auto-grants, so
+ * classifyBash can safely stay silent (return null); a `false` means "can't
+ * prove it", and the command falls through to the bashMissKind checks unchanged.
+ */
+function isSimpleReadOnly(command: string): boolean {
+  // Structural disqualifiers. Any of these means CC's fast-path declines, so
+  // classifyBash must not treat the command as simply read-only. These mirror
+  // the bashMissKind detectors below (newline-hash, process-substitution,
+  // shell-operators, too-complex) plus redirection and background — the shapes
+  // CC's own fast-path rejects — so the fast-path never swallows one of them.
+  if (/\n[ \t]*#/.test(command)) return false                    // newline-hash
+  if (/[<>]/.test(command)) return false                         // redirect / process-sub
+  if (/(?:^|[\s;&|`])\((?!\s*\))/.test(command)) return false    // subshell
+  if (/(?:^|[\s;&|`])\{\s/.test(command)) return false           // command group
+  if (/(?<!&)&(?!&)/.test(command)) return false                 // background &
+  if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return false // arithmetic with vars
+
+  const statements = command.split(/&&|\|\||[;|\n\r]/)
+  let cdCount = 0
+  let hasGit = false
+  for (const raw of statements) {
+    const seg = raw.trim()
+    if (!seg) continue
+    const tokens = seg.split(/[ \t]+/)
+    const cmd = tokens[0] ?? ''
+    if (cmd.includes('=')) return false // leading env assignment — decline
+    if (cmd === 'git') {
+      hasGit = true
+      if (!GIT_READONLY.has(tokens[1] ?? '')) return false
+      continue
+    }
+    if (!READ_ONLY.has(cmd)) return false
+    if (cmd === 'cd' || cmd === 'pushd' || cmd === 'popd') {
+      cdCount++
+      // Reject zsh `cd OLD NEW`: more than one non-flag argument.
+      const positionals = tokens.slice(1).filter((t) => t && !t.startsWith('-'))
+      if (positionals.length > 1) return false
+    }
+  }
+  if (cdCount > 1) return false            // multi-cd
+  if (cdCount >= 1 && hasGit) return false // cd + git (cd-git-compound: bare-repo attack)
+  return true
+}
+
 /**
  * Returns the bashMissKind a command resembles, or null if it should pass
  * through to the normal permission pipeline. Heuristic — errs toward
@@ -62,6 +139,11 @@ export type BashMissKind =
  */
 export function classifyBash(command: string): BashMissKind | null {
   if (!command) return null
+
+  // Read-only fast-path. CC auto-grants a simply-read-only command, so relaying
+  // it would diverge from parity. Runs first and is monotonic: it only ever
+  // returns null (drops a relay), never a bashMissKind (adds one).
+  if (isSimpleReadOnly(command)) return null
 
   // CC bashMissKind: "semantics" (newline-hash).
   // Literal newline followed by optional whitespace then '#'. The original

--- a/src/pretooluse-prompt.ts
+++ b/src/pretooluse-prompt.ts
@@ -54,14 +54,24 @@ export type BashMissKind =
   | 'flag-validation'       // CC: "flag-validation"
   | 'too-complex'           // CC: "too-complex"
 
-// Claude Code's "simple read-only command" fast-path: commands whose every
-// statement is a read-only command with no way to mutate state or escape
-// static validation. CC auto-grants these outright, so relaying them to the
-// operator is a parity violation (they never produce a blocking request). The
-// allowlist is a general read-only unix set plus `git` gated to its read-only
-// subcommands. Deliberately conservative — a command that isn't provably in
-// this set just falls through to the bashMissKind checks, so membership only
-// ever *drops* a relay, never adds one.
+// Shared with the bashMissKind detectors in classifyBash. isSimpleReadOnly
+// must reject exactly the shapes those detectors flag, or the fast-path could
+// drift into a false-positive accept — the one drift direction that loosens
+// the gate. Referencing the same const in both places keeps the two in
+// lockstep so a future tightening can't touch one without the other. (No `g`
+// flag → safe to share a single .test() target.)
+const NEWLINE_HASH    = /\n[ \t]*#/                     // CC: "semantics"
+const TOP_SUBSHELL    = /(?:^|[\s;&|`])\((?!\s*\))/     // CC: "shell-operators" (subshell)
+const TOP_CMD_GROUP   = /(?:^|[\s;&|`])\{\s/            // CC: "shell-operators" (command group)
+const ARITH_WITH_VARS = /\$\(\([^)]*[a-zA-Z_][^)]*\)\)/ // CC: "too-complex"
+
+// Command words the read-only fast-path treats as candidates. This is NOT a
+// safety allowlist — a name-level list can't prove non-mutation (`find
+// /tmp -delete`, `find . -exec rm {} +` are in here). What makes passing them
+// safe is the monotonic invariant, not the list: isSimpleReadOnly only ever
+// returns null (drops a relay), and CC auto-grants these shapes anyway, so an
+// accept can never diverge from parity. The list just scopes *which*
+// would-be-relayed shapes get dropped — its floor is O2 (`cd <dir>; <cmd>`).
 const READ_ONLY = new Set([
   'ls', 'cat', 'head', 'tail', 'wc', 'grep', 'egrep', 'fgrep', 'rg',
   'find', 'echo', 'printf', 'pwd', 'cd', 'pushd', 'popd', 'which', 'type',
@@ -72,37 +82,38 @@ const READ_ONLY = new Set([
   'printenv', 'sha1sum', 'sha256sum', 'sha512sum', 'md5sum', 'git',
 ])
 
-// git subcommands that never mutate regardless of flags. `git` sits in
-// READ_ONLY only as a gate — the subcommand must land here or the fast-path
-// declines. Mutating-capable subcommands (branch/tag/remote/config/…) are
-// left out so a flag like `git branch -d` can't slip through.
+// git subcommands with no mutating form. `git` sits in READ_ONLY only as a
+// gate — the subcommand must land here or the fast-path declines. Subcommands
+// with a write form are left out (branch/tag/remote/config, and reflog which
+// has `expire --expire=now`, symbolic-ref which writes HEAD with an argument).
 const GIT_READONLY = new Set([
-  'status', 'log', 'diff', 'show', 'blame', 'reflog', 'ls-files',
+  'status', 'log', 'diff', 'show', 'blame', 'ls-files',
   'rev-parse', 'rev-list', 'describe', 'cat-file', 'for-each-ref',
   'shortlog', 'grep', 'whatchanged', 'ls-tree', 'ls-remote', 'show-ref',
-  'symbolic-ref', 'var', 'help', 'version',
+  'var', 'help', 'version',
 ])
 
 /**
  * True if the command matches Claude Code's read-only fast-path — every
  * statement a read-only command, with no subshell, background `&`, redirection,
  * process substitution, variable arithmetic, second cd, multi-positional cd, or
- * cd-into-git. An `true` here is a strict subset of what CC auto-grants, so
- * classifyBash can safely stay silent (return null); a `false` means "can't
- * prove it", and the command falls through to the bashMissKind checks unchanged.
+ * cd-into-git. Safe to return null on a true not because the allowlist proves
+ * non-mutation (it doesn't — see READ_ONLY) but because the fast-path is
+ * monotonic: it only drops relays, and CC auto-grants these shapes regardless.
+ * A false means "can't prove the fast-path shape", and the command falls
+ * through to the bashMissKind checks unchanged.
  */
 function isSimpleReadOnly(command: string): boolean {
   // Structural disqualifiers. Any of these means CC's fast-path declines, so
-  // classifyBash must not treat the command as simply read-only. These mirror
-  // the bashMissKind detectors below (newline-hash, process-substitution,
-  // shell-operators, too-complex) plus redirection and background — the shapes
-  // CC's own fast-path rejects — so the fast-path never swallows one of them.
-  if (/\n[ \t]*#/.test(command)) return false                    // newline-hash
-  if (/[<>]/.test(command)) return false                         // redirect / process-sub
-  if (/(?:^|[\s;&|`])\((?!\s*\))/.test(command)) return false    // subshell
-  if (/(?:^|[\s;&|`])\{\s/.test(command)) return false           // command group
-  if (/(?<!&)&(?!&)/.test(command)) return false                 // background &
-  if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return false // arithmetic with vars
+  // classifyBash must not treat the command as simply read-only. The four
+  // named regexes are the exact detectors below (see the const definitions);
+  // redirection and background are additional shapes CC's fast-path rejects.
+  if (NEWLINE_HASH.test(command)) return false
+  if (/[<>]/.test(command)) return false             // redirect / process-sub
+  if (TOP_SUBSHELL.test(command)) return false
+  if (TOP_CMD_GROUP.test(command)) return false
+  if (/(?<!&)&(?!&)/.test(command)) return false     // background &
+  if (ARITH_WITH_VARS.test(command)) return false
 
   const statements = command.split(/&&|\|\||[;|\n\r]/)
   let cdCount = 0
@@ -150,7 +161,7 @@ export function classifyBash(command: string): BashMissKind | null {
   // bug (worker-202 27-min hang) was a heredoc with this shape. Checked
   // against the raw command — the analyzer's trigger explicitly requires
   // the newline to be inside a quoted arg, env value, or redirect.
-  if (/\n[ \t]*#/.test(command)) return 'newline-hash'
+  if (NEWLINE_HASH.test(command)) return 'newline-hash'
 
   // Command-start anchor for cd patterns: start-of-string, shell operator
   // (with optional trailing whitespace), or newline. Excludes plain
@@ -195,8 +206,8 @@ export function classifyBash(command: string): BashMissKind | null {
   // CC bashMissKind: "shell-operators".
   // Top-level subshell ( ... ) or command group { ... }. Excludes $( ),
   // <( ), >( ), ${ }, and escaped \(.
-  if (/(?:^|[\s;&|`])\((?!\s*\))/.test(command)) return 'shell-operators'
-  if (/(?:^|[\s;&|`])\{\s/.test(command)) return 'shell-operators'
+  if (TOP_SUBSHELL.test(command)) return 'shell-operators'
+  if (TOP_CMD_GROUP.test(command)) return 'shell-operators'
 
   // CC bashMissKind: "flag-validation".
   // Wrapper commands (env/timeout/xargs/nice/nohup) with chdir-shaped flags
@@ -208,7 +219,7 @@ export function classifyBash(command: string): BashMissKind | null {
   // CC bashMissKind: "too-complex".
   // Arithmetic expansion with non-literal contents (variables, function
   // refs) — the bash AST parser rejects these.
-  if (/\$\(\([^)]*[a-zA-Z_][^)]*\)\)/.test(command)) return 'too-complex'
+  if (ARITH_WITH_VARS.test(command)) return 'too-complex'
 
   return null
 }

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -173,10 +173,13 @@ describe('classifyBash', () => {
 
 // ---- read-only fast-path (#641) --------------------------------------------
 //
-// CC auto-grants a "simple read-only command", so classifyBash must not relay
-// it. The fast-path is monotonic: it only ever turns a would-be relay into
-// null, never the reverse. The one observable flip vs. the prior classifier is
-// O2 — `cd <dir>; <read-only>` going cd-compound → null.
+// CC-default grants a "simple read-only command" silently, so classifyBash must
+// not relay it. The fast-path is monotonic: it only ever turns a would-be relay
+// into null, never the reverse. The one observable flip vs. the prior
+// classifier is O2 — `cd <dir>; <read-only>` going cd-compound → null. The
+// allowlist holds only commands with no mutating form: a command CC-default
+// gates (e.g. `find -delete`, `sort -o`) must NOT be accepted, or the dropped
+// relay would leave a worker hanging on the TUI prompt CC raises.
 
 describe('classifyBash read-only fast-path', () => {
   // The O2 over-fire: a read-only tail after cd. Was flagged cd-compound.
@@ -225,6 +228,36 @@ describe('classifyBash read-only fast-path', () => {
   // the read-only-tail over-fire, not every cd-compound.
   it('cd + non-read-only tail still flags cd-compound', () => {
     expect(classifyBash('cd /tmp; rm -rf x')).toBe('cd-compound')
+  })
+
+  // Mutating-flag commands are left out of the allowlist wholesale (a
+  // name-level list can't gate on flags). CC-default raises an input-wait
+  // prompt on these, so the fast-path must decline and leave the relay in
+  // place. Confirmed live against a 2.1.217 default-mode TUI.
+  it('cd + find -delete stays cd-compound (find not allowlisted)', () => {
+    expect(classifyBash('cd /tmp && find . -delete')).toBe('cd-compound')
+  })
+  it('cd + sort -o stays cd-compound (sort not allowlisted)', () => {
+    expect(classifyBash('cd /tmp && sort -o out in')).toBe('cd-compound')
+  })
+  // Cost of the wholesale exclusion: a read-only `find` after cd no longer
+  // fast-paths — it falls back to the pre-existing benign cd-compound relay.
+  it('cd + read-only find falls back to cd-compound (accepted cost)', () => {
+    expect(classifyBash('cd repo && find . -name x')).toBe('cd-compound')
+  })
+
+  // Command substitution runs an inner command the word-level allowlist never
+  // inspects, so it can't be fast-pathed. A cd-prefixed one keeps its relay.
+  it('cd + $() command substitution stays cd-compound', () => {
+    expect(classifyBash('cd /tmp; echo $(rm -rf y)')).toBe('cd-compound')
+  })
+  it('cd + backtick command substitution stays cd-compound', () => {
+    expect(classifyBash('cd repo && echo `rm x`')).toBe('cd-compound')
+  })
+  // A bare read-only command substitution is null anyway (no bashMissKind),
+  // via fall-through rather than the fast-path.
+  it('bare $() stays null via fall-through', () => {
+    expect(classifyBash('echo $(date)')).toBeNull()
   })
 })
 

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -51,8 +51,11 @@ describe('classifyBash', () => {
     expect(classifyBash('cd /tmp && ls > out')).toBe('cd-compound')
   })
 
-  it('cd-compound: cd + semicolon', () => {
-    expect(classifyBash('cd /tmp; ls')).toBe('cd-compound')
+  it('cd-compound: cd + git via semicolon', () => {
+    // Semicolon path still flags when the tail isn't read-only. A read-only
+    // tail (`cd /tmp; ls`) is the O2 over-fire and now takes the fast-path —
+    // see the read-only fast-path block below.
+    expect(classifyBash('cd /tmp; git status')).toBe('cd-compound')
   })
 
   it('cd-multi-positional: zsh `cd OLD NEW`', () => {
@@ -165,6 +168,63 @@ describe('classifyBash', () => {
 
   it('null: echo of a string mentioning cd', () => {
     expect(classifyBash('echo "I will cd to /tmp"')).toBeNull()
+  })
+})
+
+// ---- read-only fast-path (#641) --------------------------------------------
+//
+// CC auto-grants a "simple read-only command", so classifyBash must not relay
+// it. The fast-path is monotonic: it only ever turns a would-be relay into
+// null, never the reverse. The one observable flip vs. the prior classifier is
+// O2 — `cd <dir>; <read-only>` going cd-compound → null.
+
+describe('classifyBash read-only fast-path', () => {
+  // The O2 over-fire: a read-only tail after cd. Was flagged cd-compound.
+  it('O2: cd + read-only tail via semicolon → null', () => {
+    expect(classifyBash('cd /tmp; ls')).toBeNull()
+  })
+  it('O2: cd + read-only tail via && → null', () => {
+    expect(classifyBash('cd /tmp && grep -rn foo src/')).toBeNull()
+  })
+  it('read-only pipeline of allowlisted commands → null', () => {
+    expect(classifyBash('git log --oneline | head -20 | cat')).toBeNull()
+  })
+  it('read-only git subcommand → null', () => {
+    expect(classifyBash('git diff --stat')).toBeNull()
+  })
+
+  // Monotonicity: every other bashMissKind still flags. The fast-path declines
+  // (falls through) rather than swallowing these — its accept set is a strict
+  // subset of genuinely read-only commands.
+  it('does not swallow multi-cd', () => {
+    expect(classifyBash('cd /tmp && ls && cd /var')).toBe('multi-cd')
+  })
+  it('does not swallow cd-multi-positional', () => {
+    expect(classifyBash('cd OLD NEW')).toBe('cd-multi-positional')
+  })
+  it('does not swallow too-complex (arith with vars)', () => {
+    expect(classifyBash('echo $((x+1))')).toBe('too-complex')
+  })
+  it('does not swallow shell-operators (subshell of read-only cmds)', () => {
+    expect(classifyBash('(ls; pwd)')).toBe('shell-operators')
+  })
+  it('does not swallow cd + git (cd-git-compound)', () => {
+    expect(classifyBash('cd /repo && git status')).toBe('cd-compound')
+  })
+  it('does not swallow a read-only tail with a write redirect', () => {
+    expect(classifyBash('cd /tmp && ls > out')).toBe('cd-compound')
+  })
+
+  // A non-allowlisted command declines the fast-path. It's null anyway (no
+  // bashMissKind, parity-correct — CC auto-grants it) but via fall-through,
+  // not the fast-path.
+  it('declines a non-allowlisted command (null via fall-through)', () => {
+    expect(classifyBash('curl -s https://example.com')).toBeNull()
+  })
+  // cd + a non-read-only tail stays cd-compound — the fast-path only removes
+  // the read-only-tail over-fire, not every cd-compound.
+  it('cd + non-read-only tail still flags cd-compound', () => {
+    expect(classifyBash('cd /tmp; rm -rf x')).toBe('cd-compound')
   })
 })
 

--- a/test/pretooluse-prompt.test.ts
+++ b/test/pretooluse-prompt.test.ts
@@ -194,8 +194,8 @@ describe('classifyBash read-only fast-path', () => {
   })
 
   // Monotonicity: every other bashMissKind still flags. The fast-path declines
-  // (falls through) rather than swallowing these — its accept set is a strict
-  // subset of genuinely read-only commands.
+  // (falls through) rather than swallowing these — a decline never changes a
+  // relay, so the only observable move is a drop, pinned to O2 above.
   it('does not swallow multi-cd', () => {
     expect(classifyBash('cd /tmp && ls && cd /var')).toBe('multi-cd')
   })


### PR DESCRIPTION
Closes #641

## What

Adds a "simple read-only command" fast-path at the top of `classifyBash`. CC auto-grants a read-only command, so relaying one to the operator diverges from parity — roost asks when CC produced no blocking request. The fast-path returns `null` (pass through, no relay) for a command whose every statement is a read-only command with none of: subshell/command-group, background `&`, redirection, process substitution, variable arithmetic, a second cd, a multi-positional cd, or cd-into-git.

## Why it's safe

The fast-path is **monotonic**: a *decline* just defers to the existing bashMissKind detectors (unchanged), so membership can only ever *drop* a relay, never add one. Its accept set is a strict *subset* of what CC grants, so an accept → silence is parity-correct. The single observable behavior flip vs. the prior classifier is **O2** from the perm-irc audit (`docs/audit-2026-06-perm-irc.md`): `cd <dir>; <read-only>` going `cd-compound` → `null`.

## Scope notes

- **U1–U4 are out of scope.** The issue body cites the pre-reframe audit framing where U1–U4 were "under-fires." The current authoritative audit (post-`692efa9`, "reframe around parity") establishes those are *not* bugs — in auto mode CC grants them, so `classifyBash` returning `null` is parity-correct silence. No new detectors added.
- **Conservative allowlist, not a full mirror.** Faithfully porting CC's per-flag `safeFlags` git table is a large drift-prone surface (the issue flags it as "its own design surface"). Instead the allowlist is a general read-only unix set plus `git` gated to read-only subcommands. Full port buys ~nothing at auto mode's ~zero relay volume. Reviewer + PM signed off on this call.

## Tests

`bun test test/pretooluse-prompt.test.ts` green (56 pass). New `read-only fast-path` block covers the O2 flip, read-only pipelines/git, and monotonicity (multi-cd / cd-multi-positional / too-complex / shell-operators / cd+git / cd+redirect all still flag).

## ⚠️ Required before ready-for-review (§598)

Per §598, any classifyBash change needs a **live empirical parity pass against the bare native TUI** (spawn an agent with no `--perm-irc`, confirm via tool_use→tool_result gaps which commands actually hold) — absolute parity, no more no less. The monotonic design lowers risk but does **not** substitute for the empirical check. I'll run it and post results before signaling ready.