### PR TITLE
Fix dispatcher crash on underscore repo basename in slug derivation

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -49,10 +49,20 @@ async function loadConfigWithPlugins(
   return { config, plugins, projectChannel }
 }
 
-function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string): string[] {
+// Per-plugin try/catch is an outer backstop: individual plugins already
+// isolate per-entry slug-derivation failures internally, but a failure before
+// any per-entry loop runs (e.g. defaultProject) would otherwise escape here
+// uncaught — this is called unguarded from both daemon boot and the
+// tick-failure fallback path, and an uncaught throw here crashes the whole
+// daemon and drops every joined channel.
+function bootChannels(plugins: Plugin[], config: OrchestratorConfig, projectChannel: string, log: PluginLogger = defaultPluginLogger): string[] {
   const chans = new Set<string>([projectChannel])
   for (const plugin of plugins) {
-    for (const c of plugin.desiredChannels(config)) chans.add(c)
+    try {
+      for (const c of plugin.desiredChannels(config)) chans.add(c)
+    } catch (e) {
+      log(`orchestrator: skipping channels for plugin ${plugin.name}: ${e}\n`)
+    }
   }
   return [...chans].sort()
 }
@@ -134,7 +144,7 @@ async function runDaemon(stateDir: string): Promise<void> {
   let config = initialConfig
   const { nick, server, port } = requireIrcConfig(config, 'daemon mode')
   const interval = Math.max(5, (config.irc?.interval_seconds ?? 60)) * 1000
-  const initialChannels = bootChannels(plugins, config, projectChannel)
+  const initialChannels = bootChannels(plugins, config, projectChannel, log)
   log(`orchestrator[daemon]: starting nick=${nick} server=${server}:${port} channels=${initialChannels.join(',')} interval=${interval / 1000}s\n`)
 
   const client = newIrcClient(nick, initialChannels)
@@ -200,7 +210,7 @@ async function runDaemon(stateDir: string): Promise<void> {
       trySay(projectChannel, `[dispatcher_error] ${msg}`)
       // Fall back to the config-only channel view so a transient GH/scrape
       // blip doesn't part every #issue-N until the next success.
-      result = { taggedEvents: [], channels: bootChannels(plugins, config, projectChannel) }
+      result = { taggedEvents: [], channels: bootChannels(plugins, config, projectChannel, log) }
     }
 
     // Reconcile IRC membership against plugins' desired set, then snapshot.

--- a/src/orchestrator/__tests__/naming.test.ts
+++ b/src/orchestrator/__tests__/naming.test.ts
@@ -33,6 +33,10 @@ describe('defaultProject', () => {
     expect(defaultProject({ repo: 'AvesAlight/Roost' })).toBe('roost')
   })
 
+  it('normalizes underscores in the repo basename fallback', () => {
+    expect(defaultProject({ repo: 'GoCarrot/debian13_root' })).toBe('debian13-root')
+  })
+
   it('throws when project invalid', () => {
     expect(() => defaultProject({ project: 'BAD NAME' })).toThrow(/invalid project/)
   })
@@ -63,6 +67,11 @@ describe('repoSlug', () => {
   it('throws when the slug would not match the project pattern', () => {
     expect(() => repoSlug('Org/bad name')).toThrow(/cannot derive slug/)
     expect(() => repoSlug('Org/-leading-dash')).toThrow(/cannot derive slug/)
+  })
+
+  it('normalizes underscores to dashes instead of throwing', () => {
+    expect(repoSlug('GoCarrot/debian13_root')).toBe('debian13-root')
+    expect(repoSlug('Org/foo_bar_baz')).toBe('foo-bar-baz')
   })
 })
 

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -20,7 +20,9 @@ export function validateProject(project: string): void {
 // Lowercases a repo basename and normalizes underscores to dashes — real repo
 // basenames commonly use underscores, and a dash is a legal slug/project char
 // where an underscore isn't. Shared by defaultProject's repo fallback and
-// repoSlug so the two derivations agree on what basename is bootable.
+// repoSlug so the two derivations agree on what basename is bootable. Widens
+// the existing cross-org-overlap footgun: `Org/foo_bar` and `Org/foo-bar` now
+// collide on the same normalized basename.
 function normalizeBasename(base: string): string {
   return base.toLowerCase().replaceAll('_', '-')
 }
@@ -44,9 +46,9 @@ export function isMultiRepo(config: OrchestratorConfig): boolean {
 }
 
 // Lowercased, underscore-normalized basename of `Owner/Repo` — interpolated
-// into nicks/channels, so must match the project pattern. Two known
-// footguns: cross-org overlap (`Org1/foo` + `Org2/foo`), and post-normalization
-// collision (`Org/foo_bar` + `Org/foo-bar`) both slugging to `foo-bar`.
+// into nicks/channels, so must match the project pattern. Cross-org overlap
+// (`Org1/foo` + `Org2/foo`) is a known footgun; see normalizeBasename for the
+// underscore/dash collision one.
 export function repoSlug(repo: string): string {
   const base = normalizeBasename(repo.split('/').pop() ?? '')
   if (!PROJECT_PATTERN.test(base)) {

--- a/src/orchestrator/naming.ts
+++ b/src/orchestrator/naming.ts
@@ -17,6 +17,14 @@ export function validateProject(project: string): void {
   }
 }
 
+// Lowercases a repo basename and normalizes underscores to dashes — real repo
+// basenames commonly use underscores, and a dash is a legal slug/project char
+// where an underscore isn't. Shared by defaultProject's repo fallback and
+// repoSlug so the two derivations agree on what basename is bootable.
+function normalizeBasename(base: string): string {
+  return base.toLowerCase().replaceAll('_', '-')
+}
+
 // Falls back to the basename of `repo` if `project` is unset. Multi-mode
 // (no `config.repo`) requires `config.project` set — no inherit target.
 export function defaultProject(config: OrchestratorConfig): string {
@@ -25,7 +33,7 @@ export function defaultProject(config: OrchestratorConfig): string {
     return config.project
   }
   if (config.repo) {
-    const base = config.repo.split('/').pop()?.toLowerCase() ?? ''
+    const base = normalizeBasename(config.repo.split('/').pop() ?? '')
     if (PROJECT_PATTERN.test(base)) return base
   }
   throw new Error('no project: multi-repo mode (no `config.repo`) requires `config.project` set in config.json')
@@ -35,11 +43,12 @@ export function isMultiRepo(config: OrchestratorConfig): boolean {
   return !config.repo
 }
 
-// Lowercased basename of `Owner/Repo` — interpolated into nicks/channels, so
-// must match the project pattern. Cross-org overlap (`Org1/foo` + `Org2/foo`)
-// is a known footgun.
+// Lowercased, underscore-normalized basename of `Owner/Repo` — interpolated
+// into nicks/channels, so must match the project pattern. Two known
+// footguns: cross-org overlap (`Org1/foo` + `Org2/foo`), and post-normalization
+// collision (`Org/foo_bar` + `Org/foo-bar`) both slugging to `foo-bar`.
 export function repoSlug(repo: string): string {
-  const base = repo.split('/').pop()?.toLowerCase() ?? ''
+  const base = normalizeBasename(repo.split('/').pop() ?? '')
   if (!PROJECT_PATTERN.test(base)) {
     throw new Error(
       `cannot derive slug from repo "${repo}": basename "${base}" must match ${PROJECT_PATTERN}`

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -768,7 +768,7 @@ describe('GitHubIssuesPlugin.runTick', () => {
 
   it('skips event routing for an entry whose own repo slug fails to derive, keeping a healthy sibling routed', async () => {
     const badEv: OrchestratorEvent = {
-      kind: 'issue_comment', repo: 'GoCarrot/bad name', issue: 6, url: 'u',
+      kind: 'issue_comment', repo: 'org/my.tool', issue: 6, url: 'u',
       author: 'bob', body: 'x', body_preview: 'x', is_worker_reply: false,
       comment_id: 1, comment_url: 'u',
     } as OrchestratorEvent
@@ -779,19 +779,43 @@ describe('GitHubIssuesPlugin.runTick', () => {
     } as OrchestratorEvent
     const logs: string[] = []
     const spy = stubIssue((repo, number) => number === 6
-      ? { snap: fakeIssueSnap({ repo: 'GoCarrot/bad name', number: 6 }), events: [badEv] }
+      ? { snap: fakeIssueSnap({ repo: 'org/my.tool', number: 6 }), events: [badEv] }
       : { snap: fakeIssueSnap({ repo: 'org/repo', number: 50 }), events: [goodEv] })
     try {
       const cfg: OrchestratorConfig = {
         project: 'proj',
         plugins: {
-          'github-issues': { watched: [{ number: 6, repo: 'GoCarrot/bad name' }, { number: 50, repo: 'org/repo' }] },
+          'github-issues': { watched: [{ number: 6, repo: 'org/my.tool' }, { number: 50, repo: 'org/repo' }] },
         },
       }
       const result = await new GitHubIssuesPlugin('#proj', (m) => { logs.push(m) }).runTick(cfg, { issues: {} })
       expect(result.taggedEvents).toHaveLength(1)
       expect(result.taggedEvents[0]?.channels).toEqual(['#proj-repo-issue-50'])
-      expect(logs.some(l => l.includes('GoCarrot/bad name#6') && l.includes('cannot derive slug'))).toBe(true)
+      expect(logs.some(l => l.includes('org/my.tool#6') && l.includes('cannot derive slug'))).toBe(true)
+      // No prior snapshot for the bad entry (first-ever tick) → skip leaves
+      // its state key unset rather than advancing to the new snapshot, so
+      // it's treated as a fresh entry (and its events replay) once the repo
+      // alias is fixed, instead of the diff baseline silently moving on.
+      expect(result.state).toEqual({ issues: { 'org/repo#50': expect.objectContaining({ number: 50 }) } })
+    } finally { spy.mockRestore() }
+  })
+
+  it('retries a bad-slug entry from its prior snapshot instead of dropping it on advance', async () => {
+    const badEv: OrchestratorEvent = {
+      kind: 'issue_comment', repo: 'org/my.tool', issue: 6, url: 'u',
+      author: 'bob', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'u',
+    } as OrchestratorEvent
+    const prev = fakeIssueSnap({ repo: 'org/my.tool', number: 6, title: 'stale' })
+    const spy = stubIssue({ snap: fakeIssueSnap({ repo: 'org/my.tool', number: 6, title: 'fresh' }), events: [badEv] })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'github-issues': { watched: [{ number: 6, repo: 'org/my.tool' }] } },
+      }
+      const result = await new GitHubIssuesPlugin('#proj').runTick(cfg, { issues: { 'org/my.tool#6': prev } })
+      expect(result.taggedEvents).toHaveLength(0)
+      expect(result.state).toEqual({ issues: { 'org/my.tool#6': prev } })
     } finally { spy.mockRestore() }
   })
 })
@@ -866,7 +890,7 @@ describe('desiredChannels', () => {
       plugins: {
         'github-prs': {
           watched: [
-            { number: 6, repo: 'GoCarrot/bad name' },
+            { number: 6, repo: 'org/my.tool' },
             { number: 25, repo: 'org/repo' },
           ],
         },
@@ -874,7 +898,20 @@ describe('desiredChannels', () => {
     }
     const chans = new GitHubPrsPlugin('#proj', (m) => { logs.push(m) }).desiredChannels(cfg)
     expect(chans).toEqual(['#proj-repo-issue-25'])
-    expect(logs.some(l => l.includes('bad name') && l.includes('cannot derive slug'))).toBe(true)
+    expect(logs.some(l => l.includes('org/my.tool') && l.includes('cannot derive slug'))).toBe(true)
+  })
+
+  it('keeps an entry watched via an explicit channel even when its auto-derived slug throws', () => {
+    const logs: string[] = []
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: {
+        'github-prs': { watched: [{ number: 6, repo: 'org/my.tool', channels: ['#explicit-chan'] }] },
+      },
+    }
+    const chans = new GitHubPrsPlugin('#proj', (m) => { logs.push(m) }).desiredChannels(cfg)
+    expect(chans).toEqual(['#explicit-chan'])
+    expect(logs.some(l => l.includes('org/my.tool') && l.includes('cannot derive slug'))).toBe(true)
   })
 })
 

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -765,6 +765,35 @@ describe('GitHubIssuesPlugin.runTick', () => {
       expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#leads', '#proj-issue-50'])
     } finally { spy.mockRestore() }
   })
+
+  it('skips event routing for an entry whose own repo slug fails to derive, keeping a healthy sibling routed', async () => {
+    const badEv: OrchestratorEvent = {
+      kind: 'issue_comment', repo: 'GoCarrot/bad name', issue: 6, url: 'u',
+      author: 'bob', body: 'x', body_preview: 'x', is_worker_reply: false,
+      comment_id: 1, comment_url: 'u',
+    } as OrchestratorEvent
+    const goodEv: OrchestratorEvent = {
+      kind: 'issue_comment', repo: 'org/repo', issue: 50, url: 'u',
+      author: 'bob', body: 'y', body_preview: 'y', is_worker_reply: false,
+      comment_id: 2, comment_url: 'u',
+    } as OrchestratorEvent
+    const logs: string[] = []
+    const spy = stubIssue((repo, number) => number === 6
+      ? { snap: fakeIssueSnap({ repo: 'GoCarrot/bad name', number: 6 }), events: [badEv] }
+      : { snap: fakeIssueSnap({ repo: 'org/repo', number: 50 }), events: [goodEv] })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'github-issues': { watched: [{ number: 6, repo: 'GoCarrot/bad name' }, { number: 50, repo: 'org/repo' }] },
+        },
+      }
+      const result = await new GitHubIssuesPlugin('#proj', (m) => { logs.push(m) }).runTick(cfg, { issues: {} })
+      expect(result.taggedEvents).toHaveLength(1)
+      expect(result.taggedEvents[0]?.channels).toEqual(['#proj-repo-issue-50'])
+      expect(logs.some(l => l.includes('GoCarrot/bad name#6') && l.includes('cannot derive slug'))).toBe(true)
+    } finally { spy.mockRestore() }
+  })
 })
 
 describe('desiredChannels', () => {

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -821,6 +821,32 @@ describe('desiredChannels', () => {
     }
     expect(new GitHubIssuesPlugin('#proj').desiredChannels(cfg)).toEqual(['#proj-foo-issue-14'])
   })
+
+  it('normalizes an underscore repo basename instead of dropping its channel', () => {
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: { 'github-prs': { watched: [{ number: 6, repo: 'GoCarrot/debian13_root' }] } },
+    }
+    expect(new GitHubPrsPlugin('#proj').desiredChannels(cfg)).toEqual(['#proj-debian13-root-issue-6'])
+  })
+
+  it('skips just the entry whose slug fails to derive, keeping a healthy sibling channel joined', () => {
+    const logs: string[] = []
+    const cfg: OrchestratorConfig = {
+      project: 'proj',
+      plugins: {
+        'github-prs': {
+          watched: [
+            { number: 6, repo: 'GoCarrot/bad name' },
+            { number: 25, repo: 'org/repo' },
+          ],
+        },
+      },
+    }
+    const chans = new GitHubPrsPlugin('#proj', (m) => { logs.push(m) }).desiredChannels(cfg)
+    expect(chans).toEqual(['#proj-repo-issue-25'])
+    expect(logs.some(l => l.includes('bad name') && l.includes('cannot derive slug'))).toBe(true)
+  })
 })
 
 describe('multi-repo runTick — slug-aware channel routing', () => {

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -287,13 +287,20 @@ export abstract class GhBase extends GhPluginBase {
   }
 
   // No watches → no project lookup (avoids requiring `project`/`repo` on minimal configs).
+  // Per-entry try/catch: a slug-derivation failure on one entry (e.g. an
+  // unrepresentable repo basename) must not drop every sibling entry's
+  // channel — log and skip just the bad one.
   protected entryChannels(config: OrchestratorConfig, entries: WatchedEntry[] | undefined): string[] {
     if (!entries?.length) return []
     const project = defaultProject(config)
     const chans = new Set<string>()
     for (const entry of entries) {
       const { repo, number, channels } = resolveRepoEntry(entry, config.repo)
-      chans.add(issueChannel(project, number, channelSlug(config, repo)))
+      try {
+        chans.add(issueChannel(project, number, channelSlug(config, repo)))
+      } catch (e) {
+        this.log(`[${this.name}] skipping auto-derived channel for ${repo}#${number}: ${e}\n`)
+      }
       for (const c of channels) chans.add(c)
     }
     return [...chans]

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -108,7 +108,17 @@ export class GitHubIssuesPlugin extends GhBase {
       this.clearEntryFailure(key)
       const { snap, events } = this.snapshotIssue(repo, number, outcome.node, prevIssue, agentLogins)
       curState.issues[key] = snap
-      const slug = channelSlug(config, snap.repo)
+      // A slug-derivation failure on this entry's own repo must not sink the
+      // rest of the batch — log and skip event routing for just this entry;
+      // it's retried (with its prev snapshot already carried forward above
+      // via curState) next tick.
+      let slug: string | undefined
+      try {
+        slug = channelSlug(config, snap.repo)
+      } catch (e) {
+        this.log(`[${this.name}] skipping event routing for ${key}: ${e}\n`)
+        continue
+      }
       for (const event of events) {
         if (event.kind === 'issue_added_to_watch') {
           const routingChannels = this.resolveChannels(

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -107,18 +107,21 @@ export class GitHubIssuesPlugin extends GhBase {
       // Clean read → clear any prior failure state and build the snapshot.
       this.clearEntryFailure(key)
       const { snap, events } = this.snapshotIssue(repo, number, outcome.node, prevIssue, agentLogins)
-      curState.issues[key] = snap
       // A slug-derivation failure on this entry's own repo must not sink the
-      // rest of the batch — log and skip event routing for just this entry;
-      // it's retried (with its prev snapshot already carried forward above
-      // via curState) next tick.
+      // rest of the batch — log and skip event routing for just this entry.
+      // Store prevIssue (not snap) on skip, matching the per-alias-failure
+      // path above: if we advanced to snap the diff baseline would move on
+      // and this tick's events would be silently dropped forever, not
+      // retried, once the repo alias is fixed.
       let slug: string | undefined
       try {
         slug = channelSlug(config, snap.repo)
       } catch (e) {
         this.log(`[${this.name}] skipping event routing for ${key}: ${e}\n`)
+        if (prevIssue) curState.issues[key] = prevIssue
         continue
       }
+      curState.issues[key] = snap
       for (const event of events) {
         if (event.kind === 'issue_added_to_watch') {
           const routingChannels = this.resolveChannels(

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -103,6 +103,9 @@ export class GitHubPrsPlugin extends GhBase {
   // when both are absent so resolveChannels falls back to entryChannels or
   // defaultChannel. pr_no_linked_issues is handled inline in runTick and
   // never reaches this function.
+  //
+  // Per-linked-issue try/catch: one closed issue whose repo's slug fails to
+  // derive must not drop routing for every other linked issue on the same PR.
   private static prEventChannels(
     config: OrchestratorConfig,
     project: string,
@@ -111,17 +114,41 @@ export class GitHubPrsPlugin extends GhBase {
     prRepo: string,
     routable: LinkedIssue[],
     linearChannels: string[],
+    log: PluginLogger,
   ): string[] {
     if (event.pr == null) return []
     if (routable.length) {
-      return [
-        ...routable.map(li => issueChannel(project, li.number, channelSlug(config, li.repo))),
-        ...linearChannels,
-      ]
+      const linkedChannels: string[] = []
+      for (const li of routable) {
+        try {
+          linkedChannels.push(issueChannel(project, li.number, channelSlug(config, li.repo)))
+        } catch (e) {
+          log(`[github-prs] skipping linked-issue channel for ${li.repo}#${li.number}: ${e}\n`)
+        }
+      }
+      return [...linkedChannels, ...linearChannels]
     }
     // No GitHub linked issues: route to Linear channels when present; otherwise
     // return [] so resolveChannels falls back to entryChannels or defaultChannel.
     return linearChannels
+  }
+
+  // Per-linked-issue try/catch, same reasoning as prEventChannels above —
+  // one bad repo among several linked issues must not drop the rest.
+  private static addRoutableChannels(
+    channels: Set<string>,
+    config: OrchestratorConfig,
+    project: string,
+    routable: LinkedIssue[],
+    log: PluginLogger,
+  ): void {
+    for (const li of routable) {
+      try {
+        channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+      } catch (e) {
+        log(`[github-prs] skipping linked-issue channel for ${li.repo}#${li.number}: ${e}\n`)
+      }
+    }
   }
 
   // Stderr-only — operator-visible in daemon.log without IRC noise.
@@ -249,7 +276,7 @@ export class GitHubPrsPlugin extends GhBase {
         if (prevPr) {
           curState.prs[key] = prevPr
           const { routable } = GitHubPrsPlugin.partitionLinked(config, prevPr.repo, prevPr.linked_issues ?? [])
-          for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+          GitHubPrsPlugin.addRoutableChannels(channels, config, project, routable, this.log)
           for (const ident of linkMap.get(prKey(prevPr.repo, prevPr.number)) ?? []) channels.add(linearIssueChannel(project, ident))
         }
         continue
@@ -259,7 +286,7 @@ export class GitHubPrsPlugin extends GhBase {
       const { snap, events } = this.snapshotPr(repo, number, outcome.node, prevPr, agentLogins)
       curState.prs[key] = snap
       const { routable, dropped } = GitHubPrsPlugin.partitionLinked(config, snap.repo, snap.linked_issues ?? [])
-      for (const li of routable) channels.add(issueChannel(project, li.number, channelSlug(config, li.repo)))
+      GitHubPrsPlugin.addRoutableChannels(channels, config, project, routable, this.log)
       // Linear cross-link channels for this PR. A PR can be attached to
       // multiple Linear issues — all matched identifiers route. Key
       // normalization (via prKey) guards against casing drift between
@@ -296,7 +323,7 @@ export class GitHubPrsPlugin extends GhBase {
           // A Linear-only match is a real routing target and earns a heads-up.
           if (linked.length || linearChannels.length) {
             const routingChannels = this.resolveChannels(
-              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels),
+              GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels, this.log),
               entryChannels
             ).filter(ch => ch !== projectChannel)
             const routingStr = routingChannels.length ? routingChannels.join(', ') : projectChannel
@@ -309,7 +336,7 @@ export class GitHubPrsPlugin extends GhBase {
         }
         if (!shouldPush(event)) continue
         taggedEvents.push({
-          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels), entryChannels),
+          channels: this.resolveChannels(GitHubPrsPlugin.prEventChannels(config, project, event, projectChannel, snap.repo, routable, linearChannels, this.log), entryChannels),
           payload: formatPayload(event),
         })
       }


### PR DESCRIPTION
Closes #669

Root cause: `repoSlug()` rejected repo basenames with underscores. The throw escaped uncaught through an unguarded `bootChannels()` re-derivation in the tick-failure catch fallback in `src/orchestrator.ts`, crashing the daemon and dropping every joined IRC channel — matching the reported "disconnected from every channel" symptom.

Two-part fix:
1. **naming.ts**: normalize underscores to dashes when deriving a slug/project from a repo basename (shared helper used by both `repoSlug` and `defaultProject`'s repo fallback), instead of throwing.
2. **Error isolation** (per §602 in this repo's learnings — audit isolation granularity, not just the trigger): push try/catch down to per-entry/per-linked-issue in `base.ts`'s `entryChannels`, `prs-plugin.ts`'s `prEventChannels`/`addRoutableChannels`, and `issues-plugin.ts`'s per-entry slug lookup, so one bad repo skips only its own channel instead of taking out every sibling's routing. `bootChannels` keeps a per-plugin try/catch as an outer backstop for failures before any per-entry loop runs (e.g. `defaultProject`).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (full suite, 1033 tests)
- [x] New tests: underscore normalization in `naming.test.ts`; sibling-survival isolation tests (desiredChannels level for PRs, runTick level for issues) using the reported multi-repo + underscore shape

🤖 Generated with Claude Code