### PR TITLE
linear-new-issues: support project-level filtering, not just team-level

### DIFF
--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -362,7 +362,14 @@ describe('tryClaimPerLinearTeam — target=linear-team', () => {
     const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:SDK')
     expect(r?.kind).toBe('error')
     expect((r as { kind: 'error'; message: string }).message).toMatch(/must be quoted/)
-    expect((r as { kind: 'error'; message: string }).message).toContain('project:"SDK"')
+    expect((r as { kind: 'error'; message: string }).message).toContain('project:"<NAME>"')
+  })
+
+  it('errors on an unquoted project filter containing a space, without echoing a truncated guess', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:SDK 4.3.14')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/must be quoted/)
+    expect((r as { kind: 'error'; message: string }).message).not.toContain('4.3.14')
   })
 
   it('errors on an empty quoted project filter', () => {

--- a/src/orchestrator/plugins/__tests__/grammar.test.ts
+++ b/src/orchestrator/plugins/__tests__/grammar.test.ts
@@ -318,26 +318,57 @@ describe('tryClaimPerLinearId', () => {
 describe('tryClaimPerLinearTeam — target=linear-team', () => {
   it('claims `watch linear-team C`', () => {
     expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C')).toEqual({
-      kind: 'ok', cmd: { verb: 'watch', team: 'C', channels: [] },
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', project: null, channels: [] },
     })
   })
 
   it('claims multi-letter team key', () => {
     expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team MAR')).toEqual({
-      kind: 'ok', cmd: { verb: 'watch', team: 'MAR', channels: [] },
+      kind: 'ok', cmd: { verb: 'watch', team: 'MAR', project: null, channels: [] },
     })
   })
 
   it('claims with channels', () => {
     expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C #triage #leads')).toEqual({
-      kind: 'ok', cmd: { verb: 'watch', team: 'C', channels: ['#triage', '#leads'] },
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', project: null, channels: ['#triage', '#leads'] },
     })
   })
 
   it('claims `unwatch linear-team C`', () => {
     expect(tryClaimPerLinearTeam('linear-team', 'unwatch linear-team C')).toEqual({
-      kind: 'ok', cmd: { verb: 'unwatch', team: 'C', channels: [] },
+      kind: 'ok', cmd: { verb: 'unwatch', team: 'C', project: null, channels: [] },
     })
+  })
+
+  it('claims a quoted project filter', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:"SDK 4.3.14"')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', project: 'SDK 4.3.14', channels: [] },
+    })
+  })
+
+  it('claims a quoted project filter alongside channels, in either order', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:"SDK 4.3.14" #triage')).toEqual({
+      kind: 'ok', cmd: { verb: 'watch', team: 'C', project: 'SDK 4.3.14', channels: ['#triage'] },
+    })
+  })
+
+  it('claims `unwatch linear-team C project:"X"` — targets the scoped entry specifically', () => {
+    expect(tryClaimPerLinearTeam('linear-team', 'unwatch linear-team C project:"X"')).toEqual({
+      kind: 'ok', cmd: { verb: 'unwatch', team: 'C', project: 'X', channels: [] },
+    })
+  })
+
+  it('errors with a fixit on an unquoted project filter', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:SDK')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/must be quoted/)
+    expect((r as { kind: 'error'; message: string }).message).toContain('project:"SDK"')
+  })
+
+  it('errors on an empty quoted project filter', () => {
+    const r = tryClaimPerLinearTeam('linear-team', 'watch linear-team C project:""')
+    expect(r?.kind).toBe('error')
+    expect((r as { kind: 'error'; message: string }).message).toMatch(/must not be empty/)
   })
 
   it('errors on lowercase team key', () => {

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -252,9 +252,14 @@ export function tryClaimPerLinearTeam(target: string, line: string): ParseResult
   // rather than let it fall through to the generic channel-shape error.
   const stray = rest1.find(t => PROJECT_STRAY_RE.test(t))
   if (stray) {
+    // Note: an unquoted value with spaces (`project:SDK 4.3.14`) only shows up
+    // here as its first token (`project:SDK`) — the rest already got split off
+    // as separate tokens by the whitespace tokenizer, with no way to recover
+    // which of them belonged to the value. Point at the generic quoted form
+    // rather than echo back a truncated (and possibly misleading) guess.
     return {
       kind: 'error',
-      message: `${verb}: project filter must be quoted — try project:"${stray.slice('project:'.length)}"`,
+      message: `${verb}: project filter must be quoted — try project:"<NAME>"`,
     }
   }
   if (quoted && quoted[1] === '') {

--- a/src/orchestrator/plugins/grammar.ts
+++ b/src/orchestrator/plugins/grammar.ts
@@ -195,18 +195,38 @@ export function tryClaimPerLinearId(line: string): ParseResult<PerLinearIdComman
 export interface PerLinearTeamCommand {
   verb: Verb
   team: string
+  project: string | null
   channels: string[]
 }
+
+// Quoted project filter — `project:"<name>"`. Quotes are required (not
+// optional sugar) because Linear project names routinely contain spaces
+// (e.g. "SDK 4.3.14"), which a plain whitespace tokenizer can't otherwise
+// tell apart from channel/team tokens. Pulled out of the raw line *before*
+// tokenizing so the quoted spaces never reach `tokenizeVerbLine`'s split.
+const PROJECT_QUOTED_RE = /\bproject:"([^"]*)"/
+const PROJECT_STRAY_RE = /^project:/i
 
 // Try to claim a per-Linear-team line for `target`. Returns:
 //   - `null` if the line isn't watch/unwatch, or doesn't lead with this target.
 //   - `{kind:'ok',cmd}` on a clean claim.
 //   - `{kind:'error',msg}` when the line claimed this plugin's target but the
-//     body fails validation (bad team key, malformed channel, etc.). Unlike
-//     `tryClaimPerN`/`tryClaimPerRepo`, there is no shape-based defer — `linear-team`
-//     is an unambiguous keyword; no other plugin claims it.
+//     body fails validation (bad team key, malformed channel, unquoted/empty
+//     project filter, etc.). Unlike `tryClaimPerN`/`tryClaimPerRepo`, there is
+//     no shape-based defer — `linear-team` is an unambiguous keyword; no other
+//     plugin claims it.
+//
+// Known limitation, accepted as-is: a project name containing `,`/`;`/newline
+// can't round-trip through a DM — `splitCommands` splits the message into
+// per-line commands before this parser ever sees a line, so those characters
+// never survive to reach the quoted-project regex below.
 export function tryClaimPerLinearTeam(target: string, line: string): ParseResult<PerLinearTeamCommand> | null {
-  const parsed = tokenizeVerbLine(line)
+  // Strip the quoted project filter (if any) before tokenizing — its value may
+  // contain spaces that a whitespace split would otherwise fragment.
+  const quoted = line.match(PROJECT_QUOTED_RE)
+  const strippedLine = quoted ? line.slice(0, quoted.index) + line.slice(quoted.index! + quoted[0].length) : line
+
+  const parsed = tokenizeVerbLine(strippedLine)
   if (!parsed) return null
   const { verb, tokens } = parsed
   const targetMatch = matchTarget(target, tokens)
@@ -226,17 +246,33 @@ export function tryClaimPerLinearTeam(target: string, line: string): ParseResult
     }
   }
 
