### PR TITLE
dispatcher CI relay: carry commit SHA, verify HEAD in APM gates

### DIFF
--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -42,7 +42,7 @@ Your IRC nick is `<project>-apm`. On boot:
 Some triggers are unambiguous — proceed directly without acking the PM first:
 
 - **PR-watch** — worker posts a draft PR with a valid closing reference; DM the dispatcher to watch it. Deterministic; see the PR-watch dance. (The reviewer is already resident from setup — you don't spawn it here.)
-- **Mark-ready + re-request review** — reviewer's latest verdict is APPROVED, the worker acks it, AND the dispatcher confirms CI green (all three deterministic; see the ready-for-review dance).
+- **Mark-ready + re-request review** — reviewer's latest verdict is APPROVED, the worker acks it, AND CI is independently verified green on the PR's current HEAD SHA (all three deterministic; see the ready-for-review dance).
 - **Follow-up filing** — PM provides title-shape + source context (e.g., "from PR #N") + milestone; APM drafts body and files.
 - **Unwatch/cleanup steps** — mechanical teardown that follows an already-confirmed merge.
 - **Watch self-authored PR** — PM explicitly says "watch PR #N and add human"; action is unambiguous (no reviewer to spawn — PM-authored PRs get none).
@@ -134,9 +134,9 @@ Trigger: a worker posts a draft PR link in an issue channel you're in. The revie
 Trigger: THREE conditions, all met — wait for whichever comes last:
 1. **The reviewer's latest PR-review verdict is APPROVED.** The reviewer headlines every review comment with exactly one of APPROVED / CHANGES REQUIRED (dispatcher relays it into the channel). CHANGES REQUIRED means the gate is not met — wait.
 2. **The worker acks the reviewer's *latest* APPROVED** ("great, thanks" or similar in the issue channel). Acks are per-verdict: when the reviewer re-emits an APPROVED after new pushes, wait for a fresh ack — never reuse one from an earlier verdict. An APPROVED may carry notes the worker chooses to still address (gated on the PM's go) — in that case wait for its push and *then* its ack. If the worker (with the PM's blessing) skips all notes, there's no push coming — its ack alone satisfies this condition. The reviewer's APPROVED stands through those pushes (same trust contract as the human's APPROVED-with-nits), so don't demand a re-verdict; only a reviewer post flagging a new problem re-opens the gate.
-3. The dispatcher reports CI passed on the current HEAD.
+3. Verify CI is green on the PR's current HEAD SHA via `gh pr view <N> --repo <owner>/<repo> --json headRefOid,statusCheckRollup` (or `gh pr checks <N>`) — don't rely on the dispatcher relay line alone; the relay can lag a fix push and cite a superseded commit.
 
