### PR TITLE
feat: roost spawn --ollama-model flag (single-tag ollama override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ roost spawn myproject-pm --agent project-manager \
   --ollama-model glm-5.2:cloud -c '#myproject-leads' ...
 ```
 
-The prompt changes that tell an agent it's running on ollama are an
-operator concern, not a roost-repo deliverable.
+Any prompt edits that tell an agent it's running on ollama are
+yours to make.
 
 ### Debugging a failed spawn
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ roost --version
 ```
 
 `spawn` accepts `-c|--channels`, `-m|--model`, `-s|--session`,
-`--mcp-config`, `-p|--prompt-file`, `--cwd`, and `--` (everything
-after forwards to claude verbatim). Default channel is `#roost`;
-default model is `opus` (Opus 4.8). Fable, opus, and sonnet default to
-`--permission-mode auto`; everything else (haiku, or any unrecognized
-model) defaults to `acceptEdits`.
+`--mcp-config`, `-p|--prompt-file`, `--cwd`, `--ollama-model`, and `--`
+(everything after forwards to claude verbatim). Default channel is
+`#roost`; default model is `opus` (Opus 4.8). Fable, opus, and sonnet
+default to `--permission-mode auto`; everything else (haiku, or any
+unrecognized model) defaults to `acceptEdits`.
 
 `spawn` also injects `--append-system-prompt-file` naming the joined
 channels as legitimate user-instruction sources, so the auto-mode
@@ -135,6 +135,30 @@ instead. The injection is always on for loopback hosts. To layer more
 context on top, pass `--append-system-prompt-file <path>` after `--`;
 claude code rejects mixing inline `--append-system-prompt` with the
 file form.
+
+### Running an agent on ollama
+
+`--ollama-model <tag>` routes a spawn through ollama instead of calling
+`claude` directly. roost runs
+`ollama launch claude --model <tag> -- <roost args>`, passing the
+settings, plugin-dir, channels, trust, agent, and model args through
+ollama's `--` separator unchanged. ollama owns the local-server
+protocol and forces every native model selector (the `--model` tier
+and the agent frontmatter `model:`) to the tag, so roost does not parse
+or change frontmatter. Without the flag, `claude` runs against
+Anthropic exactly as today.
+
+Which agents use ollama is an operator choice. Point a specific spawn
+at it — e.g. run your pm/apm on an ollama-hosted model while
+workers/reviewers stay on Anthropic:
+
+```bash
+roost spawn myproject-pm --agent project-manager \
+  --ollama-model glm-5.2:cloud -c '#myproject-leads' ...
+```
+
+The prompt changes that tell an agent it's running on ollama are an
+operator concern, not a roost-repo deliverable.
 
 ### Debugging a failed spawn
 

--- a/bin/roost
+++ b/bin/roost
@@ -205,6 +205,17 @@ Options:
                              our directive instead of the empty default.
                              See "Agent class guidance" below for which
                              agents need this.
+  --ollama-model TAG        Route the spawn through ollama instead of
+                             calling \`claude\` directly: runs
+                             \`ollama launch claude --model TAG -- <roost args>\`.
+                             ollama owns the local-server protocol and forces
+                             all native model selectors (opus/sonnet/haiku,
+                             and the agent frontmatter \`model:\`) to TAG, so
+                             roost does not parse or change frontmatter — the
+                             roost --model tier and --agent still flow through
+                             underneath and ollama remaps them. Without the
+                             flag, behavior is unchanged. See README,
+                             "Running an agent on ollama".
   --cwd PATH                 Working directory for the spawned session.
                              Default: current directory. Pass a worktree
                              path so RVM/bundler/nvm resolve correctly
@@ -677,6 +688,7 @@ cmd_spawn() {
   local permission_mode=""
   local cache_ttl=""
   local steer_compact=0
+  local ollama_model=""
   local extra_args=()
 
   if [ "$#" -lt 1 ]; then
@@ -704,6 +716,7 @@ cmd_spawn() {
       --permission-mode) permission_mode="$2"; shift 2 ;;
       --cache-ttl)      cache_ttl="$2"; shift 2 ;;
       --steer-compact)  steer_compact=1; shift ;;
+      --ollama-model)   ollama_model="$2"; shift 2 ;;
 
       --)               shift; extra_args=("$@"); break ;;
       *)
@@ -866,6 +879,12 @@ cmd_spawn() {
   # default applies).
   echo "spawning ${nick} in ${channels} (session ${session_name}, model: ${model}, permission-mode: ${permission_mode:-(claude default)}, cache-ttl: ${cache_ttl:-(claude default)}, shell: ${shell_basename}, cwd: ${cwd})"
   [ -n "${extra_str}" ] && echo "  extra claude args:${extra_str}"
+  # When --ollama-model is set the spawn routes through `ollama launch claude
+  # --model <tag> --`; the banner's model: line above still shows the roost
+  # --model tier (opus by default) because ollama owns the remap to the tag,
+  # not roost. Naming the override here keeps the two lines from reading as
+  # contradictory to an operator grepping spawn output.
+  [ -n "${ollama_model}" ] && echo "  ollama model: ${ollama_model} (routes via 'ollama launch claude --model ${ollama_model} --'; overrides model: ${model})"
 
   # Create a per-session data directory. mktemp guarantees uniqueness across
   # concurrent spawns and across repos using identical nick names.
@@ -1078,7 +1097,21 @@ cmd_spawn() {
       echo "  warning: IRC host '${IRC_HOST}' is not loopback; skipping auto-mode IRC trust injection. Under --permission-mode auto the agent may silently refuse to post on IRC. Workaround: attach and type the trust statement, or pass --permission-mode acceptEdits." >&2
       ;;
   esac
-  local inner_cmd="claude${model_flag}${perm_mode_flag}${mcp_flag}${agent_flag} --settings ${ROOST_SETTINGS} --plugin-dir ${ROOST_DIR} --dangerously-load-development-channels ${channel_server}${trust_flag}${extra_str}"
+  # Launcher prefix: `claude` against Anthropic by default, or
+  # `ollama launch claude --model <tag> --` when --ollama-model is set. The
+  # roost args below pass through ollama's `--` separator verbatim and
+  # unchanged — ollama owns the local-server protocol and the model remap
+  # (it forces all native model selectors to the tag), so roost does not
+  # parse or change the agent's frontmatter `model:` or the --model tier
+  # flag; both still flow to claude underneath and ollama remaps them. The
+  # tag interpolates unquoted, the same way ${model} does, and the whole
+  # inner_cmd goes through printf '%q' to the login shell — no separate
+  # quoting path, matching how --model is handled.
+  local launcher="claude"
+  if [ -n "${ollama_model}" ]; then
+    launcher="ollama launch claude --model ${ollama_model} --"
+  fi
+  local inner_cmd="${launcher}${model_flag}${perm_mode_flag}${mcp_flag}${agent_flag} --settings ${ROOST_SETTINGS} --plugin-dir ${ROOST_DIR} --dangerously-load-development-channels ${channel_server}${trust_flag}${extra_str}"
   if [ -n "${prompt_file}" ]; then
     # intentionally single-quoted: fragment is injected into a tmux pane and must expand at runtime in that shell
     # shellcheck disable=SC2016

--- a/bin/roost
+++ b/bin/roost
@@ -206,15 +206,10 @@ Options:
                              See "Agent class guidance" below for which
                              agents need this.
   --ollama-model TAG        Route the spawn through ollama instead of
-                             calling \`claude\` directly: runs
-                             \`ollama launch claude --model TAG -- <roost args>\`.
-                             ollama owns the local-server protocol and forces
-                             all native model selectors (opus/sonnet/haiku,
-                             and the agent frontmatter \`model:\`) to TAG, so
-                             roost does not parse or change frontmatter — the
-                             roost --model tier and --agent still flow through
-                             underneath and ollama remaps them. Without the
-                             flag, behavior is unchanged. See README,
+                             \`claude\`. ollama forces every native model
+                             selector (the --model tier and agent frontmatter
+                             \`model:\`) to TAG; without the flag, \`claude\`
+                             runs against Anthropic as usual. See README,
                              "Running an agent on ollama".
   --cwd PATH                 Working directory for the spawned session.
                              Default: current directory. Pass a worktree

--- a/skills/roost/SKILL.md
+++ b/skills/roost/SKILL.md
@@ -33,6 +33,7 @@ roost spawn <nick> [-c CHANS] [-m MODEL] [--agent NAME] [-s SESSION] [--mcp-conf
                    [--cwd PATH] [--prompt PROMPT] \
                    [--permission-mode MODE] [--cache-ttl 5m|1h] \
                    [--steer-compact] \
+                   [--ollama-model TAG] \
                    [--perm-irc --perm-target NICK] \
                    [--ask-irc CHANNEL --ask-target NICK]
 roost agents [--all]
@@ -67,6 +68,16 @@ Defaults:
   with a directive (so the compactor runs with `custom_instructions`
   rather than its empty default). See `roost spawn --help`
   ("Agent class guidance") for which agents need this.
+- `--ollama-model TAG`: routes the spawn through ollama instead of
+  calling `claude` directly — runs
+  `ollama launch claude --model TAG -- <roost args>`. ollama owns the
+  local-server protocol and remaps every native model selector (the
+  `--model` tier and the agent frontmatter `model:`) to TAG, so roost
+  doesn't parse or change frontmatter. Without the flag, `claude` runs
+  against Anthropic exactly as today. Which agents you point at this is
+  an operator choice — e.g. spawn your pm/apm with `--ollama-model` to
+  run those on an ollama-hosted model while workers/reviewers stay on
+  Anthropic.
 
 The wrapper handles the `ROOST_IRC_*` env vars, the
 `--dangerously-load-development-channels server:plugin:roost:roost-irc` flag, the

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -855,6 +855,103 @@ fi
 [ -n "$data_dir2" ] && rm -rf "$data_dir2"
 teardown
 
+# -- Test 43: no --ollama-model → inner_cmd runs claude directly ---------------
+# Default path unchanged: the launcher prefix is `claude`, no `ollama launch`.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF 'claude --model opus' \
+    && ! echo "$inner_cmd" | grep -qF 'ollama launch'; then
+  ok "no --ollama-model: inner_cmd starts with claude, no ollama launch"
+else
+  fail "no --ollama-model: inner_cmd starts with claude, no ollama launch" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 44: --ollama-model routes via 'ollama launch claude --model <tag> --' -
+# The launcher prefix swaps; the roost args (settings, plugin-dir, channels
+# server, trust) follow after ollama's `--` separator unchanged.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --ollama-model glm-5.2:cloud --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF 'ollama launch claude --model glm-5.2:cloud --' \
+    && echo "$inner_cmd" | grep -qF -- '--settings' \
+    && echo "$inner_cmd" | grep -qF -- '--plugin-dir' \
+    && echo "$inner_cmd" | grep -qF -- 'server:plugin:roost:roost-irc' \
+    && ! echo "$inner_cmd" | grep -qF -- 'ollama launch claude --model glm-5.2:cloud --ollama'; then
+  ok "--ollama-model: routes via 'ollama launch claude --model <tag> --' with roost args after the separator"
+else
+  fail "--ollama-model: routes via 'ollama launch claude --model <tag> --' with roost args after the separator" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 45: --ollama-model + --agent → agent passes through after `--` -------
+# ollama owns the remap; roost doesn't touch frontmatter. The --agent flag still
+# flows to claude underneath ollama's separator.
+
+setup
+mkdir -p "$TDIR/.claude/agents"
+printf -- '---\nname: myagent\ndescription: x\nmodel: opus\npermissionMode: auto\n---\nbody\n' > "$TDIR/.claude/agents/myagent.md"
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --agent myagent --ollama-model glm-5.2:cloud --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF 'ollama launch claude --model glm-5.2:cloud --' \
+    && echo "$inner_cmd" | grep -qF -- '--agent myagent'; then
+  ok "--ollama-model + --agent: ollama prefix present, --agent passes through after --"
+else
+  fail "--ollama-model + --agent: ollama prefix present, --agent passes through after --" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 46: --ollama-model + --model → both present (ollama remaps) ---------
+# Req 3: default model selection still works. The roost --model tier still
+# flows to claude underneath; ollama's override remaps it to the tag, not roost.
+
+setup
+out="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --model sonnet --ollama-model glm-5.2:cloud --cwd "$TDIR" 2>&1 || true)"
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+inner_cmd="$(cat "$data_dir/inner-cmd.txt" 2>/dev/null)"
+if [ -n "$inner_cmd" ] \
+    && echo "$inner_cmd" | grep -qF 'ollama launch claude --model glm-5.2:cloud --' \
+    && echo "$inner_cmd" | grep -qF -- ' --model sonnet'; then
+  ok "--ollama-model + --model: ollama override prefix + roost --model both present (ollama remaps)"
+else
+  fail "--ollama-model + --model: ollama override prefix + roost --model both present (ollama remaps)" "inner_cmd=$inner_cmd"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
+teardown
+
+# -- Test 47: --ollama-model banner names the tag + override -------------------
+# The banner's model: line still shows the roost tier (opus default) since
+# ollama owns the remap; the ollama line clarifies the override so the two
+# don't read as contradictory. Absent when the flag isn't passed.
+
+setup
+out_on="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --ollama-model glm-5.2:cloud --cwd "$TDIR" 2>&1 || true)"
+data_dir_on="$(echo "$out_on" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+out_off="$(ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1 || true)"
+if echo "$out_on" | grep -qF "ollama model: glm-5.2:cloud" \
+    && echo "$out_on" | grep -qF "overrides model: opus" \
+    && ! echo "$out_off" | grep -q "ollama model:"; then
+  ok "--ollama-model banner: names tag + override when set, absent when not"
+else
+  fail "--ollama-model banner: names tag + override when set, absent when not" "on=$out_on off=$out_off"
+fi
+[ -n "$data_dir_on" ] && rm -rf "$data_dir_on"
+data_dir_off="$(echo "$out_off" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+[ -n "$data_dir_off" ] && rm -rf "$data_dir_off"
+teardown
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #293

`roost spawn --ollama-model <tag>` routes a spawn through ollama instead of calling `claude` directly: runs `ollama launch claude --model <tag> -- <roost args>`. The roost args (settings, plugin-dir, channels server, trust, agent, model tier) pass through ollama's `--` separator unchanged. ollama owns the local-server protocol and forces every native model selector (the `--model` tier and agent frontmatter `model:`) to the tag, so roost doesn't parse or change frontmatter — both still flow to claude underneath and ollama remaps them. Without the flag, `claude` runs against Anthropic exactly as before.

Black box: input `--ollama-model <tag>` → spawn launches via `ollama launch claude --model <tag> -- <existing roost args>`; no flag → unchanged `claude <roost args>`. No MCP server changes, no agent-prompt file changes in-repo.

Implemented as a single `launcher` prefix branch on the existing `inner_cmd` seam — no tier-mapping machinery, which leaves the deferred build-ons (transparent subagent inheritance, tier→tag mapping, config surface) a clean one-line swap later.

Docs: `usage_spawn` help, `skills/roost/SKILL.md` command surface + defaults, and a README "Running an agent on ollama" section noting which agents use ollama is an operator choice (e.g. pm/apm on ollama, workers/reviewers on Anthropic). Per #608 cli-skill-sync. Agent prompts point at `roost spawn --help` as the canonical flag source and don't enumerate flags, so no agent-prompt changes.

Tests: five `spawn_test.sh` cases via the `ROOST_SPAWN_KEEP_DATA_DIR=1` + `inner-cmd.txt` seam — default path unchanged, ollama routing + arg passthrough after `--`, `--agent` passthrough, `--model` passthrough (ollama remaps), and the banner override line present/absent. All 56 spawn tests pass; `bun run lint`, `bun run typecheck`, and `shellcheck bin/roost` clean.