### PR TITLE
dispatcher: honor exact secondary-limit Retry-After via --include header capture

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/backoff.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/backoff.test.ts
@@ -97,6 +97,29 @@ describe('RateLimitBreaker — secondary (burst) schedule', () => {
   })
 })
 
+describe('RateLimitBreaker — exact Retry-After override', () => {
+  it('honors an exact override under the schedule floor (the whole point: GH often clears faster than our fixed floor)', () => {
+    const b = new RateLimitBreaker()
+    expect(b.trip(T0, SECONDARY_BACKOFF_SCHEDULE_MS, 20_000)).toBe(20_000)
+  })
+
+  it('clamps an implausibly large exact value to the schedule ceiling', () => {
+    const b = new RateLimitBreaker()
+    const ceiling = SECONDARY_BACKOFF_SCHEDULE_MS[SECONDARY_BACKOFF_SCHEDULE_MS.length - 1]
+    expect(b.trip(T0, SECONDARY_BACKOFF_SCHEDULE_MS, 999 * M)).toBe(ceiling)
+  })
+
+  it('clamps a sub-second exact value up to 1s (sanity floor, not the schedule floor)', () => {
+    const b = new RateLimitBreaker()
+    expect(b.trip(T0, SECONDARY_BACKOFF_SCHEDULE_MS, 10)).toBe(1000)
+  })
+
+  it('falls back to the schedule when no exact value is given', () => {
+    const b = new RateLimitBreaker()
+    expect(b.trip(T0, SECONDARY_BACKOFF_SCHEDULE_MS, undefined)).toBe(1 * M)
+  })
+})
+
 describe('format helpers', () => {
   it('formatBackoffNotice renders the window in minutes', () => {
     expect(formatBackoffNotice(5 * M)).toBe('[dispatcher] GH rate-limited, backing off 5m')
@@ -107,6 +130,11 @@ describe('format helpers', () => {
     // Primary is the default and keeps the original wording.
     expect(formatBackoffNotice(5 * M, 'primary')).toBe('[dispatcher] GH rate-limited, backing off 5m')
     expect(formatBackoffNotice(1 * M, 'secondary')).toBe('[dispatcher] GH secondary rate-limited, backing off 1m')
+  })
+
+  it('formatBackoffNotice renders sub-minute windows in seconds, not a rounded-down "0m"', () => {
+    expect(formatBackoffNotice(20_000, 'secondary')).toBe('[dispatcher] GH secondary rate-limited, backing off 20s')
+    expect(formatBackoffNotice(59_000, 'secondary')).toBe('[dispatcher] GH secondary rate-limited, backing off 59s')
   })
 
   it('formatReadFailureNote surfaces the failure reason and embeds the verbatim recovery command', () => {

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -409,6 +409,15 @@ describe('spawnGh --include header capture (Retry-After)', () => {
         .rejects.toMatchObject({ retryAfterMs: undefined })
     } finally { spawn.mockRestore() }
   })
+
+  it('strips the status-line+header block on a successful (exit 0) --include response, returning just the parsed body', async () => {
+    const stdout = 'HTTP/2.0 200 OK\r\nContent-Type: application/json; charset=utf-8\r\n\r\n{"remaining":10}'
+    const spawn = stubGhSpawn(stdout, 0)
+    try {
+      const result = await spawnGh(['api', '--include', 'rate_limit'], { log: () => {} })
+      expect(result).toEqual({ remaining: 10 })
+    } finally { spawn.mockRestore() }
+  })
 })
 
 describe('rollupToCiState', () => {

--- a/src/orchestrator/plugins/github/__tests__/github-api.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/github-api.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'bun:test'
-import { GhError, spawnGh, fetchRateLimit, isRateLimitError, describeReadFailure, rollupToCiState, rateLimitKind, mapBatchOutcomes } from '../github-api.js'
+import { describe, it, expect, spyOn } from 'bun:test'
+import { GhError, spawnGh, fetchRateLimit, isRateLimitError, describeReadFailure, rollupToCiState, rateLimitKind, mapBatchOutcomes, parseIncludeOutput } from '../github-api.js'
 import { computeRateLimitWarning, RATE_LIMIT_WINDOW_MS, type RateLimitInfo } from '../../_rate-limit.js'
+
+// Fake a `gh` subprocess so the header-capture tests drive gh's real
+// --include stdout contract (status line + headers + body, verified against a
+// real `gh api -i` 404) rather than a hand-shaped stand-in.
+function stubGhSpawn(stdout: string, exitCode: number, stderr = ''): { mockRestore(): void } {
+  return spyOn(Bun, 'spawn').mockReturnValue({
+    stdout, stderr, exited: Promise.resolve(exitCode),
+  } as unknown as ReturnType<typeof Bun.spawn>)
+}
 
 function mkErr(stderr: string): GhError {
   return new GhError(`gh failed (exit 1): gh api foo\n${stderr.trim()}`, stderr)
@@ -332,6 +341,73 @@ describe('rateLimitKind', () => {
     // Primary budget exhaustion and a bare 429 are not tagged secondary.
     expect(rateLimitKind(mkErr('gh: HTTP 403: API rate limit exceeded for user ID 1'))).toBe('primary')
     expect(rateLimitKind(mkErr('gh: HTTP 429: Too Many Requests'))).toBe('primary')
+  })
+})
+
+describe('parseIncludeOutput', () => {
+  it('splits the status line, lowercases header keys, and isolates the body — matches a real `gh api -i` 403', () => {
+    const raw = 'HTTP/2.0 403 Forbidden\r\nRetry-After: 30\r\nContent-Type: application/json; charset=utf-8\r\n\r\n' +
+      '{"message":"You have exceeded a secondary rate limit"}'
+    const parsed = parseIncludeOutput(raw)
+    expect(parsed.status).toBe(403)
+    expect(parsed.headers.get('retry-after')).toBe('30')
+    expect(parsed.headers.get('content-type')).toBe('application/json; charset=utf-8')
+    expect(parsed.body).toBe('{"message":"You have exceeded a secondary rate limit"}')
+  })
+
+  it('handles LF-only header blocks, not just CRLF', () => {
+    const parsed = parseIncludeOutput('HTTP/2.0 200 OK\nX-Foo: bar\n\n{"ok":true}')
+    expect(parsed.status).toBe(200)
+    expect(parsed.headers.get('x-foo')).toBe('bar')
+    expect(parsed.body).toBe('{"ok":true}')
+  })
+
+  it('passes non-HTTP text through unchanged — a call that never went through --include, or a network failure with no response at all', () => {
+    const raw = '{"data":{"e0":null}}'
+    const parsed = parseIncludeOutput(raw)
+    expect(parsed.status).toBeNull()
+    expect(parsed.headers.size).toBe(0)
+    expect(parsed.body).toBe(raw)
+  })
+})
+
+describe('spawnGh --include header capture (Retry-After)', () => {
+  it('captures a whole-second Retry-After onto the thrown GhError', async () => {
+    const stdout = 'HTTP/2.0 403 Forbidden\r\nRetry-After: 30\r\n\r\n{"message":"secondary rate limit"}'
+    const spawn = stubGhSpawn(stdout, 1, 'gh: HTTP 403: You have exceeded a secondary rate limit')
+    try {
+      await expect(spawnGh(['api', '--include', 'repos/org/repo/commits'], { log: () => {}, attempts: 1 }))
+        .rejects.toMatchObject({ retryAfterMs: 30_000 })
+    } finally { spawn.mockRestore() }
+  })
+
+  it('rounds a fractional Retry-After to the nearest ms', async () => {
+    const stdout = 'HTTP/2.0 403 Forbidden\r\nRetry-After: 1.5\r\n\r\n{}'
+    const spawn = stubGhSpawn(stdout, 1, 'gh: HTTP 403: You have exceeded a secondary rate limit')
+    try {
+      await expect(spawnGh(['api', '--include', 'x'], { log: () => {}, attempts: 1 }))
+        .rejects.toMatchObject({ retryAfterMs: 1500 })
+    } finally { spawn.mockRestore() }
+  })
+
+  it('treats a non-numeric Retry-After (an HTTP-date, or junk) as malformed — undefined, never a NaN', async () => {
+    // GitHub's documented secondary-limit Retry-After is delta-seconds; HTTP in
+    // general also allows an HTTP-date, but GH doesn't send one for this header.
+    // A stray date-shaped value must fall back cleanly, not produce NaN.
+    const stdout = 'HTTP/2.0 403 Forbidden\r\nRetry-After: Wed, 21 Oct 2015 07:28:00 GMT\r\n\r\n{}'
+    const spawn = stubGhSpawn(stdout, 1, 'gh: HTTP 403: You have exceeded a secondary rate limit')
+    try {
+      await expect(spawnGh(['api', '--include', 'x'], { log: () => {}, attempts: 1 }))
+        .rejects.toMatchObject({ retryAfterMs: undefined })
+    } finally { spawn.mockRestore() }
+  })
+
+  it('never attempts header parsing when the call did not opt into --include', async () => {
+    const spawn = stubGhSpawn('', 1, 'gh: HTTP 403: You have exceeded a secondary rate limit')
+    try {
+      await expect(spawnGh(['api', 'x'], { log: () => {}, attempts: 1 }))
+        .rejects.toMatchObject({ retryAfterMs: undefined })
+    } finally { spawn.mockRestore() }
   })
 })
 

--- a/src/orchestrator/plugins/github/__tests__/resilience.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/resilience.test.ts
@@ -241,9 +241,9 @@ function stubIssuesBatch(fn: (n: number) => BatchOutcome<GhIssueNode>): { mockRe
 // contract. Bun.spawn is the seam runGhGraphqlBatchOnce shells out through, so
 // mocking it exercises the actual per-alias-isolation and RATE_LIMITED paths
 // end-to-end — the mechanism the stubPrsBatch mock above short-circuits.
-function stubGhSpawn(stdout: string, exitCode: number): { mockRestore(): void } {
+function stubGhSpawn(stdout: string, exitCode: number, stderr = ''): { mockRestore(): void } {
   return spyOn(Bun, 'spawn').mockReturnValue({
-    stdout, stderr: '', exited: Promise.resolve(exitCode),
+    stdout, stderr, exited: Promise.resolve(exitCode),
   } as unknown as ReturnType<typeof Bun.spawn>)
 }
 
@@ -415,6 +415,37 @@ describe('gh-call resilience — per-N skip path (issues/prs)', () => {
       ])
       expect(out.get('org/repo#1')).toEqual({ ok: true, node: { number: 1, state: 'OPEN' } })
       expect(out.get('org/repo#2')!.ok).toBe(false)  // dead alias isolated, not thrown
+    } finally { spawn.mockRestore() }
+  })
+
+  it('the same partial {data,errors} body wrapped in --include\'s status-line+header block still isolates the dead alias', async () => {
+    // runBatchQuery now always passes --include, so stdout leads with
+    // `HTTP/2.0 200 OK` + headers before the body gh used to write directly.
+    // That header block must be stripped before the 'data' in parsed check —
+    // otherwise the isolation test above would pass while the real call fails.
+    const jsonBody = JSON.stringify({
+      data: { e0: { pullRequest: { number: 1, state: 'OPEN' } }, e1: { pullRequest: null } },
+      errors: [{ type: 'NOT_FOUND', path: ['e1', 'pullRequest'], message: 'Could not resolve to a PullRequest' }],
+    })
+    const wrapped = `HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n${jsonBody}`
+    const spawn = stubGhSpawn(wrapped, 1)
+    try {
+      const out = await new GhClient(() => {}).fetchPrsBatch([
+        { repo: 'org/repo', number: 1 }, { repo: 'org/repo', number: 2 },
+      ])
+      expect(out.get('org/repo#1')).toEqual({ ok: true, node: { number: 1, state: 'OPEN' } })
+      expect(out.get('org/repo#2')!.ok).toBe(false)
+    } finally { spawn.mockRestore() }
+  })
+
+  it('a whole-batch secondary rate-limit carrying a Retry-After header honors the exact sub-minute wait (real exec seam)', async () => {
+    const wrapped = 'HTTP/2.0 403 Forbidden\r\nRetry-After: 20\r\n\r\n{"message":"You have exceeded a secondary rate limit"}'
+    const spawn = stubGhSpawn(wrapped, 1, 'gh: HTTP 403: You have exceeded a secondary rate limit')
+    try {
+      const config: OrchestratorConfig = { project: 'proj', repo: 'org/repo', plugins: { 'github-prs': { watched: [{ number: 1 }] } } }
+      const result = await new GitHubPrsPlugin('#proj-leads').runTick(config, { prs: {} })
+      // 20s honored, not the schedule's 1m floor.
+      expect(oneline(result.taggedEvents[0]!)).toBe('[dispatcher] GH secondary rate-limited, backing off 20s')
     } finally { spawn.mockRestore() }
   })
 

--- a/src/orchestrator/plugins/github/backoff.ts
+++ b/src/orchestrator/plugins/github/backoff.ts
@@ -41,12 +41,18 @@ export class RateLimitBreaker {
   // in the future and concurrent trips this tick see now < until and no-op.
   // `schedule` selects the window length by rate-limit kind (primary vs
   // secondary); the escalation level is shared across kinds — repeated trips of
-  // any kind back off further. Returns the new window (ms) when it actually
-  // advanced, else null.
-  trip(now: number, schedule: ReadonlyArray<number> = BACKOFF_SCHEDULE_MS): number | null {
+  // any kind back off further. `exactMs`, when given, overrides the scheduled
+  // window with GitHub's own Retry-After value — clamped to [1s, the
+  // schedule's own ceiling] as a sanity bound, with no floor at the schedule's
+  // minimum: the point of honoring it is that GH's real burst-limiter often
+  // clears faster than our fixed floor. Returns the new window (ms) when it
+  // actually advanced, else null.
+  trip(now: number, schedule: ReadonlyArray<number> = BACKOFF_SCHEDULE_MS, exactMs?: number): number | null {
     if (this.level > 0 && now < this.until) return null
     const idx = Math.min(this.level, schedule.length - 1)
-    const window = schedule[idx]
+    const window = exactMs != null && Number.isFinite(exactMs)
+      ? Math.min(Math.max(exactMs, 1000), schedule[schedule.length - 1])
+      : schedule[idx]
     this.level = Math.min(this.level + 1, schedule.length)
     this.until = now + window
     return window
@@ -75,10 +81,13 @@ export class RateLimitBreaker {
 
 // One-line notice posted when the breaker opens or escalates. Names the kind so
 // an operator can tell a burst-limit blip (secondary) from budget exhaustion
-// (primary) without digging the log.
+// (primary) without digging the log. Sub-minute windows (an honored exact
+// Retry-After can be well under a minute) render in seconds rather than
+// rounding down to a misleading "0m".
 export function formatBackoffNotice(windowMs: number, kind: RateLimitKind = 'primary'): string {
   const label = kind === 'secondary' ? 'secondary rate-limited' : 'rate-limited'
-  return `[dispatcher] GH ${label}, backing off ${Math.round(windowMs / 60_000)}m`
+  const duration = windowMs < 60_000 ? `${Math.round(windowMs / 1000)}s` : `${Math.round(windowMs / 60_000)}m`
+  return `[dispatcher] GH ${label}, backing off ${duration}`
 }
 
 // Cooldown-gated note for an entry whose read keeps failing past the

--- a/src/orchestrator/plugins/github/base.ts
+++ b/src/orchestrator/plugins/github/base.ts
@@ -14,7 +14,7 @@ import { RateLimitBreaker, READ_FAILURE_THRESHOLD, SECONDARY_BACKOFF_SCHEDULE_MS
 // never abandons sibling reads (bun late-rejection footgun) on the first error.
 export type ReadEntryResult<T> =
   | { ok: true; value: T }
-  | { ok: false; rateLimited: true; kind: RateLimitKind }
+  | { ok: false; rateLimited: true; kind: RateLimitKind; retryAfterMs?: number }
   | { ok: false; rateLimited: false; events: TaggedEvent[] }
 
 // Shared base for plugins needing GhClient. GhBase extends this for watch-list
@@ -83,16 +83,21 @@ export abstract class GhPluginBase extends BasePlugin {
   // A rate-limit surfaced this tick: open/escalate the breaker, emit one notice
   // when it actually advanced, preserve state and channels. `kind` picks the
   // backoff schedule — secondary (burst) clears fast so it gets a ~1m floor;
-  // primary (budget) waits out the longer reset window.
+  // primary (budget) waits out the longer reset window. `retryAfterMs`, when
+  // present, only overrides the window for the secondary kind — GH's
+  // Retry-After header is the burst limiter's own answer; primary's reset is a
+  // different signal (the budget epoch) and stays schedule-only here.
   protected breakerTripResult(
     now: number,
     prevState: unknown,
     projectChannel: string,
     config: OrchestratorConfig,
     kind: RateLimitKind = 'primary',
+    retryAfterMs?: number,
   ): PluginTickResult {
     const schedule = kind === 'secondary' ? SECONDARY_BACKOFF_SCHEDULE_MS : BACKOFF_SCHEDULE_MS
-    const window = GhPluginBase._breaker.trip(now, schedule)
+    const exactMs = kind === 'secondary' ? retryAfterMs : undefined
+    const window = GhPluginBase._breaker.trip(now, schedule, exactMs)
     const taggedEvents: TaggedEvent[] = window != null
       ? [{ channels: [projectChannel], payload: { kind: 'oneline', text: formatBackoffNotice(window, kind) } }]
       : []
@@ -155,7 +160,7 @@ export abstract class GhPluginBase extends BasePlugin {
       return { ok: true, value }
     } catch (e) {
       if (!(e instanceof GhError)) throw e
-      if (isRateLimitError(e)) return { ok: false, rateLimited: true, kind: rateLimitKind(e) }
+      if (isRateLimitError(e)) return { ok: false, rateLimited: true, kind: rateLimitKind(e), retryAfterMs: e.retryAfterMs }
       const events = this.recordEntryFailure(
         cooldownKey, noteChannels, recoveryCmd, describeReadFailure(e.stderr), e.message, now,
       )

--- a/src/orchestrator/plugins/github/commits-plugin.ts
+++ b/src/orchestrator/plugins/github/commits-plugin.ts
@@ -197,7 +197,7 @@ export class GitHubCommitsPlugin extends GhPluginBase {
         now,
       )
       // Rate-limit discards this tick's partial work and preserves prev state.
-      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { commits: {} }, projectChannel, config, r.kind)
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { commits: {} }, projectChannel, config, r.kind, r.retryAfterMs)
       if (!r.ok) {
         taggedEvents.push(...r.events)
         continue

--- a/src/orchestrator/plugins/github/github-api.ts
+++ b/src/orchestrator/plugins/github/github-api.ts
@@ -108,17 +108,72 @@ export class GhError extends Error {
   // classify off — the GraphQL RATE_LIMITED case (HTTP 200 with an error node).
   // Lets isRateLimitError recognize it without a fabricated status string.
   readonly rateLimited: boolean
-  constructor(msg: string, stderr = '', attempts = 1, rateLimited = false) {
+  // Retry-After header (ms), when the call went through --include and GitHub
+  // sent one — only meaningful for the secondary/burst limiter (see
+  // rateLimitKind). undefined when absent, non-numeric, or the call didn't
+  // capture headers at all.
+  readonly retryAfterMs?: number
+  constructor(msg: string, stderr = '', attempts = 1, rateLimited = false, retryAfterMs?: number) {
     super(msg)
     this.name = 'GhError'
     this.stderr = stderr
     this.attempts = attempts
     this.rateLimited = rateLimited
+    this.retryAfterMs = retryAfterMs
   }
 }
 
+// Splits `gh api --include` output into status/headers/body. Header keys are
+// lowercased for case-insensitive lookup. `status: null` when the text doesn't
+// look like an HTTP response at all (e.g. a network failure that never reached
+// a server — stdout is empty, --include had nothing to prepend).
+export interface GhIncludeResponse {
+  status: number | null
+  headers: Map<string, string>
+  body: string
+}
+
+export function parseIncludeOutput(raw: string): GhIncludeResponse {
+  const text = raw.replace(/\r\n/g, '\n')
+  const sepIdx = text.indexOf('\n\n')
+  if (!text.startsWith('HTTP/') || sepIdx === -1) {
+    return { status: null, headers: new Map(), body: raw }
+  }
+  const head = text.slice(0, sepIdx)
+  const body = text.slice(sepIdx + 2)
+  const lines = head.split('\n')
+  const statusMatch = lines[0].match(/^HTTP\/\S+\s+(\d+)/)
+  const status = statusMatch ? Number(statusMatch[1]) : null
+  const headers = new Map<string, string>()
+  for (const line of lines.slice(1)) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    headers.set(line.slice(0, idx).trim().toLowerCase(), line.slice(idx + 1).trim())
+  }
+  return { status, headers, body }
+}
+
+// GitHub's documented secondary-limit Retry-After is always delta-seconds
+// (possibly fractional). HTTP in general also allows an HTTP-date, but GH
+// doesn't send one for this header — a non-numeric value (date or junk) is
+// treated as malformed and dropped rather than guessed at, so a bad parse
+// never feeds a NaN into the breaker's window math.
+function parseRetryAfterMs(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const seconds = Number(value)
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined
+  return Math.round(seconds * 1000)
+}
+
+function retryAfterFromIncludedStdout(stdout: string): number | undefined {
+  return parseRetryAfterMs(parseIncludeOutput(stdout).headers.get('retry-after'))
+}
+
 // Default SpawnDeps.exec — runs gh once, parses output, throws GhError on
-// non-zero exit. Tests inject a fake to avoid spawning a real gh.
+// non-zero exit. Tests inject a fake to avoid spawning a real gh. When `args`
+// carries `--include`, stdout leads with a status line + header block (present
+// on both the success and failure paths — verified against a real 404) that
+// must be stripped before JSON-parsing the body.
 async function runGhOnce(args: string[]): Promise<unknown> {
   const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' })
   const [out, errOut] = await Promise.all([
@@ -126,13 +181,18 @@ async function runGhOnce(args: string[]): Promise<unknown> {
     new Response(proc.stderr).text(),
   ])
   const exitCode = await proc.exited
+  const included = args.includes('--include')
   if (exitCode !== 0) {
     throw new GhError(
       `gh failed (exit ${exitCode}): gh ${args.join(' ')}\n${errOut.trim()}`,
-      errOut
+      errOut,
+      1,
+      false,
+      included ? retryAfterFromIncludedStdout(out) : undefined,
     )
   }
-  const trimmed = out.trim()
+  const body = included ? parseIncludeOutput(out).body : out
+  const trimmed = body.trim()
   if (!trimmed) return null
   try {
     return JSON.parse(trimmed)
@@ -146,9 +206,12 @@ async function runGhOnce(args: string[]): Promise<unknown> {
 // exec (runGhOnce) would throw and discard the resolved aliases. This exec keeps
 // stdout on a non-zero exit when a parseable GraphQL body is present, so
 // per-entry isolation survives one bad alias (verified: gh exits 1 but still
-// writes the full {data, errors} body to stdout). A non-zero exit with no usable
-// body (rate-limit / auth / network) throws, routing back through spawnGh's
-// retry + rate-limit classification.
+// writes the full {data, errors} body to stdout — with --include, that body
+// is preceded by a `HTTP/2.0 200 OK` status line + header block, which must be
+// stripped before the JSON parse or the isolation check below never sees the
+// body at all). A non-zero exit with no usable body (rate-limit / auth /
+// network) throws, routing back through spawnGh's retry + rate-limit
+// classification.
 async function runGhGraphqlBatchOnce(args: string[]): Promise<unknown> {
   const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' })
   const [out, errOut] = await Promise.all([
@@ -156,7 +219,9 @@ async function runGhGraphqlBatchOnce(args: string[]): Promise<unknown> {
     new Response(proc.stderr).text(),
   ])
   const exitCode = await proc.exited
-  const trimmed = out.trim()
+  const included = args.includes('--include')
+  const body = included ? parseIncludeOutput(out).body : out
+  const trimmed = body.trim()
   let parsed: unknown = null
   if (trimmed) {
     try { parsed = JSON.parse(trimmed) } catch { parsed = null }
@@ -167,7 +232,10 @@ async function runGhGraphqlBatchOnce(args: string[]): Promise<unknown> {
   }
   throw new GhError(
     `gh failed (exit ${exitCode}): gh ${args.join(' ')}\n${errOut.trim()}`,
-    errOut
+    errOut,
+    1,
+    false,
+    included ? retryAfterFromIncludedStdout(out) : undefined,
   )
 }
 
@@ -483,9 +551,13 @@ export function mapBatchOutcomes<T>(
 export class GhClient {
   constructor(private readonly log: PluginLogger) {}
 
+  // --include captures response headers (for Retry-After) but interleaves
+  // per-page headers into stdout under --paginate, breaking gh's JSON-array
+  // merge — so it's only added on non-paginated calls.
   private async api(endpoint: string, paginate = false): Promise<unknown> {
     const args = ['api']
     if (paginate) args.push('--paginate')
+    else args.push('--include')
     args.push(endpoint)
     return spawnGh(args, { log: this.log })
   }
@@ -532,6 +604,7 @@ export class GhClient {
     })
     const query = `query(${decls.join(',')}){ ${bodies.join(' ')} }`
     args.splice(2, 0, '-f', `query=${query}`)
+    args.push('--include')
     const raw = await spawnGh(args, { log: this.log, exec: runGhGraphqlBatchOnce })
     const env = (raw ?? {}) as GqlEnvelope
     if ((env.errors ?? []).some(e => e.type === 'RATE_LIMITED')) {

--- a/src/orchestrator/plugins/github/issues-plugin.ts
+++ b/src/orchestrator/plugins/github/issues-plugin.ts
@@ -80,7 +80,7 @@ export class GitHubIssuesPlugin extends GhBase {
       if (!(e instanceof GhError)) throw e
       // Rate-limit → back off the whole tick; discard partial work, preserve
       // prev. `kind` picks the schedule (secondary burst gets the ~1m floor).
-      if (isRateLimitError(e)) return this.breakerTripResult(now, prevState ?? { issues: {} }, projectChannel, config, rateLimitKind(e))
+      if (isRateLimitError(e)) return this.breakerTripResult(now, prevState ?? { issues: {} }, projectChannel, config, rateLimitKind(e), e.retryAfterMs)
       // Whole-batch transient failure isn't a per-entry condition, so it doesn't
       // spike per-entry counts. Preserve prev, replay channels, and surface one
       // throttled batch-level warn so a sustained outage doesn't go silent.

--- a/src/orchestrator/plugins/github/new-issues-plugin.ts
+++ b/src/orchestrator/plugins/github/new-issues-plugin.ts
@@ -165,7 +165,7 @@ export class GitHubNewIssuesPlugin extends GhPluginBase {
       )
       // Rate-limit discards this tick's partial work and preserves prev state —
       // the next clean tick re-reads and announces what's genuinely new.
-      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config, r.kind)
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config, r.kind, r.retryAfterMs)
       if (!r.ok) {
         taggedEvents.push(...r.events)
         continue

--- a/src/orchestrator/plugins/github/new-prs-plugin.ts
+++ b/src/orchestrator/plugins/github/new-prs-plugin.ts
@@ -170,7 +170,7 @@ export class GitHubNewPrsPlugin extends GhPluginBase {
       )
       // Rate-limit discards this tick's partial work and preserves prev state —
       // the next clean tick re-reads and announces what's genuinely new.
-      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config, r.kind)
+      if (!r.ok && r.rateLimited) return this.breakerTripResult(now, prevState ?? { repos: {} }, projectChannel, config, r.kind, r.retryAfterMs)
       if (!r.ok) {
         taggedEvents.push(...r.events)
         continue

--- a/src/orchestrator/plugins/github/prs-plugin.ts
+++ b/src/orchestrator/plugins/github/prs-plugin.ts
@@ -238,7 +238,7 @@ export class GitHubPrsPlugin extends GhBase {
       if (!(e instanceof GhError)) throw e
       // Rate-limit → back off the whole tick; discard partial work, preserve
       // prev. `kind` picks the schedule (secondary burst gets the ~1m floor).
-      if (isRateLimitError(e)) return this.breakerTripResult(now, prevState ?? { prs: {} }, projectChannel, config, rateLimitKind(e))
+      if (isRateLimitError(e)) return this.breakerTripResult(now, prevState ?? { prs: {} }, projectChannel, config, rateLimitKind(e), e.retryAfterMs)
       // Whole-batch transient failure isn't a per-entry condition, so it doesn't
       // spike per-entry counts. Preserve prev, replay channels, and surface one
       // throttled batch-level warn so a sustained outage doesn't go silent.


### PR DESCRIPTION
Closes #643

gh swallows the secondary-limit `Retry-After` header on stderr — only the JSON error body and status make it through, so the dispatcher's secondary-limit backoff has been schedule-only (a fixed 1m floor) even when GitHub tells us the exact wait.

## What changed

- `github-api.ts`: added `--include` to the two non-paginated gh call paths — the batched GraphQL read (`runBatchQuery`, the call most likely to trip the secondary/burst limiter) and single-page REST reads (`fetchRepoCommits` via the private `api()` helper). Added `parseIncludeOutput` to split gh's `--include` stdout (status line + headers + body) and a `retryAfterMs` field on `GhError`, populated from the `Retry-After` header on a non-zero exit. Paginated reads (`fetchRepoOpenIssues`/`fetchRepoOpenPrs`) keep `--paginate` only — `--include`'s per-page headers break gh's JSON-array merge across pages.
- `backoff.ts`: `RateLimitBreaker.trip()` takes an optional exact-ms override, clamped to `[1s, schedule ceiling]` — no floor at the schedule's own minimum, since the point is GitHub's real burst-limiter often clears faster than our fixed floor. `formatBackoffNotice` gained a seconds branch so a sub-minute honored window doesn't render as a misleading "0m".
- `base.ts` + the five plugins that call `breakerTripResult` (commits/issues/new-issues/prs/new-prs): thread `retryAfterMs` through the same path `kind` already takes. Only applied for `kind === 'secondary'` — primary-limit backoff is untouched (its real signal is the budget-reset epoch, a different problem).

Retry-After parsing only accepts delta-seconds (GitHub's documented format for the secondary limiter). HTTP in general also allows an HTTP-date, but GitHub doesn't send one here; a non-numeric value is treated as malformed and dropped rather than guessed at, falling back to the schedule.

## Verification

Confirmed empirically against real `gh api -i` / `gh api graphql -i` calls (a 404 and a bad-PR-number query) that response headers land on stdout on the failure path, not just success — the assumption the whole issue rides on. That also surfaced a real risk: `runGhGraphqlBatchOnce`'s per-alias isolation (partial `{data,errors}` body kept on a non-zero exit, from #613) JSON-parses raw stdout — with `--include`, the header block has to be stripped first or the isolation check breaks. Fixed and covered by a dedicated test.

Full suite (1080 tests) + lint/typecheck pass.