-This dance also covers re-requesting after a human leaves CHANGES_REQUESTED or COMMENT — but the three conditions above apply only to the *first* flip. The reviewer is out of the picture once the PR first goes ready: don't wait for a reviewer verdict or a worker ack of one, they won't come. Re-request once the worker's fix push lands (the PM gates that push, not you) and the dispatcher confirms CI green on the new HEAD.
+This dance also covers re-requesting after a human leaves CHANGES_REQUESTED or COMMENT — but the three conditions above apply only to the *first* flip. The reviewer is out of the picture once the PR first goes ready: don't wait for a reviewer verdict or a worker ack of one, they won't come. Re-request once the worker's fix push lands (the PM gates that push, not you) and you've verified CI is green on the PR's current HEAD SHA via `gh pr view <N> --repo <owner>/<repo> --json headRefOid,statusCheckRollup` (or `gh pr checks <N>`) — don't rely on the dispatcher relay line alone; the relay can lag a fix push and cite a superseded commit.
 
 When all conditions are met, proceed without ack:
 - `gh pr ready <N> --repo <owner>/<repo>` (no-op if already ready, that's fine).
@@ -148,7 +148,7 @@ Once ready, the PR stays in ready state through the human review loop — do NOT
 
 ### Merge + cleanup dance
 
-Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're tracking + CI is green.
+Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're tracking + verify CI is green on the PR's current HEAD SHA via `gh pr view <N> --repo <owner>/<repo> --json headRefOid,statusCheckRollup` (or `gh pr checks <N>`) — don't rely on the dispatcher relay line alone; the relay can lag a fix push and cite a superseded commit.
 
 1. Ack in `#<project>-leads`: `PR #<N> approved + CI green, ready to merge and clean up?` If the human's approval included inline nitpicks/comments, surface them: `(human left some inline nits — merge as-is or have worker address first?)`.
 2. On confirmation:

--- a/agents/associate-pm.md
+++ b/agents/associate-pm.md
@@ -148,7 +148,7 @@ Once ready, the PR stays in ready state through the human review loop — do NOT
 
 ### Merge + cleanup dance
 
-Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're tracking + verify CI is green on the PR's current HEAD SHA via `gh pr view <N> --repo <owner>/<repo> --json headRefOid,statusCheckRollup` (or `gh pr checks <N>`) — don't rely on the dispatcher relay line alone; the relay can lag a fix push and cite a superseded commit.
+Trigger: dispatcher posts a human-submitted APPROVED review on a PR you're tracking + CI is green on the PR's current HEAD SHA, verified via `gh pr view <N> --repo <owner>/<repo> --json headRefOid,statusCheckRollup` (or `gh pr checks <N>`) — don't rely on the dispatcher relay line alone; the relay can lag a fix push and cite a superseded commit.
 
 1. Ack in `#<project>-leads`: `PR #<N> approved + CI green, ready to merge and clean up?` If the human's approval included inline nitpicks/comments, surface them: `(human left some inline nits — merge as-is or have worker address first?)`.
 2. On confirmation:

--- a/src/orchestrator/plugins/_shared.ts
+++ b/src/orchestrator/plugins/_shared.ts
@@ -1,5 +1,11 @@
 // Cross-plugin reply phrasing — one rename of `config.json` flips here only.
 
+// Short commit SHA for relay lines. Null-safe: callers relay CI/commit
+// events where the SHA may be unavailable (e.g. pre-first-push snapshots).
+export function shortSha(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 7) : '?'
+}
+
 // Refusal line when a DM tries to mutate a tracked entry — only the gitignored
 // overlay is dispatcher-writable.
 export function trackedRefusal(labelStr: string, action: string): string {

--- a/src/orchestrator/plugins/github/__tests__/diff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/diff.test.ts
@@ -76,9 +76,10 @@ describe('diffPr', () => {
     const prev: PrSnap = { ...basePrSnap({ ci_state: 'PENDING' }) }
     const cur = basePrSnap({ ci_state: 'SUCCESS', head_oid: 'abc' })
     const events = diffPr(prev, cur)
-    const ev = events.find(e => e.kind === 'ci_transitioned') as { from: string; to: string } | undefined
+    const ev = events.find(e => e.kind === 'ci_transitioned') as { from: string; to: string; head_oid?: string | null } | undefined
     expect(ev?.from).toBe('PENDING')
     expect(ev?.to).toBe('SUCCESS')
+    expect(ev?.head_oid).toBe('abc')
   })
 
   it('emits ci_transitioned on new push with terminal CI', () => {

--- a/src/orchestrator/plugins/github/__tests__/format.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/format.test.ts
@@ -84,9 +84,29 @@ describe('formatEvent', () => {
     const ev: OrchestratorEvent = {
       kind: 'ci_transitioned',
       repo: 'org/repo', pr: 10, url: 'https://github.com/org/repo/pull/10',
-      from: 'PENDING', to: 'SUCCESS', head_oid: 'abc123',
+      from: 'PENDING', to: 'SUCCESS', head_oid: 'abc123def456',
     } as OrchestratorEvent
-    expect(formatEvent(ev)).toBe('PR org/repo#10 CI: PENDING → SUCCESS')
+    expect(formatEvent(ev)).toBe('PR org/repo#10 CI: PENDING → SUCCESS (abc123d)')
+  })
+
+  it('formats ci_transitioned with missing head_oid', () => {
+    const ev: OrchestratorEvent = {
+      kind: 'ci_transitioned',
+      repo: 'org/repo', pr: 10, url: 'https://github.com/org/repo/pull/10',
+      from: 'PENDING', to: 'SUCCESS', head_oid: null,
+    } as OrchestratorEvent
+    expect(formatEvent(ev)).toBe('PR org/repo#10 CI: PENDING → SUCCESS (?)')
+  })
+
+  it('formats pr_has_existing_ci_state', () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_has_existing_ci_state',
+      repo: 'org/repo', pr: 10, url: 'https://github.com/org/repo/pull/10',
+      ci_state: 'SUCCESS', head_oid: 'abc123def456',
+    } as OrchestratorEvent
+    expect(formatEvent(ev)).toBe(
+      'PR org/repo#10 CI already terminal at watch time: SUCCESS (abc123d) — https://github.com/org/repo/pull/10'
+    )
   })
 
   it('formats labels_changed', () => {

--- a/src/orchestrator/plugins/github/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/scraper.test.ts
@@ -88,6 +88,13 @@ describe('computePrEvents — new watch entry (prevSnap = null)', () => {
     expect(events.some(e => e.kind === 'pr_has_existing_ci_state')).toBe(true)
   })
 
+  it('carries head_oid on pr_has_existing_ci_state', () => {
+    const snap = basePrInternal({ ci_state: 'SUCCESS', head_oid: 'deadbeef' })
+    const { events } = computePrEvents(snap, null, new Set())
+    const ev = events.find(e => e.kind === 'pr_has_existing_ci_state') as { head_oid?: string | null } | undefined
+    expect(ev?.head_oid).toBe('deadbeef')
+  })
+
   it('does not emit pr_has_existing_ci_state for PENDING CI', () => {
     const snap = basePrInternal({ ci_state: 'PENDING' })
     const { events } = computePrEvents(snap, null, new Set())

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -17,7 +17,7 @@ import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
 import { resolveProjectChannel } from '../../naming.js'
-import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
+import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal, shortSha } from '../_shared.js'
 import { tryClaimPerRepo, type PerRepoCommand } from '../grammar.js'
 import type { GhCommit } from './github-api.js'
 import { GhPluginBase } from './base.js'
@@ -67,7 +67,7 @@ function formatCommit(entry: CommitWatchEntry, commit: GhCommit, sha: string): s
   const subject = (commit.commit?.message ?? '(no message)').split('\n')[0]?.trim() ?? ''
   const pathSuffix = entry.path ? ` [${entry.path}]` : ''
   const url = commit.html_url ?? ''
-  return `commit ${entry.repo}@${branch}${pathSuffix} ${sha.slice(0, 7)}: ${subject} — ${url}`
+  return `commit ${entry.repo}@${branch}${pathSuffix} ${shortSha(sha)}: ${subject} — ${url}`
 }
 
 export class GitHubCommitsPlugin extends GhPluginBase {

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -75,6 +75,7 @@ export interface SeedEvent extends BaseEvent {
   conversation_comment_count?: number
   comment_count?: number
   ci_state?: string | null
+  head_oid?: string | null
   stderr?: string
   tick_utc?: string
 }

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -1,5 +1,6 @@
 import type { OrchestratorEvent, CommentEvent, ReviewEvent, LabelEvent, CiEvent, StateChangeEvent, SeedEvent } from './diff.js'
 import type { TaggedEventPayload } from '../../plugin.js'
+import { shortSha } from '../_shared.js'
 
 const MULTILINE_COMMENT_KINDS: ReadonlySet<string> = new Set([
   'pr_review_comment',
@@ -77,7 +78,7 @@ export function formatEvent(event: OrchestratorEvent): string {
 
   if (kind === 'ci_transitioned') {
     const ev = event as CiEvent
-    return `PR ${tag} CI: ${ev.from} → ${ev.to}`
+    return `PR ${tag} CI: ${ev.from} → ${ev.to} (${shortSha(ev.head_oid)})`
   }
 
   if (kind === 'labels_changed') {
@@ -100,7 +101,7 @@ export function formatEvent(event: OrchestratorEvent): string {
 
   if (kind === 'pr_has_existing_ci_state') {
     const ev = event as SeedEvent
-    return `PR ${tag} CI already terminal at watch time: ${ev.ci_state} — ${event.url ?? ''}`
+    return `PR ${tag} CI already terminal at watch time: ${ev.ci_state} (${shortSha(ev.head_oid)}) — ${event.url ?? ''}`
   }
 
   if (kind === 'issue_has_existing_comments') {

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -160,7 +160,7 @@ export function computePrEvents(
     events.push({ kind: 'pr_has_existing_comments', review_comment_count: existingRev, conversation_comment_count: existingConv, ...base })
   }
   if (snap.ci_state === 'SUCCESS' || snap.ci_state === 'FAILURE') {
-    events.push({ kind: 'pr_has_existing_ci_state', ci_state: snap.ci_state, ...base })
+    events.push({ kind: 'pr_has_existing_ci_state', ci_state: snap.ci_state, head_oid: snap.head_oid, ...base })
   }
   return { events, nextWarnedNoLinked: !linked.length }
 }


### PR DESCRIPTION
Closes #678

The `ci_transitioned` and `pr_has_existing_ci_state` relay lines dropped the already-available `head_oid`, so a reader couldn't tell if a green result matched the PR's current HEAD or a superseded push. Threads `head_oid` through `SeedEvent` for the seed-state line too, and updates the APM's mark-ready *and* merge gates to independently verify CI-green-on-HEAD via `gh pr view --json headRefOid,statusCheckRollup` instead of trusting the relay text alone.

- `format.ts` / `diff.ts` / `scraper.ts`: SHA now rendered on both CI relay lines.
- New `shortSha` helper in `plugins/_shared.ts`; `commits-plugin.ts` deduped onto it.
- `agents/associate-pm.md`: both APM gates (ready-flip :137, merge :151) now require explicit HEAD-SHA verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)