### PR TITLE
Add Opus 5 pricing, bump to 0.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -37,7 +37,8 @@ export interface ModelPricing {
 export const PRICING: Readonly<Record<string, ModelPricing>> = {
   // Fable 5 — higher-powered tier above Opus, priced accordingly.
   'claude-fable-5':             { input: 10, output: 50, cache_creation_5m: 12.50, cache_creation_1h: 20,  cache_read: 1.00 },
-  // Opus 4.x current generation — $5 base input. Opus 4.1 and earlier use the $15 tier.
+  // Opus 5 and Opus 4.x current generation — $5 base input. Opus 4.1 and earlier use the $15 tier.
+  'claude-opus-5':              { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-8':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-7':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },
   'claude-opus-4-6':            { input: 5,  output: 25, cache_creation_5m: 6.25,  cache_creation_1h: 10,  cache_read: 0.50 },


### PR DESCRIPTION
Opus 5 priced same as Opus 4.8. Only change since v0.8.8, so the version bump rides along.

- `claude-opus-5` row in `src/pricing.ts` ($5 in / $25 out / $6.25 5m / $10 1h / $0.50 read)
- package.json 0.8.8 → 0.8.9

Tag goes up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)