-  const channels = rest.slice(1)
+  const rest1 = rest.slice(1)
+  // An unquoted or malformed `project:` token (e.g. `project:SDK`, or a
+  // dropped closing quote) survives tokenizing as a stray token — fixit
+  // rather than let it fall through to the generic channel-shape error.
+  const stray = rest1.find(t => PROJECT_STRAY_RE.test(t))
+  if (stray) {
+    return {
+      kind: 'error',
+      message: `${verb}: project filter must be quoted — try project:"${stray.slice('project:'.length)}"`,
+    }
+  }
+  if (quoted && quoted[1] === '') {
+    return { kind: 'error', message: `${verb}: project filter must not be empty — project:"NAME"` }
+  }
+  const project = quoted ? quoted[1] : null
+
+  const channels = rest1
   if (verb === 'unwatch') {
     if (channels.length) return { kind: 'error', message: 'unwatch takes no channel arguments' }
-    return { kind: 'ok', cmd: { verb, team: specTok, channels: [] } }
+    return { kind: 'ok', cmd: { verb, team: specTok, project, channels: [] } }
   }
   for (const c of channels) {
     if (!CHANNEL_RE.test(c)) {
       return { kind: 'error', message: `channels must match ${CHANNEL_RE.source}: got "${c}"` }
     }
   }
-  return { kind: 'ok', cmd: { verb, team: specTok, channels } }
+  return { kind: 'ok', cmd: { verb, team: specTok, project, channels } }
 }
 
 // Returns the index of the first non-target token in `tokens`, or null when

--- a/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
+++ b/src/orchestrator/plugins/linear/__tests__/new-issues-plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, spyOn, beforeAll, afterAll } from 'bun:test'
 import { LinearNewIssuesPlugin, type LinearNewIssuesPluginState, formatNewLinearIssue } from '../new-issues-plugin.js'
-import { LinearClient, type LinearIssueNode } from '../linear-api.js'
+import { LinearClient, type LinearIssueNode, type FetchTeamIssuesResult } from '../linear-api.js'
 import type { OrchestratorConfig } from '../../../config.js'
 import { RATE_LIMIT_WINDOW_MS, WARN_COOLDOWN_MS } from '../../_rate-limit.js'
 
