### PR TITLE
Surface the GraphQL-point rate-limit budget in observeRateLimit

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -399,13 +399,38 @@ describe('mapBatchOutcomes (per-alias isolation)', () => {
 describe('fetchRateLimit', () => {
   const noopLog = () => {}
 
-  it('returns parsed RateLimitInfo on success', async () => {
+  it('returns parsed core budget on success', async () => {
     const exec = async () => ({ rate: { limit: 5000, remaining: 4987, reset: 1716000000 } })
-    const info = await fetchRateLimit(noopLog, { exec })
-    expect(info).toEqual({ limit: 5000, remaining: 4987, resetAt: 1716000000 })
+    const snapshot = await fetchRateLimit(noopLog, { exec })
+    expect(snapshot?.core).toEqual({ limit: 5000, remaining: 4987, resetAt: 1716000000 })
   })
 
-  it('returns null when rate field is absent', async () => {
+  it('also parses the graphql budget from resources.graphql', async () => {
+    const exec = async () => ({
+      rate: { limit: 5000, remaining: 4987, reset: 1716000000 },
+      resources: { graphql: { limit: 5000, remaining: 4321, reset: 1716000500 } },
+    })
+    const snapshot = await fetchRateLimit(noopLog, { exec })
+    expect(snapshot?.graphql).toEqual({ limit: 5000, remaining: 4321, resetAt: 1716000500 })
+  })
+
+  it('graphql is null when resources.graphql is absent (core still returned)', async () => {
+    const exec = async () => ({ rate: { limit: 5000, remaining: 4987, reset: 1716000000 } })
+    const snapshot = await fetchRateLimit(noopLog, { exec })
+    expect(snapshot?.graphql).toBeNull()
+    expect(snapshot?.core).not.toBeNull()
+  })
+
+  it('graphql is null when resources.graphql fields are incomplete', async () => {
+    const exec = async () => ({
+      rate: { limit: 5000, remaining: 4987, reset: 1716000000 },
+      resources: { graphql: { limit: 5000 } },  // missing remaining + reset
+    })
+    const snapshot = await fetchRateLimit(noopLog, { exec })
+    expect(snapshot?.graphql).toBeNull()
+  })
+
+  it('returns null when rate field is absent (core is required)', async () => {
     const exec = async () => ({ resources: { core: { limit: 5000, remaining: 4987, reset: 1716000000 } } })
     expect(await fetchRateLimit(noopLog, { exec })).toBeNull()
   })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -1820,4 +1820,23 @@ describe('GhPluginBase.observeRateLimit — graphql budget', () => {
     expect(result).toHaveLength(1)
     expect((result[0].payload as { text: string }).text).toContain('GH-GraphQL')
   })
+
+  it('both budgets can warn in the same tick when both cooldowns are clear', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    const now = Date.now()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(GhPluginBase as any)._statics.warnedAt = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(GhPluginBase as any)._gqlStatics.warnedAt = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [{ remaining: 5000, ts: now - 160_000 }]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._graphqlRateLimitHistory = [{ remaining: 5000, ts: now - 160_000 }]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any = await (plugin as any).observeRateLimit('#proj', snapshotFetch({ remaining: 100 }, { remaining: 100 }))
+    expect(result).toHaveLength(2)
+    const texts: string[] = result.map((e: { payload: { text: string } }) => e.payload.text)
+    expect(texts.some(t => t.includes('GH-GraphQL'))).toBe(true)
+    expect(texts.some(t => t.includes('GH ') && !t.includes('GH-GraphQL'))).toBe(true)
+  })
 })

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -1708,9 +1708,8 @@ describe('GhPluginBase.observeRateLimit integration', () => {
 describe('GhPluginBase.observeRateLimit — pruning and anchor selection', () => {
   function observe(plugin: GitHubPrsPlugin, remaining: number, resetInMs = 60 * 60_000) {
     const fetch = async () => ({
-      remaining,
-      limit: 5000,
-      resetAt: Math.floor((Date.now() + resetInMs) / 1000),
+      core: { remaining, limit: 5000, resetAt: Math.floor((Date.now() + resetInMs) / 1000) },
+      graphql: null,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (plugin as any).observeRateLimit('#proj', fetch)
@@ -1763,5 +1762,62 @@ describe('GhPluginBase.observeRateLimit — pruning and anchor selection', () =>
       { remaining: 4800, ts: now - 10_000 },
     ]
     expect(await observe(plugin, 4800, 60 * 60_000)).toEqual([])
+  })
+})
+
+describe('GhPluginBase.observeRateLimit — graphql budget', () => {
+  function snapshotFetch(core: { remaining: number; resetInMs?: number }, graphql: { remaining: number; resetInMs?: number } | null) {
+    return async () => ({
+      core: { remaining: core.remaining, limit: 5000, resetAt: Math.floor((Date.now() + (core.resetInMs ?? 60 * 60_000)) / 1000) },
+      graphql: graphql
+        ? { remaining: graphql.remaining, limit: 5000, resetAt: Math.floor((Date.now() + (graphql.resetInMs ?? 60 * 60_000)) / 1000) }
+        : null,
+    })
+  }
+
+  it('logs both core and graphql budgets in one tick', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    const logs: string[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any).log = (m: string) => logs.push(m)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (plugin as any).observeRateLimit('#proj', snapshotFetch({ remaining: 5000 }, { remaining: 4000 }))
+    expect(logs.some(l => l.includes('[ratelimit] gh remaining=5000'))).toBe(true)
+    expect(logs.some(l => l.includes('[ratelimit] gh-graphql remaining=4000'))).toBe(true)
+  })
+
+  it('omits graphql log line when the snapshot has no graphql budget', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    const logs: string[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any).log = (m: string) => logs.push(m)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (plugin as any).observeRateLimit('#proj', snapshotFetch({ remaining: 5000 }, null))
+    expect(logs.some(l => l.includes('[ratelimit] gh remaining='))).toBe(true)
+    expect(logs.some(l => l.includes('gh-graphql'))).toBe(false)
+  })
+
+  it('graphql warning fires while core is in cooldown from a prior warn', async () => {
+    const plugin = new GitHubPrsPlugin('#proj')
+    const now = Date.now()
+    // Force core's cross-instance cooldown active, as if it just warned —
+    // deterministic instead of relying on a real prior warn elsewhere in the
+    // suite (GhPluginBase._statics is shared by every GH plugin/test in the file).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(GhPluginBase as any)._statics.warnedAt = now
+    // graphql's static must start clear so this test isn't order-dependent either.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(GhPluginBase as any)._gqlStatics.warnedAt = null
+
+    // Core bursts too (would warn if not suppressed); graphql also bursts for
+    // the first time and should still fire — proving the cooldowns are independent.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._rateLimitHistory = [{ remaining: 5000, ts: now - 160_000 }]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)._graphqlRateLimitHistory = [{ remaining: 5000, ts: now - 160_000 }]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (plugin as any).observeRateLimit('#proj', snapshotFetch({ remaining: 100 }, { remaining: 100 }))
+    expect(result).toHaveLength(1)
+    expect((result[0].payload as { text: string }).text).toContain('GH-GraphQL')
   })
 })

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -5,8 +5,8 @@ import { channelSlug, defaultProject, issueChannel } from '../../naming.js'
 import { BasePlugin, defaultPluginLogger, type ParseResult, type PluginLogger, type PluginTickResult, type TaggedEvent } from '../../plugin.js'
 import { addChannelsToEntry, applyUnwatchEntry, trackedRefusal } from '../_shared.js'
 import { tryClaimPerN, type PerNCommand } from '../grammar.js'
-import { GhClient, GhError, describeReadFailure, fetchRateLimit, isRateLimitError, rateLimitKind } from './github-api.js'
-import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, type RateLimitInfo, type RateLimitStatics } from '../_rate-limit.js'
+import { GhClient, GhError, describeReadFailure, fetchRateLimit, isRateLimitError, rateLimitKind, type RateLimitSnapshot } from './github-api.js'
+import { observeRateLimitFromInfo, WARN_COOLDOWN_MS, type RateLimitStatics } from '../_rate-limit.js'
 import { RateLimitBreaker, READ_FAILURE_THRESHOLD, SECONDARY_BACKOFF_SCHEDULE_MS, BACKOFF_SCHEDULE_MS, formatBackoffNotice, formatReadFailureNote, formatBatchFailureNote, type RateLimitKind } from './backoff.js'
 
 // Per-entry read outcome. `readEntry` never throws the expected gh-error
@@ -24,9 +24,13 @@ export abstract class GhPluginBase extends BasePlugin {
   protected readonly log: PluginLogger
 
   private _rateLimitHistory: Array<{ remaining: number; ts: number }> = []
+  private _graphqlRateLimitHistory: Array<{ remaining: number; ts: number }> = []
 
-  // Cross-instance cooldown handle — one warning per 10 min total.
+  // Cross-instance cooldown handles — one warning per 10 min total, core and
+  // graphql tracked independently so a graphql-budget warning isn't suppressed
+  // by (or suppresses) a core-budget one.
   private static readonly _statics: RateLimitStatics = { warnedAt: null }
+  private static readonly _gqlStatics: RateLimitStatics = { warnedAt: null }
 
   // One breaker shared across every GH plugin — they poll one shared GH budget,
   // so a rate-limit on any of them should quiet all of them.
@@ -235,13 +239,16 @@ export abstract class GhPluginBase extends BasePlugin {
   // Runs even when scrapes failed — a failing tick is often a symptom of exhaustion.
   protected async observeRateLimit(
     projectChannel: string,
-    _fetch: (log: PluginLogger) => Promise<RateLimitInfo | null> = fetchRateLimit,
+    _fetch: (log: PluginLogger) => Promise<RateLimitSnapshot | null> = fetchRateLimit,
   ): Promise<TaggedEvent[]> {
-    const info = await _fetch(this.log)
-    if (!info) return []
-    const { events, history } = observeRateLimitFromInfo(info, this._rateLimitHistory, GhPluginBase._statics, this.log, projectChannel, 'GH')
-    this._rateLimitHistory = history
-    return events
+    const snapshot = await _fetch(this.log)
+    if (!snapshot) return []
+    const core = observeRateLimitFromInfo(snapshot.core, this._rateLimitHistory, GhPluginBase._statics, this.log, projectChannel, 'GH')
+    this._rateLimitHistory = core.history
+    if (!snapshot.graphql) return core.events
+    const graphql = observeRateLimitFromInfo(snapshot.graphql, this._graphqlRateLimitHistory, GhPluginBase._gqlStatics, this.log, projectChannel, 'GH-GraphQL')
+    this._graphqlRateLimitHistory = graphql.history
+    return [...core.events, ...graphql.events]
   }
 }
 

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -232,20 +232,37 @@ export async function spawnGh(args: string[], deps: SpawnDeps): Promise<unknown>
 
 // ---- Rate limit observability ----------------------------------------------
 
+// core (REST) budget + graphql (point) budget from the same /rate_limit call.
+// graphql is null when the response doesn't carry `resources.graphql` (e.g. a
+// stale gh CLI) — core alone is still worth surfacing.
+export interface RateLimitSnapshot {
+  core: RateLimitInfo
+  graphql: RateLimitInfo | null
+}
+
+function parseBudget(raw: unknown): RateLimitInfo | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const b = raw as { remaining?: number; limit?: number; reset?: number }
+  if (b.remaining == null || b.limit == null || b.reset == null) return null
+  return { remaining: b.remaining, limit: b.limit, resetAt: b.reset }
+}
+
 // `gh api /rate_limit` — exempt endpoint, no token cost. `attempts: 1` because
 // retries would burn the budget we're trying to measure. Null on any failure.
 export async function fetchRateLimit(
   log: PluginLogger,
   deps?: Partial<SpawnDeps>
-): Promise<RateLimitInfo | null> {
+): Promise<RateLimitSnapshot | null> {
   try {
     // `attempts: 1` is last so deps can't accidentally override it.
     const raw = await spawnGh(['api', '/rate_limit'], { log, ...deps, attempts: 1 })
     if (raw == null || typeof raw !== 'object') return null
     const resp = raw as Record<string, unknown>
-    const rate = resp.rate as { remaining?: number; limit?: number; reset?: number } | undefined
-    if (!rate || rate.remaining == null || rate.limit == null || rate.reset == null) return null
-    return { remaining: rate.remaining, limit: rate.limit, resetAt: rate.reset }
+    const core = parseBudget(resp.rate)
+    if (!core) return null
+    const resources = resp.resources as Record<string, unknown> | undefined
+    const graphql = resources ? parseBudget(resources.graphql) : null
+    return { core, graphql }
   } catch {
     return null
   }


### PR DESCRIPTION
Closes #659

## What
`fetchRateLimit` now returns `{ core, graphql }`, parsed from the same `gh api /rate_limit` call (no extra cost) — `resources.graphql` was already in that response but dropped. `GhPluginBase.observeRateLimit` logs both budgets each tick and runs the existing rolling-rate exhaustion warning against graphql independently of core, with its own cross-instance cooldown (`_gqlStatics`, mirrors `_statics`).

Why this matters: #650's batch rewrite moved watched PR/issue reads onto the GraphQL-point budget, which scales with N × nested-connection depth. Without this, a primary rate-limit on that budget would surface on `resources.graphql` and be invisible to the `[ratelimit]` log line.

## Testing
- `github-api.test.ts`: `fetchRateLimit` parses `resources.graphql`, is null when absent/incomplete, core still required.
- `plugin.test.ts`: both budgets log per tick, graphql line omitted when absent, and a graphql warning fires while core's cooldown is active (proves independence — the real regression guard here, not just a parse-shape test).
- Full suite (1062 tests), lint, typecheck all green.

## Follow-up
The high-N load test called out in the issue (padding the watch list to storm-representative N as the conclusive scaling check) needs a storm-representative watch list + live creds — tracked separately in #681, enabled by this PR but out of scope for it.