### PR TITLE
feat(spawn): ROOST_SPAWN_NO_LAUNCH test seam skips the real launch

### DIFF
--- a/bin/roost
+++ b/bin/roost
@@ -982,8 +982,8 @@ cmd_spawn() {
   # suppresses the failure-cleanup trap, so spawn_test.sh can read the files
   # written above after a preflight failure exits the spawn. Prod operators
   # never set this — the success path prints "data dir: ..." after tmux comes up.
-  # This does not stop the spawn: on the success path, tmux and claude still
-  # start for real — tests must tear those sessions down themselves.
+  # This does not stop the spawn: ROOST_SPAWN_NO_LAUNCH=1 (set by the test
+  # suite) is what skips the real tmux/claude launch after staging.
   if [ "${ROOST_SPAWN_KEEP_DATA_DIR:-0}" = "1" ]; then
     echo "  data dir (preflight): ${ROOST_DATA_DIR}"
   else
@@ -1123,6 +1123,19 @@ cmd_spawn() {
   if [ "${ROOST_SPAWN_KEEP_DATA_DIR:-0}" = "1" ]; then
     echo "  inner cmd (preflight): ${inner_cmd}"
     printf '%s' "${inner_cmd}" > "${ROOST_DATA_DIR}/inner-cmd.txt"
+  fi
+
+  # Test seam: ROOST_SPAWN_NO_LAUNCH=1 stops the spawn here, before the
+  # tmux/ircd preflight and the real claude launch. spawn_test.sh assertions
+  # inspect staged files and banner output — none depend on a live session —
+  # so stage-then-exit makes the suite deterministic and fast regardless of
+  # whether ergo is running locally. Without this, an ergo-up dev box does a
+  # real tmux new-session + claude launch per test (and require_ircd's TCP
+  # probe hangs ~75s on the unroutable-IP cases), pushing the suite from
+  # seconds to ~7min. Prod operators never set this. ROOST_SPAWN_KEEP_DATA_DIR
+  # is independent: it retains the staged files for tests that inspect them.
+  if [ "${ROOST_SPAWN_NO_LAUNCH:-0}" = "1" ]; then
+    exit 0
   fi
 
   require_tmux

--- a/test/spawn_test.sh
+++ b/test/spawn_test.sh
@@ -8,6 +8,14 @@ PASS=0
 FAIL=0
 TDIR=""
 
+# Skip the real tmux + claude launch: every assertion inspects staged files
+# or banner output, none need a live session. Without this, an ergo-up dev
+# box launches a real claude per test (and require_ircd's TCP probe hangs
+# ~75s on the unroutable-IP cases), pushing the suite from seconds to ~7min.
+# CI is unaffected (no ergo → require_ircd fails fast anyway); this just
+# makes the ergo-up path match.
+export ROOST_SPAWN_NO_LAUNCH=1
+
 ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
 fail() { echo "FAIL: $1 ${2:+— $2}"; FAIL=$((FAIL+1)); }
 
@@ -18,8 +26,8 @@ setup() {
 
 teardown() {
   rm -rf "$TDIR"
-  # On dev boxes with ergo running, shell-resolution tests pass through to a
-  # real tmux new-session — kill it so the next test gets a fresh "roost-testnick".
+  # belt-and-suspenders: NO_LAUNCH never starts a session, but if a caller
+  # dropped the flag, don't leak roost-testnick into the next test.
   tmux kill-session -t "roost-testnick" 2>/dev/null || true
   trap - EXIT
   TDIR=""
@@ -950,6 +958,35 @@ fi
 [ -n "$data_dir_on" ] && rm -rf "$data_dir_on"
 data_dir_off="$(echo "$out_off" | sed -n 's/.*data dir (preflight): //p' | head -1)"
 [ -n "$data_dir_off" ] && rm -rf "$data_dir_off"
+teardown
+
+# -- Test 48: ROOST_SPAWN_NO_LAUNCH=1 exits 0 before the real launch --------
+# The suite sets NO_LAUNCH globally, so a broken seam that falls through to
+# require_ircd still looks green on CI (no ergo → require_ircd exits 2, and
+# every other test ||-true's the exit code). The regression is silent on CI
+# and only surfaces as a slow ergo-up dev box. This pins the seam directly:
+# exit 0, no roost-testnick tmux session left behind, returns in well under
+# the 30s dismissal-timeout, and preflight staging still ran. Catches
+# fallthrough on ergo-up (session left behind + slow) and ergo-down (exit 2
+# instead of 0).
+
+setup
+tmux kill-session -t roost-testnick 2>/dev/null || true
+SECONDS=0
+out="$(ROOST_SPAWN_NO_LAUNCH=1 ROOST_SPAWN_KEEP_DATA_DIR=1 "${ROOST_BIN}" spawn testnick --cwd "$TDIR" 2>&1)"; rc=$?
+elapsed=$SECONDS
+no_session=1
+if tmux has-session -t roost-testnick 2>/dev/null; then no_session=0; fi
+tmux kill-session -t roost-testnick 2>/dev/null || true
+data_dir="$(echo "$out" | sed -n 's/.*data dir (preflight): //p' | head -1)"
+if [ "$rc" -eq 0 ] && [ "$no_session" -eq 1 ] && [ "$elapsed" -le 10 ] \
+    && [ -n "$data_dir" ]; then
+  ok "NO_LAUNCH: exits 0 before launch (no tmux session, fast, preflight staged)"
+else
+  fail "NO_LAUNCH: exits 0 before launch (no tmux session, fast, preflight staged)" \
+    "rc=$rc no_session=$no_session elapsed=${elapsed}s out=$out"
+fi
+[ -n "$data_dir" ] && rm -rf "$data_dir"
 teardown
 
 echo ""


### PR DESCRIPTION
Closes #694

## What

Local-dev `bash test/spawn_test.sh` with ergo up took ~7min, and CI's `Shell tests — spawn` step took ~4m33s on main. Per-test measurement pinned two cost sources (not just the dismissal loop the issue named):

- **Unbounded `/dev/tcp` probe** — `require_ircd`'s probe to the unroutable `192.0.2.1` (2 tests) hangs ~75s each on macOS and ~136s each on Linux (TCP SYN retransmit, no timeout). This was the single biggest hit on both local-dev and CI, and it's not the dismissal loop.
- **Real claude launches (local-dev only)** — ~4 tests reaching preflight without `ROOST_SPAWN_KEEP_DATA_DIR` (tests 2, 4, 5, 18a) launched a real tmux+claude session and waited on the dev-channels dismissal loop, hitting its 30s timeout under load. CI never hit this: claude isn't installed there and `require_ircd` fails before the launch (no ergo on 6667 during the shell steps — `bun test`'s ergo is on a random port, torn down first).

## Fix

New `ROOST_SPAWN_NO_LAUNCH=1` seam in `bin/roost`: when set, spawn exits 0 right after staging (inner-cmd.txt, roost-settings.json, trust-prompt), before `require_tmux` / `require_ircd` and the real launch. `spawn_test.sh` exports it once at the top. `ROOST_SPAWN_KEEP_DATA_DIR` keeps its existing meaning (retain staged files for inspection); the two seams are independent and single-purpose.

A guard test (Test 48) pins the seam: exit 0, no `roost-testnick` tmux session left behind, returns in ≤10s, preflight staged. Without it, a broken seam falling through to `require_ircd` stays green on CI (no ergo → exit 2, every other test `||-true`s the code) and only surfaces as a slow dev box. The guard catches fallthrough on ergo-up (session left behind) and ergo-down (exit 2 instead of 0).

## Validation

- `bash test/spawn_test.sh` locally (ergo up): **6:55 → 2.2s**, 57/57 pass.
- CI `Shell tests — spawn` step: **~4:33 on main → 2s on this PR** (run 30161401641). The seam bypasses `require_ircd` entirely, so the two unroutable-IP hangs never happen on CI either.
- Ergo-up and ergo-down (dead-port) runs identical — the seam makes ergo presence irrelevant to the suite.
- Guard test verified both directions: passes with the seam intact, fails with the seam broken (ergo-up: session left behind; ergo-down: exit 2).
- `shellcheck bin/roost` clean; `agents_test.sh` (9) and `compact-hook_test.sh` (14) still pass.
- No test asserts on post-launch output, so suppressing the launch breaks nothing.

## Follow-ups

- `require_ircd`'s unbounded `/dev/tcp` probe (~75–136s hang on unroutable IPs) is a separate operator footgun — typo'd `ROOST_IRC_SERVER`. Filed as a non-blocking prod-path hardening follow-up (#696, bounded probe); PM routing via the APM.
- A coverage tradeoff around global `NO_LAUNCH` and the `require_ircd` probe path, plus an operator `--dry-run` flag, are raised on the review thread for alex.

🤖 Generated with Claude Code