@@ -34,8 +34,15 @@ function makePlugin(channel = '#proj-leads'): { plugin: LinearNewIssuesPlugin; c
 }
 
 // Stub fetchTeamOpenIssues on the prototype so all instances in a test get the mock.
-function stubFetch(response: LinearIssueNode[] | null) {
-  return spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue(response)
+// `response === null` maps to team-not-found (the common case in these tests);
+// pass a tagged result directly for project-not-found scenarios.
+function stubFetch(response: LinearIssueNode[] | null | FetchTeamIssuesResult) {
+  const tagged: FetchTeamIssuesResult = response === null
+    ? { kind: 'team-not-found' }
+    : Array.isArray(response)
+      ? { kind: 'ok', issues: response }
+      : response
+  return spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue(tagged)
 }
 
 // Suppress the rate-limit observe path — `getLastRateLimit` returns null, no events.
@@ -194,7 +201,7 @@ describe('LinearNewIssuesPlugin.runTick', () => {
     const calls: string[] = []
     const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (team: string) => {
       calls.push(team)
-      return team === 'C' ? [issue('C-1')] : [issue('MAR-2')]
+      return { kind: 'ok', issues: team === 'C' ? [issue('C-1')] : [issue('MAR-2')] }
     })
     try {
       const config: OrchestratorConfig = {
@@ -216,7 +223,7 @@ describe('LinearNewIssuesPlugin.runTick', () => {
 
   it('seeds a new team entry without emitting when added to an existing config', async () => {
     const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (team: string) => {
-      return team === 'C' ? [issue('C-1')] : [issue('MAR-10'), issue('MAR-11')]
+      return { kind: 'ok', issues: team === 'C' ? [issue('C-1')] : [issue('MAR-10'), issue('MAR-11')] }
     })
     try {
       const config: OrchestratorConfig = {
@@ -271,6 +278,115 @@ describe('LinearNewIssuesPlugin.runTick', () => {
       const result = await plugin.runTick(baseConfig(), prevState([]))
       expect(result.taggedEvents).toHaveLength(0)
       expect(logs.some(l => l.includes('network error'))).toBe(true)
+    } finally { spy.mockRestore() }
+  })
+})
+
+describe('LinearNewIssuesPlugin.runTick — project-scoped watches', () => {
+  stubRateLimit()
+
+  it('passes the project name through to fetchTeamOpenIssues', async () => {
+    const calls: Array<[string, string | undefined]> = []
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (team, project) => {
+      calls.push([team, project])
+      return { kind: 'ok', issues: [] }
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'linear-new-issues': { watched: [{ team: 'C', linearProject: 'SDK 4.3.14' }] } },
+      }
+      const { plugin } = makePlugin()
+      await plugin.runTick(config, null)
+      expect(calls).toEqual([['C', 'SDK 4.3.14']])
+    } finally { spy.mockRestore() }
+  })
+
+  it('keeps a scoped and an unscoped watch on the same team as independent seen-sets', async () => {
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (_team, project) => {
+      return { kind: 'ok', issues: project ? [issue('C-1'), issue('C-2')] : [issue('C-1'), issue('C-2'), issue('C-3')] }
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'linear-new-issues': { watched: [{ team: 'C' }, { team: 'C', linearProject: 'SDK 4.3.14' }] } },
+      }
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(config, { teams: { C: ['C-1'], 'C::SDK 4.3.14': ['C-1'] } })
+      const texts = result.taggedEvents.map(e => (e.payload as { text: string }).text)
+      expect(texts.some(t => t.includes('C-2'))).toBe(true)
+      expect(texts.some(t => t.includes('C-3'))).toBe(true)
+      const state = result.state as LinearNewIssuesPluginState
+      expect(state.teams['C']).toEqual(['C-1', 'C-2', 'C-3'])
+      expect(state.teams['C::SDK 4.3.14']).toEqual(['C-1', 'C-2'])
+    } finally { spy.mockRestore() }
+  })
+
+  // The sharp collision test: two *scoped* entries on the same team with
+  // different project names must not share a state key or a cooldown slot.
+  it('keeps two scoped watches on the same team, different projects, fully independent', async () => {
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (_team, project) => {
+      if (project === 'X') return { kind: 'ok', issues: [issue('C-1'), issue('C-2')] }
+      if (project === 'Y') return { kind: 'ok', issues: [issue('C-10')] }
+      throw new Error(`unexpected project ${project}`)
+    })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'linear-new-issues': {
+            watched: [
+              { team: 'C', linearProject: 'X' },
+              { team: 'C', linearProject: 'Y' },
+            ],
+          },
+        },
+      }
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(config, { teams: { 'C::X': ['C-1'], 'C::Y': [] } })
+      const texts = result.taggedEvents.map(e => (e.payload as { text: string }).text)
+      expect(texts.some(t => t.includes('C-2'))).toBe(true)
+      expect(texts.some(t => t.includes('C-10'))).toBe(true)
+      const state = result.state as LinearNewIssuesPluginState
+      expect(state.teams['C::X']).toEqual(['C-1', 'C-2'])
+      expect(state.teams['C::Y']).toEqual(['C-10'])
+    } finally { spy.mockRestore() }
+  })
+
+  it('emits "project not found in team" (not "team not found") when only the project is missing', async () => {
+    const spy = stubFetch({ kind: 'project-not-found' })
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: { 'linear-new-issues': { watched: [{ team: 'C', linearProject: 'Nope' }] } },
+      }
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(config, null)
+      const warnings = result.taggedEvents.filter(e => (e.payload as { text?: string }).text?.includes('not found'))
+      expect(warnings).toHaveLength(1)
+      const text = (warnings[0]?.payload as { text: string }).text
+      expect(text).toContain('project "Nope" not found in team C')
+      expect(text).toContain('unwatch linear-team C project:"Nope"')
+    } finally { spy.mockRestore() }
+  })
+
+  it('a typo\'d project on team C does not suppress team C\'s own not-found cooldown, and vice versa', async () => {
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockImplementation(async (_team, project) =>
+      project ? { kind: 'project-not-found' } : { kind: 'team-not-found' },
+    )
+    try {
+      const config: OrchestratorConfig = {
+        project: 'proj',
+        plugins: {
+          'linear-new-issues': {
+            watched: [{ team: 'C' }, { team: 'C', linearProject: 'Typo' }],
+          },
+        },
+      }
+      const { plugin } = makePlugin()
+      const result = await plugin.runTick(config, null)
+      const warnings = result.taggedEvents.filter(e => (e.payload as { text?: string }).text?.includes('not found'))
+      expect(warnings).toHaveLength(2)
     } finally { spy.mockRestore() }
   })
 })
