### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roost",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump for the 0.9.0 milestone release.

What's new since 0.8.9:
- `roost spawn --ollama-model TAG` — first-class ollama support (#293)
- Batch consecutive PR comments into one IRC message (#689)
- Relay backlogged PR/issue comments to channel on watch (#688)
- `ROOST_SPAWN_NO_LAUNCH` test seam skips the real launch (#694)
