### PR TITLE
Add roost --version / -v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,6 @@ jobs:
 
       - name: Shell tests — compact-hook
         run: bash test/compact-hook_test.sh
+
+      - name: Shell tests — version
+        run: bash test/version_test.sh

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ roost list
 roost attach worker-1
 roost shutdown worker-1
 roost status
+roost --version
 ```
 
 `spawn` accepts `-c|--channels`, `-m|--model`, `-s|--session`,

--- a/bin/roost
+++ b/bin/roost
@@ -38,9 +38,17 @@ IRC_HOST="${ROOST_IRC_SERVER:-127.0.0.1}"
 IRC_PORT=6667
 SESSION_PREFIX="roost-"
 
+print_version() {
+  local pkg="${ROOST_DIR}/package.json"
+  local version
+  version="$(grep -m1 '"version"' "${pkg}" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+  echo "roost ${version}"
+}
+
 usage() {
   cat <<EOF
 Usage: roost <command> [args]
+       roost -v | --version
 
 Commands:
   init                     Bootstrap config, .gitignore, and copy prompts.
@@ -54,6 +62,7 @@ Commands:
   root                     Print the roost plugin root directory.
   send <nick> <message...> Inject text into a nick's tmux pane.
   hook-exec <name>         Exec a hook entry point — used in spawned hook configs.
+  -v, --version            Print the installed roost version.
 
 Quick start:
   roost init
@@ -1462,6 +1471,7 @@ case "${cmd}" in
   send)      cmd_send "$@" ;;
   hook-exec) cmd_hook_exec "$@" ;;
   root)      echo "${ROOST_DIR}" ;;
+  -v|--version) print_version ;;
   -h|--help|help) usage ;;
   *) echo "error: unknown command: ${cmd}" >&2; usage; exit 1 ;;
 esac

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -41,6 +41,7 @@ roost list
 roost attach <nick>
 roost tail <nick> [-n LINES]
 roost status
+roost --version | -v
 ```
 
 Defaults:

--- a/test/version_test.sh
+++ b/test/version_test.sh
@@ -11,7 +11,7 @@ FAIL=0
 ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
 fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
 
-expected_version="$(grep -m1 '"version"' "${REPO}/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+expected_version="$(node -p "require('${REPO}/package.json').version")"
 expected="roost ${expected_version}"
 
 out_long="$("${ROOST_BIN}" --version)"

--- a/test/version_test.sh
+++ b/test/version_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tests for `roost --version` / `-v`. Plain bash, no bats.
+# Run: bash test/version_test.sh
+set -uo pipefail
+
+ROOST_BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/bin/roost"
+REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+PASS=0
+FAIL=0
+
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
+
+expected_version="$(grep -m1 '"version"' "${REPO}/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+expected="roost ${expected_version}"
+
+out_long="$("${ROOST_BIN}" --version)"
+if [ "$out_long" = "$expected" ]; then
+  ok "roost --version prints the package.json version"
+else
+  fail "roost --version prints the package.json version" "got=[$out_long] want=[$expected]"
+fi
+
+out_short="$("${ROOST_BIN}" -v)"
+if [ "$out_short" = "$expected" ]; then
+  ok "roost -v prints the package.json version"
+else
+  fail "roost -v prints the package.json version" "got=[$out_short] want=[$expected]"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #668

Adds top-level `--version` / `-v` flags to `bin/roost`, printing `roost <version>` read from `package.json`. Confirmed `package.json` ships in the brew-installed tree (`libexec.install Dir["*", ".[!.]*"]` in the tap formula) before relying on it as the source of truth.

- `print_version()` reads and parses `package.json` with grep/sed (no jq dependency)
- self-validating shell test (`test/version_test.sh`) asserts the flag output against `package.json`'s own version, so it can't rot at the next bump
- usage(), SKILL.md, README updated to mention the new flags

## Test plan
- [x] `bash test/version_test.sh` passes
- [x] `bun run lint` clean
- [x] manual: `roost --version`, `roost -v`, `roost --help`