@@ -351,8 +467,8 @@ describe('LinearNewIssuesPlugin.runTick — team not found', () => {
     }
     // Put team C in cooldown (warned just now), team MAR has never warned
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(plugin as any)._teamNotFoundWarnedAt.set('C', Date.now())
-    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue(null)
+    ;(plugin as any)._notFoundWarnedAt.set('C', Date.now())
+    const spy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue({ kind: 'team-not-found' })
     try {
       const result = await plugin.runTick(config, null)
       const warnings = result.taggedEvents.filter(e => (e.payload as { text?: string }).text?.includes('not found'))
@@ -368,7 +484,7 @@ describe('LinearNewIssuesPlugin.runTick — team not found', () => {
       const { plugin } = makePlugin()
       // Seed cooldown as if warning fired WARN_COOLDOWN_MS + 1ms ago
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(plugin as any)._teamNotFoundWarnedAt.set('C', Date.now() - WARN_COOLDOWN_MS - 1)
+      ;(plugin as any)._notFoundWarnedAt.set('C', Date.now() - WARN_COOLDOWN_MS - 1)
       const result = await plugin.runTick(baseConfig(), null)
       const warnings = result.taggedEvents.filter(e => (e.payload as { text?: string }).text?.includes('not found'))
       expect(warnings).toHaveLength(1)
@@ -428,7 +544,7 @@ describe('LinearNewIssuesPlugin.observeLinearRateLimit — warning emission', ()
     ;(plugin as any)._rateLimitHistory = [
       { remaining: 2500, ts: Date.now() - 160_000 },
     ]
-    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue({ kind: 'ok', issues: [] })
     try {
       const result = await plugin.runTick(baseConfig(), prevState([]))
       const warnings = result.taggedEvents.filter(e =>
@@ -450,7 +566,7 @@ describe('LinearNewIssuesPlugin.observeLinearRateLimit — warning emission', ()
       limit: 2500,
       resetAt: Math.floor((Date.now() + 60 * 60_000) / 1000),
     })
-    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue({ kind: 'ok', issues: [] })
     try {
       const result = await plugin.runTick(baseConfig(), prevState([]))
       const warnings = result.taggedEvents.filter(e =>
@@ -474,7 +590,7 @@ describe('LinearNewIssuesPlugin.observeLinearRateLimit — warning emission', ()
     ;(plugin as any)._rateLimitHistory = [
       { remaining: 2500, ts: Date.now() - RATE_LIMIT_WINDOW_MS - 10_000 },
     ]
-    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue([])
+    const fetchSpy = spyOn(LinearClient.prototype, 'fetchTeamOpenIssues').mockResolvedValue({ kind: 'ok', issues: [] })
     try {
       const result = await plugin.runTick(baseConfig(), prevState([]))
       const warnings = result.taggedEvents.filter(e =>

--- a/src/orchestrator/plugins/linear/linear-api.ts
+++ b/src/orchestrator/plugins/linear/linear-api.ts
@@ -308,6 +308,43 @@ const TEAM_OPEN_ISSUES_QUERY = `query($teamKey: String!) {
   }
 }`
 
+// Project-scoped variant — fetches the project-existence check and the
+// filtered issue list off the same team node in one round trip, so a scoped
+// watch costs the same one API call per tick as an unscoped one.
+const TEAM_PROJECT_OPEN_ISSUES_QUERY = `query($teamKey: String!, $projectName: String!) {
+  teams(filter: { key: { eq: $teamKey } }) {
+    nodes {
+      projects(filter: { name: { eq: $projectName } }) {
+        nodes { id }
+      }
+      issues(filter: { state: { type: { nin: ["completed", "canceled"] } }, project: { name: { eq: $projectName } } }) {
+        nodes { id identifier title labels { nodes { name } } url }
+      }
+    }
+  }
+}`
+
+// Result of `fetchTeamOpenIssues`. `team-not-found`/`project-not-found` are
+// distinct so callers can emit the right "renamed or deleted?" warning text —
+// a team typo and a project typo look the same to a user staring at silence.
+export type FetchTeamIssuesResult =
+  | { kind: 'team-not-found' }
+  | { kind: 'project-not-found' }
+  | { kind: 'ok'; issues: LinearIssueNode[] }
+
+function parseIssueNodes(nodes: unknown[]): LinearIssueNode[] {
+  return nodes
+    .filter((n): n is Record<string, unknown> => n != null && typeof n === 'object')
+    .map(n => ({
+      id: typeof n.id === 'string' ? n.id : '',
+      identifier: typeof n.identifier === 'string' ? n.identifier : '',
+      title: typeof n.title === 'string' ? n.title : null,
+      labels: isLabelsShape(n.labels) ? n.labels : null,
+      url: typeof n.url === 'string' ? n.url : null,
+    }))
+    .filter(n => n.id && n.identifier)
+}
+
 // ---- Probe shape ----------------------------------------------------------
 
 export interface LinearProbeResult {
@@ -371,26 +408,28 @@ export class LinearClient {
     return result.body.data
   }
 
-  // Fetch open (not completed, not canceled) issues for a team identified by key
-  // (e.g. "C", "MAR"). Returns null when the team key is not found (renamed or
-  // deleted); returns an empty array when the team exists but has no open issues.
-  async fetchTeamOpenIssues(teamKey: string): Promise<LinearIssueNode[] | null> {
+  // Fetch open (not completed, not canceled) issues for a team identified by
+  // key (e.g. "C", "MAR"), optionally scoped to a Linear project name within
+  // that team. `team-not-found` covers a renamed/deleted team key;
+  // `project-not-found` covers a renamed/deleted/typo'd project name within
+  // an otherwise-valid team; `ok` (possibly with an empty `issues` array)
+  // covers everything resolving cleanly.
+  async fetchTeamOpenIssues(teamKey: string, linearProject?: string): Promise<FetchTeamIssuesResult> {
+    if (linearProject) {
+      const data = (await this.graphql(TEAM_PROJECT_OPEN_ISSUES_QUERY, { teamKey, projectName: linearProject })) as {
+        teams?: { nodes?: Array<{ projects?: { nodes?: unknown[] }; issues?: { nodes?: unknown[] } }> }
+      } | undefined | null
+      const teamNode = data?.teams?.nodes?.[0]
+      if (!teamNode) return { kind: 'team-not-found' }
+      if ((teamNode.projects?.nodes ?? []).length === 0) return { kind: 'project-not-found' }
+      return { kind: 'ok', issues: parseIssueNodes(teamNode.issues?.nodes ?? []) }
+    }
     const data = (await this.graphql(TEAM_OPEN_ISSUES_QUERY, { teamKey })) as {
       teams?: { nodes?: Array<{ issues?: { nodes?: unknown[] } }> }
     } | undefined | null
     const teamNode = data?.teams?.nodes?.[0]
-    if (!teamNode) return null
-    const nodes = teamNode.issues?.nodes ?? []
-    return nodes
-      .filter((n): n is Record<string, unknown> => n != null && typeof n === 'object')
-      .map(n => ({
-        id: typeof n.id === 'string' ? n.id : '',
-        identifier: typeof n.identifier === 'string' ? n.identifier : '',
-        title: typeof n.title === 'string' ? n.title : null,
-        labels: isLabelsShape(n.labels) ? n.labels : null,
-        url: typeof n.url === 'string' ? n.url : null,
-      }))
-      .filter(n => n.id && n.identifier)
+    if (!teamNode) return { kind: 'team-not-found' }
+    return { kind: 'ok', issues: parseIssueNodes(teamNode.issues?.nodes ?? []) }
   }
 
   // Boot probe: confirms auth + identifies the workspace and teams. Throws

--- a/src/orchestrator/plugins/linear/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/linear/new-issues-plugin.ts
@@ -1,12 +1,15 @@
-// Per-team new-issue triage feed for Linear. Polls watched teams for open
-// issues and announces the first time a given Linear ID is observed.
+// Per-team (optionally per-project) new-issue triage feed for Linear. Polls
+// watched teams for open issues and announces the first time a given Linear
+// ID is observed.
 //
 // DM grammar: claims target=`linear-team` — `watch linear-team <TEAM>
-// [#chan ...]`. Team key must match `^[A-Z]+$`.
+// [project:"<NAME>"] [#chan ...]`. Team key must match `^[A-Z]+$`.
 //
-// State slice: `{ teams: Record<string, string[]> }`. Seeding (`prev===null`)
-// and first-observation of a new team entry both capture without emitting.
-// Removed entries are carried forward so remove-then-readd doesn't replay.
+// State slice: `{ teams: Record<string, string[]> }`, keyed by
+// `entryKey(team, linearProject)` — bare team key when unscoped, `team::project`
+// when scoped. Seeding (`prev===null`) and first-observation of a new watch
+// entry both capture without emitting. Removed entries are carried forward so
+// remove-then-readd doesn't replay.
 import type { Command } from '../../dispatcher-dm-handler.js'
 import type { OrchestratorConfig } from '../../config.js'
 import type { ParseResult, PluginTickResult, TaggedEvent } from '../../plugin.js'
@@ -15,11 +18,24 @@ import { resolveProjectChannel } from '../../naming.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, type RateLimitStatics } from '../_rate-limit.js'
 import { tryClaimPerLinearTeam, type PerLinearTeamCommand } from '../grammar.js'
-import { LinearClient, type LinearIssueNode } from './linear-api.js'
+import { LinearClient, type FetchTeamIssuesResult, type LinearIssueNode } from './linear-api.js'
 
 export interface LinearNewIssuesWatchEntry {
   team: string
+  // Optional Linear project name scoping this watch to one project within
+  // `team`. Named `linearProject`, not `project` — `OrchestratorConfig.project`
+  // already means the roost project/repo elsewhere in this codebase, and a
+  // same-named field meaning something unrelated one file over invites drift.
+  linearProject?: string
   channels?: string[]
+}
+
+// Identity key for a watch entry: (team, linearProject) pair, not team alone —
+// `watch linear-team C` and `watch linear-team C project:"X"` are independent
+// watches that coexist. Unscoped entries key on the bare team so on-disk state
+// from before project filtering existed keeps matching without a migration.
+function entryKey(team: string, linearProject?: string | null): string {
+  return linearProject ? `${team}::${linearProject}` : team
 }
 
 interface LinearNewIssuesPluginConfig {
@@ -36,8 +52,12 @@ export class LinearNewIssuesPlugin extends BasePlugin {
   private readonly log: PluginLogger
   private readonly client: LinearClient
   private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
-  // Per-instance Map (vs class-static _statics for rate-limit) — team-missing is a per-watcher signal, rate-limit is per-API-budget shared across instances.
-  private _teamNotFoundWarnedAt = new Map<string, number>()
+  // Per-instance Map (vs class-static _statics for rate-limit) — not-found is a
+  // per-watcher signal, rate-limit is per-API-budget shared across instances.
+  // Keyed by `entryKey(team, linearProject)`, not bare team — two scoped
+  // watches on the same team with different (typo'd) project names each get
+  // their own cooldown slot, so one doesn't suppress the other's warning.
+  private _notFoundWarnedAt = new Map<string, number>()
 
   private static readonly _statics: RateLimitStatics = { warnedAt: null }
 
@@ -60,8 +80,8 @@ export class LinearNewIssuesPlugin extends BasePlugin {
     if (cmd.kind === 'help') return this.formatHelpSection()
     if (cmd.kind === 'plugin' && cmd.plugin === this.name) {
       const c = cmd.cmd as PerLinearTeamCommand
-      if (c.verb === 'watch') return this.applyWatch(merged, local, c.team, c.channels)
-      return this.applyUnwatch(merged, local, c.team)
+      if (c.verb === 'watch') return this.applyWatch(merged, local, c.team, c.project, c.channels)
+      return this.applyUnwatch(merged, local, c.team, c.project)
     }
     return null
   }
@@ -70,13 +90,20 @@ export class LinearNewIssuesPlugin extends BasePlugin {
     return this.pluginConfig<LinearNewIssuesPluginConfig>(config)?.watched ?? []
   }
 
-  private applyWatch(merged: OrchestratorConfig, local: OrchestratorConfig, team: string, channels: string[]): string {
-    const labelStr = `linear-team ${team}`
-    const match = (e: LinearNewIssuesWatchEntry) => e.team === team
+  private applyWatch(
+    merged: OrchestratorConfig,
+    local: OrchestratorConfig,
+    team: string,
+    project: string | null,
+    channels: string[],
+  ): string {
+    const labelStr = project ? `linear-team ${team} project:"${project}"` : `linear-team ${team}`
+    const match = (e: LinearNewIssuesWatchEntry) => entryKey(e.team, e.linearProject) === entryKey(team, project)
     if (!this.mergedWatched(merged).some(match)) {
       const slice = this.localSlice<LinearNewIssuesPluginConfig>(local)
       slice.watched ??= []
       const entry: LinearNewIssuesWatchEntry = { team }
+      if (project) entry.linearProject = project
       if (channels.length) entry.channels = [...channels]
       slice.watched.push(entry)
       return channels.length ? `watching ${labelStr} + ${channels.join(' ')}` : `watching ${labelStr}`
@@ -86,34 +113,37 @@ export class LinearNewIssuesPlugin extends BasePlugin {
     return addChannelsToEntry(localEntry, channels, labelStr)
   }
 
-  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, team: string): string {
+  private applyUnwatch(merged: OrchestratorConfig, local: OrchestratorConfig, team: string, project: string | null): string {
+    const labelStr = project ? `linear-team ${team} project:"${project}"` : `linear-team ${team}`
     return applyUnwatchEntry<LinearNewIssuesWatchEntry>(
       this.mergedWatched(merged),
       this.pluginConfig<LinearNewIssuesPluginConfig>(local)?.watched ?? [],
-      e => e.team === team,
-      `linear-team ${team}`,
+      e => entryKey(e.team, e.linearProject) === entryKey(team, project),
+      labelStr,
     )
   }
 
   private formatListSection(merged: OrchestratorConfig): string {
     const entries = this.mergedWatched(merged)
-    const byTeam = new Map<string, Set<string>>()
+    const byKey = new Map<string, { team: string; project: string | null; chans: Set<string> }>()
     const order: string[] = []
     for (const e of entries) {
-      let chans = byTeam.get(e.team)
-      if (!chans) {
-        chans = new Set<string>()
-        byTeam.set(e.team, chans)
-        order.push(e.team)
+      const key = entryKey(e.team, e.linearProject)
+      let g = byKey.get(key)
+      if (!g) {
+        g = { team: e.team, project: e.linearProject ?? null, chans: new Set<string>() }
+        byKey.set(key, g)
+        order.push(key)
       }
-      for (const c of e.channels ?? []) chans.add(c)
+      for (const c of e.channels ?? []) g.chans.add(c)
     }
-    const header = `${this.name} (${byTeam.size}):`
-    if (!byTeam.size) return `${header}\n  (none)`
-    const lines = order.map(t => {
-      const chans = byTeam.get(t)!
-      const chansStr = chans.size ? ` + ${[...chans].join(' ')}` : ''
-      return `  ${t}${chansStr}`
+    const header = `${this.name} (${byKey.size}):`
+    if (!byKey.size) return `${header}\n  (none)`
+    const lines = order.map(k => {
+      const g = byKey.get(k)!
+      const projStr = g.project ? ` project:"${g.project}"` : ''
+      const chansStr = g.chans.size ? ` + ${[...g.chans].join(' ')}` : ''
+      return `  ${g.team}${projStr}${chansStr}`
     })
     return [header, ...lines].join('\n')
   }
@@ -121,9 +151,9 @@ export class LinearNewIssuesPlugin extends BasePlugin {
   private formatHelpSection(): string {
     return [
       `${this.name} commands (DM only):`,
-      `  watch linear-team <TEAM> [#chan ...]   — watch new-issues feed for TEAM`,
-      `  unwatch linear-team <TEAM>             — stop watching new-issues feed`,
-      `  watch list                             — include this plugin's watched teams in the reply`,
+      `  watch linear-team <TEAM> [project:"<NAME>"] [#chan ...]   — watch new-issues feed for TEAM, optionally scoped to a project`,
+      `  unwatch linear-team <TEAM> [project:"<NAME>"]              — stop watching new-issues feed`,
+      `  watch list                                                 — include this plugin's watched teams in the reply`,
     ].join('\n')
   }
 
@@ -150,37 +180,44 @@ export class LinearNewIssuesPlugin extends BasePlugin {
     const nextTeams: Record<string, string[]> = prev ? { ...prev.teams } : {}
 
     for (const entry of watchEntries) {
-      const { team, channels } = entry
+      const { team, linearProject, channels } = entry
+      const key = entryKey(team, linearProject)
+      const watchLabel = linearProject ? `team ${team} project "${linearProject}"` : `team ${team}`
+      const unwatchCmd = linearProject ? `unwatch linear-team ${team} project:"${linearProject}"` : `unwatch linear-team ${team}`
       const announcementChannels = channels?.length
         ? [...channels]
         : [resolveProjectChannel(config)]
 
-      let issues: LinearIssueNode[] | null
+      let result: FetchTeamIssuesResult
       try {
-        issues = await this.client.fetchTeamOpenIssues(team)
+        result = await this.client.fetchTeamOpenIssues(team, linearProject)
       } catch (e) {
-        this.log(`linear-new-issues: error fetching team ${team}: ${e instanceof Error ? e.message : String(e)}\n`)
+        this.log(`linear-new-issues: error fetching ${watchLabel}: ${e instanceof Error ? e.message : String(e)}\n`)
         continue
       }
 
-      if (issues === null) {
+      if (result.kind !== 'ok') {
         const now = Date.now()
-        const lastWarnedAt = this._teamNotFoundWarnedAt.get(team) ?? 0
+        const lastWarnedAt = this._notFoundWarnedAt.get(key) ?? 0
         if (now - lastWarnedAt > WARN_COOLDOWN_MS) {
-          this._teamNotFoundWarnedAt.set(team, now)
+          this._notFoundWarnedAt.set(key, now)
+          const reason = result.kind === 'team-not-found'
+            ? `team ${team} not found`
+            : `project "${linearProject}" not found in team ${team}`
           taggedEvents.push({
             channels: [...announcementChannels],
-            payload: { kind: 'oneline', text: `[linear-new-issues] team ${team} not found — renamed or deleted? Unwatch with: \`unwatch linear-team ${team}\`` },
+            payload: { kind: 'oneline', text: `[linear-new-issues] ${reason} — renamed or deleted? Unwatch with: \`${unwatchCmd}\`` },
           })
         }
         continue
       }
+      const issues = result.issues
 
-      // First observation of this team (or full re-seed): capture without emitting.
-      const isFirstForTeam = prev === null || prev.teams[team] === undefined
-      const seen = new Set<string>(prev?.teams[team] ?? [])
+      // First observation of this watch (or full re-seed): capture without emitting.
+      const isFirstForKey = prev === null || prev.teams[key] === undefined
+      const seen = new Set<string>(prev?.teams[key] ?? [])
 
-      if (!isFirstForTeam) {
+      if (!isFirstForKey) {
         const newIssues = issues
           .filter(i => !seen.has(i.identifier))
           .sort((a, b) => linearIdNum(a.identifier) - linearIdNum(b.identifier))
@@ -193,7 +230,7 @@ export class LinearNewIssuesPlugin extends BasePlugin {
       }
 
       for (const i of issues) seen.add(i.identifier)
-      nextTeams[team] = [...seen].sort((a, b) => linearIdNum(a) - linearIdNum(b))
+      nextTeams[key] = [...seen].sort((a, b) => linearIdNum(a) - linearIdNum(b))
     }
 
     taggedEvents.push(...this.observeLinearRateLimit(resolveProjectChannel(config)))


### PR DESCRIPTION
Closes #667

`watch linear-team <TEAM>` now optionally takes `project:"<NAME>"` to scope the new-issue feed to one Linear project within that team, instead of always announcing every open issue for the whole team.

- Grammar: `project:"<name>"` is pulled out of the raw line before whitespace tokenizing (project names have spaces), with a fixit for the unquoted/empty forms.
- `LinearClient.fetchTeamOpenIssues` returns a tagged result (`team-not-found` / `project-not-found` / `ok`) instead of null-or-array, so a typo'd project name gets its own warning, symmetric with the existing team-not-found one — one GraphQL call either way.
- Watch entries key on `(team, linearProject)`, not team alone, so a bare team watch and one or more project-scoped watches on the same team coexist with independent seen-sets and independent not-found cooldowns.
- Field is `linearProject`, not `project` — `config.project` already means the roost project/repo elsewhere in this codebase.

Known accepted limitation: a project name containing `,`/`;`/newline can't round-trip through a DM (`splitCommands` splits the message before this parser sees a line).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (full suite, 1066 pass)