### PR TITLE
Post backlogged PR/issue comments to channel on watch

### DIFF
--- a/src/orchestrator/plugins/github/__tests__/format.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/format.test.ts
@@ -109,6 +109,37 @@ describe('formatEvent', () => {
     )
   })
 
+  it('formats pr_has_existing_comments framing (no elision)', () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_has_existing_comments',
+      repo: 'org/repo', pr: 10, url: 'https://github.com/org/repo/pull/10',
+      backlog_total: 3, backlog_posted: 3,
+    } as OrchestratorEvent
+    expect(formatEvent(ev)).toBe('PR org/repo#10 BACKLOG: posting 3 pre-watch comments below')
+  })
+
+  it('formats pr_has_existing_comments framing (elided)', () => {
+    const ev: OrchestratorEvent = {
+      kind: 'pr_has_existing_comments',
+      repo: 'org/repo', pr: 10, url: 'https://github.com/org/repo/pull/10',
+      backlog_total: 25, backlog_posted: 20,
+    } as OrchestratorEvent
+    expect(formatEvent(ev)).toBe(
+      'PR org/repo#10 BACKLOG: showing 20 most recent of 25 pre-watch comments — earlier at https://github.com/org/repo/pull/10'
+    )
+  })
+
+  it('formats issue_has_existing_comments framing (elided)', () => {
+    const ev: OrchestratorEvent = {
+      kind: 'issue_has_existing_comments',
+      repo: 'org/repo', issue: 20, url: 'https://github.com/org/repo/issues/20',
+      backlog_total: 30, backlog_posted: 20,
+    } as OrchestratorEvent
+    expect(formatEvent(ev)).toBe(
+      'Issue org/repo#20 BACKLOG: showing 20 most recent of 30 pre-watch comments — earlier at https://github.com/org/repo/issues/20'
+    )
+  })
+
   it('formats labels_changed', () => {
     const ev: OrchestratorEvent = {
       kind: 'labels_changed',

--- a/src/orchestrator/plugins/github/__tests__/plugin.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/plugin.test.ts
@@ -112,6 +112,43 @@ describe('GitHubPrsPlugin.runTick', () => {
     } finally { spy.mockRestore() }
   })
 
+  it('routes backlog framing + pre-watch comment events to the linked-issue channel like live comments', async () => {
+    const framingEv: OrchestratorEvent = {
+      kind: 'pr_has_existing_comments',
+      repo: 'org/repo', pr: 25, url: 'https://example.com/p/25', title: 'P',
+      linked_issues: [{ repo: 'org/repo', number: 14 }],
+      backlog_total: 1, backlog_posted: 1,
+    } as OrchestratorEvent
+    const commentEv: OrchestratorEvent = {
+      kind: 'pr_conversation_comment',
+      repo: 'org/repo', pr: 25, url: 'https://example.com/p/25',
+      author: 'linear-bot', body: 'Linked to PROJ-123', body_preview: 'Linked to PROJ-123', is_worker_reply: false,
+      comment_id: 9, comment_url: 'https://example.com/c/9',
+      linked_issues: [{ repo: 'org/repo', number: 14 }],
+    } as OrchestratorEvent
+    const spy = stubPr({
+      snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 14 }] }),
+      events: [framingEv, commentEv],
+    })
+    try {
+      const cfg: OrchestratorConfig = {
+        project: 'proj', repo: 'org/repo',
+        plugins: {
+          'github-prs': { watched: [{ number: 25, channels: ['#extra'] }] },
+          'github-issues': { watched: [] },
+        },
+      }
+      const result = await new GitHubPrsPlugin('#proj').runTick(cfg, { prs: {} })
+      expect(result.taggedEvents).toHaveLength(2)
+      // framing line ships first (oneline), routed to the linked-issue channel unioned with entry
+      expect(result.taggedEvents[0]?.payload.kind).toBe('oneline')
+      expect(result.taggedEvents[0]?.channels.sort()).toEqual(['#extra', '#proj-issue-14'])
+      // the pre-watch comment routes identically to a live comment
+      expect(result.taggedEvents[1]?.payload.kind).toBe('multiline')
+      expect(result.taggedEvents[1]?.channels.sort()).toEqual(['#extra', '#proj-issue-14'])
+    } finally { spy.mockRestore() }
+  })
+
   it('persists scraped PR state under its own slice', async () => {
     const spy = stubPr({
       snap: fakePrSnap({ linked_issues: [{ repo: 'org/repo', number: 7 }] }), events: [],

--- a/src/orchestrator/plugins/github/__tests__/scraper.test.ts
+++ b/src/orchestrator/plugins/github/__tests__/scraper.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { computePrEvents, computeIssueEvents, buildPrSnapshot, buildIssueSnapshot } from '../scraper.js'
+import { BACKLOG_COMMENT_CAP } from '../diff.js'
 import type { PrSnap, IssueSnap } from '../types.js'
 import type { PrSnapInternal, IssueSnapInternal } from '../scraper.js'
 import type { GhPrNode, GhIssueNode } from '../github-api.js'
@@ -63,23 +64,89 @@ describe('computePrEvents — new watch entry (prevSnap = null)', () => {
     expect(ev?.linked_issues).toEqual([{ repo: 'org/repo', number: 5 }, { repo: 'org/repo', number: 6 }])
   })
 
-  it('emits pr_has_existing_comments when review comments exist', () => {
-    const snap = basePrInternal({ seen_review_comment_ids: [1, 2] })
+  it('posts pre-watch review comments as real comment events, framed by pr_has_existing_comments', () => {
+    const snap = basePrInternal({
+      seen_review_comment_ids: [1, 2],
+      _review_comments_by_id: {
+        1: { id: 1, html_url: 'rc/1', user: { login: 'alice' }, body: 'nit one', path: 'a.ts', line: 10 },
+        2: { id: 2, html_url: 'rc/2', user: { login: 'bob' }, body: 'nit two', path: 'b.ts', line: 20 },
+      },
+    })
     const { events } = computePrEvents(snap, null, new Set())
-    const ev = events.find(e => e.kind === 'pr_has_existing_comments') as { review_comment_count?: number } | undefined
-    expect(ev?.review_comment_count).toBe(2)
+    const framing = events.find(e => e.kind === 'pr_has_existing_comments') as { backlog_total?: number; backlog_posted?: number } | undefined
+    expect(framing?.backlog_total).toBe(2)
+    expect(framing?.backlog_posted).toBe(2)
+    const comments = events.filter(e => e.kind === 'pr_review_comment') as Array<{ body: string; comment_url?: string; author?: string }>
+    expect(comments).toHaveLength(2)
+    expect(comments.map(c => c.body)).toEqual(['nit one', 'nit two'])
+    expect(comments.every(c => c.comment_url?.startsWith('rc/'))).toBe(true)
   })
 
-  it('emits pr_has_existing_comments when conversation comments exist', () => {
-    const snap = basePrInternal({ seen_conversation_comment_ids: [3] })
+  it('posts pre-watch conversation comments as real comment events', () => {
+    const snap = basePrInternal({
+      seen_conversation_comment_ids: [3],
+      _conversation_comments_by_id: { 3: { id: 3, html_url: 'c/3', user: { login: 'carol' }, body: 'hello' } },
+    })
     const { events } = computePrEvents(snap, null, new Set())
-    const ev = events.find(e => e.kind === 'pr_has_existing_comments') as { conversation_comment_count?: number } | undefined
-    expect(ev?.conversation_comment_count).toBe(1)
+    const framing = events.find(e => e.kind === 'pr_has_existing_comments') as { backlog_total?: number } | undefined
+    expect(framing?.backlog_total).toBe(1)
+    const comments = events.filter(e => e.kind === 'pr_conversation_comment') as Array<{ body: string }>
+    expect(comments.map(c => c.body)).toEqual(['hello'])
   })
 
-  it('does not emit pr_has_existing_comments when no existing comments', () => {
+  it('emits the framing line before the backlog comment events (header-then-dump)', () => {
+    const snap = basePrInternal({
+      seen_conversation_comment_ids: [3],
+      _conversation_comments_by_id: { 3: { id: 3, html_url: 'c/3', user: { login: 'carol' }, body: 'hello' } },
+    })
+    const { events } = computePrEvents(snap, null, new Set())
+    const framingIdx = events.findIndex(e => e.kind === 'pr_has_existing_comments')
+    const firstCommentIdx = events.findIndex(e => e.kind === 'pr_conversation_comment')
+    expect(framingIdx).toBeGreaterThanOrEqual(0)
+    expect(framingIdx).toBeLessThan(firstCommentIdx)
+  })
+
+  it('merges review/conversation/review backlog by id ascending (chronological)', () => {
+    // ids interleaved across types: review comment 100, conversation 200, review 300
+    const snap = basePrInternal({
+      seen_review_comment_ids: [100],
+      seen_conversation_comment_ids: [200],
+      seen_review_ids: [300],
+      _review_comments_by_id: { 100: { id: 100, html_url: 'rc/100', user: { login: 'a' }, body: 'rc' } },
+      _conversation_comments_by_id: { 200: { id: 200, html_url: 'c/200', user: { login: 'b' }, body: 'conv' } },
+      _reviews_by_id: { 300: { id: 300, html_url: 'r/300', user: { login: 'c' }, body: 'rev', state: 'APPROVED' } },
+    })
+    const { events } = computePrEvents(snap, null, new Set())
+    const backlogKinds = ['pr_review_comment', 'pr_conversation_comment', 'pr_review_submitted']
+    const order = events.filter(e => backlogKinds.includes(e.kind)).map(e => e.kind)
+    expect(order).toEqual(['pr_review_comment', 'pr_conversation_comment', 'pr_review_submitted'])
+    const framing = events.find(e => e.kind === 'pr_has_existing_comments') as { backlog_total?: number } | undefined
+    expect(framing?.backlog_total).toBe(3)
+  })
+
+  it('does not emit pr_has_existing_comments or backlog events when none', () => {
     const { events } = computePrEvents(basePrInternal(), null, new Set())
     expect(events.some(e => e.kind === 'pr_has_existing_comments')).toBe(false)
+    expect(events.some(e => ['pr_review_comment', 'pr_conversation_comment', 'pr_review_submitted'].includes(e.kind))).toBe(false)
+  })
+
+  it('caps the backlog to most-recent-K and records elision on the framing line', () => {
+    const total = BACKLOG_COMMENT_CAP + 5
+    const ids = Array.from({ length: total }, (_, i) => i + 1)
+    const byId: Record<number, { id: number; html_url: string; user: { login: string }; body: string }> = {}
+    for (const id of ids) byId[id] = { id, html_url: `c/${id}`, user: { login: 'u' }, body: `body ${id}` }
+    const snap = basePrInternal({ seen_conversation_comment_ids: ids, _conversation_comments_by_id: byId })
+    const { events } = computePrEvents(snap, null, new Set())
+    const framing = events.find(e => e.kind === 'pr_has_existing_comments') as { backlog_total?: number; backlog_posted?: number } | undefined
+    expect(framing?.backlog_total).toBe(total)
+    expect(framing?.backlog_posted).toBe(BACKLOG_COMMENT_CAP)
+    const comments = events.filter(e => e.kind === 'pr_conversation_comment') as Array<{ body: string }>
+    expect(comments).toHaveLength(BACKLOG_COMMENT_CAP)
+    // most-recent-K: the kept ids are the last BACKLOG_COMMENT_CAP, in ascending order
+    const keptBodies = comments.map(c => c.body)
+    const expectedFirst = `body ${ids[total - BACKLOG_COMMENT_CAP]}`
+    expect(keptBodies[0]).toBe(expectedFirst)
+    expect(keptBodies[keptBodies.length - 1]).toBe(`body ${ids[ids.length - 1]}`)
   })
 
   it('emits pr_has_existing_ci_state for terminal CI', () => {
@@ -123,16 +190,28 @@ describe('computeIssueEvents — new watch entry (prevIssue = null)', () => {
     expect(events.some(e => e.kind === 'issue_added_to_watch')).toBe(true)
   })
 
-  it('emits issue_has_existing_comments when comments exist', () => {
-    const snap = baseIssueInternal({ seen_comment_ids: [1, 2, 3] })
+  it('posts pre-watch issue comments as real comment events, framed by issue_has_existing_comments', () => {
+    const snap = baseIssueInternal({
+      seen_comment_ids: [1, 2, 3],
+      _comments_by_id: {
+        1: { id: 1, html_url: 'c/1', user: { login: 'x' }, body: 'a' },
+        2: { id: 2, html_url: 'c/2', user: { login: 'y' }, body: 'b' },
+        3: { id: 3, html_url: 'c/3', user: { login: 'z' }, body: 'c' },
+      },
+    })
     const events = computeIssueEvents(snap, null, new Set())
-    const ev = events.find(e => e.kind === 'issue_has_existing_comments') as { comment_count?: number } | undefined
-    expect(ev?.comment_count).toBe(3)
+    const framing = events.find(e => e.kind === 'issue_has_existing_comments') as { backlog_total?: number; backlog_posted?: number } | undefined
+    expect(framing?.backlog_total).toBe(3)
+    expect(framing?.backlog_posted).toBe(3)
+    const comments = events.filter(e => e.kind === 'issue_comment') as Array<{ body: string; comment_url?: string }>
+    expect(comments.map(c => c.body)).toEqual(['a', 'b', 'c'])
+    expect(comments.every(c => c.comment_url?.startsWith('c/'))).toBe(true)
   })
 
-  it('does not emit issue_has_existing_comments when no comments', () => {
+  it('does not emit issue_has_existing_comments or backlog events when no comments', () => {
     const events = computeIssueEvents(baseIssueInternal(), null, new Set())
     expect(events.some(e => e.kind === 'issue_has_existing_comments')).toBe(false)
+    expect(events.some(e => e.kind === 'issue_comment')).toBe(false)
   })
 })
 

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -71,9 +71,10 @@ export interface SeedEvent extends BaseEvent {
     | 'pr_merged'
     | 'pr_closed'
     | 'pr_no_linked_issues'
-  review_comment_count?: number
-  conversation_comment_count?: number
-  comment_count?: number
+  // Backlog dump framing: total pre-watch items found, and how many were
+  // actually posted (total > posted means the rest were elided by the cap).
+  backlog_total?: number
+  backlog_posted?: number
   ci_state?: string | null
   head_oid?: string | null
   stderr?: string
@@ -97,6 +98,14 @@ const ALWAYS_PUSH_KINDS = new Set([
 ])
 const MEANINGFUL_LABEL_PREFIXES = ['phase:', 'plan:']
 const MEANINGFUL_LABELS_EXACT = new Set(['ready-for-merge'])
+
+// Most pre-watch items to post inline when a PR/issue is newly watched.
+// Backlog is a one-time dump at watch time, so this only bites on large
+// pre-watch histories; the typical linkback case (a handful of comments)
+// always posts in full. When elided, the most recent K are kept (the
+// actionable tail of an active thread) and the framing line points to the
+// URL for earlier history.
+export const BACKLOG_COMMENT_CAP = 20
 
 export function shouldPush(event: OrchestratorEvent): boolean {
   const kind = event.kind
@@ -169,6 +178,42 @@ export function formatCommentEvent(
   return ev
 }
 
+// Review-event builder — mirrors formatCommentEvent so the live diff and the
+// backlog dump share one construction path. state is uppercased to match the
+// REST-shaped value shouldPush/format key on.
+export function formatReviewEvent(
+  r: GhReview,
+  opts: {
+    reviewId: number
+    repo?: string
+    pr?: number
+    url: string
+    agentLogins?: Set<string>
+    linkedIssues?: LinkedIssue[]
+  }
+): ReviewEvent {
+  const author = r.user?.login
+  const body = r.body ?? ''
+  const isAgentAuthor = Boolean(opts.agentLogins?.size && author && opts.agentLogins.has(author))
+  const ev: ReviewEvent = {
+    kind: 'pr_review_submitted',
+    review_id: opts.reviewId,
+    review_url: r.html_url,
+    author,
+    state: (r.state ?? '').toUpperCase(),
+    body,
+    body_preview: body.slice(0, 280),
+    is_worker_reply: isAgentAuthor,
+  }
+  if (opts.repo) ev.repo = opts.repo
+  if (opts.pr != null) {
+    ev.pr = opts.pr
+    ev.url = opts.url
+    if (opts.linkedIssues?.length) ev.linked_issues = opts.linkedIssues
+  }
+  return ev
+}
+
 // ---- PR diff ---------------------------------------------------------------
 
 function linkedSpread(linked: LinkedIssue[]): { linked_issues?: LinkedIssue[] } {
@@ -235,19 +280,7 @@ export function diffPr(
 
   for (const rid of newIds(prev.seen_review_ids, cur._reviews_by_id)) {
     const review = cur._reviews_by_id[rid] as GhReview
-    const reviewAuthor = review.user?.login
-    events.push({
-      kind: 'pr_review_submitted',
-      repo, pr: n, url: cur.url ?? '',
-      review_id: rid,
-      review_url: review.html_url,
-      author: reviewAuthor,
-      state: (review.state ?? '').toUpperCase(),
-      body: review.body ?? '',
-      body_preview: (review.body ?? '').slice(0, 280),
-      is_worker_reply: Boolean(agentLogins?.size && reviewAuthor && agentLogins.has(reviewAuthor)),
-      ...linkedSpread(linked),
-    } as ReviewEvent)
+    events.push(formatReviewEvent(review, { reviewId: rid, repo, pr: n, url: cur.url ?? '', agentLogins, linkedIssues: linked }))
   }
 
   return events
@@ -279,4 +312,76 @@ export function diffIssue(
   }
 
   return events
+}
+
+// ---- Backlog dump (newly-watched PR/issue) ---------------------------------
+//
+// When a PR/issue is first watched, pre-watch comments/reviews already exist
+// on GitHub (Linear linkback bot comments, prior review threads, etc.). The
+// count-only "scan manually" summary left agents without context; these
+// builders emit the actual items as the same event kinds the live diff uses,
+// so they route and render identically to fresh comments.
+//
+// GitHub databaseIds are globally monotonic across node types, so merging
+// review/conversation/review events by id gives true chronological order —
+// the readable shape for a one-time history dump. The most-recent-K cap keeps
+// a long pre-watch thread from flooding the channel; within the posted K,
+// order stays ascending (oldest→newest) so the thread reads naturally.
+
+interface BacklogItem {
+  id: number
+  ev: OrchestratorEvent
+}
+
+function pickMostRecentK(items: BacklogItem[], cap: number): BacklogItem[] {
+  items.sort((a, b) => a.id - b.id)
+  const start = Math.max(0, items.length - cap)
+  return items.slice(start)
+}
+
+export function backlogPrEvents(
+  snap: PrSnapInternal,
+  agentLogins: Set<string>,
+  cap: number = BACKLOG_COMMENT_CAP,
+): { events: OrchestratorEvent[]; total: number; posted: number } {
+  const linked = snap.linked_issues ?? []
+  const opts = { repo: snap.repo, pr: snap.number, url: snap.url ?? '', agentLogins, linkedIssues: linked }
+
+  const items: BacklogItem[] = []
+  for (const id of snap.seen_review_comment_ids) {
+    const c = snap._review_comments_by_id[id]
+    if (!c) continue
+    items.push({ id, ev: formatCommentEvent(c, { kind: 'pr_review_comment', ...opts }) })
+  }
+  for (const id of snap.seen_conversation_comment_ids) {
+    const c = snap._conversation_comments_by_id[id]
+    if (!c) continue
+    items.push({ id, ev: formatCommentEvent(c, { kind: 'pr_conversation_comment', ...opts }) })
+  }
+  for (const id of snap.seen_review_ids) {
+    const r = snap._reviews_by_id[id]
+    if (!r) continue
+    items.push({ id, ev: formatReviewEvent(r, { reviewId: id, ...opts }) })
+  }
+
+  const posted = pickMostRecentK(items, cap)
+  return { events: posted.map(i => i.ev), total: items.length, posted: posted.length }
+}
+
+export function backlogIssueEvents(
+  snap: IssueSnapInternal,
+  agentLogins: Set<string>,
+  cap: number = BACKLOG_COMMENT_CAP,
+): { events: OrchestratorEvent[]; total: number; posted: number } {
+  const opts = { repo: snap.repo, issue: snap.number, url: snap.url ?? '', agentLogins }
+
+  const items: BacklogItem[] = []
+  for (const id of snap.seen_comment_ids) {
+    const c = snap._comments_by_id[id]
+    if (!c) continue
+    items.push({ id, ev: formatCommentEvent(c, { kind: 'issue_comment', ...opts }) })
+  }
+
+  const posted = pickMostRecentK(items, cap)
+  return { events: posted.map(i => i.ev), total: items.length, posted: posted.length }
 }

--- a/src/orchestrator/plugins/github/diff.ts
+++ b/src/orchestrator/plugins/github/diff.ts
@@ -180,7 +180,7 @@ export function formatCommentEvent(
 
 // Review-event builder — mirrors formatCommentEvent so the live diff and the
 // backlog dump share one construction path. state is uppercased to match the
-// REST-shaped value shouldPush/format key on.
+// REST-shaped value format renders in the review header.
 export function formatReviewEvent(
   r: GhReview,
   opts: {
@@ -317,20 +317,22 @@ export function diffIssue(
 // ---- Backlog dump (newly-watched PR/issue) ---------------------------------
 //
 // When a PR/issue is first watched, pre-watch comments/reviews already exist
-// on GitHub (Linear linkback bot comments, prior review threads, etc.). The
-// count-only "scan manually" summary left agents without context; these
-// builders emit the actual items as the same event kinds the live diff uses,
-// so they route and render identically to fresh comments.
+// on GitHub. These builders emit the actual items as the same event kinds
+// the live diff uses, so they route and render identically to fresh comments.
 //
 // GitHub databaseIds are globally monotonic across node types, so merging
 // review/conversation/review events by id gives true chronological order —
 // the readable shape for a one-time history dump. The most-recent-K cap keeps
 // a long pre-watch thread from flooding the channel; within the posted K,
 // order stays ascending (oldest→newest) so the thread reads naturally.
+//
+// Formatting is deferred to a thunk per item so only the kept K are formatted
+// — the cap exists to bound the work for a large pre-watch history, and
+// formatting every item then discarding the tail would defeat that.
 
 interface BacklogItem {
   id: number
-  ev: OrchestratorEvent
+  format: () => OrchestratorEvent
 }
 
 function pickMostRecentK(items: BacklogItem[], cap: number): BacklogItem[] {
@@ -351,21 +353,21 @@ export function backlogPrEvents(
   for (const id of snap.seen_review_comment_ids) {
     const c = snap._review_comments_by_id[id]
     if (!c) continue
-    items.push({ id, ev: formatCommentEvent(c, { kind: 'pr_review_comment', ...opts }) })
+    items.push({ id, format: () => formatCommentEvent(c, { kind: 'pr_review_comment', ...opts }) })
   }
   for (const id of snap.seen_conversation_comment_ids) {
     const c = snap._conversation_comments_by_id[id]
     if (!c) continue
-    items.push({ id, ev: formatCommentEvent(c, { kind: 'pr_conversation_comment', ...opts }) })
+    items.push({ id, format: () => formatCommentEvent(c, { kind: 'pr_conversation_comment', ...opts }) })
   }
   for (const id of snap.seen_review_ids) {
     const r = snap._reviews_by_id[id]
     if (!r) continue
-    items.push({ id, ev: formatReviewEvent(r, { reviewId: id, ...opts }) })
+    items.push({ id, format: () => formatReviewEvent(r, { reviewId: id, ...opts }) })
   }
 
   const posted = pickMostRecentK(items, cap)
-  return { events: posted.map(i => i.ev), total: items.length, posted: posted.length }
+  return { events: posted.map(i => i.format()), total: items.length, posted: posted.length }
 }
 
 export function backlogIssueEvents(
@@ -379,9 +381,9 @@ export function backlogIssueEvents(
   for (const id of snap.seen_comment_ids) {
     const c = snap._comments_by_id[id]
     if (!c) continue
-    items.push({ id, ev: formatCommentEvent(c, { kind: 'issue_comment', ...opts }) })
+    items.push({ id, format: () => formatCommentEvent(c, { kind: 'issue_comment', ...opts }) })
   }
 
   const posted = pickMostRecentK(items, cap)
-  return { events: posted.map(i => i.ev), total: items.length, posted: posted.length }
+  return { events: posted.map(i => i.format()), total: items.length, posted: posted.length }
 }

--- a/src/orchestrator/plugins/github/format.ts
+++ b/src/orchestrator/plugins/github/format.ts
@@ -96,7 +96,12 @@ export function formatEvent(event: OrchestratorEvent): string {
 
   if (kind === 'pr_has_existing_comments') {
     const ev = event as SeedEvent
-    return `PR ${tag} BACKLOG: ${ev.review_comment_count ?? 0} review + ${ev.conversation_comment_count ?? 0} conversation comments existed before watch — scan manually: ${event.url ?? ''}`
+    const total = ev.backlog_total ?? 0
+    const posted = ev.backlog_posted ?? total
+    if (posted < total) {
+      return `PR ${tag} BACKLOG: showing ${posted} most recent of ${total} pre-watch comments — earlier at ${event.url ?? ''}`
+    }
+    return `PR ${tag} BACKLOG: posting ${total} pre-watch comments below`
   }
 
   if (kind === 'pr_has_existing_ci_state') {
@@ -106,7 +111,12 @@ export function formatEvent(event: OrchestratorEvent): string {
 
   if (kind === 'issue_has_existing_comments') {
     const ev = event as SeedEvent
-    return `Issue ${tag} BACKLOG: ${ev.comment_count ?? 0} comments existed before watch — scan manually: ${event.url ?? ''}`
+    const total = ev.backlog_total ?? 0
+    const posted = ev.backlog_posted ?? total
+    if (posted < total) {
+      return `Issue ${tag} BACKLOG: showing ${posted} most recent of ${total} pre-watch comments — earlier at ${event.url ?? ''}`
+    }
+    return `Issue ${tag} BACKLOG: posting ${total} pre-watch comments below`
   }
 
   if (kind === 'dispatcher_error') {

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -11,7 +11,7 @@
 import type { PrSnap, IssueSnap } from './types.js'
 import type { GhComment, GhReview, GhPrNode, GhIssueNode } from './github-api.js'
 import { labelNames, rollupToCiState } from './github-api.js'
-import { diffPr, diffIssue, type OrchestratorEvent } from './diff.js'
+import { diffPr, diffIssue, backlogPrEvents, backlogIssueEvents, type OrchestratorEvent } from './diff.js'
 
 // ---- Snapshot types & helpers ---------------------------------------------
 
@@ -154,10 +154,13 @@ export function computePrEvents(
   const base = { repo: snap.repo, pr: snap.number, url: snap.url ?? '', title: snap.title ?? '', ...(linked.length ? { linked_issues: linked } : undefined) }
   const events: OrchestratorEvent[] = [{ kind: 'pr_added_to_watch', ...base }]
   if (!linked.length) events.push({ kind: 'pr_no_linked_issues', ...base })
-  const existingRev = snap.seen_review_comment_ids.length
-  const existingConv = snap.seen_conversation_comment_ids.length
-  if (existingRev || existingConv) {
-    events.push({ kind: 'pr_has_existing_comments', review_comment_count: existingRev, conversation_comment_count: existingConv, ...base })
+  // Pre-watch comments/reviews: post them straight to the channel as real
+  // comment events (framed by pr_has_existing_comments) rather than a
+  // count-only "scan manually" summary. Framing line first → header-then-dump.
+  const backlog = backlogPrEvents(snap, agentLogins)
+  if (backlog.total > 0) {
+    events.push({ kind: 'pr_has_existing_comments', ...base, backlog_total: backlog.total, backlog_posted: backlog.posted })
+    events.push(...backlog.events)
   }
   if (snap.ci_state === 'SUCCESS' || snap.ci_state === 'FAILURE') {
     events.push({ kind: 'pr_has_existing_ci_state', ci_state: snap.ci_state, head_oid: snap.head_oid, ...base })
@@ -176,8 +179,10 @@ export function computeIssueEvents(
   // New to watch list
   const base = { repo: snap.repo, issue: snap.number, url: snap.url ?? '', title: snap.title ?? '' }
   const events: OrchestratorEvent[] = [{ kind: 'issue_added_to_watch', ...base }]
-  if (snap.seen_comment_ids.length) {
-    events.push({ kind: 'issue_has_existing_comments', comment_count: snap.seen_comment_ids.length, ...base })
+  const backlog = backlogIssueEvents(snap, agentLogins)
+  if (backlog.total > 0) {
+    events.push({ kind: 'issue_has_existing_comments', ...base, backlog_total: backlog.total, backlog_posted: backlog.posted })
+    events.push(...backlog.events)
   }
   return events
 }

--- a/src/orchestrator/plugins/github/scraper.ts
+++ b/src/orchestrator/plugins/github/scraper.ts
@@ -154,9 +154,8 @@ export function computePrEvents(
   const base = { repo: snap.repo, pr: snap.number, url: snap.url ?? '', title: snap.title ?? '', ...(linked.length ? { linked_issues: linked } : undefined) }
   const events: OrchestratorEvent[] = [{ kind: 'pr_added_to_watch', ...base }]
   if (!linked.length) events.push({ kind: 'pr_no_linked_issues', ...base })
-  // Pre-watch comments/reviews: post them straight to the channel as real
-  // comment events (framed by pr_has_existing_comments) rather than a
-  // count-only "scan manually" summary. Framing line first → header-then-dump.
+  // Pre-watch comments/reviews: post them to the channel as real comment
+  // events framed by pr_has_existing_comments. Framing line first → header-then-dump.
   const backlog = backlogPrEvents(snap, agentLogins)
   if (backlog.total > 0) {
     events.push({ kind: 'pr_has_existing_comments', ...base, backlog_total: backlog.total, backlog_posted: backlog.posted })


### PR DESCRIPTION
Closes #688

When a PR or issue is newly watched and already has comments on GitHub (Linear linkback bot comments, prior review threads), the dispatcher emitted a count-only "scan manually" backlog line — agents had to leave IRC to read the actual content. The seed tick now emits the pre-watch comments/reviews as the same event kinds the live diff uses, so they route and render identically to fresh comments, framed by a reworded BACKLOG line.

Black box:
- input: a watched PR/issue's first scrape (prev = null) carrying pre-watch review comments, conversation comments, and reviews.
- output: one oneline `BACKLOG: posting N pre-watch comments below` framing event, then N real comment/review events (multiline) routed to the same channels a live comment would reach (linked-issue channel, unioned with entry channels).
- side effect: none beyond the existing seed tick (events are ephemeral; only the snapshot is persisted).

The backlog is merged by id across review/conversation/review streams — GitHub databaseIds are globally monotonic, so id-sort gives true chronological order. A `BACKLOG_COMMENT_CAP` (20) keeps a long pre-watch thread from flooding the channel: most-recent-K is posted (the actionable tail), and the framing line points to the URL for earlier history when elided. The typical linkback case (a handful of comments) always posts in full.

`formatReviewEvent` is extracted from `diffPr`'s inline construction so the live diff and the backlog dump share one review-event builder.

Scope: PR + github-issue backlog (same class, same plugin). Linear-issue backlog is a separate plugin with its own event types/format — raised as a 0.9.1 follow-up. Built on the current seam with no new payload variant, so the #695 thin-pipe refactor adapts the consumer without rework here.

🤖 Generated with Claude Code