### PR TITLE
Bump version to 0.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump for the 0.8.8 release.

What's new since v0.8.7:
- CI relay carries commit SHA; APM ready/merge gates independently verify green-on-HEAD (#678)
- Batched GraphQL read + REST reads honor exact secondary-limit Retry-After via `--include` header capture (#643)
- GraphQL-point rate-limit budget surfaced in observeRateLimit (#659)
- Linear new-issues watch supports project-level filtering, not just team-level (#667)
- `.claude/agents` symlink committed so worktrees/clones get reviewer-agent spawns for free (#672)
- `roost --version`/`-v` (#668)
- classifyBash read-only fast-path, empirically parity-tested against the native TUI (#641)
- Fixed a slug-derivation crash and a silent-event-drop bug in the GitHub plugins (#669)
- `import.meta.main` guard on the orchestrator entrypoint (#665)
- `reviewThreads` GraphQL query fixed to fetch the newest 100 comments, not the oldest (#652)

🤖 Generated with [Claude Code](https://claude.com/claude-code)