### PR TITLE
Read review-thread comments newest-first

### DIFF
--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -338,7 +338,7 @@ const PR_NODE_FIELDS = `
     closingIssuesReferences(first:25){ nodes{ number repository{ nameWithOwner } } }
     reviews(last:${BATCH_CONNECTION_CAP}){ totalCount nodes{ databaseId url author{ login } body state } }
     comments(last:${BATCH_CONNECTION_CAP}){ totalCount nodes{ databaseId url author{ login } body } }
-    reviewThreads(last:${BATCH_CONNECTION_CAP}){ totalCount nodes{ comments(first:${BATCH_CONNECTION_CAP}){ nodes{ databaseId url author{ login } body path line originalLine } } } }
+    reviewThreads(last:${BATCH_CONNECTION_CAP}){ totalCount nodes{ comments(last:${BATCH_CONNECTION_CAP}){ nodes{ databaseId url author{ login } body path line originalLine } } } }
 `
 
 const ISSUE_NODE_FIELDS = `


### PR DESCRIPTION
Closes #652

Flips the nested `reviewThreads{ comments(first:N) }` connection to `last:N` in `github-api.ts`, matching every sibling connection in the same batched query (`reviews`, top-level `comments`, `reviewThreads` itself). Before this, a thread with more than the 100-comment batch cap would under-read its newest replies instead of its oldest, and `warnTruncation` doesn't catch this per-thread case (tracked as a known, accepted asymmetry — see issue discussion).

One-line diff, no new test: pagination direction isn't behaviorally unit-testable and a query-string pin would be fragile. `bun run typecheck`, `bun run lint`, and `bun test` all pass.